### PR TITLE
JSON encoding escapes html-unsafe characters &, <, >

### DIFF
--- a/lisp/lisplib/libjson/encode.go
+++ b/lisp/lisplib/libjson/encode.go
@@ -274,7 +274,7 @@ func (enc *encoder) encodeString(s string) error {
 	start := 0
 	for i := 0; i < len(s); {
 		if b := s[i]; b < utf8.RuneSelf {
-			if safeSet[b] {
+			if htmlSafeSet[b] {
 				i++
 				continue
 			}
@@ -341,21 +341,22 @@ func (enc *encoder) encodeString(s string) error {
 	return nil
 }
 
-// NOTE:  safeSet is from the json package
-// safeSet holds the value true if the ASCII character with the given array
-// position can be represented inside a JSON string without any further
-// escaping.
+// NOTE:  htmlSafeSet is from the json package
+// htmlSafeSet holds the value true if the ASCII character with the given
+// array position can be safely represented inside a JSON string, embedded
+// inside of HTML <script> tags, without any additional escaping.
 //
 // All values are true except for the ASCII control characters (0-31), the
-// double quote ("), and the backslash character ("\").
-var safeSet = [utf8.RuneSelf]bool{
+// double quote ("), the backslash character ("\"), HTML opening and closing
+// tags ("<" and ">"), and the ampersand ("&").
+var htmlSafeSet = [utf8.RuneSelf]bool{
 	' ':      true,
 	'!':      true,
 	'"':      false,
 	'#':      true,
 	'$':      true,
 	'%':      true,
-	'&':      true,
+	'&':      false,
 	'\'':     true,
 	'(':      true,
 	')':      true,
@@ -377,9 +378,9 @@ var safeSet = [utf8.RuneSelf]bool{
 	'9':      true,
 	':':      true,
 	';':      true,
-	'<':      true,
+	'<':      false,
 	'=':      true,
-	'>':      true,
+	'>':      false,
 	'?':      true,
 	'@':      true,
 	'A':      true,


### PR DESCRIPTION
This behavior is consistent with encoding behavior prior to v1.14.0 as
escapeHTML is enabled by default in encoding/json.