### PR TITLE
Fix zip panic bug 

### DIFF
--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -1354,13 +1354,13 @@ func builtinZip(env *LEnv, args *LVal) *LVal {
 	if typespec.Type != LSymbol {
 		return env.Errorf("first argument is not a valid type specifier: %v", typespec.Type)
 	}
-	n := 0
+	n := lists[0].Len()
 	for _, list := range lists {
 		if !isSeq(list) {
 			return env.Errorf("argument is not a proper list: %v", list.Type)
 		}
 		m := list.Len()
-		if n == 0 || m < n {
+		if m < n {
 			n = m
 		}
 	}

--- a/lisp/fp_test.go
+++ b/lisp/fp_test.go
@@ -45,6 +45,10 @@ func TestFP(t *testing.T) {
 			{"(apply (curry-function zip 'list) (zip 'list '(1 2 3) '('a 'b 'c)))", "'('(1 2 3) '('a 'b 'c))", ""},
 			{"(zip 'vector '(1 2 3) '('a 'b 'c))", "(vector (vector 1 'a) (vector 2 'b) (vector 3 'c))", ""},
 			{"(apply (curry-function zip 'vector) (map 'list identity (zip 'vector '(1 2 3) '('a 'b 'c))))", "(vector (vector 1 2 3) (vector 'a 'b 'c))", ""},
+			{"(zip 'list '(1) '())", "'()", ""},
+			{"(zip 'list (vector 1) '())", "'()", ""},
+			{"(zip 'list '() '(1))", "'()", ""},
+			{"(zip 'vector '() '() '(1))", "(vector)", ""},
 		}},
 		{"simple composition", elpstest.TestSequence{
 			{"(defun f (y) (+ y 1))", "()", ""},


### PR DESCRIPTION
Fix zip panic bug.

I wanted to avoid an explicit check on all of the args being empty, to keep the code clean and concise.

This means that I call Len on the first list of the argument but I believe this is fine and all the edge case get handled.  I believe the guarantee that lists has at least 1 element is provided higher up when zip builtin is exposed, so we can safely index into 0th position. 
I believe that same setup is providing a guarantee that the argument is a list or vector, so we can safely get its length.

Regression tests included; without we get a panic as outlines in the issue

closes https://github.com/luthersystems/elps/issues/22