### PR TITLE
Add regular expressions to schema library

### DIFF
--- a/lisp/lisplib/libjson/libjson_test.lisp
+++ b/lisp/lisplib/libjson/libjson_test.lisp
@@ -35,7 +35,7 @@
                                     :string-numbers false))
   )
 
-(test "mashal"
+(test "marshal"
   (assert-string= """null"""
                   (json:dump-string ()))
   (assert-string= """true"""

--- a/lisp/lisplib/libschema/README.md
+++ b/lisp/lisplib/libschema/README.md
@@ -121,6 +121,10 @@ The following inbuilt types are available within the library:
 Requires the value to be one of those specified as arguments to the function.
 
 
+* `(s:regexp pattern)`
+Requires the value to match the supplied pattern. Any regular expression that can be parsed by go is acceptable - see https://github.com/google/re2/wiki/Syntax for syntax.
+  
+
 * `(s:len length)` 
   Requires the value to have the specified length.
   

--- a/lisp/lisplib/libschema/libschema_test.lisp
+++ b/lisp/lisplib/libschema/libschema_test.lisp
@@ -9,11 +9,26 @@
           (assert-equal (s:validate mystring y) "ERROR"))
       (s:deftype "myconditionalstring" s:string (s:in "x" "y" "z"))
       (handler-bind (('wrong-type (lambda (&rest e) "ERROR")))
-                (assert-equal (s:validate myconditionalstring y) "ERROR"))
+            (assert-equal (s:validate myconditionalstring y) "ERROR"))
       (handler-bind (('failed-constraint (lambda (&rest e) "ERROR")))
-                (assert-equal (s:validate myconditionalstring x) "ERROR"))
+            (assert-equal (s:validate myconditionalstring x) "ERROR"))
       (assert-nil (s:validate mystring "x"))
       (assert-nil (s:validate mystring "y"))
+)
+
+(test "deftype-regexp"
+      (s:deftype "mystring" s:string (s:regexp "^Hello"))
+      (assert-nil (s:validate mystring "Hello mum"))
+      (handler-bind (('failed-constraint (lambda (&rest e) "ERROR")))
+          (assert-equal (s:validate mystring "goodbye mum") "ERROR"))
+      (handler-bind (('failed-constraint (lambda (&rest e) "ERROR")))
+          (assert-equal (s:validate mystring "well hello there") "ERROR"))
+      (s:deftype "isodate" s:string (s:regexp "^([1-9][0-9]{3})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])?$"))
+      (assert-nil (s:validate isodate "2020-04-31"))
+      (handler-bind (('failed-constraint (lambda (&rest e) "ERROR")))
+          (assert-equal (s:validate isodate "3/4/21") "ERROR"))
+      (handler-bind (('bad-arguments (lambda (&rest e) "ERROR")))
+        (assert-equal (s:deftype "x" s:string (s:regexp "*")) "ERROR"))
 )
 
 (test "deftype-int"


### PR DESCRIPTION
This was an obvious oversight - soon as I thought "how would I check a postcode or a phone number" it was clear it was necessary. This is pretty performant as the regex is only complied once when the schema is defined.