### PR TITLE
JSON performance improvements

### DIFF
--- a/elpstest/sortedmap.go
+++ b/elpstest/sortedmap.go
@@ -1,0 +1,165 @@
+package elpstest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertSortedMap runs tests to ensure that m satisfies constraints required
+// for sorted maps.  The following properties are tested by AssertSortedMap:
+//
+//		The m.Keys and m.Entries produce lists with the expected length,
+//		m.Len()
+//
+//		Repeated calls to m.Entries() return equal lists of pairs
+//
+//		Repeated calls to m.Keys() return equal lists
+//
+//		The lists returned by m.Keys() and m.Entries() have consistent elements
+//		and order.
+//
+//		Calling m.Get() with a key from m.Entries() returns a value consistent
+//		with that entry.
+//
+// AssertSortedMap does not test any of the following properties:
+//
+//		Success/Failure of insertions or deletions -- m must already be
+//		populated with values.
+//
+//		Restrictions the implementation places on the types of keys/values.
+//
+//		Any measure of correctness in the ordering of entries/keys.  The only
+//		requirement is that the order be fixed for a given set of key-value
+//		pairs.
+func AssertSortedMap(t *testing.T, m lisp.Map) bool {
+	t.Helper()
+	if !assert.NotEqual(t, 0, m.Len(), "Cannot test an empty sorted-map") {
+		return false
+	}
+	if !testFixed(t, "Entries", 3, func() (*lisp.LVal, error) { return mapEntries(m) }) {
+		return false
+	}
+	if !testFixed(t, "Keys", 3, func() (*lisp.LVal, error) { return mapKeys(m) }) {
+		return false
+	}
+	if !testEntryKeyOrder(t, m) {
+		return false
+	}
+	if !testGetEntries(t, m) {
+		return false
+	}
+	return true
+}
+
+func testFixed(t *testing.T, method string, n int, fn func() (*lisp.LVal, error)) bool {
+	t.Helper()
+	expect, err := fn()
+	if !assert.NoError(t, err) {
+		return false
+	}
+	for i := 0; i < n; i++ {
+		v, err := fn()
+		if !assert.NoError(t, err) {
+			return false
+		}
+		res := expect.Equal(v)
+		err = lisp.GoError(res)
+		if !assert.NoError(t, err) {
+			return false
+		}
+		ok := lisp.True(res)
+		if !assert.True(t, ok, "%s got: %v expected: %v", method, v, expect) {
+			return false
+		}
+	}
+	return true
+}
+
+func testEntryKeyOrder(t *testing.T, m lisp.Map) bool {
+	t.Helper()
+	entries, err := mapEntries(m)
+	if !assert.NoError(t, err) {
+		return false
+	}
+	keys, err := mapKeys(m)
+	if !assert.NoError(t, err) {
+		return false
+	}
+	if !assert.Equal(t, entries.Len(), keys.Len()) {
+		// already tested indirectly so this is just paranoia
+		return false
+	}
+	for i := range entries.Cells {
+		key := entries.Cells[i].Cells[0]
+		eq := key.Equal(keys.Cells[i])
+		err := lisp.GoError(eq)
+		if !assert.NoError(t, err, "Keys and Entries cannot be tested at index %d -- expect: %v got: %v", i, key, keys.Cells[i]) {
+			return false
+		}
+		if !assert.True(t, lisp.True(eq), "Keys and Entries not consistent at index %d -- expect: %v got: %v", i, key, keys.Cells[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func testGetEntries(t *testing.T, m lisp.Map) bool {
+	t.Helper()
+	entries, err := mapEntries(m)
+	if !assert.NoError(t, err) {
+		return false
+	}
+	for i := range entries.Cells {
+		pair := entries.Cells[i]
+		key, val := pair.Cells[0], pair.Cells[1]
+		v, ok := m.Get(key)
+		if !assert.True(t, ok, "Entries %d was not found in map: %v", i, key) {
+		}
+		eq := val.Equal(v)
+		err := lisp.GoError(eq)
+		if !assert.NoError(t, err, "Entry for key %v cannot be tested at index %d -- expected: %v got: %v", key, i, val, v) {
+			return false
+		}
+		if !assert.True(t, lisp.True(eq), "Entry for key %v not consistent at index %d -- expected: %v got: %v", key, i, val, v) {
+			return false
+		}
+	}
+	return true
+}
+
+func mapKeys(m lisp.Map) (*lisp.LVal, error) {
+	v := m.Keys()
+	err := lisp.GoError(v)
+	if err != nil {
+		return nil, err
+	}
+	if v.Type != lisp.LSExpr {
+		return nil, fmt.Errorf("Keys did not return a list")
+	}
+	if v.Len() != m.Len() {
+		return nil, fmt.Errorf("Keys has an invalid length")
+	}
+	return v, nil
+}
+
+func mapEntries(m lisp.Map) (*lisp.LVal, error) {
+	cells := make([]*lisp.LVal, m.Len())
+	res := m.Entries(cells)
+	err := lisp.GoError(res)
+	if err != nil {
+		return nil, err
+	}
+	if res.Type != lisp.LInt || res.Int != len(cells) {
+		err := fmt.Errorf("Entries returned %v (expected %d)", res, len(cells))
+		return nil, err
+	}
+	for i := range cells {
+		if cells[i].Type != lisp.LSExpr || cells[i].Len() != 2 {
+			return nil, fmt.Errorf("Entries index %d is not valid : %v", i, cells[i])
+		}
+	}
+	return lisp.QExpr(cells), nil
+}

--- a/go.sum
+++ b/go.sum
@@ -73,7 +73,6 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd h1:r7DufRZuZbWB7j439YfAzP8RPDa9unLkpwQKUYbIMPI=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/lisp/lisplib/libjson/encode.go
+++ b/lisp/lisplib/libjson/encode.go
@@ -1,0 +1,365 @@
+package libjson
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"unicode/utf8"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+func init() {
+	encoderFuncs[lisp.LBytes] = (*encoder).encodeLBytes
+	encoderFuncs[lisp.LSymbol] = (*encoder).encodeLSymbol
+	encoderFuncs[lisp.LString] = (*encoder).encodeLString
+	encoderFuncs[lisp.LInt] = (*encoder).encodeLInt
+	encoderFuncs[lisp.LFloat] = (*encoder).encodeLFloat
+	encoderFuncs[lisp.LNative] = (*encoder).encodeLNative
+	encoderFuncs[lisp.LQuote] = (*encoder).encodeLQuote
+	encoderFuncs[lisp.LSExpr] = (*encoder).encodeLSExpr
+	encoderFuncs[lisp.LArray] = (*encoder).encodeArray
+	encoderFuncs[lisp.LSortMap] = (*encoder).encodeSortMap
+	encoderFuncs[lisp.LTaggedVal] = (*encoder).encodeTaggedVal
+}
+
+var encoderFuncs [lisp.LTypeMax]func(enc *encoder, v *lisp.LVal) error
+
+type encoder struct {
+	stringNums bool
+	buf        bytes.Buffer
+}
+
+func newEncoder(stringNums bool) *encoder {
+	return &encoder{stringNums: stringNums}
+}
+
+func (enc *encoder) bytes() []byte {
+	return enc.buf.Bytes()
+}
+
+func (enc *encoder) reset() {
+	enc.buf.Reset()
+}
+
+func (enc *encoder) encode(v *lisp.LVal) error {
+	if v.IsNil() {
+		enc.buf.WriteString("null")
+		return nil
+	}
+	if fn := encoderFuncs[v.Type]; fn != nil {
+		return fn(enc, v)
+	}
+	return fmt.Errorf("invalid type encountered: %v", lisp.GetType(v))
+}
+
+func (enc *encoder) encodeLQuote(v *lisp.LVal) error {
+	return enc.encode(v.Cells[0])
+}
+
+func (enc *encoder) encodeArray(v *lisp.LVal) (err error) {
+	switch v.Cells[0].Len() {
+	case 0:
+		return enc.encode(v.Cells[1].Cells[0])
+	case 1:
+		return enc.encodeSExpr(v.Cells[1].Cells)
+	default:
+		return fmt.Errorf("cannot serialize array with dimensions: %v", v.Cells[0])
+	}
+}
+
+func (enc *encoder) encodeSortMap(v *lisp.LVal) (err error) {
+	// TODO:  Cache map entries slices to help with "widely nested" objects
+	enc.buf.WriteByte('{')
+	ents := v.MapEntries()
+	for i := range ents.Cells {
+		if i > 0 {
+			enc.buf.WriteByte(',')
+		}
+		err = enc.encodeMapKey(ents.Cells[i].Cells[0])
+		if err != nil {
+			return err
+		}
+		enc.buf.WriteByte(':')
+		err = enc.encode(ents.Cells[i].Cells[1])
+		if err != nil {
+			return err
+		}
+	}
+	enc.buf.WriteByte('}')
+	return nil
+}
+
+func (enc *encoder) encodeMapKey(v *lisp.LVal) error {
+	if v.Type != lisp.LString && v.Type != lisp.LSymbol {
+		return invalidKeyTypeError(v.Type)
+	}
+	return enc.encodeString(v.Str)
+}
+
+type invalidKeyTypeError lisp.LType
+
+func (e invalidKeyTypeError) Error() string {
+	return fmt.Sprintf("invalid map key type: %v", lisp.LType(e))
+}
+
+func (enc *encoder) encodeTaggedVal(v *lisp.LVal) error {
+	// Eventually there may be a way for lisp objects to implement custom
+	// serialization but for now tagged values just have the user-data
+	// serialized directly.
+	return enc.encode(v.Cells[0])
+}
+
+func (enc *encoder) encodeLSExpr(v *lisp.LVal) error {
+	return enc.encodeSExpr(v.Cells)
+}
+
+func (enc *encoder) encodeSExpr(cells []*lisp.LVal) (err error) {
+	enc.buf.WriteByte('[')
+	for i, v := range cells {
+		if i > 0 {
+			enc.buf.WriteByte(',')
+		}
+		err = enc.encode(v)
+		if err != nil {
+			return err
+		}
+	}
+	enc.buf.WriteByte(']')
+	return nil
+}
+
+func (enc *encoder) encodeLNative(v *lisp.LVal) error {
+	return enc.encodeNative(v.Native)
+}
+
+func (enc *encoder) encodeNative(v interface{}) error {
+	b, err := json.Marshal(v)
+	enc.buf.Write(b)
+	return err
+}
+
+func (enc *encoder) encodeLInt(v *lisp.LVal) error {
+	return enc.encodeInt(v.Int)
+}
+
+func (enc *encoder) encodeInt(x int) (err error) {
+	if enc.stringNums {
+		return enc.encodeString(strconv.Itoa(x))
+	}
+	_, err = fmt.Fprint(&enc.buf, x)
+	return err
+}
+
+func (enc *encoder) encodeLFloat(v *lisp.LVal) error {
+	return enc.encodeFloat(v.Float)
+}
+
+func (enc *encoder) encodeFloat(x float64) error {
+	if enc.stringNums {
+		return enc.encodeString(strconv.FormatFloat(x, 'g', -1, 64))
+	}
+	b, err := json.Marshal(x)
+	enc.buf.Write(b)
+	return err
+}
+
+func (enc *encoder) encodeLBytes(v *lisp.LVal) (err error) {
+	// FIXME:  Reduce allocations here or use a fixed size buffer.
+	return enc.encodeString(base64.StdEncoding.EncodeToString(v.Bytes()))
+}
+
+func (enc *encoder) encodeLSymbol(v *lisp.LVal) (err error) {
+	if v.Str == lisp.TrueSymbol || v.Str == lisp.FalseSymbol {
+		enc.buf.WriteString(v.Str)
+		return nil
+	}
+	return enc.encodeString(v.Str)
+}
+
+func (enc *encoder) encodeLString(v *lisp.LVal) error {
+	return enc.encodeString(v.Str)
+}
+
+// NOTE:  encodeString adapted from the json package.
+// https://cs.opensource.google/go/go/+/refs/tags/go1.16.4:src/encoding/json/encode.go;l=1029
+func (enc *encoder) encodeString(s string) error {
+	const hex = "0123456789abcdef"
+	enc.buf.WriteByte('"')
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if safeSet[b] {
+				i++
+				continue
+			}
+			if start < i {
+				enc.buf.WriteString(s[start:i])
+			}
+			enc.buf.WriteByte('\\')
+			switch b {
+			case '\\', '"':
+				enc.buf.WriteByte(b)
+			case '\n':
+				enc.buf.WriteByte('n')
+			case '\r':
+				enc.buf.WriteByte('r')
+			case '\t':
+				enc.buf.WriteByte('t')
+			default:
+				// This encodes bytes < 0x20 except for \t, \n and \r.
+				// If escapeHTML is set, it also escapes <, >, and &
+				// because they can lead to security holes when
+				// user-controlled strings are rendered into JSON
+				// and served to some browsers.
+				enc.buf.WriteString(`u00`)
+				enc.buf.WriteByte(hex[b>>4])
+				enc.buf.WriteByte(hex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRuneInString(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				enc.buf.WriteString(s[start:i])
+			}
+			enc.buf.WriteString(`\ufffd`)
+			i += size
+			start = i
+			continue
+		}
+		// U+2028 is LINE SEPARATOR.
+		// U+2029 is PARAGRAPH SEPARATOR.
+		// They are both technically valid characters in JSON strings,
+		// but don't work in JSONP, which has to be evaluated as JavaScript,
+		// and can lead to security holes there. It is valid JSON to
+		// escape them, so we do so unconditionally.
+		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
+		if c == '\u2028' || c == '\u2029' {
+			if start < i {
+				enc.buf.WriteString(s[start:i])
+			}
+			enc.buf.WriteString(`\u202`)
+			enc.buf.WriteByte(hex[c&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(s) {
+		enc.buf.WriteString(s[start:])
+	}
+	enc.buf.WriteByte('"')
+	return nil
+}
+
+// NOTE:  safeSet is from the json package
+// safeSet holds the value true if the ASCII character with the given array
+// position can be represented inside a JSON string without any further
+// escaping.
+//
+// All values are true except for the ASCII control characters (0-31), the
+// double quote ("), and the backslash character ("\").
+var safeSet = [utf8.RuneSelf]bool{
+	' ':      true,
+	'!':      true,
+	'"':      false,
+	'#':      true,
+	'$':      true,
+	'%':      true,
+	'&':      true,
+	'\'':     true,
+	'(':      true,
+	')':      true,
+	'*':      true,
+	'+':      true,
+	',':      true,
+	'-':      true,
+	'.':      true,
+	'/':      true,
+	'0':      true,
+	'1':      true,
+	'2':      true,
+	'3':      true,
+	'4':      true,
+	'5':      true,
+	'6':      true,
+	'7':      true,
+	'8':      true,
+	'9':      true,
+	':':      true,
+	';':      true,
+	'<':      true,
+	'=':      true,
+	'>':      true,
+	'?':      true,
+	'@':      true,
+	'A':      true,
+	'B':      true,
+	'C':      true,
+	'D':      true,
+	'E':      true,
+	'F':      true,
+	'G':      true,
+	'H':      true,
+	'I':      true,
+	'J':      true,
+	'K':      true,
+	'L':      true,
+	'M':      true,
+	'N':      true,
+	'O':      true,
+	'P':      true,
+	'Q':      true,
+	'R':      true,
+	'S':      true,
+	'T':      true,
+	'U':      true,
+	'V':      true,
+	'W':      true,
+	'X':      true,
+	'Y':      true,
+	'Z':      true,
+	'[':      true,
+	'\\':     false,
+	']':      true,
+	'^':      true,
+	'_':      true,
+	'`':      true,
+	'a':      true,
+	'b':      true,
+	'c':      true,
+	'd':      true,
+	'e':      true,
+	'f':      true,
+	'g':      true,
+	'h':      true,
+	'i':      true,
+	'j':      true,
+	'k':      true,
+	'l':      true,
+	'm':      true,
+	'n':      true,
+	'o':      true,
+	'p':      true,
+	'q':      true,
+	'r':      true,
+	's':      true,
+	't':      true,
+	'u':      true,
+	'v':      true,
+	'w':      true,
+	'x':      true,
+	'y':      true,
+	'z':      true,
+	'{':      true,
+	'|':      true,
+	'}':      true,
+	'~':      true,
+	'\u007f': true,
+}

--- a/lisp/lisplib/libjson/libjson_test.lisp
+++ b/lisp/lisplib/libjson/libjson_test.lisp
@@ -94,16 +94,85 @@
                     (json:load-string "\"ok-json\""))))
 
 (benchmark-simple "load-object"
-  (dotimes (n 1000)
-    (json:load-string """{"test1": 123, "test2": 456, "test3": 789}""")))
+  (let ([b (to-bytes """{"test1": 123, "test2": 456, "test3": 789}""")])
+    (dotimes (n 1000)
+      (json:load-bytes b))))
 
 (benchmark-simple "load-array"
-  (dotimes (n 1000)
-    (json:load-string """["test1", 123, "test2", 456, "test3", 789]""")))
+  (let ([b (to-bytes """["test1", 123, "test2", 456, "test3", 789]""")])
+    (dotimes (n 1000)
+      (json:load-bytes b))))
 
 (benchmark-simple "load-nested"
-  (dotimes (n 1000)
-    (json:load-string """{"test1": 123, "test2": 456, "test3": {"test1": 123, "test2": 456, "test3": 789}}""")))
+  (let ([b (to-bytes """{"test1": 123, "test2": 456, "test3": {"test1": 123, "test2": 456, "test3": 789}}""")])
+    (dotimes (n 1000)
+      (json:load-bytes b))))
+
+(benchmark-simple "load-github"
+  (let ([b (to-bytes github-json)])
+    (dotimes (n 1000)
+      (json:load-bytes b))))
+
+(set 'benchmark-input-get-nested """
+{
+  "e0": 12,
+  "e1":
+  {
+    "e0": 34
+  },
+  "e2":
+  [
+    {
+      "e0": 56
+    }
+  ],
+  "e3":
+  [
+    {
+      "e0":
+      {
+        "e0": 78
+      },
+      "e1":
+      [
+        {
+          "e0": 90
+        }
+      ]
+    }
+  ]
+}
+""")
+
+(benchmark-simple "get-nested-baseline"
+  (let ([v (json:load-bytes (to-bytes benchmark-input-get-nested))])
+    (dotimes (n 1000)
+      (assert-equal 12
+                    (thread-first v
+                                  (get "e0")))
+      (assert-equal 34
+                    (thread-first v
+                                  (get "e1")
+                                  (get "e0")))
+      (assert-equal 56
+                    (thread-first v
+                                  (get "e2")
+                                  (nth 0)
+                                  (get "e0")))
+      (assert-equal 78
+                    (thread-first v
+                                  (get "e3")
+                                  (nth 0)
+                                  (get "e0")
+                                  (get "e0")))
+      (assert-equal 90
+                    (thread-first v
+                                  (get "e3")
+                                  (nth 0)
+                                  (get "e1")
+                                  (nth 0)
+                                  (get "e0")))
+      )))
 
 (benchmark-simple "dump-object"
   (let* ([val (sorted-map "test1" 123 "test2" 456 "test3" 789)])
@@ -119,3 +188,135 @@
   (let* ([val (sorted-map "test1" 123 "test2" 456 "test3" (sorted-map "test1" 123 "test2" 456 "test3" 789))])
     (dotimes (n 1000)
       (json:dump-string val))))
+
+(benchmark-simple "dump-github"
+  (let* ([val (json:load-string github-json)])
+    (dotimes (n 1000)
+      (json:dump-string val))))
+
+; curl https://api.github.com/repos/luthersystems/elps  
+(set 'github-json """
+{
+  "id": 158678640,
+  "node_id": "MDEwOlJlcG9zaXRvcnkxNTg2Nzg2NDA=",
+  "name": "elps",
+  "full_name": "luthersystems/elps",
+  "private": false,
+  "owner": {
+    "login": "luthersystems",
+    "id": 20160060,
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjIwMTYwMDYw",
+    "avatar_url": "https://avatars.githubusercontent.com/u/20160060?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/luthersystems",
+    "html_url": "https://github.com/luthersystems",
+    "followers_url": "https://api.github.com/users/luthersystems/followers",
+    "following_url": "https://api.github.com/users/luthersystems/following{/other_user}",
+    "gists_url": "https://api.github.com/users/luthersystems/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/luthersystems/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/luthersystems/subscriptions",
+    "organizations_url": "https://api.github.com/users/luthersystems/orgs",
+    "repos_url": "https://api.github.com/users/luthersystems/repos",
+    "events_url": "https://api.github.com/users/luthersystems/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/luthersystems/received_events",
+    "type": "Organization",
+    "site_admin": false
+  },
+  "html_url": "https://github.com/luthersystems/elps",
+  "description": "An embedded lisp interpreter",
+  "fork": false,
+  "url": "https://api.github.com/repos/luthersystems/elps",
+  "forks_url": "https://api.github.com/repos/luthersystems/elps/forks",
+  "keys_url": "https://api.github.com/repos/luthersystems/elps/keys{/key_id}",
+  "collaborators_url": "https://api.github.com/repos/luthersystems/elps/collaborators{/collaborator}",
+  "teams_url": "https://api.github.com/repos/luthersystems/elps/teams",
+  "hooks_url": "https://api.github.com/repos/luthersystems/elps/hooks",
+  "issue_events_url": "https://api.github.com/repos/luthersystems/elps/issues/events{/number}",
+  "events_url": "https://api.github.com/repos/luthersystems/elps/events",
+  "assignees_url": "https://api.github.com/repos/luthersystems/elps/assignees{/user}",
+  "branches_url": "https://api.github.com/repos/luthersystems/elps/branches{/branch}",
+  "tags_url": "https://api.github.com/repos/luthersystems/elps/tags",
+  "blobs_url": "https://api.github.com/repos/luthersystems/elps/git/blobs{/sha}",
+  "git_tags_url": "https://api.github.com/repos/luthersystems/elps/git/tags{/sha}",
+  "git_refs_url": "https://api.github.com/repos/luthersystems/elps/git/refs{/sha}",
+  "trees_url": "https://api.github.com/repos/luthersystems/elps/git/trees{/sha}",
+  "statuses_url": "https://api.github.com/repos/luthersystems/elps/statuses/{sha}",
+  "languages_url": "https://api.github.com/repos/luthersystems/elps/languages",
+  "stargazers_url": "https://api.github.com/repos/luthersystems/elps/stargazers",
+  "contributors_url": "https://api.github.com/repos/luthersystems/elps/contributors",
+  "subscribers_url": "https://api.github.com/repos/luthersystems/elps/subscribers",
+  "subscription_url": "https://api.github.com/repos/luthersystems/elps/subscription",
+  "commits_url": "https://api.github.com/repos/luthersystems/elps/commits{/sha}",
+  "git_commits_url": "https://api.github.com/repos/luthersystems/elps/git/commits{/sha}",
+  "comments_url": "https://api.github.com/repos/luthersystems/elps/comments{/number}",
+  "issue_comment_url": "https://api.github.com/repos/luthersystems/elps/issues/comments{/number}",
+  "contents_url": "https://api.github.com/repos/luthersystems/elps/contents/{+path}",
+  "compare_url": "https://api.github.com/repos/luthersystems/elps/compare/{base}...{head}",
+  "merges_url": "https://api.github.com/repos/luthersystems/elps/merges",
+  "archive_url": "https://api.github.com/repos/luthersystems/elps/{archive_format}{/ref}",
+  "downloads_url": "https://api.github.com/repos/luthersystems/elps/downloads",
+  "issues_url": "https://api.github.com/repos/luthersystems/elps/issues{/number}",
+  "pulls_url": "https://api.github.com/repos/luthersystems/elps/pulls{/number}",
+  "milestones_url": "https://api.github.com/repos/luthersystems/elps/milestones{/number}",
+  "notifications_url": "https://api.github.com/repos/luthersystems/elps/notifications{?since,all,participating}",
+  "labels_url": "https://api.github.com/repos/luthersystems/elps/labels{/name}",
+  "releases_url": "https://api.github.com/repos/luthersystems/elps/releases{/id}",
+  "deployments_url": "https://api.github.com/repos/luthersystems/elps/deployments",
+  "created_at": "2018-11-22T10:01:06Z",
+  "updated_at": "2021-05-16T03:55:18Z",
+  "pushed_at": "2021-05-16T03:55:15Z",
+  "git_url": "git://github.com/luthersystems/elps.git",
+  "ssh_url": "git@github.com:luthersystems/elps.git",
+  "clone_url": "https://github.com/luthersystems/elps.git",
+  "svn_url": "https://github.com/luthersystems/elps",
+  "homepage": null,
+  "size": 2892,
+  "stargazers_count": 13,
+  "watchers_count": 13,
+  "language": "Go",
+  "has_issues": true,
+  "has_projects": true,
+  "has_downloads": true,
+  "has_wiki": true,
+  "has_pages": true,
+  "forks_count": 7,
+  "mirror_url": null,
+  "archived": false,
+  "disabled": false,
+  "open_issues_count": 3,
+  "license": {
+    "key": "bsd-3-clause",
+    "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+    "spdx_id": "BSD-3-Clause",
+    "url": "https://api.github.com/licenses/bsd-3-clause",
+    "node_id": "MDc6TGljZW5zZTU="
+  },
+  "forks": 7,
+  "open_issues": 3,
+  "watchers": 13,
+  "default_branch": "master",
+  "temp_clone_token": null,
+  "organization": {
+    "login": "luthersystems",
+    "id": 20160060,
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjIwMTYwMDYw",
+    "avatar_url": "https://avatars.githubusercontent.com/u/20160060?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/luthersystems",
+    "html_url": "https://github.com/luthersystems",
+    "followers_url": "https://api.github.com/users/luthersystems/followers",
+    "following_url": "https://api.github.com/users/luthersystems/following{/other_user}",
+    "gists_url": "https://api.github.com/users/luthersystems/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/luthersystems/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/luthersystems/subscriptions",
+    "organizations_url": "https://api.github.com/users/luthersystems/orgs",
+    "repos_url": "https://api.github.com/users/luthersystems/repos",
+    "events_url": "https://api.github.com/users/luthersystems/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/luthersystems/received_events",
+    "type": "Organization",
+    "site_admin": false
+  },
+  "network_count": 7,
+  "subscribers_count": 6
+}
+""")

--- a/lisp/lisplib/libjson/sortedmap.go
+++ b/lisp/lisplib/libjson/sortedmap.go
@@ -1,0 +1,93 @@
+package libjson
+
+import (
+	"sort"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// SortedMap implements lisp.Map and only supports string keys.  Values must be
+// lisp.LVal.
+type SortedMap map[string]interface{}
+
+var _ lisp.Map = SortedMap(nil)
+
+func (m SortedMap) Len() int {
+	return len(m)
+}
+
+func (m SortedMap) Get(k *lisp.LVal) (*lisp.LVal, bool) {
+	if k.Type != lisp.LString {
+		return lisp.Errorf("sorted-map decoded from json cannot hold key with type %s", lisp.GetType(k)), false
+	}
+	x, ok := m[k.Str]
+	if !ok {
+		return lisp.Nil(), false
+	}
+	return mapLVal(x), true
+}
+
+func (m SortedMap) Del(k *lisp.LVal) *lisp.LVal {
+	if k.Type != lisp.LString {
+		return lisp.Errorf("sorted-map decoded from json cannot hold key with type %s", lisp.GetType(k))
+	}
+	delete(m, k.Str)
+	return lisp.Nil()
+}
+
+func (m SortedMap) Set(k *lisp.LVal, v *lisp.LVal) *lisp.LVal {
+	if k.Type != lisp.LString {
+		return lisp.Errorf("sorted-map decoded from json cannot hold key with type %s", lisp.GetType(k))
+	}
+	m[k.Str] = v
+	return lisp.Nil()
+}
+
+func (m SortedMap) Entries(cells []*lisp.LVal) *lisp.LVal {
+	if len(m) == 0 {
+		return lisp.Int(0)
+	}
+	if len(cells) < len(m) {
+		return lisp.Errorf("buffer has insufficient length")
+	}
+	i := 0
+	for k, x := range m {
+		cells[i] = lisp.QExpr([]*lisp.LVal{
+			lisp.String(k),
+			mapLVal(x),
+		})
+		i++
+	}
+	sort.Sort(mapEntriesByKey(cells[:i]))
+	return lisp.Int(len(cells))
+}
+
+func (m SortedMap) Keys() (keys *lisp.LVal) {
+	cells := make([]*lisp.LVal, len(m))
+	keys = m.Entries(cells) // save stack space :\
+	if keys.Type == lisp.LError {
+		return keys
+	}
+	keys = lisp.QExpr(cells)
+	for i := range cells {
+		cells[i] = cells[i].Cells[0]
+	}
+	return keys
+}
+
+// mapEntriesByKey is duplicated from the lisp package but probably deserves to
+// be because that may have to deal other types of keys where we are focused
+// only on strings.
+type mapEntriesByKey []*lisp.LVal
+
+func (m mapEntriesByKey) Len() int           { return len(m) }
+func (m mapEntriesByKey) Less(i, j int) bool { return m[i].Cells[0].Str < m[j].Cells[0].Str }
+func (m mapEntriesByKey) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+
+func mapLVal(x interface{}) (v *lisp.LVal) {
+	var ok bool
+	if v, ok = x.(*lisp.LVal); ok {
+		return v
+	}
+	return lisp.Errorf("value is not an LVal: %T", x)
+}

--- a/lisp/lisplib/libjson/sortedmap_test.go
+++ b/lisp/lisplib/libjson/sortedmap_test.go
@@ -1,0 +1,17 @@
+package libjson_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/elpstest"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libjson"
+)
+
+func TestMapImpl(t *testing.T) {
+	m := libjson.SortedMap{}
+	m.Set(lisp.String("a"), lisp.Int(1))
+	m.Set(lisp.Symbol("b"), lisp.Int(2))
+	m.Set(lisp.String("c"), lisp.Int(3))
+	elpstest.AssertSortedMap(t, m)
+}

--- a/lisp/map_test.go
+++ b/lisp/map_test.go
@@ -6,7 +6,16 @@ import (
 	"testing"
 
 	"github.com/luthersystems/elps/elpstest"
+	"github.com/luthersystems/elps/lisp"
 )
+
+func TestMapImpl(t *testing.T) {
+	m := lisp.SortedMap().Map()
+	m.Set(lisp.String("a"), lisp.Int(1))
+	m.Set(lisp.Symbol("b"), lisp.Int(2))
+	m.Set(lisp.String("c"), lisp.Int(3))
+	elpstest.AssertSortedMap(t, m)
+}
 
 func TestMaps(t *testing.T) {
 	tests := elpstest.TestSuite{


### PR DESCRIPTION
- Add json benchmarks using a github api response

- Added a custom json encoder which avoids serializing an intermediate
  representations and instead directly marshals LVals.

- Changed the implementation of `sorted-map` to use an interface which
  the json package is able to satisfy, avoiding extra map allocations.