### PR TITLE
RFC - `format` implementation

### DIFF
--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -2289,10 +2289,10 @@ func builtinFormatString(env *LEnv, args *LVal) *LVal {
 			p = strings.Join(strings.Fields(p), "")
 			// TODO:  Allow non-empty formatting directives
 			if p != "{}" {
-				return env.Errorf("formatting direcives must be empty")
+				return env.Errorf("formatting directives must be empty")
 			}
 			if anonIndex >= len(fvals) {
-				return env.Errorf("too many formatting direcives for supplied values")
+				return env.Errorf("too many formatting directives for supplied values")
 			}
 			val := fvals[anonIndex]
 			if val.Type == LString && !val.Quoted {
@@ -2321,7 +2321,7 @@ func parseFormatString(f string) ([]string, error) {
 		}
 		if tok.typ == formatClose {
 			if len(tokens) == 0 || tokens[0].typ != formatClose {
-				return nil, fmt.Errorf("unexpected closing brace '}' outside of formatting direcive")
+				return nil, fmt.Errorf("unexpected closing brace '}' outside of formatting directive")
 			}
 			s = append(s, "}")
 			tokens = tokens[2:]

--- a/lisp/format_test.go
+++ b/lisp/format_test.go
@@ -1,0 +1,185 @@
+package lisp
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatStringSimple(t *testing.T) {
+	env := NewEnv(nil)
+	format := String("Swap a symbol here {}")
+	arg1 := String("yeah")
+	args := &LVal{Cells: []*LVal{format, arg1}}
+	formatted := builtinFormatString(env, args)
+	assert.Equal(t, "Swap a symbol here yeah", formatted.Str)
+}
+
+func TestFormatStringComplex(t *testing.T) {
+	env := NewEnv(nil)
+	format := String("Swap a symbol here ")
+	built := format.Str
+	args := []*LVal{format}
+	for x := 0; x < 100; x++ {
+		args[0] = String(fmt.Sprintf("%s {}, blah blah,", args[0].Str))
+		built = fmt.Sprintf("%s %d, blah blah,", built, x)
+		args = append(args, String(strconv.Itoa(x)))
+		formatted := builtinFormatString(env, &LVal{Cells: args})
+		assert.Equal(t, built, formatted.Str)
+	}
+}
+
+func TestFormatStringUnmatched(t *testing.T) {
+	env := NewEnv(nil)
+	format := String("Swap a symbol here }")
+	arg1 := String("yeah")
+	args := &LVal{Cells: []*LVal{format, arg1}}
+	formatted := builtinFormatString(env, args)
+	assert.Equal(t, LError, formatted.Type)
+}
+
+func TestTokenizeFormatString(t *testing.T) {
+	x := tokenizeFormatString("This is a formatted {} string yeah {}.")
+	assert.Equal(t, []formatToken{
+		{typ: formatText, text: "This is a formatted "},
+		{typ: formatOpen, text: "{"},
+		{typ: formatClose, text: "}"},
+		{typ: formatText, text: " string yeah "},
+		{typ: formatOpen, text: "{"},
+		{typ: formatClose, text: "}"},
+		{typ: formatText, text: "."},
+	}, x)
+}
+
+var formatTokenRegexp = regexp.MustCompile(`\{(\d+)\}`)
+
+// var formatBadTokenPattern = regexp.MustCompile(`(?:\{[^\d\}]|[^\{\d]\})`) // This is slooooow...
+// var formatBadTokenPattern = regexp.MustCompile(`\{[^\d\}]`) // This is also slow enough that I'd ditch it
+
+func quickformatBuiltin(env *LEnv, args *LVal) *LVal {
+	format := args.Cells[0]
+	//if formatBadTokenPattern.MatchString(format.Str) {
+	//return env.Errorf("unmatched token")
+	//}
+	replacements := make([]interface{}, len(args.Cells)-1)
+	for k, v := range args.Cells[1:] {
+		if v.Type == LString && !v.Quoted {
+			replacements[k] = v.Str
+		} else {
+			replacements[k] = v.String()
+		}
+	}
+	if format.Type != LString {
+		return env.Errorf("first argument is not a string")
+	}
+	pattern := formatTokenRegexp.ReplaceAllString(strings.ReplaceAll(strings.ReplaceAll(format.Str, "%", "%%"), "{}", "%s"), "%[$1]s")
+	return String(fmt.Sprintf(pattern, replacements...))
+}
+
+func TestQuickFormatStringSimple(t *testing.T) {
+	env := NewEnv(nil)
+	format := String("Swap a symbol here {}")
+	arg1 := String("yeah")
+	args := &LVal{Cells: []*LVal{format, arg1}}
+	formatted := quickformatBuiltin(env, args)
+	assert.Equal(t, "Swap a symbol here yeah", formatted.Str)
+}
+
+func TestQuickFormatStringComplex(t *testing.T) {
+	env := NewEnv(nil)
+	format := String("Swap a symbol here ")
+	built := format.Str
+	args := []*LVal{format}
+	for x := 0; x < 100; x++ {
+		args[0] = String(fmt.Sprintf("%s {}, blah blah,", args[0].Str))
+		built = fmt.Sprintf("%s %d, blah blah,", built, x)
+		args = append(args, String(strconv.Itoa(x)))
+		formatted := quickformatBuiltin(env, &LVal{Cells: args})
+		assert.Equal(t, built, formatted.Str)
+	}
+}
+
+func TestQuickFormatStringUnmatched(t *testing.T) {
+	env := NewEnv(nil)
+	format := String("Swap a symbol here }")
+	arg1 := String("yeah")
+	args := &LVal{Cells: []*LVal{format, arg1}}
+	formatted := quickformatBuiltin(env, args)
+	assert.Equal(t, LError, formatted.Type)
+}
+
+func TestQuickFormatStringPositional(t *testing.T) {
+	env := NewEnv(nil)
+	format := String("Swap a symbol here {2} and here {1}")
+	arg1 := String("yeah")
+	arg2 := String("oh")
+	args := &LVal{Cells: []*LVal{format, arg1, arg2}}
+	formatted := quickformatBuiltin(env, args)
+	assert.Equal(t, "Swap a symbol here oh and here yeah", formatted.Str)
+}
+
+func BenchmarkQuickFormatString(t *testing.B) {
+	env := NewEnv(nil)
+	format := String("Swap a symbol here {} and {} and {}")
+	for x := 0; x < t.N; x++ {
+		args := []*LVal{format, String("A"), String("B"), String("C")}
+		formatted := quickformatBuiltin(env, &LVal{Cells: args})
+		assert.Equal(t, "Swap a symbol here A and B and C", formatted.Str)
+	}
+}
+
+func BenchmarkQuickFormatStringWithPositionalToken(t *testing.B) {
+	env := NewEnv(nil)
+	format := String("Swap a symbol here {} and {} and {1}")
+	for x := 0; x < t.N; x++ {
+		args := []*LVal{format, String("A"), String("B")}
+		formatted := quickformatBuiltin(env, &LVal{Cells: args})
+		assert.Equal(t, "Swap a symbol here A and B and A", formatted.Str)
+	}
+}
+
+func BenchmarkQuickFormatStringWithATonOfTokens(t *testing.B) {
+	env := NewEnv(nil)
+	format := String("Swap a symbol here ")
+	built := format.Str
+	args := []*LVal{format}
+	for x := 0; x < 100; x++ {
+		args[0] = String(fmt.Sprintf("%s {}, blah blah,", args[0].Str))
+		built = fmt.Sprintf("%s %d, blah blah,", built, x)
+		args = append(args, String(strconv.Itoa(x)))
+	}
+	for x := 0; x < t.N; x++ {
+		formatted := quickformatBuiltin(env, &LVal{Cells: args})
+		assert.Equal(t, built, formatted.Str)
+	}
+}
+
+func BenchmarkFormatString(t *testing.B) {
+	env := NewEnv(nil)
+	format := String("Swap a symbol here {} and {} and {}")
+	for x := 0; x < t.N; x++ {
+		args := []*LVal{format, String("A"), String("B"), String("C")}
+		formatted := builtinFormatString(env, &LVal{Cells: args})
+		assert.Equal(t, "Swap a symbol here A and B and C", formatted.Str)
+	}
+}
+
+func BenchmarkFormatStringWithATonOfTokens(t *testing.B) {
+	env := NewEnv(nil)
+	format := String("Swap a symbol here ")
+	built := format.Str
+	args := []*LVal{format}
+	for x := 0; x < 100; x++ {
+		args[0] = String(fmt.Sprintf("%s {}, blah blah,", args[0].Str))
+		built = fmt.Sprintf("%s %d, blah blah,", built, x)
+		args = append(args, String(strconv.Itoa(x)))
+	}
+	for x := 0; x < t.N; x++ {
+		formatted := builtinFormatString(env, &LVal{Cells: args})
+		assert.Equal(t, built, formatted.Str)
+	}
+}


### PR DESCRIPTION
The implementation of `format` is cool but probably overcomplex for what it actually does. There's also a `TODO` to add positional parameters.

I've written a (much) simpler implementation that supports positional parameters. You'll find it in `format_test.go` as `quickformatBuiltin` at the moment. I've also written a series of tests and benchmarks for both implementations.

As it stands, there is code there to support unmatched brackets, but the more I think about it, the less desirable I think that actually is. Mistakes are obvious because the number of brackets won't match the number of parameters and this gives a way to use a literal curly bracket. Considering the performance impact of it as well, this seems reasonable.

With unmatched checking turned off, performance for this version is around 20% better for simple strings:

```
BenchmarkQuickFormatString
BenchmarkQuickFormatString-8                      	  727240	      1533 ns/op
```
versus
```
BenchmarkFormatString
BenchmarkFormatString-8                           	  631561	      1887 ns/op
```

With a lot of tokens, the gap is a lot wider:

```
BenchmarkQuickFormatStringWithATonOfTokens
BenchmarkQuickFormatStringWithATonOfTokens-8      	  116503	     10249 ns/op
```
versus
```
BenchmarkFormatStringWithATonOfTokens
BenchmarkFormatStringWithATonOfTokens-8           	   69565	     16725 ns/op
```

Performance is marginally slower with positional tokens, but not a lot:

```
BenchmarkQuickFormatStringWithPositionalToken
BenchmarkQuickFormatStringWithPositionalToken-8   	  727245	      1666 ns/op
```

Turning on the simple bad token check, performance drops to:
```
BenchmarkQuickFormatString
BenchmarkQuickFormatString-8                      	  599984	      1723 ns/op
BenchmarkQuickFormatStringWithATonOfTokens
BenchmarkQuickFormatStringWithATonOfTokens-8      	   88561	     13319 ns/op
```

and if I use the "comprehensive" check:
```
BenchmarkQuickFormatString
BenchmarkQuickFormatString-8                      	  380971	      2916 ns/op
BenchmarkQuickFormatStringWithATonOfTokens
BenchmarkQuickFormatStringWithATonOfTokens-8      	   18986	     63204 ns/op
```