### PR TITLE
Comprehensive documentation, diagnostics, and linter improvements

### DIFF
--- a/_examples/random/oop.lisp
+++ b/_examples/random/oop.lisp
@@ -192,7 +192,7 @@
 
 ;; rational represents a rational number and wraps a struct with two fields.
 (deftype 'rational (n d)
-  (cond ((not (int? n))
+  (cond ((not (int? n)) ; nolint:cond-missing-else
          (error 'type-error (format-string "first argument is not an int: {}" (type n))))
         ((not (int? d))
          (error 'type-error (format-string "second argument is not an int: {}" (type d)))))

--- a/cmd/diagnostic.go
+++ b/cmd/diagnostic.go
@@ -1,0 +1,110 @@
+// Copyright © 2024 The ELPS authors
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/luthersystems/elps/diagnostic"
+	"github.com/luthersystems/elps/lisp"
+	lintpkg "github.com/luthersystems/elps/lint"
+)
+
+func colorMode() diagnostic.ColorMode {
+	switch colorFlag {
+	case "always":
+		return diagnostic.ColorAlways
+	case "never":
+		return diagnostic.ColorNever
+	default:
+		return diagnostic.ColorAuto
+	}
+}
+
+func newRenderer() *diagnostic.Renderer {
+	return &diagnostic.Renderer{Color: colorMode()}
+}
+
+// lispErrorToDiagnostic converts an LError value to a Diagnostic for display.
+func lispErrorToDiagnostic(lerr *lisp.LVal) diagnostic.Diagnostic {
+	ev := (*lisp.ErrorVal)(lerr)
+	d := diagnostic.Diagnostic{
+		Severity: diagnostic.SeverityError,
+		Message:  ev.ErrorMessage(),
+	}
+
+	// Add the function context to the message if available
+	fname := ev.FunName()
+	if fname != "" {
+		d.Message = fname + ": " + d.Message
+	}
+	if lerr.Str != "" && lerr.Str != "error" {
+		d.Message = lerr.Str + ": " + d.Message
+	}
+
+	// Add source span if available
+	if lerr.Source != nil && lerr.Source.Pos >= 0 {
+		span := diagnostic.Span{
+			File: lerr.Source.File,
+			Line: lerr.Source.Line,
+			Col:  lerr.Source.Col,
+		}
+		// Prefer physical path for reading source
+		if lerr.Source.Path != "" {
+			span.File = lerr.Source.Path
+		}
+		d.Spans = append(d.Spans, span)
+	}
+
+	// Add stack trace frames as notes
+	stack := lerr.CallStack()
+	if stack != nil {
+		for i := len(stack.Frames) - 1; i >= 0; i-- {
+			frame := &stack.Frames[i]
+			name := frame.QualifiedFunName(lisp.DefaultUserPackage)
+			if name == "" {
+				continue
+			}
+			loc := "unknown"
+			if frame.Source != nil {
+				loc = frame.Source.String()
+			}
+			d.Notes = append(d.Notes, "in "+name+" at "+loc)
+		}
+	}
+
+	return d
+}
+
+// lintDiagToDiagnostic converts a lint.Diagnostic to a diagnostic.Diagnostic.
+func lintDiagToDiagnostic(ld lintpkg.Diagnostic) diagnostic.Diagnostic {
+	d := diagnostic.Diagnostic{
+		Severity: diagnostic.SeverityWarning,
+		Message:  ld.Message + " (" + ld.Analyzer + ")",
+	}
+	if ld.Pos.Line > 0 {
+		d.Spans = append(d.Spans, diagnostic.Span{
+			File: ld.Pos.File,
+			Line: ld.Pos.Line,
+			Col:  ld.Pos.Col,
+		})
+	}
+	return d
+}
+
+// renderLispError renders a lisp error with diagnostic formatting to stderr.
+func renderLispError(lerr *lisp.LVal) {
+	d := lispErrorToDiagnostic(lerr)
+	r := newRenderer()
+	_ = r.Render(os.Stderr, d)
+}
+
+// renderLintDiagnostics renders lint diagnostics with diagnostic formatting to stderr.
+func renderLintDiagnostics(diags []lintpkg.Diagnostic) {
+	var ds []diagnostic.Diagnostic
+	for _, ld := range diags {
+		ds = append(ds, lintDiagToDiagnostic(ld))
+	}
+	r := newRenderer()
+	_ = r.RenderAll(os.Stderr, ds)
+}

--- a/cmd/diagnostic.go
+++ b/cmd/diagnostic.go
@@ -90,6 +90,7 @@ func lintDiagToDiagnostic(ld lintpkg.Diagnostic) diagnostic.Diagnostic {
 		})
 	}
 	d.Notes = append(d.Notes, ld.Notes...)
+	d.Notes = append(d.Notes, "to suppress: add \"; nolint:"+ld.Analyzer+"\" as a comment on this line")
 	return d
 }
 

--- a/cmd/diagnostic.go
+++ b/cmd/diagnostic.go
@@ -89,12 +89,17 @@ func lintDiagToDiagnostic(ld lintpkg.Diagnostic) diagnostic.Diagnostic {
 			Col:  ld.Pos.Col,
 		})
 	}
+	d.Notes = append(d.Notes, ld.Notes...)
 	return d
 }
 
 // renderLispError renders a lisp error with diagnostic formatting to stderr.
-func renderLispError(lerr *lisp.LVal) {
+// If sourceFile is non-empty, a hint to run elps lint is appended.
+func renderLispError(lerr *lisp.LVal, sourceFiles ...string) {
 	d := lispErrorToDiagnostic(lerr)
+	if len(sourceFiles) > 0 && sourceFiles[0] != "" {
+		d.Notes = append(d.Notes, "try: elps lint "+sourceFiles[0])
+	}
 	r := newRenderer()
 	_ = r.Render(os.Stderr, d)
 }

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -21,9 +21,32 @@ var docSourceFile string
 
 // docCmd represents the doc command
 var docCmd = &cobra.Command{
-	Use:   "doc QUERY",
-	Short: "Show elps documentation",
-	Long:  `Show documentation for an elps package or function.`,
+	Use:   "doc [flags] QUERY",
+	Short: "Show elps documentation for functions, packages, and symbols",
+	Long: `Show built-in documentation for ELPS functions, macros, operators,
+constants, and packages.
+
+By default, looks up a function or variable by name. Use -p to list all
+exported symbols in a package. Use -f to load a source file first (useful
+for documenting your own code).
+
+Documentation is generated from doc strings embedded in function definitions
+and package declarations. All built-in and standard library functions have
+documentation.
+
+Examples:
+  elps doc map                     Show docs for the map function
+  elps doc defun                   Show docs for the defun macro
+  elps doc math:sin                Show docs for a qualified symbol
+  elps doc -p math                 List all exports in the math package
+  elps doc -p lisp                 List core language functions
+  elps doc -f mylib.lisp my-func   Load a file, then show docs for my-func
+
+Common packages to explore:
+  lisp      Core language (140+ builtins: map, filter, reduce, car, cdr, ...)
+  math      Trigonometry, logarithms, constants (pi, inf)
+  string    String operations (concat, split, join, ...)
+  json      JSON serialization (json:encode, json:decode, json:null)`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
 			_ = cmd.Help()

--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -20,11 +20,29 @@ var (
 
 var fmtCmd = &cobra.Command{
 	Use:   "fmt [flags] [files...]",
-	Short: "Format elps source files",
-	Long: `Format elps source files.
+	Short: "Format ELPS source files",
+	Long: `Format ELPS Lisp source files, similar to gofmt for Go.
 
-With no files and no flags, reads from stdin and writes to stdout.
-With files, prints formatted output to stdout (use -w to overwrite).`,
+Normalizes whitespace and indentation, aligns forms according to Lisp
+conventions, and preserves comments. The formatter is idempotent.
+
+With no files, reads from stdin and writes to stdout.
+With files, prints formatted output to stdout unless -w is given.
+
+Modes:
+  (default)   Print formatted code to stdout
+  -w          Write result back to source file
+  -d          Display a diff of changes
+  -l          List files that would be changed
+
+Examples:
+  elps fmt file.lisp               Print formatted output
+  elps fmt -w file.lisp            Format in place
+  elps fmt -w *.lisp               Format all lisp files in place
+  elps fmt -d file.lisp            Show what would change
+  elps fmt -l *.lisp               List files needing formatting
+  cat file.lisp | elps fmt         Format from stdin
+  elps fmt --indent-size 4 f.lisp  Use 4-space indentation`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := formatter.DefaultConfig()
 		cfg.IndentSize = fmtIndentSize

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -113,7 +113,7 @@ Examples:
 				os.Exit(2)
 			}
 		} else {
-			lint.FormatText(os.Stderr, allDiags)
+			renderLintDiagnostics(allDiags)
 		}
 		os.Exit(1)
 	},
@@ -136,7 +136,7 @@ func lintStdin(l *lint.Linter) error {
 			return err
 		}
 	} else {
-		lint.FormatText(os.Stderr, diags)
+		renderLintDiagnostics(diags)
 	}
 	os.Exit(1)
 	return nil

--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -13,8 +13,28 @@ import (
 // replCmd represents the repl command
 var replCmd = &cobra.Command{
 	Use:   "repl",
-	Short: "Run a lisp repl",
-	Long:  `Run a lisp repl.`,
+	Short: "Start an interactive ELPS Lisp REPL",
+	Long: `Start an interactive read-eval-print loop for ELPS Lisp.
+
+All standard library packages are loaded automatically. Line editing and
+in-session command history are supported via readline. Use Ctrl-D or
+Ctrl-C to exit.
+
+Example REPL session:
+  elps> (+ 1 2)
+  3
+  elps> (defun square (x) (* x x))
+  ()
+  elps> (square 5)
+  25
+  elps> (use-package 'math)
+  ()
+  elps> math:pi
+  3.141592653589793
+  elps> (help 'map)
+  ...
+  elps> (apropos "sort")
+  ...`,
 	Run: func(cmd *cobra.Command, args []string) {
 		repl.RunRepl(filepath.Base(os.Args[0]) + "> ")
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,11 @@ Standard library packages (use with use-package or qualified names):
   s         Schema type predicates
 
 Documentation is built in: use (help 'symbol) in the REPL or elps doc <name>
-from the command line. Use elps doc -p <package> to explore a package.`,
+from the command line. Use elps doc -p <package> to explore a package.
+
+More information:
+  Source code:     https://github.com/luthersystems/elps
+  Documentation:   https://github.com/luthersystems/docs`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-var cfgFile string
+var (
+	cfgFile   string
+	colorFlag string
+)
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -40,6 +43,8 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.elps.yaml)")
+	rootCmd.PersistentFlags().StringVar(&colorFlag, "color", "auto",
+		`Control colored output: "auto", "always", or "never".`)
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,19 +39,11 @@ Language overview:
   Error handling uses (handler-bind ...) and (ignore-errors ...).
 
 Standard library packages (use with use-package or qualified names):
-  math      Mathematical functions, constants (pi, inf)
-  string    String manipulation (concat, split, join, upper, lower, ...)
-  json      JSON encoding/decoding
-  regexp    Regular expression matching
-  time      Date/time operations
-  base64    Base64 encoding/decoding
-  testing   Test framework (assert-equal, assert-nil, test, test-let)
-  help      Documentation introspection (doc, doc-string, apropos)
-  golang    Go interop utilities
-  s         Schema type predicates
+  elps doc -l                    List all packages with descriptions
+  elps doc -p <package>          Show all exports in a package
 
 Documentation is built in: use (help 'symbol) in the REPL or elps doc <name>
-from the command line. Use elps doc -p <package> to explore a package.
+from the command line. Use (help-packages) in the REPL to list all packages.
 
 More information:
   Source code:     https://github.com/luthersystems/elps

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,13 +18,40 @@ var (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "elps",
-	Short: "It's \"ellipse\" ;)",
-	Long: `
-The elps command provides a standalone lisp interpreter as an example of a Go
-program embedding elps.  The interpreter is presented as a demonstration in a
-"basic" embedded configuration.  It is not intended to be executed in
-production environments.
-`,
+	Short: "ELPS — Embedded Lisp interpreter",
+	Long: `ELPS is an embedded Lisp interpreter implemented in Go. It provides a
+standalone CLI for running, linting, formatting, and exploring ELPS Lisp code.
+
+Getting started:
+  elps run file.lisp           Run a Lisp source file
+  elps run -e '(+ 1 2)'       Evaluate an expression
+  elps repl                    Start an interactive REPL
+  elps doc map                 Show documentation for a function
+  elps doc -p math             List all exports in a package
+  elps lint file.lisp          Run static analysis checks
+  elps fmt file.lisp           Format source code
+
+Language overview:
+  ELPS is a Lisp-1 dialect (single namespace for functions and values).
+  Booleans are the symbols true and false. The empty list () is nil/falsey.
+  Functions are defined with (defun name (args) body) and called as (name args).
+  Packages provide namespacing: (in-package 'my-pkg), (use-package 'math).
+  Error handling uses (handler-bind ...) and (ignore-errors ...).
+
+Standard library packages (use with use-package or qualified names):
+  math      Mathematical functions, constants (pi, inf)
+  string    String manipulation (concat, split, join, upper, lower, ...)
+  json      JSON encoding/decoding
+  regexp    Regular expression matching
+  time      Date/time operations
+  base64    Base64 encoding/decoding
+  testing   Test framework (assert-equal, assert-nil, test, test-let)
+  help      Documentation introspection (doc, doc-string, apropos)
+  golang    Go interop utilities
+  s         Schema type predicates
+
+Documentation is built in: use (help 'symbol) in the REPL or elps doc <name>
+from the command line. Use elps doc -p <package> to explore a package.`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -19,9 +19,25 @@ var (
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{
-	Use:   "run",
-	Short: "Run lisp code",
-	Long:  `Run lisp code provided supplied via the command line or a file.`,
+	Use:   "run [flags] [files...]",
+	Short: "Run elps source files or expressions",
+	Long: `Run ELPS Lisp code from files or command-line expressions.
+
+With file arguments, each file is loaded and executed in order. With -e,
+arguments are interpreted as Lisp expressions and evaluated directly.
+
+The runtime loads all standard library packages automatically. User code
+starts in the "user" package and can import other packages with use-package.
+
+Examples:
+  elps run hello.lisp              Run a source file
+  elps run lib.lisp app.lisp       Load files in order (lib first)
+  elps run -e '(+ 1 2)'            Evaluate an expression
+  elps run -e -p '(* 6 7)'         Evaluate and print the result
+
+Exit codes:
+  0  Success
+  1  Runtime error (use elps lint to catch common mistakes before running)`,
 	Run: func(cmd *cobra.Command, args []string) {
 		env := lisp.NewEnv(nil)
 		reader := parser.NewReader()
@@ -45,7 +61,7 @@ var runCmd = &cobra.Command{
 		for i := range args {
 			res := env.LoadFile(args[i])
 			if res.Type == lisp.LError {
-				renderLispError(res)
+				renderLispError(res, args[i])
 				os.Exit(1)
 			}
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -45,7 +45,7 @@ var runCmd = &cobra.Command{
 		for i := range args {
 			res := env.LoadFile(args[i])
 			if res.Type == lisp.LError {
-				_, _ = (*lisp.ErrorVal)(res).WriteTrace(os.Stderr)
+				renderLispError(res)
 				os.Exit(1)
 			}
 		}

--- a/diagnostic/color.go
+++ b/diagnostic/color.go
@@ -1,0 +1,74 @@
+// Copyright © 2024 The ELPS authors
+
+package diagnostic
+
+import (
+	"os"
+)
+
+// ColorMode controls when ANSI color codes are used.
+type ColorMode int
+
+const (
+	ColorAuto   ColorMode = iota // detect based on terminal and NO_COLOR
+	ColorAlways                  // always use colors
+	ColorNever                   // never use colors
+)
+
+// palette holds the ANSI escape sequences for diagnostic output.
+type palette struct {
+	bold      string
+	red       string
+	yellow    string
+	blue      string
+	cyan      string
+	boldRed   string
+	boldBlue  string
+	boldCyan  string
+	reset     string
+}
+
+var ansiPalette = palette{
+	bold:      "\033[1m",
+	red:       "\033[31m",
+	yellow:    "\033[33m",
+	blue:      "\033[34m",
+	cyan:      "\033[36m",
+	boldRed:   "\033[1;31m",
+	boldBlue:  "\033[1;34m",
+	boldCyan:  "\033[1;36m",
+	reset:     "\033[0m",
+}
+
+var noPalette = palette{}
+
+// choosePalette selects the appropriate color palette based on the mode
+// and the output file descriptor.
+func choosePalette(mode ColorMode, w *os.File) palette {
+	switch mode {
+	case ColorAlways:
+		return ansiPalette
+	case ColorNever:
+		return noPalette
+	default: // ColorAuto
+		if os.Getenv("NO_COLOR") != "" {
+			return noPalette
+		}
+		if !isTerminal(w) {
+			return noPalette
+		}
+		return ansiPalette
+	}
+}
+
+// isTerminal reports whether f is connected to a terminal.
+func isTerminal(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/diagnostic/diagnostic.go
+++ b/diagnostic/diagnostic.go
@@ -1,0 +1,46 @@
+// Copyright © 2024 The ELPS authors
+
+// Package diagnostic provides Rust-style annotated error rendering for
+// ELPS CLI output. It is intentionally independent of the lisp/ package
+// so that it can be used by any CLI command without creating import cycles.
+package diagnostic
+
+// Severity indicates the severity level of a diagnostic.
+type Severity int
+
+const (
+	SeverityError Severity = iota
+	SeverityWarning
+	SeverityNote
+)
+
+func (s Severity) String() string {
+	switch s {
+	case SeverityError:
+		return "error"
+	case SeverityWarning:
+		return "warning"
+	case SeverityNote:
+		return "note"
+	default:
+		return "unknown"
+	}
+}
+
+// Span identifies a region of source code to highlight in the diagnostic.
+type Span struct {
+	File   string // path for reading source; display name if unreadable
+	Line   int    // 1-based line number
+	Col    int    // 1-based start column
+	EndCol int    // 1-based end column (0 = auto-detect from source)
+	Label  string // text shown under the underline
+}
+
+// Diagnostic represents a single error, warning, or note with optional
+// source annotations and trailing notes.
+type Diagnostic struct {
+	Severity Severity
+	Message  string
+	Spans    []Span
+	Notes    []string // "= note:" lines (stack trace frames, etc.)
+}

--- a/diagnostic/renderer.go
+++ b/diagnostic/renderer.go
@@ -1,0 +1,230 @@
+// Copyright © 2024 The ELPS authors
+
+package diagnostic
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode/utf8"
+)
+
+// Renderer formats diagnostics as Rust-style annotated source snippets.
+type Renderer struct {
+	// Color controls ANSI color output. Default is ColorAuto.
+	Color ColorMode
+
+	// SourceReader reads source file contents. If nil, os.ReadFile is used.
+	SourceReader func(string) ([]byte, error)
+}
+
+// Render writes a single diagnostic to w.
+func (r *Renderer) Render(w io.Writer, d Diagnostic) error {
+	p := choosePalette(r.Color, fileFromWriter(w))
+	bw := bufio.NewWriter(w)
+	ew := &errWriter{w: bw}
+
+	// Header: "error: message" or "warning: message"
+	r.writeHeader(ew, d, p)
+
+	// Source spans
+	for _, span := range d.Spans {
+		r.writeSpan(ew, span, p)
+	}
+
+	// Notes
+	for _, note := range d.Notes {
+		ew.printf("   %s=%s note: %s\n", p.boldCyan, p.reset, note)
+	}
+
+	if ew.err != nil {
+		return ew.err
+	}
+	return bw.Flush()
+}
+
+// RenderAll writes all diagnostics to w separated by blank lines.
+func (r *Renderer) RenderAll(w io.Writer, diags []Diagnostic) error {
+	for i, d := range diags {
+		if i > 0 {
+			if _, err := io.WriteString(w, "\n"); err != nil {
+				return err
+			}
+		}
+		if err := r.Render(w, d); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// errWriter wraps a writer and captures the first error, short-circuiting
+// subsequent writes. This avoids checking every fmt.Fprintf return value.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (ew *errWriter) printf(format string, a ...interface{}) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = fmt.Fprintf(ew.w, format, a...)
+}
+
+func (ew *errWriter) print(s string) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = io.WriteString(ew.w, s)
+}
+
+func (r *Renderer) writeHeader(ew *errWriter, d Diagnostic, p palette) {
+	var sevColor, sevText string
+	switch d.Severity {
+	case SeverityError:
+		sevColor = p.boldRed
+		sevText = "error"
+	case SeverityWarning:
+		sevColor = p.yellow
+		sevText = "warning"
+	case SeverityNote:
+		sevColor = p.boldCyan
+		sevText = "note"
+	}
+	ew.printf("%s%s%s%s:%s %s%s%s\n",
+		sevColor, p.bold, sevText, p.reset,
+		p.reset,
+		p.bold, d.Message, p.reset)
+}
+
+func (r *Renderer) writeSpan(ew *errWriter, span Span, p palette) {
+	// Location line: "  --> file:line:col"
+	loc := span.File
+	if span.Line > 0 {
+		loc = fmt.Sprintf("%s:%d", span.File, span.Line)
+		if span.Col > 0 {
+			loc = fmt.Sprintf("%s:%d:%d", span.File, span.Line, span.Col)
+		}
+	}
+	ew.printf("  %s-->%s %s\n", p.boldBlue, p.reset, loc)
+
+	// Try to read and display the source line
+	source := r.readSourceLine(span.File, span.Line)
+	if source == "" {
+		// No source available — just show the location line with a gutter
+		ew.printf("   %s|%s\n", p.boldBlue, p.reset)
+		return
+	}
+
+	lineStr := fmt.Sprintf("%d", span.Line)
+	pad := strings.Repeat(" ", len(lineStr))
+
+	// Empty gutter line
+	ew.printf(" %s%s |%s\n", p.boldBlue, pad, p.reset)
+
+	// Source line with line number
+	// Replace tabs with spaces for consistent alignment
+	displaySource := strings.ReplaceAll(source, "\t", "    ")
+	ew.printf(" %s%s |%s  %s\n", p.boldBlue, lineStr, p.reset, displaySource)
+
+	// Underline
+	col := span.Col
+	endCol := span.EndCol
+	if col <= 0 {
+		col = 1
+	}
+	if endCol <= 0 {
+		endCol = r.detectEndCol(source, col)
+	}
+	if endCol < col {
+		endCol = col
+	}
+	underLen := endCol - col + 1
+
+	// Account for tab expansion in positioning
+	prefix := ""
+	if col > 1 && col-1 <= len(source) {
+		prefix = source[:col-1]
+	}
+	displayCol := displayWidth(prefix)
+
+	underPad := strings.Repeat(" ", displayCol)
+	underline := strings.Repeat("^", underLen)
+
+	ew.printf(" %s%s |%s  %s%s%s%s", p.boldBlue, pad, p.reset, underPad, p.boldRed, underline, p.reset)
+	if span.Label != "" {
+		ew.printf(" %s%s%s", p.boldRed, span.Label, p.reset)
+	}
+	ew.print("\n")
+
+	// Trailing gutter
+	ew.printf(" %s%s |%s\n", p.boldBlue, pad, p.reset)
+}
+
+func (r *Renderer) readSourceLine(file string, line int) string {
+	if line <= 0 || file == "" || file == "<native code>" {
+		return ""
+	}
+	reader := r.SourceReader
+	if reader == nil {
+		reader = func(name string) ([]byte, error) {
+			return os.ReadFile(name) //nolint:gosec // reads user-specified source files for display
+		}
+	}
+	data, err := reader(file)
+	if err != nil {
+		return ""
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for i := 1; scanner.Scan(); i++ {
+		if i == line {
+			return scanner.Text()
+		}
+	}
+	return ""
+}
+
+// detectEndCol scans from col to find the end of the current token.
+func (r *Renderer) detectEndCol(source string, col int) int {
+	if col <= 0 || col > len(source) {
+		return col
+	}
+	end := col - 1 // 0-based
+	for end < len(source) {
+		ch, size := utf8.DecodeRuneInString(source[end:])
+		if ch == ' ' || ch == '\t' || ch == ')' || ch == ']' || ch == '(' || ch == '[' {
+			break
+		}
+		end += size
+	}
+	if end == col-1 {
+		return col // single character
+	}
+	return end // convert back to 1-based end column
+}
+
+// displayWidth returns the display width of a string, expanding tabs to 4 spaces.
+func displayWidth(s string) int {
+	w := 0
+	for _, ch := range s {
+		if ch == '\t' {
+			w += 4
+		} else {
+			w++
+		}
+	}
+	return w
+}
+
+// fileFromWriter attempts to extract an *os.File from a writer for terminal
+// detection. Returns nil if the writer is not backed by a file.
+func fileFromWriter(w io.Writer) *os.File {
+	if f, ok := w.(*os.File); ok {
+		return f
+	}
+	return nil
+}

--- a/diagnostic/renderer_test.go
+++ b/diagnostic/renderer_test.go
@@ -1,0 +1,219 @@
+// Copyright © 2024 The ELPS authors
+
+package diagnostic
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// testRenderer returns a Renderer with colors disabled and a fake source reader.
+func testRenderer(sources map[string]string) *Renderer {
+	return &Renderer{
+		Color: ColorNever,
+		SourceReader: func(name string) ([]byte, error) {
+			s, ok := sources[name]
+			if !ok {
+				return nil, &fakeErr{name}
+			}
+			return []byte(s), nil
+		},
+	}
+}
+
+type fakeErr struct{ name string }
+
+func (e *fakeErr) Error() string { return "not found: " + e.name }
+
+func TestRenderError(t *testing.T) {
+	r := testRenderer(map[string]string{
+		"test.lisp": "(set! false 42)",
+	})
+
+	d := Diagnostic{
+		Severity: SeverityError,
+		Message:  "cannot rebind constant: false",
+		Spans: []Span{
+			{File: "test.lisp", Line: 1, Col: 7, EndCol: 11, Label: "set! target is a language constant"},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := r.Render(&buf, d); err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.String()
+
+	// Verify key structural elements
+	assertContains(t, got, "error: cannot rebind constant: false")
+	assertContains(t, got, "--> test.lisp:1:7")
+	assertContains(t, got, "(set! false 42)")
+	assertContains(t, got, "^^^^^")
+	assertContains(t, got, "set! target is a language constant")
+}
+
+func TestRenderWarning(t *testing.T) {
+	r := testRenderer(map[string]string{
+		"test.lisp": "(set x 1)\n(set x 2)",
+	})
+
+	d := Diagnostic{
+		Severity: SeverityWarning,
+		Message:  "repeated set on symbol: x",
+		Spans: []Span{
+			{File: "test.lisp", Line: 2, Col: 1, EndCol: 9},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := r.Render(&buf, d); err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.String()
+	assertContains(t, got, "warning: repeated set on symbol: x")
+	assertContains(t, got, "--> test.lisp:2:1")
+	assertContains(t, got, "(set x 2)")
+}
+
+func TestRenderNoSource(t *testing.T) {
+	r := testRenderer(nil)
+
+	d := Diagnostic{
+		Severity: SeverityError,
+		Message:  "some error",
+		Spans: []Span{
+			{File: "<stdin>", Line: 5, Col: 3},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := r.Render(&buf, d); err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.String()
+	assertContains(t, got, "error: some error")
+	assertContains(t, got, "--> <stdin>:5:3")
+	// Should have a gutter but no source line
+	assertContains(t, got, "|")
+	assertNotContains(t, got, "^")
+}
+
+func TestRenderNotes(t *testing.T) {
+	r := testRenderer(map[string]string{
+		"test.lisp": "(my-fn 1 2)",
+	})
+
+	d := Diagnostic{
+		Severity: SeverityError,
+		Message:  "unbound symbol: my-fn",
+		Spans: []Span{
+			{File: "test.lisp", Line: 1, Col: 2, EndCol: 6},
+		},
+		Notes: []string{
+			"in user:my-fn at test.lisp:1:1",
+			"called from user:main at main.lisp:10:5",
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := r.Render(&buf, d); err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.String()
+	assertContains(t, got, "= note: in user:my-fn at test.lisp:1:1")
+	assertContains(t, got, "= note: called from user:main at main.lisp:10:5")
+}
+
+func TestRenderAutoDetectEndCol(t *testing.T) {
+	r := testRenderer(map[string]string{
+		"test.lisp": "(defun true () 42)",
+	})
+
+	d := Diagnostic{
+		Severity: SeverityError,
+		Message:  "cannot rebind constant: true",
+		Spans: []Span{
+			{File: "test.lisp", Line: 1, Col: 8}, // EndCol=0 → auto-detect
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := r.Render(&buf, d); err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.String()
+	// "true" starts at col 8 and is 4 chars → should produce "^^^^"
+	assertContains(t, got, "^^^^")
+}
+
+func TestRenderMultipleDiagnostics(t *testing.T) {
+	r := testRenderer(map[string]string{
+		"test.lisp": "(set x 1)\n(set x 2)\n(if true)",
+	})
+
+	diags := []Diagnostic{
+		{
+			Severity: SeverityWarning,
+			Message:  "repeated set on symbol: x",
+			Spans:    []Span{{File: "test.lisp", Line: 2, Col: 1, EndCol: 9}},
+		},
+		{
+			Severity: SeverityWarning,
+			Message:  "if requires 2-3 arguments",
+			Spans:    []Span{{File: "test.lisp", Line: 3, Col: 1, EndCol: 9}},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := r.RenderAll(&buf, diags); err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.String()
+	// Should have both diagnostics separated by blank line
+	parts := strings.Split(got, "\n\n")
+	if len(parts) < 2 {
+		t.Errorf("expected diagnostics separated by blank line, got:\n%s", got)
+	}
+	assertContains(t, got, "repeated set on symbol: x")
+	assertContains(t, got, "if requires 2-3 arguments")
+}
+
+func TestRenderNoSpans(t *testing.T) {
+	r := testRenderer(nil)
+
+	d := Diagnostic{
+		Severity: SeverityError,
+		Message:  "library error: file not found",
+	}
+
+	var buf bytes.Buffer
+	if err := r.Render(&buf, d); err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.String()
+	assertContains(t, got, "error: library error: file not found")
+	// Should be just the header, no arrows or source
+	assertNotContains(t, got, "-->")
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Errorf("output does not contain %q:\n%s", want, got)
+	}
+}
+
+func assertNotContains(t *testing.T, got, unwanted string) {
+	t.Helper()
+	if strings.Contains(got, unwanted) {
+		t.Errorf("output unexpectedly contains %q:\n%s", unwanted, got)
+	}
+}

--- a/elpsutil/elpsutil.go
+++ b/elpsutil/elpsutil.go
@@ -48,6 +48,12 @@ type Package interface {
 	PackageName() string
 }
 
+// PackageDocumented allows an elps package to provide a documentation string.
+type PackageDocumented interface {
+	Package
+	PackageDoc() string
+}
+
 // PackageInit allows initialization of an elps package implemented in Go.
 type PackageInit interface {
 	Package
@@ -164,6 +170,9 @@ func PackageLoader(p Package) Loader {
 		e = env.InPackage(name)
 		if !e.IsNil() {
 			return e
+		}
+		if dp, ok := p.(PackageDocumented); ok {
+			env.SetPackageDoc(dp.PackageDoc())
 		}
 		initLoader := packageInit(p)
 		e = initLoader(env)

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -207,7 +207,7 @@ var AnalyzerCondMissingElse = &Analyzer{
 				return // malformed clause, handled by cond-structure
 			}
 			head := last.Cells[0]
-			if head.Type == lisp.LSymbol && (head.Str == "else" || head.Str == "true") {
+			if head.Type == lisp.LSymbol && isCondDefault(head.Str) {
 				return // has default clause
 			}
 			src := SourceOf(sexpr)
@@ -219,6 +219,12 @@ var AnalyzerCondMissingElse = &Analyzer{
 		})
 		return nil
 	},
+}
+
+// isCondDefault returns true if sym is a recognized default-clause head for cond.
+// ELPS users commonly write (else ...), (true ...), (:else ...), or (:true ...).
+func isCondDefault(sym string) bool {
+	return sym == "else" || sym == "true" || sym == ":else" || sym == ":true"
 }
 
 // posFromSource converts a *token.Location to a Position, handling nil.
@@ -298,7 +304,7 @@ var AnalyzerCondStructure = &Analyzer{
 				}
 
 				// Check for misplaced else
-				if clause.Cells[0].Type == lisp.LSymbol && clause.Cells[0].Str == "else" {
+				if clause.Cells[0].Type == lisp.LSymbol && isCondDefault(clause.Cells[0].Str) {
 					if i != last {
 						pass.Reportf(clauseSrc.Source, "cond else clause must be last (is clause %d of %d)", i, last)
 					}

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -56,6 +56,13 @@ func (p *Pass) Report(d Diagnostic) {
 	p.diagnostics = append(p.diagnostics, d)
 }
 
+// ReportWithNotes records a diagnostic with additional hint text.
+func (p *Pass) ReportWithNotes(d Diagnostic, notes ...string) {
+	d.Analyzer = p.Analyzer.Name
+	d.Notes = append(d.Notes, notes...)
+	p.diagnostics = append(p.diagnostics, d)
+}
+
 // Reportf is a convenience for reporting a diagnostic at a position.
 func (p *Pass) Reportf(source *token.Location, format string, args ...interface{}) {
 	d := Diagnostic{
@@ -77,6 +84,9 @@ type Diagnostic struct {
 
 	// Analyzer is the name of the check that found this problem.
 	Analyzer string `json:"analyzer"`
+
+	// Notes are optional hint text lines for the user.
+	Notes []string `json:"notes,omitempty"`
 }
 
 // Position identifies a location in source code.
@@ -98,8 +108,13 @@ func (p Position) String() string {
 }
 
 // String returns the diagnostic in go vet style: file:line: message (analyzer)
+// with optional note lines appended.
 func (d Diagnostic) String() string {
-	return fmt.Sprintf("%s: %s (%s)", d.Pos, d.Message, d.Analyzer)
+	s := fmt.Sprintf("%s: %s (%s)", d.Pos, d.Message, d.Analyzer)
+	for _, n := range d.Notes {
+		s += "\n  = note: " + n
+	}
+	return s
 }
 
 // Linter runs a set of analyzers over source files.

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -269,5 +269,6 @@ func DefaultAnalyzers() []*Analyzer {
 		AnalyzerDefunStructure,
 		AnalyzerCondStructure,
 		AnalyzerBuiltinArity,
+		AnalyzerQuoteCall,
 	}
 }

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -270,5 +270,6 @@ func DefaultAnalyzers() []*Analyzer {
 		AnalyzerCondStructure,
 		AnalyzerBuiltinArity,
 		AnalyzerQuoteCall,
+		AnalyzerCondMissingElse,
 	}
 }

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -644,6 +644,31 @@ func TestCondMissingElse_Negative_SingleElse(t *testing.T) {
 	assertNoDiags(t, diags)
 }
 
+func TestCondMissingElse_Negative_KeywordElse(t *testing.T) {
+	source := "(cond\n  ((= x 1) \"one\")\n  (:else \"default\"))"
+	diags := lintCheck(t, AnalyzerCondMissingElse, source)
+	assertNoDiags(t, diags)
+}
+
+func TestCondMissingElse_Negative_KeywordTrue(t *testing.T) {
+	source := "(cond\n  ((= x 1) \"one\")\n  (:true \"default\"))"
+	diags := lintCheck(t, AnalyzerCondMissingElse, source)
+	assertNoDiags(t, diags)
+}
+
+func TestCondStructure_Negative_KeywordElseLast(t *testing.T) {
+	source := "(cond\n  ((= x 1) \"one\")\n  (:else \"default\"))"
+	diags := lintCheck(t, AnalyzerCondStructure, source)
+	assertNoDiags(t, diags)
+}
+
+func TestCondStructure_Positive_MisplacedKeywordElse(t *testing.T) {
+	source := "(cond\n  (:else \"default\")\n  ((= x 1) \"one\"))"
+	diags := lintCheck(t, AnalyzerCondStructure, source)
+	assert.Len(t, diags, 1)
+	assert.Contains(t, diags[0].Message, "else clause must be last")
+}
+
 // --- nolint suppression ---
 
 func TestNolint_SuppressAll(t *testing.T) {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -611,6 +611,39 @@ func TestQuoteCall_Negative_DynamicName(t *testing.T) {
 	assertNoDiags(t, diags)
 }
 
+// --- cond-missing-else ---
+
+func TestCondMissingElse_Positive_NoDefault(t *testing.T) {
+	source := "(cond\n  ((= x 1) \"one\")\n  ((= x 2) \"two\"))"
+	diags := lintCheck(t, AnalyzerCondMissingElse, source)
+	assert.Len(t, diags, 1)
+	assertHasDiag(t, diags, "no default")
+	assert.NotEmpty(t, diags[0].Notes)
+}
+
+func TestCondMissingElse_Negative_HasElse(t *testing.T) {
+	source := "(cond\n  ((= x 1) \"one\")\n  (else \"default\"))"
+	diags := lintCheck(t, AnalyzerCondMissingElse, source)
+	assertNoDiags(t, diags)
+}
+
+func TestCondMissingElse_Negative_HasTrue(t *testing.T) {
+	source := "(cond\n  ((= x 1) \"one\")\n  (true \"default\"))"
+	diags := lintCheck(t, AnalyzerCondMissingElse, source)
+	assertNoDiags(t, diags)
+}
+
+func TestCondMissingElse_Negative_EmptyCond(t *testing.T) {
+	diags := lintCheck(t, AnalyzerCondMissingElse, `(cond)`)
+	assertNoDiags(t, diags)
+}
+
+func TestCondMissingElse_Negative_SingleElse(t *testing.T) {
+	source := "(cond (else \"only\"))"
+	diags := lintCheck(t, AnalyzerCondMissingElse, source)
+	assertNoDiags(t, diags)
+}
+
 // --- nolint suppression ---
 
 func TestNolint_SuppressAll(t *testing.T) {
@@ -779,10 +812,11 @@ func TestBracketListIgnored(t *testing.T) {
 
 func TestDefaultAnalyzers(t *testing.T) {
 	analyzers := DefaultAnalyzers()
-	assert.Len(t, analyzers, 8)
+	assert.Len(t, analyzers, 9)
 	names := AnalyzerNames()
 	assert.Equal(t, []string{
 		"builtin-arity",
+		"cond-missing-else",
 		"cond-structure",
 		"defun-structure",
 		"if-arity",

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -78,6 +78,10 @@ var (
 		{"export", Formals(VarArgSymbol, "symbol"), builtinExport,
 			`Marks symbols as exported from the current package, making them
 			available to other packages via use-package. Returns nil.`},
+		{"package-doc", Formals("docstring"), builtinPackageDoc,
+			`Sets the documentation string for the current package. The
+			argument must be a string describing the package's purpose.
+			Typically called immediately after (in-package ...). Returns nil.`},
 		{"set", Formals("sym", "val"), builtinSet,
 			`Binds val to the quoted symbol sym in the current package scope,
 			creating or overwriting the binding. Returns the bound value. This
@@ -498,6 +502,15 @@ func builtinExport(env *LEnv, args *LVal) *LVal {
 			return env.Errorf("argument is not a symbol, a string, or a list of valid types: %v", arg.Type)
 		}
 	}
+	return Nil()
+}
+
+func builtinPackageDoc(env *LEnv, args *LVal) *LVal {
+	doc := args.Cells[0]
+	if doc.Type != LString {
+		return env.Errorf("argument is not a string: %v", doc.Type)
+	}
+	env.Runtime.Package.Doc = doc.Str
 	return Nil()
 }
 

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -488,7 +488,7 @@ func builtinInPackage(env *LEnv, args *LVal) *LVal {
 			}
 			parts = append(parts, arg.Str)
 		}
-		pkg.Doc = strings.Join(parts, " ")
+		pkg.Doc = JoinDocStrings(parts)
 	}
 	return Nil()
 }

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -681,7 +681,7 @@ func builtinToBytes(env *LEnv, args *LVal) *LVal {
 		return Bytes([]byte(val.Str))
 	}
 	// TODO:  Allow sequences of integers to be turned into bytes?
-	return env.Errorf("cannot convert type to string: %v", val.Type)
+	return env.Errorf("cannot convert type to bytes: %v", val.Type)
 }
 
 func toString(val *LVal) (string, error) {
@@ -717,7 +717,7 @@ func builtinToInt(env *LEnv, args *LVal) *LVal {
 	case LFloat:
 		return Int(int(val.Float))
 	default:
-		return env.Errorf("cannot convert type to string: %v", val.Type)
+		return env.Errorf("cannot convert type to int: %v", val.Type)
 	}
 }
 
@@ -735,7 +735,7 @@ func builtinToFloat(env *LEnv, args *LVal) *LVal {
 	case LFloat:
 		return val
 	default:
-		return env.Errorf("cannot convert type to string: %v", val.Type)
+		return env.Errorf("cannot convert type to float: %v", val.Type)
 	}
 }
 
@@ -976,7 +976,7 @@ func builtinCompose(env *LEnv, args *LVal) *LVal {
 		return env.Errorf("second argument is not a function: %s", g.Type)
 	}
 	if g.IsSpecialFun() {
-		return env.Errorf("first argument is not a regular function: %v", g.FunType)
+		return env.Errorf("second argument is not a regular function: %v", g.FunType)
 	}
 	formals := g.Cells[0].Copy()
 	gcall := SExpr(make([]*LVal, 0, len(formals.Cells)+1))

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -388,7 +388,7 @@ func DefaultBuiltins() []LBuiltinDef {
 	}
 	offset := len(langBuiltins)
 	for i := range userBuiltins {
-		ops[offset+i] = langBuiltins[i]
+		ops[offset+i] = userBuiltins[i]
 	}
 	return ops
 }

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -24,6 +24,9 @@ func InitializeUserEnv(env *LEnv, config ...Config) *LVal {
 	env.Runtime.Registry.DefinePackage(DefaultLangPackage)
 	env.Runtime.Registry.Lang = DefaultLangPackage
 	env.Runtime.Package = env.Runtime.Registry.Packages[env.Runtime.Registry.Lang]
+	env.Runtime.Package.Doc = `The core ELPS language package. Provides fundamental data types,
+		control flow, function and macro definition, package management,
+		error handling, collections, I/O, and the type system.`
 	env.AddMacros(true)
 	env.AddSpecialOps(true)
 	env.AddBuiltins(true)
@@ -32,6 +35,7 @@ func InitializeUserEnv(env *LEnv, config ...Config) *LVal {
 		return rc
 	}
 	env.Runtime.Registry.DefinePackage(DefaultUserPackage)
+	env.Runtime.Registry.Packages[DefaultUserPackage].Doc = "The default user package for application code."
 	rc = env.InPackage(Symbol(DefaultUserPackage))
 	if GoError(rc) != nil {
 		return rc
@@ -149,6 +153,11 @@ func (env *LEnv) DefinePackage(name *LVal) *LVal {
 	}
 	env.Runtime.Registry.DefinePackage(name.Str)
 	return Nil()
+}
+
+// SetPackageDoc sets the documentation string for the current package.
+func (env *LEnv) SetPackageDoc(doc string) {
+	env.Runtime.Package.Doc = doc
 }
 
 func (env *LEnv) InPackage(name *LVal) *LVal {

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -160,6 +160,11 @@ func (env *LEnv) SetPackageDoc(doc string) {
 	env.Runtime.Package.Doc = doc
 }
 
+// SetSymbolDoc sets the documentation string for a symbol in the current package.
+func (env *LEnv) SetSymbolDoc(name, doc string) {
+	env.Runtime.Package.SymbolDocs[name] = doc
+}
+
 func (env *LEnv) InPackage(name *LVal) *LVal {
 	if name.Type != LSymbol && name.Type != LString {
 		return env.Errorf("argument cannot be converted to string: %v", name.Type)

--- a/lisp/eval_test.go
+++ b/lisp/eval_test.go
@@ -37,14 +37,14 @@ string"""`, `"\"\"a raw\nstring"`, ""},
 			{"false", "false", ""},
 			// A bit brittle, but it's ok for now. Replace with a more robust
 			// test later if problematic.
-			{"a", "test:1: unbound symbol: a", ""},
+			{"a", "test:1:1: unbound symbol: a", ""},
 		}},
 		{"set", elpstest.TestSequence{
 			{`(set 'x 1)`, `1`, ``},
 			{`x`, `1`, ``},
 			{`(set 'x 2)`, `2`, ``},
 			{`x`, `2`, ``},
-			{`(set 'true 2)`, `test:1: lisp:set: cannot rebind constant: true`, ``},
+			{`(set 'true 2)`, `test:1:1: lisp:set: cannot rebind constant: true`, ``},
 		}},
 		{"lists basics", elpstest.TestSequence{
 			{"'()", "'()", ""},
@@ -284,7 +284,7 @@ string"""`, `"\"\"a raw\nstring"`, ""},
 			{"(make-sequence 0 5)", "'(0 1 2 3 4)", ""},
 			{"(make-sequence 0 5 2)", "'(0 2 4)", ""},
 			{"(make-sequence 0 2 0.5)", "'(0 0.5 1 1.5)", ""},
-			{"(make-sequence 0 5 0)", "test:1: lisp:make-sequence: third argument is not positive", ""},
+			{"(make-sequence 0 5 0)", "test:1:1: lisp:make-sequence: third argument is not positive", ""},
 			{"(make-sequence 10 5 2)", "'()", ""},
 		}},
 		{"filtering", elpstest.TestSequence{
@@ -308,7 +308,7 @@ string"""`, `"\"\"a raw\nstring"`, ""},
 			{"(reject 'vector (expr (< % 3)) '(0 1 1 -1 2 2))", "(vector)", ""},
 			{`(select 'list (lambda (x) (string= "b" (to-string x))) '(a b c))`, `'(b)`, ``},
 			{`(reject 'list (lambda (x) (string= "b" (to-string x))) '(a b c))`, `'(a c)`, ``},
-			{`(select 'list quote '(a b c))`, `test:1: lisp:select: second argument is not a regular function`, ``},
+			{`(select 'list quote '(a b c))`, `test:1:1: lisp:select: second argument is not a regular function`, ``},
 		}},
 		{"defun", elpstest.TestSequence{
 			// defun macro
@@ -320,7 +320,7 @@ string"""`, `"\"\"a raw\nstring"`, ""},
 			{"(fn2 1 2)", "3", ""},
 		}},
 		{"errors", elpstest.TestSequence{
-			{`(list 1 2 (error 'test-error "test message") 4)`, "test:1: test-error: test message", ""},
+			{`(list 1 2 (error 'test-error "test message") 4)`, "test:1:11: test-error: test message", ""},
 		}},
 	}
 	elpstest.RunTestSuite(t, tests)

--- a/lisp/fp_test.go
+++ b/lisp/fp_test.go
@@ -17,7 +17,7 @@ func TestFP(t *testing.T) {
 			// be tested in an earlier test (say eval_test.go) because the
 			// function id used in the error messages of anonymous functions
 			// is not deterministic.
-			{"(f 1 2 3)", "test:1: f: invalid number of arguments: 3", ""},
+			{"(f 1 2 3)", "test:1:1: f: invalid number of arguments: 3", ""},
 		}},
 		{"map-reduce", elpstest.TestSequence{
 			{"(map 'list 'list '(1 2 3))", "'('(1) '(2) '(3))", ""},

--- a/lisp/goerror_test.go
+++ b/lisp/goerror_test.go
@@ -55,7 +55,7 @@ func TestLoadErrors(t *testing.T) {
 	})
 	lerr = env.Eval(testsrc)
 	msg := lisp.GoError(lerr).Error()
-	assert.Equal(t, "<native code>: lisp:load-string: load-string:1: unmatched-syntax: unmatched (", msg)
+	assert.Equal(t, "<native code>: lisp:load-string: load-string:1:1: unmatched-syntax: unclosed ( opened at load-string:1:1", msg)
 
 	testsrc = lisp.SExpr([]*lisp.LVal{
 		lisp.Symbol("load-string"),
@@ -65,7 +65,7 @@ func TestLoadErrors(t *testing.T) {
 	})
 	lerr = env.Eval(testsrc)
 	msg = lisp.GoError(lerr).Error()
-	assert.Equal(t, "<native code>: lisp:load-string: test.lisp:1: unmatched-syntax: unmatched (", msg)
+	assert.Equal(t, "<native code>: lisp:load-string: test.lisp:1:2: unmatched-syntax: unclosed ( opened at test.lisp:1:2", msg)
 
 	testsrc = lisp.SExpr([]*lisp.LVal{
 		lisp.Symbol("load-string"),
@@ -75,7 +75,7 @@ func TestLoadErrors(t *testing.T) {
 	})
 	lerr = env.Eval(testsrc)
 	msg = lisp.GoError(lerr).Error()
-	assert.Equal(t, "<native code>: lisp:load-string: test.lisp:1: unmatched-syntax: unmatched [", msg)
+	assert.Equal(t, "<native code>: lisp:load-string: test.lisp:1:2: unmatched-syntax: unclosed [ opened at test.lisp:1:2", msg)
 
 	testsrc = lisp.SExpr([]*lisp.LVal{
 		lisp.Symbol("load-string"),
@@ -85,7 +85,7 @@ func TestLoadErrors(t *testing.T) {
 	})
 	lerr = env.Eval(testsrc)
 	msg = lisp.GoError(lerr).Error()
-	assert.Equal(t, "<native code>: lisp:load-string: test.lisp:1: parse-error: unexpected token: )", msg)
+	assert.Equal(t, "<native code>: lisp:load-string: test.lisp:1:3: parse-error: unexpected token: )", msg)
 
 	testsrc = lisp.SExpr([]*lisp.LVal{
 		lisp.Symbol("load-string"),
@@ -95,7 +95,7 @@ func TestLoadErrors(t *testing.T) {
 	})
 	lerr = env.Eval(testsrc)
 	msg = lisp.GoError(lerr).Error()
-	assert.Equal(t, "<native code>: lisp:load-string: test.lisp:1: parse-error: unexpected token: )", msg)
+	assert.Equal(t, "<native code>: lisp:load-string: test.lisp:1:6: parse-error: unexpected token: )", msg)
 
 	testsrc = lisp.SExpr([]*lisp.LVal{
 		lisp.Symbol("load-string"),
@@ -105,7 +105,7 @@ func TestLoadErrors(t *testing.T) {
 	})
 	lerr = env.Eval(testsrc)
 	msg = lisp.GoError(lerr).Error()
-	assert.Equal(t, msg, "<native code>: lisp:load-string: test.lisp:1: scan-error: unexpected text starting with '^'", msg)
+	assert.Equal(t, "<native code>: lisp:load-string: test.lisp:1:8: scan-error: unexpected text starting with '^'", msg)
 
 	testsrc = lisp.SExpr([]*lisp.LVal{
 		lisp.Symbol("load-string"),
@@ -115,5 +115,5 @@ func TestLoadErrors(t *testing.T) {
 	})
 	lerr = env.Eval(testsrc)
 	msg = lisp.GoError(lerr).Error()
-	assert.Equal(t, "test.lisp:1: test-error: test error message", msg)
+	assert.Equal(t, "test.lisp:1:1: test-error: test error message", msg)
 }

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -993,11 +993,29 @@ func (v *LVal) String() string {
 	return v.str(false)
 }
 
+// JoinDocStrings joins multiple doc string parts into a single string.
+// Non-empty strings are joined with spaces.  Empty strings produce blank
+// lines, acting as paragraph separators.
+func JoinDocStrings(parts []string) string {
+	var b strings.Builder
+	for i, p := range parts {
+		if p == "" {
+			b.WriteString("\n\n")
+		} else {
+			if i > 0 && parts[i-1] != "" {
+				b.WriteByte(' ')
+			}
+			b.WriteString(p)
+		}
+	}
+	return b.String()
+}
+
 // Docstring returns the docstring of the function reference v.  If v is not
 // a function Docstring returns the empty string.  For user-defined functions,
-// consecutive leading string expressions in the body are concatenated with
-// spaces to form the docstring (the body must contain at least one
-// non-string expression after the doc strings).
+// consecutive leading string expressions in the body are concatenated to form
+// the docstring (the body must contain at least one non-string expression
+// after the doc strings).  Empty strings produce paragraph breaks.
 func (v *LVal) Docstring() string {
 	if v.Type != LFun {
 		return ""
@@ -1022,7 +1040,7 @@ func (v *LVal) Docstring() string {
 		// Only treat as docstring if there's at least one non-string
 		// body expression after the strings.
 		if len(parts) < len(v.Cells)-1 {
-			return strings.Join(parts, " ")
+			return JoinDocStrings(parts)
 		}
 	}
 	return ""

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -133,7 +133,7 @@ var lvalTypeStrings = []string{
 }
 
 func (t LType) String() string {
-	if int(t) >= len(lvalTypeStrings) { //nolint:gosec // bounded by iota constants
+	if t >= LType(len(lvalTypeStrings)) {
 		return lvalTypeStrings[LInvalid]
 	}
 	return lvalTypeStrings[t]

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -994,7 +994,10 @@ func (v *LVal) String() string {
 }
 
 // Docstring returns the docstring of the function reference v.  If v is not
-// a function Docstring returns the empty string.
+// a function Docstring returns the empty string.  For user-defined functions,
+// consecutive leading string expressions in the body are concatenated with
+// spaces to form the docstring (the body must contain at least one
+// non-string expression after the doc strings).
 func (v *LVal) Docstring() string {
 	if v.Type != LFun {
 		return ""
@@ -1009,7 +1012,18 @@ func (v *LVal) Docstring() string {
 	// functions without documentation so there must be a length check on the
 	// function body.
 	if len(v.Cells) > 2 && v.Cells[1].Type == LString {
-		return v.Cells[1].Str
+		var parts []string
+		for i := 1; i < len(v.Cells); i++ {
+			if v.Cells[i].Type != LString {
+				break
+			}
+			parts = append(parts, v.Cells[i].Str)
+		}
+		// Only treat as docstring if there's at least one non-string
+		// body expression after the strings.
+		if len(parts) < len(v.Cells)-1 {
+			return strings.Join(parts, " ")
+		}
 	}
 	return ""
 }

--- a/lisp/lisplib/libbase64/libbase64.go
+++ b/lisp/lisplib/libbase64/libbase64.go
@@ -30,8 +30,14 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 }
 
 var builtins = []*libutil.Builtin{
-	libutil.Function("encode", lisp.Formals("data"), builtinEncode),
-	libutil.Function("decode", lisp.Formals("base64-data"), builtinDecode),
+	libutil.FunctionDoc("encode", lisp.Formals("data"), builtinEncode,
+		`Encodes data using standard base64 encoding and returns the
+		result as bytes. The argument may be a string or bytes value.`),
+	libutil.FunctionDoc("decode", lisp.Formals("base64-data"), builtinDecode,
+		`Decodes base64-encoded data and returns the result as bytes.
+		The argument may be a string or bytes value containing valid
+		standard base64. Returns an error if the input is not valid
+		base64.`),
 }
 
 func builtinEncode(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {

--- a/lisp/lisplib/libbase64/libbase64.go
+++ b/lisp/lisplib/libbase64/libbase64.go
@@ -23,6 +23,7 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	if !e.IsNil() {
 		return e
 	}
+	env.SetPackageDoc("Base64 encoding and decoding using the standard alphabet (RFC 4648).")
 	for _, fn := range builtins {
 		env.AddBuiltins(true, fn)
 	}

--- a/lisp/lisplib/libgolang/libgolang.go
+++ b/lisp/lisplib/libgolang/libgolang.go
@@ -34,6 +34,7 @@ type builtin struct {
 	formals *lisp.LVal
 	fun     lisp.LBuiltin
 	name    string
+	docs    string
 }
 
 func (fun *builtin) Name() string {
@@ -48,11 +49,29 @@ func (fun *builtin) Eval(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	return fun.fun(env, args)
 }
 
+func (fun *builtin) Docstring() string {
+	return fun.docs
+}
+
 var builtins = []*builtin{
-	{lisp.Formals("native-value"), BuiltinString, "string"},
-	{lisp.Formals("native-value"), BuiltinInt, "int"},
-	{lisp.Formals("native-value"), BuiltinFloat, "float"},
-	{lisp.Formals("native-struct", "field-name"), BuiltinStructField, "struct-field"},
+	{lisp.Formals("native-value"), BuiltinString, "string",
+		`Extracts a Go string from a native value and returns it as an
+		ELPS string. The native value must hold a Go string or a type
+		with underlying kind string. Does not convert non-string types
+		to strings (use to-string for that).`},
+	{lisp.Formals("native-value"), BuiltinInt, "int",
+		`Extracts a Go integer from a native value and returns it as an
+		ELPS int. Accepts any native value with an underlying integer
+		kind (signed or unsigned). Returns an error on overflow.`},
+	{lisp.Formals("native-value"), BuiltinFloat, "float",
+		`Extracts a Go float from a native value and returns it as an
+		ELPS float. Accepts native values with underlying kind float32
+		or float64.`},
+	{lisp.Formals("native-struct", "field-name"), BuiltinStructField, "struct-field",
+		`Reads an exported field from a native Go struct value using
+		reflection. field-name is a string or symbol naming the field
+		(must start with an uppercase letter). Returns the field value
+		as a native value. Automatically dereferences pointers.`},
 }
 
 // BuiltinString returns a string held by the native value (it does not convert

--- a/lisp/lisplib/libgolang/libgolang.go
+++ b/lisp/lisplib/libgolang/libgolang.go
@@ -24,6 +24,8 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	if !e.IsNil() {
 		return e
 	}
+	env.SetPackageDoc(`Go interop: extract strings, integers, and floats from native Go
+		objects, and read struct fields via reflection.`)
 	for _, fn := range builtins {
 		env.AddBuiltins(true, fn)
 	}

--- a/lisp/lisplib/libhelp/libhelp.go
+++ b/lisp/lisplib/libhelp/libhelp.go
@@ -28,6 +28,7 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	if !e.IsNil() {
 		return e
 	}
+	env.SetPackageDoc("Interactive documentation: inspect functions, variables, and package exports.")
 	for _, op := range ops {
 		env.AddSpecialOps(true, op)
 	}
@@ -128,6 +129,21 @@ func RenderPkgExported(w io.Writer, env *lisp.LEnv, query string) error {
 	pkg := env.Runtime.Registry.Packages[query]
 	if pkg == nil {
 		return fmt.Errorf("no package: %q", query)
+	}
+	_, err := fmt.Fprintf(w, "package %s\n", pkg.Name)
+	if err != nil {
+		return err
+	}
+	if pkg.Doc != "" {
+		doc := cleanDocstring(pkg.Doc)
+		_, err = fmt.Fprintln(w, doc)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = fmt.Fprintln(w)
+	if err != nil {
+		return err
 	}
 	exports := pkg.Externals
 	for i, exsym := range exports {

--- a/lisp/lisplib/libhelp/libhelp_test.go
+++ b/lisp/lisplib/libhelp/libhelp_test.go
@@ -3,10 +3,13 @@
 package libhelp_test
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/lisp/lisplib/libhelp"
 	"github.com/luthersystems/elps/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,4 +50,73 @@ func TestDocstring(t *testing.T) {
 	if assert.Equal(t, lisp.LFun, lisp2.Type) {
 		assert.Equal(t, "abc", lisp2.Docstring())
 	}
+}
+
+func newTestEnv(t *testing.T) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	env.Runtime.Library = &lisp.RelativeFileSystemLibrary{}
+	rc := lisp.InitializeUserEnv(env)
+	require.True(t, rc.IsNil())
+	rc = lisplib.LoadLibrary(env)
+	require.True(t, rc.IsNil())
+	rc = env.InPackage(lisp.String(lisp.DefaultUserPackage))
+	require.True(t, rc.IsNil())
+	return env
+}
+
+func TestPackageDoc(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Core packages should have doc strings
+	packages := []string{"lisp", "user", "time", "math", "string", "base64",
+		"json", "regexp", "golang", "testing", "help", "s"}
+	for _, name := range packages {
+		pkg := env.Runtime.Registry.Packages[name]
+		if assert.NotNilf(t, pkg, "package %q should exist", name) {
+			assert.NotEqualf(t, "", pkg.Doc, "package %q should have a doc string", name)
+		}
+	}
+}
+
+func TestRenderPkgExported_IncludesDoc(t *testing.T) {
+	env := newTestEnv(t)
+
+	var buf bytes.Buffer
+	err := libhelp.RenderPkgExported(&buf, env, "math")
+	require.NoError(t, err)
+	output := buf.String()
+
+	// Should start with package header
+	assert.True(t, strings.HasPrefix(output, "package math\n"),
+		"output should start with package header, got: %s", output)
+	// Should contain the doc string content
+	assert.Contains(t, output, "Mathematical functions")
+}
+
+func TestPackageDocBuiltin(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Use package-doc from lisp source
+	rc := env.LoadString("test.lisp", `
+	(in-package 'test-pkg)
+	(package-doc "A test package for unit testing.")
+	(export 'my-fn)
+	(defun my-fn () 42)
+	`)
+	require.Truef(t, rc.IsNil(), "LoadString failed: %v", rc)
+
+	pkg := env.Runtime.Registry.Packages["test-pkg"]
+	require.NotNil(t, pkg)
+	assert.Equal(t, "A test package for unit testing.", pkg.Doc)
+
+	// Verify it renders
+	var buf bytes.Buffer
+	err := libhelp.RenderPkgExported(&buf, env, "test-pkg")
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "package test-pkg")
+	assert.Contains(t, output, "A test package for unit testing.")
+	assert.Contains(t, output, "my-fn")
 }

--- a/lisp/lisplib/libjson/json.go
+++ b/lisp/lisplib/libjson/json.go
@@ -45,14 +45,43 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 // set of package builtin functions that use it.
 func Builtins(s *Serializer) []*libutil.Builtin {
 	return []*libutil.Builtin{
-		libutil.Function("message-bytes", lisp.Formals("json-message"), s.MessageBytesBuiltin),
-		libutil.Function("dump-message", lisp.Formals("object", lisp.KeyArgSymbol, "string-numbers"), s.DumpMessageBuiltin),
-		libutil.Function("load-message", lisp.Formals("json-message", lisp.KeyArgSymbol, "string-numbers"), s.LoadMessageBuiltin),
-		libutil.Function("dump-bytes", lisp.Formals("object", lisp.KeyArgSymbol, "string-numbers"), s.DumpBytesBuiltin),
-		libutil.Function("load-bytes", lisp.Formals("json-bytes", lisp.KeyArgSymbol, "string-numbers"), s.LoadBytesBuiltin),
-		libutil.Function("dump-string", lisp.Formals("object", lisp.KeyArgSymbol, "string-numbers"), s.DumpStringBuiltin),
-		libutil.Function("load-string", lisp.Formals("json-string", lisp.KeyArgSymbol, "string-numbers"), s.LoadStringBuiltin),
-		libutil.Function("use-string-numbers", lisp.Formals("bool"), s.UseStringNumbersBuiltin),
+		libutil.FunctionDoc("message-bytes", lisp.Formals("json-message"), s.MessageBytesBuiltin,
+			`Extracts the raw byte content from a native JSON message object
+			(json.RawMessage). Returns a bytes value. Use this to get the
+			underlying bytes of a message for further processing.`),
+		libutil.FunctionDoc("dump-message", lisp.Formals("object", lisp.KeyArgSymbol, "string-numbers"), s.DumpMessageBuiltin,
+			`Serializes an ELPS value to a native JSON message object
+			(json.RawMessage) suitable for embedding in Go structures.
+			The :string-numbers keyword controls whether numbers are
+			serialized as JSON strings (default: serializer setting).`),
+		libutil.FunctionDoc("load-message", lisp.Formals("json-message", lisp.KeyArgSymbol, "string-numbers"), s.LoadMessageBuiltin,
+			`Parses a native JSON message object (json.RawMessage) into
+			ELPS values. The :string-numbers keyword controls whether
+			JSON numbers are returned as strings (default: serializer
+			setting).`),
+		libutil.FunctionDoc("dump-bytes", lisp.Formals("object", lisp.KeyArgSymbol, "string-numbers"), s.DumpBytesBuiltin,
+			`Serializes an ELPS value to JSON and returns the result as
+			bytes. Sorted-maps become JSON objects, arrays become JSON
+			arrays, strings/ints/floats map naturally. The :string-numbers
+			keyword controls whether numbers are serialized as strings.`),
+		libutil.FunctionDoc("load-bytes", lisp.Formals("json-bytes", lisp.KeyArgSymbol, "string-numbers"), s.LoadBytesBuiltin,
+			`Parses a JSON bytes value into ELPS values. JSON objects become
+			sorted-maps, arrays become ELPS arrays, strings/numbers map
+			naturally. The :string-numbers keyword controls whether JSON
+			numbers are returned as strings.`),
+		libutil.FunctionDoc("dump-string", lisp.Formals("object", lisp.KeyArgSymbol, "string-numbers"), s.DumpStringBuiltin,
+			`Serializes an ELPS value to a JSON string. Like dump-bytes
+			but returns a string instead of bytes. The :string-numbers
+			keyword controls whether numbers are serialized as strings.`),
+		libutil.FunctionDoc("load-string", lisp.Formals("json-string", lisp.KeyArgSymbol, "string-numbers"), s.LoadStringBuiltin,
+			`Parses a JSON string into ELPS values. Like load-bytes but
+			accepts a string argument. The :string-numbers keyword controls
+			whether JSON numbers are returned as strings.`),
+		libutil.FunctionDoc("use-string-numbers", lisp.Formals("bool"), s.UseStringNumbersBuiltin,
+			`Sets the default string-numbers mode for the JSON serializer.
+			When true, numbers are serialized as JSON strings and JSON
+			numbers are parsed as strings. Affects all dump/load functions
+			that don't explicitly pass :string-numbers. Returns nil.`),
 	}
 }
 

--- a/lisp/lisplib/libjson/json.go
+++ b/lisp/lisplib/libjson/json.go
@@ -36,6 +36,8 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	env.SetPackageDoc(`JSON serialization and deserialization. Marshal ELPS values to
 		JSON bytes or strings and unmarshal JSON into ELPS data structures.`)
 	env.PutGlobal(lisp.Symbol("null"), lisp.Symbol("json:null"))
+	env.SetSymbolDoc("null", "The JSON null sentinel symbol. Used to represent null in JSON serialization.")
+	env.Runtime.Package.Exports("null")
 	s := DefaultSerializer()
 	for _, fn := range Builtins(s) {
 		env.AddBuiltins(true, fn)

--- a/lisp/lisplib/libjson/json.go
+++ b/lisp/lisplib/libjson/json.go
@@ -33,6 +33,8 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	if !e.IsNil() {
 		return e
 	}
+	env.SetPackageDoc(`JSON serialization and deserialization. Marshal ELPS values to
+		JSON bytes or strings and unmarshal JSON into ELPS data structures.`)
 	env.PutGlobal(lisp.Symbol("null"), lisp.Symbol("json:null"))
 	s := DefaultSerializer()
 	for _, fn := range Builtins(s) {

--- a/lisp/lisplib/libmath/libmath.go
+++ b/lisp/lisplib/libmath/libmath.go
@@ -26,8 +26,12 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	env.SetPackageDoc(`Mathematical functions: trigonometry, logarithms, exponents, absolute
 		value, floor/ceiling, rounding, and mathematical constants (pi, inf).`)
 	env.PutGlobal(lisp.Symbol("pi"), lisp.Float(math.Pi))
+	env.SetSymbolDoc("pi", "The ratio of a circle's circumference to its diameter (3.14159...).")
 	env.PutGlobal(lisp.Symbol("inf"), lisp.Float(math.Inf(1)))
+	env.SetSymbolDoc("inf", "Positive infinity (IEEE 754).")
 	env.PutGlobal(lisp.Symbol("-inf"), lisp.Float(math.Inf(-1)))
+	env.SetSymbolDoc("-inf", "Negative infinity (IEEE 754).")
+	env.Runtime.Package.Exports("pi", "inf", "-inf")
 	for _, fn := range builtins {
 		env.AddBuiltins(true, fn)
 	}

--- a/lisp/lisplib/libmath/libmath.go
+++ b/lisp/lisplib/libmath/libmath.go
@@ -23,6 +23,8 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	if !e.IsNil() {
 		return e
 	}
+	env.SetPackageDoc(`Mathematical functions: trigonometry, logarithms, exponents, absolute
+		value, floor/ceiling, rounding, and mathematical constants (pi, inf).`)
 	env.PutGlobal(lisp.Symbol("pi"), lisp.Float(math.Pi))
 	env.PutGlobal(lisp.Symbol("inf"), lisp.Float(math.Inf(1)))
 	env.PutGlobal(lisp.Symbol("-inf"), lisp.Float(math.Inf(-1)))

--- a/lisp/lisplib/libmath/libmath.go
+++ b/lisp/lisplib/libmath/libmath.go
@@ -33,26 +33,64 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 }
 
 var builtins = []*libutil.Builtin{
-	libutil.Function("nan?", lisp.Formals("number"), builtinIsNaN),
-	libutil.Function("abs", lisp.Formals("number"), builtinAbs),
-	libutil.Function("ceil", lisp.Formals("number"), builtinCeil),
-	libutil.Function("floor", lisp.Formals("number"), builtinFloor),
-	libutil.Function("sqrt", lisp.Formals("number"), builtinSqrt),
-	libutil.Function("exp", lisp.Formals("number"), builtinExp),
-	libutil.Function("ln", lisp.Formals("number"), builtinLn),
-	libutil.Function("log", lisp.Formals("base", "number"), builtinLog),
-	libutil.Function("sin", lisp.Formals("radians"), builtinSin),
-	libutil.Function("sinh", lisp.Formals("radians"), builtinSinh),
-	libutil.Function("asin", lisp.Formals("radians"), builtinAsin),
-	libutil.Function("asinh", lisp.Formals("radians"), builtinAsinh),
-	libutil.Function("cos", lisp.Formals("radians"), builtinCos),
-	libutil.Function("cosh", lisp.Formals("radians"), builtinCosh),
-	libutil.Function("acos", lisp.Formals("radians"), builtinAcos),
-	libutil.Function("acosh", lisp.Formals("radians"), builtinAcosh),
-	libutil.Function("tan", lisp.Formals("radians"), builtinTan),
-	libutil.Function("tanh", lisp.Formals("radians"), builtinTanh),
-	libutil.Function("atan", lisp.Formals("radians", lisp.OptArgSymbol, "quotient"), builtinAtan),
-	libutil.Function("atanh", lisp.Formals("radians"), builtinAtanh),
+	libutil.FunctionDoc("nan?", lisp.Formals("number"), builtinIsNaN,
+		`Returns true if number is IEEE 754 NaN (not-a-number). Integers
+		always return false. Returns an error if the argument is not
+		a number.`),
+	libutil.FunctionDoc("abs", lisp.Formals("number"), builtinAbs,
+		`Returns the absolute value of number. Preserves the type: an int
+		argument returns an int, a float returns a float. Returns an
+		error on integer overflow (min-int).`),
+	libutil.FunctionDoc("ceil", lisp.Formals("number"), builtinCeil,
+		`Returns the smallest float not less than number (rounds toward
+		positive infinity). Integers are returned unchanged. The result
+		is always a float for float input.`),
+	libutil.FunctionDoc("floor", lisp.Formals("number"), builtinFloor,
+		`Returns the largest float not greater than number (rounds toward
+		negative infinity). Integers are returned unchanged. The result
+		is always a float for float input.`),
+	libutil.FunctionDoc("sqrt", lisp.Formals("number"), builtinSqrt,
+		`Returns the square root of number as a float. Accepts int or
+		float arguments.`),
+	libutil.FunctionDoc("exp", lisp.Formals("number"), builtinExp,
+		`Returns e raised to the power of number (e^x) as a float.
+		Accepts int or float arguments.`),
+	libutil.FunctionDoc("ln", lisp.Formals("number"), builtinLn,
+		`Returns the natural logarithm (base e) of number as a float.
+		Accepts int or float arguments.`),
+	libutil.FunctionDoc("log", lisp.Formals("base", "number"), builtinLog,
+		`Returns the logarithm of number in the given base as a float.
+		Both arguments must be numbers. Computed as ln(number)/ln(base).`),
+	libutil.FunctionDoc("sin", lisp.Formals("radians"), builtinSin,
+		`Returns the sine of radians as a float.`),
+	libutil.FunctionDoc("sinh", lisp.Formals("radians"), builtinSinh,
+		`Returns the hyperbolic sine of radians as a float.`),
+	libutil.FunctionDoc("asin", lisp.Formals("radians"), builtinAsin,
+		`Returns the arcsine (inverse sine) in radians as a float.
+		The argument must be in the range [-1, 1].`),
+	libutil.FunctionDoc("asinh", lisp.Formals("radians"), builtinAsinh,
+		`Returns the inverse hyperbolic sine as a float.`),
+	libutil.FunctionDoc("cos", lisp.Formals("radians"), builtinCos,
+		`Returns the cosine of radians as a float.`),
+	libutil.FunctionDoc("cosh", lisp.Formals("radians"), builtinCosh,
+		`Returns the hyperbolic cosine of radians as a float.`),
+	libutil.FunctionDoc("acos", lisp.Formals("radians"), builtinAcos,
+		`Returns the arccosine (inverse cosine) in radians as a float.
+		The argument must be in the range [-1, 1].`),
+	libutil.FunctionDoc("acosh", lisp.Formals("radians"), builtinAcosh,
+		`Returns the inverse hyperbolic cosine as a float. The argument
+		must be >= 1.`),
+	libutil.FunctionDoc("tan", lisp.Formals("radians"), builtinTan,
+		`Returns the tangent of radians as a float.`),
+	libutil.FunctionDoc("tanh", lisp.Formals("radians"), builtinTanh,
+		`Returns the hyperbolic tangent of radians as a float.`),
+	libutil.FunctionDoc("atan", lisp.Formals("radians", lisp.OptArgSymbol, "quotient"), builtinAtan,
+		`Returns the arctangent as a float. With one argument, returns
+		atan(radians). With two arguments, returns atan2(radians,
+		quotient), computing the angle in the correct quadrant.`),
+	libutil.FunctionDoc("atanh", lisp.Formals("radians"), builtinAtanh,
+		`Returns the inverse hyperbolic tangent as a float. The argument
+		must be in the range (-1, 1).`),
 }
 
 func builtinIsNaN(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {

--- a/lisp/lisplib/libregexp/libregexp.go
+++ b/lisp/lisplib/libregexp/libregexp.go
@@ -30,10 +30,21 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 }
 
 var builtins = []*libutil.Builtin{
-	libutil.Function("regexp?", lisp.Formals("value"), BuiltinIsRegexp),
-	libutil.Function("regexp-compile", lisp.Formals("pattern"), BuiltinCompile),
-	libutil.Function("regexp-pattern", lisp.Formals("re"), BuiltinPattern),
-	libutil.Function("regexp-match?", lisp.Formals("re", "text"), BuiltinIsMatch),
+	libutil.FunctionDoc("regexp?", lisp.Formals("value"), BuiltinIsRegexp,
+		`Returns true if value is a compiled regular expression (created
+		by regexp-compile). Returns false for all other types.`),
+	libutil.FunctionDoc("regexp-compile", lisp.Formals("pattern"), BuiltinCompile,
+		`Compiles a regular expression pattern string and returns a native
+		regexp object. Uses Go's RE2 syntax. Returns an error with
+		condition 'invalid-regexp-pattern' if the pattern is invalid.`),
+	libutil.FunctionDoc("regexp-pattern", lisp.Formals("re"), BuiltinPattern,
+		`Returns the pattern string of a compiled regexp object. The
+		argument may be a compiled regexp or a string (which will be
+		compiled first).`),
+	libutil.FunctionDoc("regexp-match?", lisp.Formals("re", "text"), BuiltinIsMatch,
+		`Returns true if the regexp matches text. re may be a compiled
+		regexp or a pattern string (compiled on each call). text may be
+		a string or bytes value.`),
 }
 
 func BuiltinIsRegexp(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {

--- a/lisp/lisplib/libregexp/libregexp.go
+++ b/lisp/lisplib/libregexp/libregexp.go
@@ -23,6 +23,7 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	if !e.IsNil() {
 		return e
 	}
+	env.SetPackageDoc("Regular expression compilation and matching using Go RE2 syntax.")
 	for _, fn := range builtins {
 		env.AddBuiltins(true, fn)
 	}

--- a/lisp/lisplib/libschema/libschema.go
+++ b/lisp/lisplib/libschema/libschema.go
@@ -73,8 +73,20 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	// We export the type symbols to the package to make writing code using it less messy
 	for _, symbol := range symbols {
 		env.PutGlobal(lisp.Symbol(symbol), lisp.String(symbol))
-		env.Runtime.Package.Externals = append(env.Runtime.Package.Externals, symbol)
 	}
+	env.Runtime.Package.Exports(symbols...)
+	env.SetSymbolDoc("string", "Type name for string values.")
+	env.SetSymbolDoc("number", "Type name for numeric values (int or float).")
+	env.SetSymbolDoc("int", "Type name for integer values.")
+	env.SetSymbolDoc("float", "Type name for floating-point values.")
+	env.SetSymbolDoc("fun", "Type name for function values.")
+	env.SetSymbolDoc("bytes", "Type name for byte-sequence values.")
+	env.SetSymbolDoc("error", "Type name for error values.")
+	env.SetSymbolDoc("sorted-map", "Type name for sorted-map (associative array) values.")
+	env.SetSymbolDoc("array", "Type name for array values.")
+	env.SetSymbolDoc("bool", "Type name for boolean values (true or false).")
+	env.SetSymbolDoc("tagged-value", "Type name for user-defined tagged values (created with deftype/new).")
+	env.SetSymbolDoc("any", "Type name matching any value type (no type constraint).")
 	return lisp.Nil()
 }
 

--- a/lisp/lisplib/libschema/libschema.go
+++ b/lisp/lisplib/libschema/libschema.go
@@ -64,6 +64,9 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	if !e.IsNil() {
 		return e
 	}
+	env.SetPackageDoc(`Schema validation: define typed validators with constraints and
+		check values against them at runtime. Validators compose to
+		describe complex data structures.`)
 	for _, fn := range builtins {
 		env.AddBuiltins(true, fn)
 	}

--- a/lisp/lisplib/libschema/libschema.go
+++ b/lisp/lisplib/libschema/libschema.go
@@ -76,32 +76,109 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 }
 
 var builtins = []*libutil.Builtin{
-	libutil.Function("deftype", lisp.Formals("name", "type", lisp.VarArgSymbol, "constraints"), builtinDefType),
-	libutil.Function("make-validator", lisp.Formals("name", "type", lisp.VarArgSymbol, "constraints"), builtinMakeValidator),
-	libutil.Function("in", lisp.Formals("&rest", "allowed-values"), builtinAllowedValues),
-	libutil.Function("gt", lisp.Formals("allowed-value"), builtinGreaterThan),
-	libutil.Function("gte", lisp.Formals("allowed-value"), builtinGreaterThanOrEqual),
-	libutil.Function("lt", lisp.Formals("allowed-value"), builtinLessThan),
-	libutil.Function("lte", lisp.Formals("allowed-value"), builtinLessThanOrEqual),
-	libutil.Function("positive", lisp.Formals(), builtinPositive),
-	libutil.Function("negative", lisp.Formals(), builtinNegative),
-	libutil.Function("validate", lisp.Formals("type", "input"), builtinValidate),
-	libutil.Function("len", lisp.Formals("allowed-value"), builtinLen),
-	libutil.Function("lengt", lisp.Formals("allowed-value"), builtinLenGreaterThan),
-	libutil.Function("lengte", lisp.Formals("allowed-value"), builtinLenGreaterThanOrEqual),
-	libutil.Function("lenlt", lisp.Formals("allowed-value"), builtinLenLessThan),
-	libutil.Function("lenlte", lisp.Formals("allowed-value"), builtinLenLessThanOrEqual),
-	libutil.Function("of", lisp.Formals("&rest", "allowed-types"), builtinArrayOf),
-	libutil.Function("has-key", lisp.Formals("key", "&rest", "allowed-types"), builtinHasKey),
-	libutil.Function("may-have-key", lisp.Formals("key", "&rest", "allowed-types"), builtinMayHaveKey),
-	libutil.Function("no-other-keys", lisp.Formals("&rest", "constraints"), builtinNoOtherKeys),
-	libutil.Function("when", lisp.Formals("key", "constraint", "matchKey", "&rest", "constraints"), builtinWhen),
-	libutil.Function("is-true", lisp.Formals(), builtinIsTrue),
-	libutil.Function("is-false", lisp.Formals(), builtinIsFalse),
-	libutil.Function("is-truthy", lisp.Formals(), builtinIsTruthy),
-	libutil.Function("is-falsy", lisp.Formals(), builtinIsFalsy),
-	libutil.Function("not", lisp.Formals("constraint"), builtinIsNot),
-	libutil.Function("regexp", lisp.Formals("pattern"), builtinRegexp),
+	libutil.FunctionDoc("deftype", lisp.Formals("name", "type", lisp.VarArgSymbol, "constraints"), builtinDefType,
+		`Defines a named schema type and binds it as a global symbol.
+		name is a string used as both the type name and symbol binding.
+		type is a type string ("string", "int", "float", "number",
+		"bool", "array", "sorted-map", "fun", "tagged-value", "any").
+		Additional constraint functions may be passed to further
+		restrict valid values. Use with s:validate to check values.`),
+	libutil.FunctionDoc("make-validator", lisp.Formals("name", "type", lisp.VarArgSymbol, "constraints"), builtinMakeValidator,
+		`Creates and returns a validator function without binding it.
+		Like deftype but returns the validator instead of creating a
+		global binding. name may be a string or a typedef (tagged
+		value). When name is a typedef, the type argument is treated
+		as a constraint on the user-data and "tagged-value" is implied.`),
+	libutil.FunctionDoc("in", lisp.Formals("&rest", "allowed-values"), builtinAllowedValues,
+		`Returns a constraint that checks if the input is equal to one
+		of the allowed values. Useful for creating enum-like types.
+		Example: (s:in "red" "green" "blue").`),
+	libutil.FunctionDoc("gt", lisp.Formals("allowed-value"), builtinGreaterThan,
+		`Returns a constraint that checks if the input is strictly
+		greater than allowed-value. Works with numeric types.`),
+	libutil.FunctionDoc("gte", lisp.Formals("allowed-value"), builtinGreaterThanOrEqual,
+		`Returns a constraint that checks if the input is greater than
+		or equal to allowed-value. Works with numeric types.`),
+	libutil.FunctionDoc("lt", lisp.Formals("allowed-value"), builtinLessThan,
+		`Returns a constraint that checks if the input is strictly less
+		than allowed-value. Works with numeric types.`),
+	libutil.FunctionDoc("lte", lisp.Formals("allowed-value"), builtinLessThanOrEqual,
+		`Returns a constraint that checks if the input is less than or
+		equal to allowed-value. Works with numeric types.`),
+	libutil.FunctionDoc("positive", lisp.Formals(), builtinPositive,
+		`Returns a constraint that checks if the input is strictly
+		greater than zero.`),
+	libutil.FunctionDoc("negative", lisp.Formals(), builtinNegative,
+		`Returns a constraint that checks if the input is strictly
+		less than zero.`),
+	libutil.FunctionDoc("validate", lisp.Formals("type", "input"), builtinValidate,
+		`Validates input against a type validator function (created by
+		deftype or make-validator). Returns nil on success or an error
+		with a condition string describing the validation failure.`),
+	libutil.FunctionDoc("len", lisp.Formals("allowed-value"), builtinLen,
+		`Returns a constraint that checks if the length of the input
+		equals allowed-value. Works with strings, bytes, and arrays.`),
+	libutil.FunctionDoc("lengt", lisp.Formals("allowed-value"), builtinLenGreaterThan,
+		`Returns a constraint that checks if the length of the input is
+		strictly greater than allowed-value. Works with strings, bytes,
+		and arrays.`),
+	libutil.FunctionDoc("lengte", lisp.Formals("allowed-value"), builtinLenGreaterThanOrEqual,
+		`Returns a constraint that checks if the length of the input is
+		greater than or equal to allowed-value. Works with strings,
+		bytes, and arrays.`),
+	libutil.FunctionDoc("lenlt", lisp.Formals("allowed-value"), builtinLenLessThan,
+		`Returns a constraint that checks if the length of the input is
+		strictly less than allowed-value. Works with strings, bytes,
+		and arrays.`),
+	libutil.FunctionDoc("lenlte", lisp.Formals("allowed-value"), builtinLenLessThanOrEqual,
+		`Returns a constraint that checks if the length of the input is
+		less than or equal to allowed-value. Works with strings, bytes,
+		and arrays.`),
+	libutil.FunctionDoc("of", lisp.Formals("&rest", "allowed-types"), builtinArrayOf,
+		`Returns a constraint for arrays that checks each element matches
+		one of the allowed types. Each allowed-type is a type string
+		passed to the type handler. Example: (s:of "string") checks all
+		elements are strings.`),
+	libutil.FunctionDoc("has-key", lisp.Formals("key", "&rest", "allowed-types"), builtinHasKey,
+		`Returns a constraint for sorted-maps that checks the map has
+		the specified key and its value matches one of the allowed
+		types. key is a string. Returns the key name on success (used
+		by no-other-keys).`),
+	libutil.FunctionDoc("may-have-key", lisp.Formals("key", "&rest", "allowed-types"), builtinMayHaveKey,
+		`Returns a constraint for sorted-maps that checks if the key
+		exists, and if so, validates its value matches one of the
+		allowed types. If the key is absent, validation passes.
+		Returns the key name on success (used by no-other-keys).`),
+	libutil.FunctionDoc("no-other-keys", lisp.Formals("&rest", "constraints"), builtinNoOtherKeys,
+		`Returns a constraint for sorted-maps that rejects maps with
+		keys not declared by the given has-key or may-have-key
+		constraints. Pass all key constraints as arguments.`),
+	libutil.FunctionDoc("when", lisp.Formals("key", "constraint", "matchKey", "&rest", "constraints"), builtinWhen,
+		`Returns a conditional constraint for sorted-maps. When the value
+		at key satisfies constraint, the value at matchKey must satisfy
+		all additional constraints. If the condition is not met, the
+		constraint passes.`),
+	libutil.FunctionDoc("is-true", lisp.Formals(), builtinIsTrue,
+		`Returns a constraint that checks if the input is the boolean
+		true symbol.`),
+	libutil.FunctionDoc("is-false", lisp.Formals(), builtinIsFalse,
+		`Returns a constraint that checks if the input is the boolean
+		false symbol.`),
+	libutil.FunctionDoc("is-truthy", lisp.Formals(), builtinIsTruthy,
+		`Returns a constraint that checks if the input is truthy.
+		Truthy values include: true, non-empty strings (not "false"),
+		non-empty arrays/maps/bytes, and positive numbers.`),
+	libutil.FunctionDoc("is-falsy", lisp.Formals(), builtinIsFalsy,
+		`Returns a constraint that checks if the input is falsy (the
+		logical negation of is-truthy).`),
+	libutil.FunctionDoc("not", lisp.Formals("constraint"), builtinIsNot,
+		`Returns a constraint that negates another constraint. The
+		input passes if the inner constraint fails, and fails if the
+		inner constraint passes.`),
+	libutil.FunctionDoc("regexp", lisp.Formals("pattern"), builtinRegexp,
+		`Returns a constraint that checks if a string input matches
+		the given regular expression pattern. Uses Go RE2 syntax.
+		Returns an error if the pattern is invalid.`),
 }
 
 // This is the `s:validate` keyword. It checks its input matches the type

--- a/lisp/lisplib/libstring/libstring.go
+++ b/lisp/lisplib/libstring/libstring.go
@@ -24,6 +24,8 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	if !e.IsNil() {
 		return e
 	}
+	env.SetPackageDoc(`String manipulation: case conversion, splitting, joining,
+		repetition, and trimming.`)
 	for _, fn := range builtins {
 		env.AddBuiltins(true, fn)
 	}

--- a/lisp/lisplib/libstring/libstring.go
+++ b/lisp/lisplib/libstring/libstring.go
@@ -31,15 +31,36 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 }
 
 var builtins = []*libutil.Builtin{
-	libutil.Function("lowercase", lisp.Formals("str"), builtinLower),
-	libutil.Function("uppercase", lisp.Formals("str"), builtinUpper),
-	libutil.Function("split", lisp.Formals("str", "sep"), builtinSplit),
-	libutil.Function("join", lisp.Formals("list", "sep"), builtinJoin),
-	libutil.Function("repeat", lisp.Formals("str", "n"), builtinRepeat),
-	libutil.Function("trim-space", lisp.Formals("str"), builtinTrimSpace),
-	libutil.Function("trim", lisp.Formals("str", "cutset"), builtinTrim),
-	libutil.Function("trim-left", lisp.Formals("str", "cutset"), builtinTrimLeft),
-	libutil.Function("trim-right", lisp.Formals("str", "cutset"), builtinTrimRight),
+	libutil.FunctionDoc("lowercase", lisp.Formals("str"), builtinLower,
+		`Returns a copy of str with all Unicode characters converted to
+		lowercase.`),
+	libutil.FunctionDoc("uppercase", lisp.Formals("str"), builtinUpper,
+		`Returns a copy of str with all Unicode characters converted to
+		uppercase.`),
+	libutil.FunctionDoc("split", lisp.Formals("str", "sep"), builtinSplit,
+		`Splits str on each occurrence of the separator string sep and
+		returns a list of the substrings between separators. If sep is
+		empty, splits after each UTF-8 character.`),
+	libutil.FunctionDoc("join", lisp.Formals("list", "sep"), builtinJoin,
+		`Concatenates a list of strings with sep inserted between each
+		element. Returns a single string. All elements of list must be
+		strings.`),
+	libutil.FunctionDoc("repeat", lisp.Formals("str", "n"), builtinRepeat,
+		`Returns a new string consisting of n copies of str concatenated
+		together. n must be a non-negative integer.`),
+	libutil.FunctionDoc("trim-space", lisp.Formals("str"), builtinTrimSpace,
+		`Returns str with all leading and trailing whitespace removed
+		(spaces, tabs, newlines, etc.).`),
+	libutil.FunctionDoc("trim", lisp.Formals("str", "cutset"), builtinTrim,
+		`Returns str with all leading and trailing characters found in
+		cutset removed. The cutset is a string of individual characters
+		to trim, not a prefix/suffix.`),
+	libutil.FunctionDoc("trim-left", lisp.Formals("str", "cutset"), builtinTrimLeft,
+		`Returns str with all leading characters found in cutset removed.
+		The cutset is a string of individual characters to trim.`),
+	libutil.FunctionDoc("trim-right", lisp.Formals("str", "cutset"), builtinTrimRight,
+		`Returns str with all trailing characters found in cutset removed.
+		The cutset is a string of individual characters to trim.`),
 }
 
 func builtinLower(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {

--- a/lisp/lisplib/libtesting/libtesting.go
+++ b/lisp/lisplib/libtesting/libtesting.go
@@ -95,22 +95,55 @@ func (s *TestSuite) Benchmark(i int) *Test {
 
 func (s *TestSuite) Macros() []*libutil.Builtin {
 	return []*libutil.Builtin{
-		libutil.Function("test-let", lisp.Formals("name", "bindings", lisp.VarArgSymbol, "exprs"), s.MacroTestLet),
-		libutil.Function("test-let*", lisp.Formals("name", "bindings", lisp.VarArgSymbol, "exprs"), s.MacroTestLetSeq),
-		libutil.Function("benchmark-simple", lisp.Formals("name", lisp.VarArgSymbol, "exprs"), s.MacroBenchmarkSimple),
-		libutil.Function("assert=", lisp.Formals("expect", "num"), s.MacroAssertNumEq),
-		libutil.Function("assert-string=", lisp.Formals("expect", "str"), s.MacroAssertStringEq),
-		libutil.Function("assert-equal", lisp.Formals("expect", "expression"), s.MacroAssertEqual),
-		libutil.Function("assert-nil", lisp.Formals("expression"), s.MacroAssertNil),
-		libutil.Function("assert-not-nil", lisp.Formals("expression"), s.MacroAssertNotNil),
-		libutil.Function("assert-not", lisp.Formals("expression"), s.MacroAssertNot),
+		libutil.FunctionDoc("test-let", lisp.Formals("name", "bindings", lisp.VarArgSymbol, "exprs"), s.MacroTestLet,
+			`Defines a named test with local let bindings. Expands to
+			(test name (let (bindings) exprs...)). The bindings use
+			parallel binding (let) semantics.`),
+		libutil.FunctionDoc("test-let*", lisp.Formals("name", "bindings", lisp.VarArgSymbol, "exprs"), s.MacroTestLetSeq,
+			`Defines a named test with local let* bindings. Like test-let
+			but uses sequential binding (let*) semantics, so later
+			bindings can reference earlier ones.`),
+		libutil.FunctionDoc("benchmark-simple", lisp.Formals("name", lisp.VarArgSymbol, "exprs"), s.MacroBenchmarkSimple,
+			`Defines a simple benchmark that runs exprs repeatedly.
+			Expands to (benchmark name (count) (dotimes (_ count) exprs...)).
+			The iteration count is provided by the benchmark harness.`),
+		libutil.FunctionDoc("assert=", lisp.Formals("expect", "num"), s.MacroAssertNumEq,
+			`Asserts that two expressions evaluate to numerically equal
+			values. Both expect and num must evaluate to numbers (int or
+			float). Reports the expected and actual values on failure.`),
+		libutil.FunctionDoc("assert-string=", lisp.Formals("expect", "str"), s.MacroAssertStringEq,
+			`Asserts that two expressions evaluate to equal strings.
+			Both expect and str must evaluate to string values. Reports
+			the expected and actual values on failure.`),
+		libutil.FunctionDoc("assert-equal", lisp.Formals("expect", "expression"), s.MacroAssertEqual,
+			`Asserts that two expressions are structurally equal using
+			equal?. Works with any value types. Reports the expected
+			and actual values on failure.`),
+		libutil.FunctionDoc("assert-nil", lisp.Formals("expression"), s.MacroAssertNil,
+			`Asserts that expression evaluates to nil. Reports the
+			actual value on failure.`),
+		libutil.FunctionDoc("assert-not-nil", lisp.Formals("expression"), s.MacroAssertNotNil,
+			`Asserts that expression does not evaluate to nil. Reports
+			the expression on failure.`),
+		libutil.FunctionDoc("assert-not", lisp.Formals("expression"), s.MacroAssertNot,
+			`Asserts that expression evaluates to a falsey value (nil or
+			false). Reports the actual value on failure.`),
 	}
 }
 
 func (s *TestSuite) Ops() []*libutil.Builtin {
 	return []*libutil.Builtin{
-		libutil.Function("test", lisp.Formals("name", lisp.VarArgSymbol, "exprs"), s.OpTest),
-		libutil.Function("benchmark", lisp.Formals("name", "args", lisp.VarArgSymbol, "exprs"), s.OpBenchmark),
+		libutil.FunctionDoc("test", lisp.Formals("name", lisp.VarArgSymbol, "exprs"), s.OpTest,
+			`Defines a named test case. name must be a string. The body
+			expressions are wrapped in a lambda and registered with the
+			test suite for later execution. Use assert macros inside
+			the body to check conditions.`),
+		libutil.FunctionDoc("benchmark", lisp.Formals("name", "args", lisp.VarArgSymbol, "exprs"), s.OpBenchmark,
+			`Defines a named benchmark. name must be a string. args is a
+			list containing a single symbol that receives the iteration
+			count. The body should use dotimes or similar to run the
+			benchmarked code count times. Prefer benchmark-simple for
+			simple cases.`),
 	}
 }
 

--- a/lisp/lisplib/libtesting/libtesting.go
+++ b/lisp/lisplib/libtesting/libtesting.go
@@ -25,6 +25,8 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	if !e.IsNil() {
 		return e
 	}
+	env.SetPackageDoc(`Test framework: define named tests and benchmarks with assertion
+		helpers (assert-equal, assert-nil, assert-not-nil, etc.).`)
 	suite := NewTestSuite()
 	env.PutGlobal(lisp.Symbol(DefaultSuiteSymbol), lisp.Native(suite))
 	for _, fn := range suite.Ops() {

--- a/lisp/lisplib/libtime/libtime.go
+++ b/lisp/lisplib/libtime/libtime.go
@@ -23,6 +23,8 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	if !e.IsNil() {
 		return e
 	}
+	env.SetPackageDoc(`Time operations: parsing, formatting, comparison, and arithmetic
+		on UTC timestamps and durations. Wraps Go's time package.`)
 	for _, fn := range builtins {
 		env.AddBuiltins(true, fn)
 	}

--- a/lisp/lisplib/libtime/libtime.go
+++ b/lisp/lisplib/libtime/libtime.go
@@ -52,22 +52,67 @@ func GetDuration(v *lisp.LVal) (time.Duration, bool) {
 }
 
 var builtins = []*libutil.Builtin{
-	libutil.Function("utc-now", lisp.Formals(), BuiltinUTCNow),
-	libutil.Function("parse-rfc3339", lisp.Formals("timestamp"), BuiltinParseRFC3339),
-	libutil.Function("parse-rfc3339-nano", lisp.Formals("timestamp"), BuiltinParseRFC3339Nano),
-	libutil.Function("format-rfc3339", lisp.Formals("datetime"), BuiltinFormatRFC3339),
-	libutil.Function("format-rfc3339-nano", lisp.Formals("datetime"), BuiltinFormatRFC3339Nano),
-	libutil.Function("time=", lisp.Formals("a", "b"), BuiltinTimeEq),
-	libutil.Function("time<", lisp.Formals("a", "b"), BuiltinTimeLT),
-	libutil.Function("time>", lisp.Formals("a", "b"), BuiltinTimeGT),
-	libutil.Function("time-add", lisp.Formals("datetime", "duration"), BuiltinTimeAdd),
-	libutil.Function("time-elapsed", lisp.Formals("start"), BuiltinElapsed),
-	libutil.Function("time-from", lisp.Formals("start", "end"), BuiltinDurationBetween),
-	libutil.Function("parse-duration", lisp.Formals("duration-string"), BuiltinParseDuration),
-	libutil.Function("duration-s", lisp.Formals("time-duration"), BuiltinDurationSeconds),
-	libutil.Function("duration-ms", lisp.Formals("time-duration"), BuiltinDurationMS),
-	libutil.Function("duration-ns", lisp.Formals("time-duration"), BuiltinDurationNS),
-	libutil.Function("sleep", lisp.Formals("time-duration"), BuiltinSleep),
+	libutil.FunctionDoc("utc-now", lisp.Formals(), BuiltinUTCNow,
+		`Returns the current time in UTC as a native time value. Takes no
+		arguments. Use format-rfc3339 or format-rfc3339-nano to convert
+		the result to a string.`),
+	libutil.FunctionDoc("parse-rfc3339", lisp.Formals("timestamp"), BuiltinParseRFC3339,
+		`Parses an RFC 3339 timestamp string (e.g. "2023-01-15T10:30:00Z")
+		and returns a native time value. Returns an error if the string
+		is not valid RFC 3339 format. For nanosecond precision, use
+		parse-rfc3339-nano.`),
+	libutil.FunctionDoc("parse-rfc3339-nano", lisp.Formals("timestamp"), BuiltinParseRFC3339Nano,
+		`Parses an RFC 3339 timestamp string with nanosecond precision
+		(e.g. "2023-01-15T10:30:00.123456789Z") and returns a native
+		time value. Returns an error if the string is not valid format.`),
+	libutil.FunctionDoc("format-rfc3339", lisp.Formals("datetime"), BuiltinFormatRFC3339,
+		`Formats a native time value as an RFC 3339 string with second
+		precision (e.g. "2023-01-15T10:30:00Z"). Returns a string.
+		The argument must be a native time value from utc-now or
+		parse-rfc3339.`),
+	libutil.FunctionDoc("format-rfc3339-nano", lisp.Formals("datetime"), BuiltinFormatRFC3339Nano,
+		`Formats a native time value as an RFC 3339 string with nanosecond
+		precision (e.g. "2023-01-15T10:30:00.123456789Z"). Returns a
+		string. The argument must be a native time value.`),
+	libutil.FunctionDoc("time=", lisp.Formals("a", "b"), BuiltinTimeEq,
+		`Returns true if the two native time values represent the same
+		instant. Both arguments must be native time values.`),
+	libutil.FunctionDoc("time<", lisp.Formals("a", "b"), BuiltinTimeLT,
+		`Returns true if time a is before time b. Both arguments must
+		be native time values.`),
+	libutil.FunctionDoc("time>", lisp.Formals("a", "b"), BuiltinTimeGT,
+		`Returns true if time a is after time b. Both arguments must
+		be native time values.`),
+	libutil.FunctionDoc("time-add", lisp.Formals("datetime", "duration"), BuiltinTimeAdd,
+		`Returns a new time value equal to datetime plus duration. The
+		first argument must be a native time value and the second must
+		be a native duration value (from parse-duration or time-from).`),
+	libutil.FunctionDoc("time-elapsed", lisp.Formals("start"), BuiltinElapsed,
+		`Returns the duration elapsed since start as a native duration
+		value. Equivalent to (time-from start (utc-now)). The argument
+		must be a native time value.`),
+	libutil.FunctionDoc("time-from", lisp.Formals("start", "end"), BuiltinDurationBetween,
+		`Returns the duration between start and end as a native duration
+		value (end - start). Both arguments must be native time values.
+		The result can be negative if end is before start.`),
+	libutil.FunctionDoc("parse-duration", lisp.Formals("duration-string"), BuiltinParseDuration,
+		`Parses a Go-style duration string and returns a native duration
+		value. Valid units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+		Examples: "1h30m", "500ms", "2h45m30s". Returns an error if the
+		string cannot be parsed.`),
+	libutil.FunctionDoc("duration-s", lisp.Formals("time-duration"), BuiltinDurationSeconds,
+		`Returns the number of seconds in the duration as a float.
+		The argument must be a native duration value.`),
+	libutil.FunctionDoc("duration-ms", lisp.Formals("time-duration"), BuiltinDurationMS,
+		`Returns the number of milliseconds in the duration as a float.
+		The argument must be a native duration value.`),
+	libutil.FunctionDoc("duration-ns", lisp.Formals("time-duration"), BuiltinDurationNS,
+		`Returns the number of nanoseconds in the duration as an integer.
+		The argument must be a native duration value. Returns an error
+		if the value overflows an int.`),
+	libutil.FunctionDoc("sleep", lisp.Formals("time-duration"), BuiltinSleep,
+		`Pauses execution for the specified duration. The argument must
+		be a native duration value (from parse-duration). Returns nil.`),
 }
 
 func BuiltinUTCNow(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {

--- a/lisp/macro.go
+++ b/lisp/macro.go
@@ -229,12 +229,14 @@ func findAndUnquote(env *LEnv, v *LVal, depth int) *LVal {
 
 	unquote, err := getUnquoteType(v)
 	if err != nil {
+		env.Loc = v.Source
 		return env.Error(err)
 	}
 	if unquote == unquoteSpliced {
 		// v looks like ``(unquote-splicing expr)''
 		expr := v.Cells[1]
 		if depth == 0 || quoteLevel > 0 {
+			env.Loc = v.Source
 			return env.Errorf("unquote-splicing used in an invalid context")
 		}
 		return doUnquoteSpliced(env, expr)

--- a/lisp/macro.go
+++ b/lisp/macro.go
@@ -10,15 +10,33 @@ import (
 
 var userMacros []*langBuiltin
 var langMacros = []*langBuiltin{
-	{"defmacro", Formals("name", "formals", "expr"), macroDefmacro, ""},
+	{"defmacro", Formals("name", "formals", "expr"), macroDefmacro,
+		`Defines a named macro in the current package. The body receives
+		unevaluated forms and must return a form to be evaluated at the
+		call site. Use quasiquote/unquote to construct the expansion.`},
 	{"defun", Formals("name", "formals", VarArgSymbol, "expr"), macroDefun,
 		`Defines a named function in the current package.`},
-	{"deftype", Formals("name", "constructor-formals", VarArgSymbol, "constructor-exprs"), macroDeftype, ""},
-	{"curry-function", Formals("fun", VarArgSymbol, "args"), macroCurryFun, ""},
+	{"deftype", Formals("name", "constructor-formals", VarArgSymbol, "constructor-exprs"), macroDeftype,
+		`Defines a tagged type constructor bound to name in the current
+		package. The formals and body define a constructor function that
+		computes user data for new instances created with (new name ...).
+		Returns the qualified type symbol.`},
+	{"curry-function", Formals("fun", VarArgSymbol, "args"), macroCurryFun,
+		`Returns a new function that calls fun with args prepended to any
+		additional arguments supplied at call time. Equivalent to
+		(lambda (&rest rest) (apply fun arg1 arg2 ... rest)).`},
 	// get-default is a macro because we only want to evaluate the expression
 	// bound to default if the key doesn't exist in the map.
-	{"get-default", Formals("map", "key", "default"), macroGetDefault, ""},
-	{"trace", Formals("expr", OptArgSymbol, "message"), macroTrace, ""},
+	{"get-default", Formals("map", "key", "default"), macroGetDefault,
+		`Looks up key in a sorted-map, returning the associated value if
+		found. If the key is not present, evaluates and returns default.
+		The default expression is only evaluated when the key is missing
+		(lazy evaluation).`},
+	{"trace", Formals("expr", OptArgSymbol, "message"), macroTrace,
+		`Evaluates expr, prints the result to stderr prefixed by message
+		(default "TRACE") using debug-print, then returns the result.
+		The expression is evaluated exactly once. Useful for debugging
+		without altering control flow.`},
 }
 
 // RegisterDefaultMacro adds the given function to the list returned by

--- a/lisp/macro_test.go
+++ b/lisp/macro_test.go
@@ -33,13 +33,13 @@ func TestMacros(t *testing.T) {
 			{"(quasiquote ((unquote-splicing '(reverse 'list '(1 2 3)))))", "'(reverse 'list '(1 2 3))", ""},
 			{"(quasiquote (1 2 (unquote-splicing '(3 4)) 5))", "'(1 2 3 4 5)", ""},
 			{"(let ((xs '(2 1))) (quasiquote (concat 'list '(1 2) (unquote xs))))", "'(concat 'list '(1 2) '(2 1))", ""},
-			{"(quasiquote (unquote test-symbol))", "test:1: lisp:quasiquote: unbound symbol: test-symbol", ""},
-			{"(quasiquote (list (unquote-splicing test-symbol)))", "test:1: lisp:quasiquote: unbound symbol: test-symbol", ""},
-			{"(quasiquote (list (unquote-splicing 1 2)))", "test:1: lisp:quasiquote: unquote-splicing: one argument expected (got 2)", ""},
-			{"(quasiquote (list (unquote 1 2)))", "test:1: lisp:quasiquote: unquote: one argument expected (got 2)", ""},
-			{"(quasiquote (unquote-splicing '(+ 2 3)))", "test:1: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
-			{"(quasiquote '(unquote-splicing '(+ 2 3)))", "test:1: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
-			{"(quasiquote ''(unquote-splicing '(+ 2 3)))", "test:1: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
+			{"(quasiquote (unquote test-symbol))", "test:1:22: lisp:quasiquote: unbound symbol: test-symbol", ""},
+			{"(quasiquote (list (unquote-splicing test-symbol)))", "test:1:37: lisp:quasiquote: unbound symbol: test-symbol", ""},
+			{"(quasiquote (list (unquote-splicing 1 2)))", "test:1:19: lisp:quasiquote: unquote-splicing: one argument expected (got 2)", ""},
+			{"(quasiquote (list (unquote 1 2)))", "test:1:19: lisp:quasiquote: unquote: one argument expected (got 2)", ""},
+			{"(quasiquote (unquote-splicing '(+ 2 3)))", "test:1:13: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
+			{"(quasiquote '(unquote-splicing '(+ 2 3)))", "test:1:40: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
+			{"(quasiquote ''(unquote-splicing '(+ 2 3)))", "test:1:41: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
 			{"(quasiquote ((unquote-splicing '(+ 2 3))))", "'(+ 2 3)", ""},
 		}},
 		{"defmacro", elpstest.TestSequence{
@@ -107,11 +107,11 @@ func TestMacros(t *testing.T) {
 			`, `()`, ``},
 			{`(f 1 3)`, `6`, ``},
 			{`(f 11 3)`, `12`, ``},
-			{`(test-x 11 3)`, `test:1: unbound symbol: test-x`, ``},
+			{`(test-x 11 3)`, `test:1:2: unbound symbol: test-x`, ``},
 			{`(macrolet (
 				[m1 (y) (quasiquote (+ 1 (unquote y)))]
 				[m2 (y) (quasiquote (* (unquote (m1 y)) 2))])
-				(m2 3))`, `test:3: lisp:quasiquote: unbound symbol: m1`, ``},
+				(m2 3))`, `test:3:38: lisp:quasiquote: unbound symbol: m1`, ``},
 		}},
 	}
 	elpstest.RunTestSuite(t, tests)

--- a/lisp/op.go
+++ b/lisp/op.go
@@ -71,6 +71,7 @@ func opSetUpdate(env *LEnv, args *LVal) *LVal {
 	if val.Type == LError {
 		return val
 	}
+	env.Loc = key.Source
 	return env.Update(key, val)
 }
 

--- a/lisp/op.go
+++ b/lisp/op.go
@@ -133,7 +133,7 @@ func DefaultSpecialOps() []LBuiltinDef {
 	}
 	offset := len(langSpecialOps)
 	for i := range userSpecialOps {
-		ops[offset+i] = langSpecialOps[i]
+		ops[offset+i] = userSpecialOps[i]
 	}
 	return ops
 }

--- a/lisp/op_test.go
+++ b/lisp/op_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestSpecialOp(t *testing.T) {
 	debugstack := `Stack Trace [4 frames -- entrypoint last]:
-  height 3: test:4: lisp:debug-stack
-  height 2: test:4: lisp:progn
-  height 1: test:2: lisp:let
-  height 0: test:1: lisp:let [terminal]
+  height 3: test:4:20: lisp:debug-stack
+  height 2: test:4:13: lisp:progn
+  height 1: test:2:5: lisp:let
+  height 0: test:1:1: lisp:let [terminal]
 `
 	tests := elpstest.TestSuite{
 		{"if", elpstest.TestSequence{
@@ -44,8 +44,8 @@ func TestSpecialOp(t *testing.T) {
 			{`x`, `2`, ``},
 			{`(let ([x 'a]) (set! x 'b) x)`, `'b`, ``},
 			{`x`, `2`, ``},
-			{`(set! false x)`, `test:1: lisp:set!: cannot rebind constant: false`, ``},
-			{`(set! foo 3)`, `test:1: lisp:set!: symbol not bound: foo`, ``},
+			{`(set! false x)`, `test:1:7: lisp:set!: cannot rebind constant: false`, ``},
+			{`(set! foo 3)`, `test:1:7: lisp:set!: symbol not bound: foo`, ``},
 		}},
 		{"let*", elpstest.TestSequence{
 			{`(let* ())`, "()", ""},
@@ -65,7 +65,7 @@ func TestSpecialOp(t *testing.T) {
 		{"flet", elpstest.TestSequence{
 			{`(flet [])`, `()`, ``},
 			{`(flet ([f (x) x]) (f 2))`, `2`, ``},
-			{`(flet ([f (x) (f (+ x 1))]) (f 0))`, `test:1: f: unbound symbol: f`, ``},
+			{`(flet ([f (x) (f (+ x 1))]) (f 0))`, `test:1:16: f: unbound symbol: f`, ``},
 			{`(defun orig () 1)`, `()`, ``},
 			{`(flet ([orig () 2] [f () (orig)]) (f))`, `1`, ``},
 		}},
@@ -141,7 +141,7 @@ func TestSpecialOp(t *testing.T) {
 			{`(qualified-symbol x)`, `'user:x`, ``},
 			{`(qualified-symbol 'lisp:x)`, `'lisp:x`, ``},
 			{`(qualified-symbol lisp:x)`, `'lisp:x`, ``},
-			{`(qualified-symbol 3)`, `test:1: lisp:qualified-symbol: argument is not a symbol: 'int`, ``},
+			{`(qualified-symbol 3)`, `test:1:1: lisp:qualified-symbol: argument is not a symbol: 'int`, ``},
 			{`(in-package 'other)`, `()`, ``},
 			{`(qualified-symbol 'x)`, `'other:x`, ``},
 		}},

--- a/lisp/op_test.go
+++ b/lisp/op_test.go
@@ -45,7 +45,7 @@ func TestSpecialOp(t *testing.T) {
 			{`(let ([x 'a]) (set! x 'b) x)`, `'b`, ``},
 			{`x`, `2`, ``},
 			{`(set! false x)`, `test:1:7: lisp:set!: cannot rebind constant: false`, ``},
-			{`(set! foo 3)`, `test:1:7: lisp:set!: symbol not bound: foo`, ``},
+			{`(set! foo 3)`, `test:1:7: lisp:set!: symbol not bound: foo (set! only mutates existing bindings; use set to create new ones)`, ``},
 		}},
 		{"let*", elpstest.TestSequence{
 			{`(let* ())`, "()", ""},

--- a/lisp/package.go
+++ b/lisp/package.go
@@ -137,7 +137,7 @@ func (pkg *Package) Update(k, v *LVal) *LVal {
 	}
 	_, ok := pkg.Symbols[k.Str]
 	if !ok {
-		return Errorf("symbol not bound: %v", k)
+		return Errorf("symbol not bound: %v (set! only mutates existing bindings; use set to create new ones)", k)
 	}
 	pkg.put(k, v)
 	return Nil()

--- a/lisp/package.go
+++ b/lisp/package.go
@@ -31,6 +31,7 @@ func (r *PackageRegistry) DefinePackage(name string) *Package {
 // belongs to the LEnv that creates it.
 type Package struct {
 	Name      string
+	Doc       string
 	Symbols   map[string]*LVal
 	FunNames  map[string]string
 	Externals []string

--- a/lisp/package.go
+++ b/lisp/package.go
@@ -30,19 +30,21 @@ func (r *PackageRegistry) DefinePackage(name string) *Package {
 // Package is a named set of bound symbols.  A package is interpreted code and
 // belongs to the LEnv that creates it.
 type Package struct {
-	Name      string
-	Doc       string
-	Symbols   map[string]*LVal
-	FunNames  map[string]string
-	Externals []string
+	Name       string
+	Doc        string
+	Symbols    map[string]*LVal
+	SymbolDocs map[string]string
+	FunNames   map[string]string
+	Externals  []string
 }
 
 // NewPackage initializes and returns a package with the given name.
 func NewPackage(name string) *Package {
 	return &Package{
-		Name:     name,
-		Symbols:  make(map[string]*LVal),
-		FunNames: make(map[string]string),
+		Name:       name,
+		Symbols:    make(map[string]*LVal),
+		SymbolDocs: make(map[string]string),
+		FunNames:   make(map[string]string),
 	}
 }
 

--- a/lisp/scope_test.go
+++ b/lisp/scope_test.go
@@ -13,7 +13,7 @@ func TestScope(t *testing.T) {
 		{"lexical scope", elpstest.TestSequence{
 			// simple lexical scoping tests
 			{"(let ((x 1)) x)", "1", ""},
-			{"x", "test:1: unbound symbol: x", ""},
+			{"x", "test:1:1: unbound symbol: x", ""},
 			{"(set 'x 1)", "1", ""},
 			{"(let ((x 2)) x)", "2", ""},
 			{"x", "1", ""},

--- a/lisp/stack_test.go
+++ b/lisp/stack_test.go
@@ -14,52 +14,52 @@ func TestStack(t *testing.T) {
 			// One of the most trivial tail recursive functions.
 			{`(defun tr1 (x) (if (< 0 x) (tr1 (- x 1)) (debug-stack)))`, `()`, ``},
 			{`(let ([x 10]) (tr1 x))`, `()`, `Stack Trace [4 frames -- entrypoint last]:
-  height 3: test:1: lisp:debug-stack
-  height 2: test:1: lisp:if [terminal]
-  height 1: test:1: user:tr1 [terminal]
-  height 0: test:1: lisp:let [terminal]
+  height 3: test:1:42: lisp:debug-stack
+  height 2: test:1:16: lisp:if [terminal]
+  height 1: test:1:15: user:tr1 [terminal]
+  height 0: test:1:1: lisp:let [terminal]
 `},
 			// The funcall builtin is capable of triggering tail recursion optimization.
 			{`(defun tr2 (x) (if (< 0 x) (funcall tr2 (- x 1)) (debug-stack)))`, `()`, ``},
 			{`(let ([x 10]) (tr2 x))`, `()`, `Stack Trace [4 frames -- entrypoint last]:
-  height 3: test:1: lisp:debug-stack
-  height 2: test:1: lisp:if [terminal]
-  height 1: test:1: user:tr2 [terminal]
-  height 0: test:1: lisp:let [terminal]
+  height 3: test:1:50: lisp:debug-stack
+  height 2: test:1:16: lisp:if [terminal]
+  height 1: test:1:15: user:tr2 [terminal]
+  height 0: test:1:1: lisp:let [terminal]
 `},
 			// Even if there is a let that binds lexical variables before the
 			// tail-recursive call tail recursion can succeed because argument
 			// values are evaluated before the stack is collapsed.
 			{`(defun tr3 (x) (if (< 0 x) (let ([y (- x 1)]) (tr3 y)) (debug-stack)))`, `()`, ``},
 			{`(let ([x 10]) (tr3 x))`, `()`, `Stack Trace [4 frames -- entrypoint last]:
-  height 3: test:1: lisp:debug-stack
-  height 2: test:1: lisp:if [terminal]
-  height 1: test:1: user:tr3 [terminal]
-  height 0: test:1: lisp:let [terminal]
+  height 3: test:1:56: lisp:debug-stack
+  height 2: test:1:16: lisp:if [terminal]
+  height 1: test:1:15: user:tr3 [terminal]
+  height 0: test:1:1: lisp:let [terminal]
 `},
 			// No tail recursion optimization in this final test.  The
 			// non-terminal (TROBlock) handler-bind frame prevents tail
 			// recursion
 			{`(defun tr4 (x) (if (< 0 x) (handler-bind ([condition (lambda (&rest x))])  (tr4 (- x 1))) (debug-stack)))`, `()`, ``},
 			{`(let ([x 1]) (tr4 x))`, `()`, `Stack Trace [7 frames -- entrypoint last]:
-  height 6: test:1: lisp:debug-stack
-  height 5: test:1: lisp:if [terminal]
-  height 4: test:1: user:tr4 [terminal]
-  height 3: test:1: lisp:handler-bind [tro-blocked]
-  height 2: test:1: lisp:if [terminal]
-  height 1: test:1: user:tr4 [terminal]
-  height 0: test:1: lisp:let [terminal]
+  height 6: test:1:91: lisp:debug-stack
+  height 5: test:1:16: lisp:if [terminal]
+  height 4: test:1:76: user:tr4 [terminal]
+  height 3: test:1:28: lisp:handler-bind [tro-blocked]
+  height 2: test:1:16: lisp:if [terminal]
+  height 1: test:1:14: user:tr4 [terminal]
+  height 0: test:1:1: lisp:let [terminal]
 `},
 		}},
 		{"effective stack height", elpstest.TestSequence{
 			{`(defun recursive () (+ 1 (recursive)))`, `()`, ``},
 			{`(defun tail-recursive (n) (if (> n 0) (tail-recursive (- n 1)) ()))`, `()`, ``},
-			{`(recursive)`, `test:1: recursive: physical stack height exceeded maximum: 25001`, ``},
+			{`(recursive)`, `test:1:26: recursive: physical stack height exceeded maximum: 25001`, ``},
 			// NOTE:  It's a little hard to control the function reported in
 			// the following error message.  It may change if there is a change
 			// in the function definition or to the maximum logical stack
 			// height.
-			{`(tail-recursive 100000)`, `test:1: lisp:if: logical stack height exceeded maximum: 50001`, ``},
+			{`(tail-recursive 100000)`, `test:1:31: lisp:if: logical stack height exceeded maximum: 50001`, ``},
 		}},
 	}
 	elpstest.RunTestSuite(t, tests)

--- a/lisp/taggedval_test.go
+++ b/lisp/taggedval_test.go
@@ -56,11 +56,11 @@ func TestTaggedVals(t *testing.T) {
 			{`(tagged-value? o)`, `true`, ``},
 			{`(user-data o)`, `"hello"`, ``},
 			{`(tagged-value? "hello")`, `false`, ``},
-			{`(user-data "hello")`, `test:1: lisp:user-data: argument is not a tagged value: 'string`, ``},
+			{`(user-data "hello")`, `test:1:1: lisp:user-data: argument is not a tagged value: 'string`, ``},
 		}},
 		{"constructor", elpstest.TestSequence{
 			{`(set 'even (new lisp:typedef 'user:even (lambda (x) (if (int? x) (* x 2) (error 'type-error (format-string "argument is not an int: {}" (type x)))))))`, `#{lisp:typedef '('user:even (lambda (x) (if (int? x) (* x 2) (error 'type-error (format-string "argument is not an int: {}" (type x))))))}`, ``},
-			{`(new even "hello")`, `test:1: type-error: argument is not an int: 'string`, ``},
+			{`(new even "hello")`, `test:1:74: type-error: argument is not an int: 'string`, ``},
 			{`(new even 1)`, `#{user:even 2}`, ``},
 		}},
 		{"deftype", elpstest.TestSequence{

--- a/lisp/x/profiler/callgrind.go
+++ b/lisp/x/profiler/callgrind.go
@@ -3,6 +3,7 @@ package profiler
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"sync"
@@ -12,6 +13,27 @@ import (
 	"github.com/luthersystems/elps/parser/token"
 )
 
+// errWriter wraps an io.Writer and captures the first write error,
+// short-circuiting subsequent writes after a failure.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (ew *errWriter) printf(format string, args ...interface{}) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = fmt.Fprintf(ew.w, format, args...)
+}
+
+func (ew *errWriter) print(s string) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = fmt.Fprint(ew.w, s)
+}
+
 // A profiler implementation that builds Callgrind files.
 // Heavily influenced by how XDebug works for PHP. Not because
 // I like PHP but because XDebug is very light
@@ -20,6 +42,7 @@ type callgrindProfiler struct {
 	profiler
 	sync.Mutex
 	writer     *os.File
+	writeErr   error
 	startTime  time.Time
 	refs       map[string]int
 	refCounter int
@@ -56,9 +79,14 @@ func (p *callgrindProfiler) Enable() error {
 	if p.writer == nil {
 		return errors.New("no output set in profiler")
 	}
-	fmt.Fprintf(p.writer, "version: 1\ncreator: elps %s (Go %s)\n", lisp.ElpsVersion, runtime.Version()) //nolint:errcheck // profiler output
-	fmt.Fprintf(p.writer, "cmd: Eval\npart: 1\npositions: line\n\n")                                    //nolint:errcheck // profiler output
-	fmt.Fprintf(p.writer, "events: Time_(ns) Memory_(bytes)\n\n")                                       //nolint:errcheck // profiler output
+	w := &errWriter{w: p.writer}
+	w.printf("version: 1\ncreator: elps %s (Go %s)\n", lisp.ElpsVersion, runtime.Version())
+	w.printf("cmd: Eval\npart: 1\npositions: line\n\n")
+	w.printf("events: Time_(ns) Memory_(bytes)\n\n")
+	if w.err != nil {
+		p.Unlock()
+		return w.err
+	}
 	p.callRefs = make(map[int32]*callRef)
 	p.startTime = time.Now()
 	p.refs = make(map[string]int)
@@ -92,27 +120,31 @@ func (p *callgrindProfiler) Complete() error {
 	ref := p.getCallRefAndDecrement()
 	p.Lock()
 	defer p.Unlock()
+	if p.writeErr != nil {
+		return p.writeErr
+	}
 	// Generate entrypoint
 	ref.duration = time.Since(ref.start)
-	fmt.Fprintf(p.writer, "fl=%s\n", p.getRef(ref.file))   //nolint:errcheck // profiler output
-	fmt.Fprintf(p.writer, "fn=%s\n", p.getRef(ref.name))  //nolint:errcheck // profiler output
-	fmt.Fprintf(p.writer, "%d %d %d\n", 0, ref.duration, 0) //nolint:errcheck // profiler output
+	w := &errWriter{w: p.writer}
+	w.printf("fl=%s\n", p.getRef(ref.file))
+	w.printf("fn=%s\n", p.getRef(ref.name))
+	w.printf("%d %d %d\n", 0, ref.duration, 0)
 	// Output the things we called
 	for _, entry := range ref.children {
-		fmt.Fprintf(p.writer, "cfl=%s\n", p.getRef(entry.file))  //nolint:errcheck // profiler output
-		fmt.Fprintf(p.writer, "cfn=%s\n", p.getRef(entry.name))  //nolint:errcheck // profiler output
-		fmt.Fprint(p.writer, "calls=1 0 0\n")                    //nolint:errcheck // profiler output
-		fmt.Fprintf(p.writer, "%d %d %d\n", entry.line, entry.duration, 0) //nolint:errcheck // profiler output
+		w.printf("cfl=%s\n", p.getRef(entry.file))
+		w.printf("cfn=%s\n", p.getRef(entry.name))
+		w.print("calls=1 0 0\n")
+		w.printf("%d %d %d\n", entry.line, entry.duration, 0)
 	}
-	fmt.Fprint(p.writer, "\n") //nolint:errcheck // profiler output
+	w.print("\n")
 	duration := time.Since(p.startTime)
 	ms := &runtime.MemStats{}
 	runtime.ReadMemStats(ms)
-	fmt.Fprintf(p.writer, "summary %d %d\n\n", duration.Nanoseconds(), ms.TotalAlloc) //nolint:errcheck // profiler output
-	if err := p.writer.Close(); err != nil {
-		return err
+	w.printf("summary %d %d\n\n", duration.Nanoseconds(), ms.TotalAlloc)
+	if w.err != nil {
+		return w.err
 	}
-	return nil
+	return p.writer.Close()
 }
 
 func (p *callgrindProfiler) getRef(name string) string {
@@ -179,13 +211,17 @@ func (p *callgrindProfiler) end(fun *lisp.LVal) {
 	}
 	p.Lock()
 	defer p.Unlock()
+	if p.writeErr != nil {
+		return
+	}
 	fName, _ := p.prettyFunName(fun)
 	loc := getSourceLoc(fun)
+	w := &errWriter{w: p.writer}
 	// Write what function we've been observing and where to find it
 	if loc != nil {
-		fmt.Fprintf(p.writer, "fl=%s\n", p.getRef(loc.File)) //nolint:errcheck // profiler output
+		w.printf("fl=%s\n", p.getRef(loc.File))
 	}
-	fmt.Fprintf(p.writer, "fn=%s\n", p.getRef(fName)) //nolint:errcheck // profiler output
+	w.printf("fn=%s\n", p.getRef(fName))
 	ref := p.getCallRefAndDecrement()
 	ref.duration = time.Since(ref.start)
 	if ref.duration == 0 {
@@ -206,14 +242,17 @@ func (p *callgrindProfiler) end(fun *lisp.LVal) {
 	if loc != nil {
 		line = loc.Line
 	}
-	fmt.Fprintf(p.writer, "%d %d %d\n", line, ref.duration, memory) //nolint:errcheck // profiler output
+	w.printf("%d %d %d\n", line, ref.duration, memory)
 	// Output the things we called
 	for _, entry := range ref.children {
-		fmt.Fprintf(p.writer, "cfl=%s\n", p.getRef(entry.file))  //nolint:errcheck // profiler output
-		fmt.Fprintf(p.writer, "cfn=%s\n", p.getRef(entry.name))  //nolint:errcheck // profiler output
-		fmt.Fprint(p.writer, "calls=1 0 0\n")                    //nolint:errcheck // profiler output
-		fmt.Fprintf(p.writer, "%d %d %d\n", entry.line, entry.duration, memory) //nolint:errcheck // profiler output
+		w.printf("cfl=%s\n", p.getRef(entry.file))
+		w.printf("cfn=%s\n", p.getRef(entry.name))
+		w.print("calls=1 0 0\n")
+		w.printf("%d %d %d\n", entry.line, entry.duration, memory)
 	}
 	// and end the entry
-	fmt.Fprint(p.writer, "\n") //nolint:errcheck // profiler output
+	w.print("\n")
+	if w.err != nil {
+		p.writeErr = w.err
+	}
 }

--- a/parser/regexparser/parser.go
+++ b/parser/regexparser/parser.go
@@ -171,7 +171,7 @@ func newParsecParser() parsec.Parser {
 type nodeType uint
 
 func (t nodeType) String() string {
-	if int(t) >= len(nodeTypeStrings) { //nolint:gosec // bounded by iota constants
+	if t >= nodeType(len(nodeTypeStrings)) {
 		return "INVALID"
 	}
 	return nodeTypeStrings[t]

--- a/parser/token/scanner.go
+++ b/parser/token/scanner.go
@@ -328,6 +328,7 @@ func (s *Scanner) LocStart() *Location {
 		Path: s.path,
 		Line: s.startLine,
 		Pos:  startPos,
+		Col:  startPos - s.startLinePos + 1,
 	}
 }
 
@@ -339,6 +340,7 @@ func (s *Scanner) Loc() *Location {
 		Path: s.path,
 		Line: s.line,
 		Pos:  s.totalPos,
+		Col:  s.totalPos - s.linePos + 1,
 	}
 }
 

--- a/parser/token/scanner_test.go
+++ b/parser/token/scanner_test.go
@@ -157,10 +157,10 @@ func TestScannerLoc(t *testing.T) {
 	assert.Equal(t, 10, tokens[1].Source.Pos)
 	assert.Equal(t, 20, tokens[2].Source.Pos)
 	assert.Equal(t, 25, tokens[3].Source.Pos)
-	assert.Equal(t, "test:1", tokens[0].Source.String())
-	assert.Equal(t, "test:2", tokens[1].Source.String())
-	assert.Equal(t, "test:3", tokens[2].Source.String())
-	assert.Equal(t, "test:3", tokens[3].Source.String())
+	assert.Equal(t, "test:1:1", tokens[0].Source.String())
+	assert.Equal(t, "test:2:1", tokens[1].Source.String())
+	assert.Equal(t, "test:3:1", tokens[2].Source.String())
+	assert.Equal(t, "test:3:6", tokens[3].Source.String())
 }
 
 type byteFiller byte


### PR DESCRIPTION
## Summary

Closes #43, closes #68, closes #70.

This PR makes ELPS self-documenting and AI-agent-friendly. The goal is that a human or AI can use `(help ...)`, `elps doc`, and `elps --help` to learn how to write ELPS automatically, with progressive disclosure of guidance at every level.

### Parser & Error Improvements (#68)
- **Column numbers** in all error locations (`file:line:col` format)
- **Bracket mismatch detection** with both opening and closing locations reported
- **Rust-style diagnostic rendering** (`diagnostic/` package): `^^^` underlines, ANSI colors (auto/always/never + `NO_COLOR`), stack trace notes. Zero `lisp/` dependencies.
- **Improved `set!` error message** with guidance on `set` vs `set!` semantics
- **Fixed copy-paste error messages** in type conversion and compose builtins
- **Fixed `DefaultBuiltins`/`DefaultSpecialOps`** overwriting user-registered functions with lang copies

### Macro Expansion Source Locations (#43)
- `stampMacroExpansion()` replaces synthetic source locations in macro-expanded nodes with the call-site location. Errors from builtin macros like `defun` now show `file:line` instead of `<native code>`.

### Nolint/Nosec Cleanup (#70)
- **Reduced nolint annotations** via `errWriter` pattern for profiler, fixed G115 integer casts
- **Test improvements** from QA review

### Documentation System
- **Comprehensive doc strings** for all 140+ builtins, operators, macros, and stdlib functions
- **Package-level doc strings** for all standard library packages
- **Multi-string doc strings** — functions can use multiple string arguments for readable Go source
- **Paragraph breaks** via empty strings in doc string lists
- **Symbol/constant documentation** and `defconst` macro
- **Dynamic package listing** — `elps doc -l` and `(help-packages)` iterate `Registry.Packages` at runtime (extensible for embedders)

### Linter Enhancements
- **9 analyzers** (up from 7): added `quote-call` and `cond-missing-else`
- **`quote-call`**: warns on `(set x 42)` where first arg should be quoted `(set 'x 42)`
- **`cond-missing-else`**: warns when cond has no default clause
- **`:else`/`:true` keyword support** — cond analyzers recognize ELPS keyword syntax for default clauses
- **Notes/hints on all diagnostics** — every warning includes actionable guidance (e.g., "set creates a new binding; set! mutates an existing one")
- **Nolint suppression hint** on every diagnostic — `= note: to suppress: add "; nolint:check-name" as a comment on this line`
- **`elps lint` suggestion** on runtime errors — `= note: try: elps lint file.lisp`

### CLI Improvements
- **Rich `--help` text** for all commands (run, doc, repl, fmt, lint) with examples, exit codes, and language overview
- **`elps doc -l`** / `--list-packages` flag lists all loaded packages with descriptions and export counts
- **`--color` persistent flag** (auto/always/never) for diagnostic output
- **Repository links** in `elps --help` output

## Example Diagnostic Output

```
warning: cond has no default (else) clause (cond-missing-else)
  --> example.lisp:5:3
   |
 5 |    (cond
   |    ^
   |
   = note: add (else ...) or (true ...) as the last clause to handle unmatched cases
   = note: to suppress: add "; nolint:cond-missing-else" as a comment on this line
```

## Example Package Listing

```
$ elps doc -l
  base64        Base64 encoding and decoding (2 exports)
  help          Interactive documentation (4 exports)
  json          JSON serialization and deserialization (9 exports)
  lisp          The core ELPS language package (134 exports)
  math          Mathematical functions (23 exports)
  string        String manipulation (9 exports)
  testing       Test framework (11 exports)
  ...
```

## Test Plan
- [x] `make test` — all Go tests + lisp example files pass
- [x] `make static-checks` — zero golangci-lint issues
- [x] `./elps lint ./...` — clean on all repo files
- [x] `./elps fmt -l ./...` — formatting check passes
- [x] `go test ./diagnostic/...` — renderer tests
- [x] `go test ./lint/...` — 30+ lint analyzer tests including keyword `:else`/`:true`
- [x] Manual: diagnostic rendering, color modes, `NO_COLOR`, pipe detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>