### PR TITLE
Add Claude Code slash commands for common ELPS workflows

### DIFF
--- a/.claude/commands/add-builtin.md
+++ b/.claude/commands/add-builtin.md
@@ -1,0 +1,87 @@
+# Add a New Builtin Function
+
+Add a new builtin function to the ELPS interpreter. This is a specialized workflow for the most common type of change in this repo.
+
+## Arguments
+
+Describe the builtin to add (e.g., "string-reverse that reverses a string", "list-flatten that flattens nested lists").
+
+## Steps
+
+### 1. Read Existing Patterns
+
+Read `lisp/builtins.go` to understand the naming conventions and argument handling patterns used by existing builtins.
+
+### 2. Implement the Builtin
+
+Add to `lisp/builtins.go`:
+
+```go
+func builtinMyFunc(env *LEnv, args *LVal) *LVal {
+    // args.Cells contains the arguments after arity checking
+    arg1 := args.Cells[0]
+    // Implementation here
+    return result
+}
+```
+
+### 3. Register with Docstring
+
+Add to `DefaultBuiltins()` in `lisp/builtins.go`:
+
+```go
+{
+    "my-func",
+    Formals("arg1", FmtString("&optional"), "arg2"),
+    builtinMyFunc,
+    `Short description of what my-func does.
+
+Returns the result of the operation.`,
+},
+```
+
+Available format types for `Formals()`:
+- Required: `"arg1"` (untyped), `FmtString("arg1")` (typed)
+- Optional: `FmtString("&optional"), "opt-arg"`
+- Variadic: `FmtString("&rest"), "rest-args"`
+- Keyword: `FmtString("&key"), "key-arg"`
+
+### 4. Write Tests
+
+Add test cases in `lisp/lisp_test.go` using the `TestSuite`/`TestSequence` pattern:
+
+```go
+{
+    Expr:   `(my-func "hello")`,
+    Result: `"olleh"`,
+},
+{
+    Expr:   `(my-func "")`,
+    Result: `""`,
+},
+{
+    Expr:  `(my-func)`,
+    Error: true, // arity check fails
+},
+```
+
+### 5. Update Language Reference
+
+Add documentation to `docs/lang.md` under the appropriate section. This file is embedded in the binary and served via `elps doc --guide`.
+
+### 6. Verify
+
+```bash
+go build -o elps .
+go test -v -run TestMyFunc ./lisp/...   # targeted test
+make test                                # full suite
+./elps doc -m                            # docstring check
+./elps doc my-func                       # verify docs render
+```
+
+## Key Rules
+
+- Docstrings are **mandatory** -- CI will fail without them
+- Error handling uses `env.Errorf(...)` returning `*LVal`, NOT Go `error`
+- Always check return values: `if v.Type == LError { return v }`
+- Use `Formals()` for argument declaration -- never parse args manually

--- a/.claude/commands/add-linter-check.md
+++ b/.claude/commands/add-linter-check.md
@@ -1,0 +1,105 @@
+# Add a New Lint Analyzer
+
+Add a new static analysis check to the ELPS linter. This is a prescriptive 3-file-touch workflow.
+
+## Arguments
+
+Describe the lint check to add (e.g., "detect unused imports", "flag nested if without else").
+
+## Steps
+
+### 1. Design the Check
+
+Before writing code, determine:
+- Check name (kebab-case, e.g., `unused-import`)
+- What pattern does it detect?
+- Simple per-expression check (`WalkSExprs`) or context-sensitive (custom walker)?
+- Diagnostic message (concise, actionable)
+- False positive risks and mitigations
+
+### 2. File 1: `lint/analyzers.go` -- Define the Analyzer
+
+```go
+var AnalyzerMyCheck = &Analyzer{
+    Name: "my-check",
+    Doc:  "Check that ... (one-line description)",
+    Run: func(pass *Pass) error {
+        WalkSExprs(pass.Exprs, func(sexpr *lisp.LVal, depth int) {
+            head := HeadSymbol(sexpr)
+            if head != "target-form" {
+                return
+            }
+            // Check logic
+            if /* violation detected */ {
+                src := SourceOf(sexpr)
+                pass.Report(Diagnostic{
+                    Message: "descriptive error message",
+                    Pos:     posFromSource(src.Source),
+                    Notes:   []string{"; nolint:my-check"},
+                })
+            }
+        })
+        return nil
+    },
+}
+```
+
+Available helpers: `WalkSExprs`, `Walk`, `HeadSymbol`, `ArgCount`, `SourceOf`, `posFromSource`, `pass.Report`, `pass.Reportf`
+
+For context-sensitive checks, use a custom recursive walker with depth/state tracking (see `walkRethrowContext` for an example).
+
+### 3. File 2: `lint/lint.go` -- Register in `DefaultAnalyzers()`
+
+Add to the return slice:
+```go
+func DefaultAnalyzers() []*Analyzer {
+    return []*Analyzer{
+        // ... existing analyzers ...
+        AnalyzerMyCheck,
+    }
+}
+```
+
+### 4. File 3: `lint/lint_test.go` -- Write Tests
+
+At minimum three categories:
+
+```go
+// Positive: should trigger diagnostic
+func TestMyCheck_Positive(t *testing.T) {
+    diags := lintCheck(t, AnalyzerMyCheck, `(bad-pattern arg)`)
+    assert.Len(t, diags, 1)
+    assertHasDiag(t, diags, "descriptive error")
+    assertDiagOnLine(t, diags, 1, "descriptive error")
+}
+
+// Negative: should NOT trigger
+func TestMyCheck_Negative(t *testing.T) {
+    diags := lintCheck(t, AnalyzerMyCheck, `(good-pattern arg1 arg2)`)
+    assertNoDiags(t, diags)
+}
+
+// Nolint suppression
+func TestMyCheck_Nolint(t *testing.T) {
+    diags := lintCheck(t, AnalyzerMyCheck,
+        `(bad-pattern arg) ; nolint:my-check`)
+    assertNoDiags(t, diags)
+}
+```
+
+Update `TestDefaultAnalyzers` -- increment the expected analyzer count.
+
+### 5. Verify
+
+```bash
+go test -v ./lint/...          # linter tests pass
+make test                      # full test suite
+./elps lint ./...              # no false positives on codebase
+```
+
+## False Positive Mitigations
+
+- User-defined functions shadowing builtins: pre-scan for `defun`/`defmacro`
+- Macro template bodies: forms inside quasiquote templates aren't real calls
+- Formals lists: parameter lists look like function calls but aren't
+- Threading macros: children get an extra arg at expansion time

--- a/.claude/commands/add-stdlib-package.md
+++ b/.claude/commands/add-stdlib-package.md
@@ -1,0 +1,123 @@
+# Add a New Standard Library Package
+
+Create a new stdlib package for the ELPS interpreter following the established pattern.
+
+## Arguments
+
+Describe the package to add (e.g., "file I/O package", "crypto hashing package").
+
+## Steps
+
+### 1. Plan the Package
+
+Define:
+- Package name (lowercase, e.g., `"file"`, `"crypto"`)
+- Functions to export with signatures
+- Any global constants
+- Package-level documentation
+
+### 2. Create Package Directory
+
+Create `lisp/lisplib/lib<name>/lib<name>.go`:
+
+```go
+package lib<name>
+
+import (
+    "github.com/luthersystems/elps/lisp"
+    "github.com/luthersystems/elps/lisp/lisplib/libutil"
+)
+
+const DefaultPackageName = "<name>"
+
+func LoadPackage(env *lisp.LEnv) *lisp.LVal {
+    name := lisp.Symbol(DefaultPackageName)
+    e := env.DefinePackage(name)
+    if !e.IsNil() { return e }
+    e = env.InPackage(name)
+    if !e.IsNil() { return e }
+
+    env.SetPackageDoc(`Short description of the package.
+
+Detailed description of what the package provides.`)
+
+    for _, fn := range builtins {
+        env.AddBuiltins(true, fn)
+    }
+    return lisp.Nil()
+}
+
+var builtins = []*libutil.Builtin{
+    libutil.FunctionDoc("my-func",
+        lisp.Formals("arg1", "arg2"),
+        builtinMyFunc,
+        `Description of what my-func does.`),
+}
+
+func builtinMyFunc(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+    arg1 := args.Cells[0]
+    _ = arg1
+    return lisp.Nil()
+}
+```
+
+### Key Rules
+
+- Always use `libutil.FunctionDoc()` -- never `libutil.Function()`. CI enforces docstrings.
+- Error propagation: `env.Errorf(...)` returns `*LVal`, never Go `error`
+- Export all public symbols: `env.Runtime.Package.Exports("func1", "func2")`
+
+### 3. Register in `LoadLibrary()`
+
+Edit `lisp/lisplib/lisplib.go`:
+
+1. Add import: `"github.com/luthersystems/elps/lisp/lisplib/lib<name>"`
+2. Add to loader list:
+```go
+e = lib<name>.LoadPackage(env)
+if !e.IsNil() { return e }
+```
+
+### 4. Write Tests
+
+Create `lisp/lisplib/lib<name>/lib<name>_test.go`:
+
+```go
+package lib<name>_test
+
+import (
+    "testing"
+    "github.com/luthersystems/elps/elpstest"
+)
+
+func TestLib<Name>(t *testing.T) {
+    runner := &elpstest.Runner{}
+    runner.RunTestFile(t, "testdata/<name>_test.lisp")
+}
+```
+
+Create `lisp/lisplib/lib<name>/testdata/<name>_test.lisp`:
+
+```lisp
+(use-package 'testing)
+(use-package '<name>)
+
+(test "my-func basic usage"
+  (assert-equal (my-func "arg1" "arg2") expected-result))
+
+(test "my-func error handling"
+  (assert-error (my-func)))
+```
+
+### 5. Verify
+
+```bash
+go test -v ./lisp/lisplib/lib<name>/...   # package tests
+make test                                  # full suite
+./elps doc -m                              # docstring check
+./elps doc <name>                          # docs render correctly
+```
+
+### 6. Update Language Reference
+
+Add the package to `docs/lang.md` if it's user-facing.

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,63 @@
+# Codebase Audit
+
+Perform a systematic, multi-category audit of the ELPS codebase. Modeled on the approach used in PR #74.
+
+## Arguments
+
+Optional: focus area (e.g., `security`, `bugs`, `performance`, `tests`, `docs`, `quality`, or a package path like `lisp/`).
+
+## Steps
+
+### 1. Create Branch
+
+```bash
+git fetch origin main
+git checkout -b audit/<focus-or-date> origin/main
+```
+
+### 2. Scan Each Category
+
+Work through categories systematically. For each finding: understand it, fix it, write a test if applicable, commit as a logical unit.
+
+#### Category 1: Bugs
+Scan for: dead code, copy-paste errors, off-by-one errors, nil dereference paths, race conditions, silently ignored error `*LVal` returns.
+Where: `lisp/`, `parser/`, `formatter/`, `lint/`
+
+#### Category 2: Security
+Scan for: input validation gaps, path traversal/symlink following, permission checks, integer overflow, unsafe type assertions.
+Run: `golangci-lint run --enable gosec ./...`
+Where: `lisp/lisplib/`, `cmd/`, `repl/`
+
+#### Category 3: Performance
+Scan for: unnecessary allocations in hot paths, copies vs pointers, unsized maps, repeated computation, string concatenation in loops.
+Run: `/project:benchmark` for before/after comparison.
+Where: `lisp/eval.go`, `lisp/builtins.go`, `parser/rdparser/`
+
+#### Category 4: Tests
+Scan for: coverage gaps, missing edge cases, error path coverage, test isolation issues, flaky tests.
+Run: `go test -cover ./...`
+Where: All `_test.go` files
+
+#### Category 5: Documentation
+Scan for: missing docstrings (`./elps doc -m`), stale `docs/lang.md`, incorrect help text, missing examples.
+Where: `docs/lang.md`, builtin/op/macro definitions, `CLAUDE.md`
+
+#### Category 6: Code Quality
+Scan for: golangci-lint findings, inconsistent patterns, dead imports, TODO/FIXME/HACK comments, naming inconsistencies.
+Where: Entire codebase
+
+### 3. Commit Logically
+
+Group fixes by category:
+- `fix: resolve nil dereference in handler-bind error path`
+- `security: validate file paths before opening`
+- `perf: pre-size maps in parser initialization`
+- `test: add coverage for edge cases in builtin arithmetic`
+
+### 4. Verify
+
+Run `/project:verify` after all fixes.
+
+### 5. Create PR
+
+Use `/project:pr`. Structure the PR body with categorized findings and counts per category.

--- a/.claude/commands/benchmark.md
+++ b/.claude/commands/benchmark.md
@@ -1,0 +1,84 @@
+# Run Benchmarks
+
+Run before/after benchmark comparisons using `benchstat` to measure performance impact.
+
+## Arguments
+
+Optional: package path to benchmark (default: all packages). E.g., `./lisp/...`, `./parser/rdparser/...`
+
+## Steps
+
+### 1. Find Benchmarks
+
+```bash
+go test -list 'Benchmark' ./... 2>/dev/null | grep -E '^Benchmark'
+```
+
+### 2. Capture Baseline (Before Changes)
+
+Stash or switch to the base branch:
+
+```bash
+git stash   # or: git checkout main
+go test -bench=. -benchmem -count=5 -timeout=300s ./... | tee /tmp/bench-before.txt
+git stash pop   # or: git checkout <feature-branch>
+```
+
+For specific packages:
+```bash
+go test -bench=. -benchmem -count=5 ./lisp/... | tee /tmp/bench-before.txt
+```
+
+### 3. Make Changes
+
+Implement the optimization or code change.
+
+### 4. Capture After
+
+```bash
+go test -bench=. -benchmem -count=5 -timeout=300s ./... | tee /tmp/bench-after.txt
+```
+
+Use the same flags and packages as the baseline.
+
+### 5. Compare
+
+```bash
+benchstat base=/tmp/bench-before.txt pr=/tmp/bench-after.txt
+```
+
+If `benchstat` is not installed:
+```bash
+go install golang.org/x/perf/cmd/benchstat@latest
+```
+
+### 6. Report Results
+
+| Metric | Meaning |
+|--------|---------|
+| `sec/op` | Time per operation (lower is better) |
+| `B/op` | Memory per operation (lower is better) |
+| `allocs/op` | Allocations per operation (lower is better) |
+| `~` | No statistically significant change |
+| `+`/`-` | Significant change with confidence interval |
+
+Flag any benchmark that regresses by more than 5% with statistical significance.
+
+Format results as a summary table:
+
+```
+| Benchmark | Before | After | Change |
+|-----------|--------|-------|--------|
+| BenchmarkEval | 1.23 us/op | 1.15 us/op | -6.5% |
+```
+
+## CI Integration
+
+The repo has `.github/workflows/benchmark.yml` that automatically runs benchstat on PRs and posts results as a PR comment. Results are informational -- they don't gate merges.
+
+## Cleanup
+
+Remove temp files when done:
+```bash
+rm -f /tmp/bench-before.txt /tmp/bench-after.txt
+```

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,43 @@
+# Commit Changes
+
+Create a well-formed commit for the current changes in the ELPS repository.
+
+## Steps
+
+1. Run `git status` to see all modified and untracked files.
+
+2. Run `git diff` to review staged and unstaged changes.
+
+3. Run `git log --oneline -10` to see recent commit message style.
+
+4. Stage relevant files individually (avoid `git add .`):
+   ```bash
+   git add <specific-files>
+   ```
+
+5. Draft a commit message following these conventions:
+   - Use imperative mood: "Add ...", "Fix ...", "Update ..."
+   - First line under 72 characters
+   - Explain the "why" not just the "what"
+   - If fixing a bug, mention the symptom
+   - If closing an issue, include `Closes #N` or `Fixes #N` in the body
+   - Add `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` at the end
+
+6. Create the commit using a HEREDOC:
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   <commit message here>
+
+   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+
+7. Verify with `git status` and `git log --oneline -3`.
+
+## Rules
+
+- Never commit files that contain secrets (.env, credentials, API keys)
+- Never use `git add -A` or `git add .` -- always stage specific files
+- Never amend previous commits unless explicitly asked
+- Never push unless explicitly asked

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,74 @@
+# Implement a Code Change
+
+Implement any code change in the ELPS codebase: features, bug fixes, builtins, parser changes, CLI updates, etc.
+
+## Arguments
+
+Describe what to implement (e.g., "add a string-reverse builtin", "fix off-by-one in parser").
+
+## Steps
+
+### 1. Classify the Change
+
+Determine the change type to know which files to touch:
+
+| Type | Primary Files | Test Pattern |
+|------|--------------|--------------|
+| builtin | `lisp/builtins.go` | `TestSuite` + `TestSequence` in `lisp/lisp_test.go` |
+| special-op | `lisp/op.go` | `TestSuite` + `TestSequence` in `lisp/lisp_test.go` |
+| macro | `lisp/macro.go` | `TestSuite` + `TestSequence` in `lisp/lisp_test.go` |
+| linter | `lint/analyzers.go`, `lint/lint.go` | `lint/lint_test.go` (use `/project:add-linter-check`) |
+| stdlib | `lisp/lisplib/lib<name>/` | `elpstest.Runner` + `.lisp` test file (use `/project:add-stdlib-package`) |
+| cli | `cmd/<command>.go` | Manual verification or integration tests |
+| formatter | `formatter/formatter.go` | `formatter/formatter_test.go` |
+| parser | `parser/rdparser/rdparser.go` | `parser/rdparser/rdparser_test.go` |
+| diagnostic | `diagnostic/diagnostic.go` | `diagnostic/diagnostic_test.go` |
+| bug-fix | Varies -- find root cause first | Regression test reproducing the bug |
+| docs | `docs/lang.md`, `CLAUDE.md` | `./elps doc --guide` to verify rendering |
+
+### 2. Create a Branch
+
+```bash
+git fetch origin main
+git checkout -b <type>/<short-description> origin/main
+```
+
+Branch prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `perf/`, `issue-<N>/`
+
+### 3. Read Before Writing
+
+Always read the files you plan to modify before making changes. Understand existing patterns.
+
+### 4. Implement
+
+#### Go Rules
+- Function signature: `func builtinXxx(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal`
+- Argument parsing: Use `Formals("name", ...)` with format types (`FmtString`, `FmtInt`, `FmtFloat`, `FmtBool`, `FmtSymbol`, `FmtAny`, `FmtList`, `FmtFun`, `FmtSortedMap`)
+- Error propagation: Return `env.Errorf(...)` -- errors are `*LVal` with `Type == LError`, NOT Go `error`
+- After any call returning `*LVal`, check `if v.Type == lisp.LError { return v }`
+- Docstrings are mandatory -- CI runs `elps doc -m`
+- Register in `DefaultBuiltins()`, `DefaultSpecialOps()`, or `DefaultMacros()`
+
+#### Lisp Rules
+- `set` creates bindings; `set!` mutates existing bindings
+- No backtick quasiquote -- ELPS doesn't have it
+- `true`/`false` are symbols; `()` is nil/falsey
+- Keywords start with `:`, qualified symbols use `:` (e.g., `math:pi`)
+
+### 5. Write Tests
+
+For builtins/ops/macros, use `TestSuite` + `TestSequence`:
+```go
+{Expr: `(my-builtin "arg")`, Result: `"expected"`},
+{Expr: `(my-builtin)`, Error: true},
+```
+
+For bug fixes, write a regression test that fails without the fix.
+
+### 6. Verify
+
+Run `/project:verify` (all 6 CI gate steps).
+
+### 7. Update Docs
+
+If user-facing, update `docs/lang.md`. The file is embedded in the binary via `//go:embed`.

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -1,0 +1,74 @@
+# Run Linters and Fix Issues
+
+Run all linters on the ELPS codebase and fix any issues found.
+
+## Steps
+
+### 1. Go Static Analysis
+
+```bash
+golangci-lint run ./...
+```
+
+Fix any issues reported. Common categories:
+- `gosec`: security issues (G104 unchecked errors, G304 file inclusion, G306 permissions)
+- `staticcheck`: code simplification and correctness
+- `govet`: suspicious constructs
+
+### 2. ELPS Source Formatting
+
+```bash
+./elps fmt -l ./...
+```
+
+The `-l` flag lists files that would be reformatted. If any are listed:
+```bash
+./elps fmt ./...
+```
+
+This reformats all `.lisp` files in-place using ELPS indent rules (align, body, special forms).
+
+### 3. ELPS Static Analysis
+
+```bash
+./elps lint ./...
+```
+
+Current analyzers:
+| Check | Description |
+|-------|-------------|
+| `set-usage` | Flags repeated `set` on same symbol (should use `set!`) |
+| `in-package-toplevel` | Flags `in-package` inside nested forms |
+| `if-arity` | Requires exactly 3 args (condition, then, else) |
+| `let-bindings` | Validates `let`/`let*` binding list structure |
+| `defun-structure` | Validates `defun`/`defmacro` form structure |
+| `cond-structure` | Validates `cond` clause structure and `else` placement |
+| `builtin-arity` | Checks argument counts for known builtins |
+| `quote-call` | Flags unquoted `set`/`defconst` arguments |
+| `cond-missing-else` | Flags `cond` with no default clause |
+| `rethrow-context` | Flags `rethrow` used outside `handler-bind` |
+| `unnecessary-progn` | Flags redundant `progn` wrappers |
+
+Fix findings or suppress false positives with `; nolint:check-name` trailing comments.
+
+### 4. Documentation Completeness
+
+```bash
+./elps doc -m
+```
+
+If missing docstrings are reported, add them to the function/macro/op definitions. All builtins, special operators, macros, and library exports must have docstrings.
+
+## Build First
+
+If `./elps` doesn't exist or is stale, build it first:
+```bash
+go build -o elps .
+```
+
+## Fixing Patterns
+
+- **gosec G104** (unchecked error): Use `errWriter` pattern or explicitly handle the error
+- **set-usage**: Change subsequent `set` to `set!` for re-binding
+- **unnecessary-progn**: Remove the wrapping `(progn ...)` since the parent form supports multiple body expressions
+- **Missing docstring**: Add documentation string(s) to the function definition

--- a/.claude/commands/pickup-issue.md
+++ b/.claude/commands/pickup-issue.md
@@ -1,0 +1,64 @@
+# Pick Up a GitHub Issue
+
+Handle the complete lifecycle from GitHub issue to PR: read, plan, implement, verify, ship.
+
+## Arguments
+
+Issue number (e.g., `45`).
+
+## Steps
+
+### 1. Fetch Issue Details
+
+```bash
+gh issue view <N> --repo luthersystems/elps
+```
+
+Read the full issue: title, body, labels, and discussion comments.
+
+### 2. Classify and Create Branch
+
+| Issue Type | Branch Prefix | Workflow |
+|------------|--------------|----------|
+| Bug report | `fix/` | Write failing test first, then fix |
+| Feature request | `feature/` | Use `/project:implement` |
+| New lint check | `feature/` | Use `/project:add-linter-check` |
+| New stdlib package | `feature/` | Use `/project:add-stdlib-package` |
+| Performance | `perf/` | Use `/project:benchmark` + `/project:implement` |
+| Documentation | `docs/` | Update `docs/lang.md` or `CLAUDE.md` |
+
+```bash
+git fetch origin main
+git checkout -b issue-<N>/<short-description> origin/main
+```
+
+### 3. Plan
+
+Before writing code:
+1. Read all files relevant to the change
+2. Identify extension points and interfaces
+3. Consider edge cases mentioned in the issue
+4. If the issue is ambiguous, ask the user for clarification
+
+### 4. Implement
+
+Follow the appropriate skill's workflow. For bug fixes, always:
+1. Write a failing test that reproduces the bug
+2. Verify the test fails
+3. Fix the bug
+4. Verify the test passes
+
+### 5. Verify
+
+Run `/project:verify` (all 6 CI gate steps).
+
+### 6. Create PR
+
+Run `/project:pr`. Ensure the PR body includes `Closes #<N>` to auto-close the issue.
+
+## Multi-Commit Strategy
+
+For larger issues, create logical commits:
+- Each commit should be a coherent, self-contained change
+- Commit messages explain the "why"
+- The PR tells a clear story through its commit history

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,82 @@
+# Create Pull Request
+
+Ship changes by running verification, pushing, and creating a PR against `main`.
+
+## Steps
+
+### 1. Pre-flight Checks
+
+Ensure all changes are committed:
+```bash
+git status
+```
+
+If there are uncommitted changes, commit them first (use `/project:commit`).
+
+### 2. Fetch and Rebase
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+Resolve any conflicts before proceeding.
+
+### 3. Run Full Verification
+
+Run the complete CI gate (see `/project:verify` for details). All 6 steps must pass:
+
+```bash
+go build -o elps .
+make test
+golangci-lint run ./...
+./elps fmt -l ./...
+./elps lint ./...
+./elps doc -m
+```
+
+If any step fails, fix the issue and re-run from the beginning.
+
+### 4. Push
+
+```bash
+git push -u origin $(git branch --show-current)
+```
+
+### 5. Create the PR
+
+```bash
+gh pr create --title "<concise title under 70 chars>" --body "$(cat <<'EOF'
+## Summary
+- <what changed and why>
+
+## Test Plan
+- [ ] `make test` passes
+- [ ] `make static-checks` passes
+- [ ] `./elps fmt -l ./...` reports no changes
+- [ ] `./elps lint ./...` reports no diagnostics
+- [ ] `./elps doc -m` reports no missing docs
+
+Closes #<N>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 6. Report
+
+Return the PR URL to the user.
+
+## PR Title Guidelines
+
+- Keep under 70 characters
+- Use imperative mood: "Add ...", "Fix ...", "Update ..."
+- Be specific: "Add rethrow builtin for handler-bind" not "Add new feature"
+
+## Rules
+
+- Always target `main` unless explicitly told otherwise
+- Always run verification before creating the PR
+- Include `Closes #N` when the PR resolves an issue
+- Never merge PRs -- create the PR and wait for human review

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,66 @@
+# Cut a Release
+
+Create a new tagged release for the ELPS project.
+
+## Arguments
+
+Optional: version bump type (`patch`, `minor`, `major`). Defaults to `patch`.
+
+## Steps
+
+### 1. Determine Version
+
+Check the latest tag:
+```bash
+gh api repos/luthersystems/elps/tags --jq '.[0].name'
+```
+
+The project uses semantic versioning: `v<major>.<minor>.<patch>`
+
+Determine the new version based on the bump type:
+- **patch** (default): bug fixes, small improvements (e.g., v1.16.14 -> v1.16.15)
+- **minor**: new features, new builtins, new CLI commands (e.g., v1.16.14 -> v1.17.0)
+- **major**: breaking changes to the API or language semantics (e.g., v1.16.14 -> v2.0.0)
+
+### 2. Ensure Main is Clean
+
+```bash
+git fetch origin main
+git checkout main
+git pull origin main
+```
+
+### 3. Run Full Verification
+
+Run `/project:verify` to ensure main is in a releasable state.
+
+### 4. Create the Tag
+
+```bash
+git tag v<new-version>
+git push origin v<new-version>
+```
+
+### 5. Create GitHub Release
+
+```bash
+gh release create v<new-version> --generate-notes --title "v<new-version>"
+```
+
+The `--generate-notes` flag auto-generates a changelog from merged PRs since the last release.
+
+### 6. Verify
+
+```bash
+gh release view v<new-version> --repo luthersystems/elps
+```
+
+Confirm the release was created with the correct tag and changelog.
+
+## Rules
+
+- Never create a release from a feature branch -- always from `main`
+- Always run verification before tagging
+- Use `--generate-notes` for consistent changelog format
+- The tag name must match `v<semver>` format (e.g., `v1.16.15`)
+- Ask the user to confirm the version number before creating the tag

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,62 @@
+# Review a Pull Request
+
+Perform a thorough code review of a pull request.
+
+## Arguments
+
+PR number (e.g., `76`).
+
+## Steps
+
+### 1. Fetch PR Details
+
+```bash
+gh pr view <N> --repo luthersystems/elps
+gh pr diff <N> --repo luthersystems/elps
+```
+
+### 2. Understand the Change
+
+Read the PR title, description, and linked issues. Understand the intent before reviewing code.
+
+### 3. Review the Diff
+
+Check each changed file for:
+
+#### Correctness
+- Does the logic match the stated intent?
+- Are edge cases handled (nil, empty, max values, error paths)?
+- For builtins: is error propagation correct (`v.Type == LError` checks)?
+- For linter checks: are there false positive risks?
+
+#### Style and Conventions
+- Function naming: `builtinXxx` for builtins, `opXxx` for ops, `opMacroXxx` for macros
+- Docstrings present on all exported builtins/ops/macros?
+- Lisp code uses `set` for first binding, `set!` for mutation?
+- Go errors use `env.Errorf(...)` pattern, not Go `error` interface?
+
+#### Tests
+- Are there tests for the new functionality?
+- Do tests cover positive cases, negative cases, and edge cases?
+- For bug fixes: is there a regression test?
+- For linter checks: are there nolint suppression tests?
+
+#### Documentation
+- Is `docs/lang.md` updated for user-facing changes?
+- Are docstrings complete and accurate?
+
+### 4. Check CI Status
+
+```bash
+gh pr checks <N> --repo luthersystems/elps
+```
+
+### 5. Summarize
+
+Provide a structured review:
+- **Summary**: What the PR does in 1-2 sentences
+- **Findings**: List any issues found, categorized as:
+  - **Blocking**: Must fix before merge
+  - **Non-blocking**: Suggestions for improvement
+  - **Nit**: Style/formatting preferences
+- **Verdict**: Approve, request changes, or needs discussion

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,61 @@
+# Run Tests
+
+Run the ELPS test suite -- full or targeted.
+
+## Arguments
+
+- No arguments: run the full test suite
+- Package path: run tests for a specific package (e.g., `./lisp/...`, `./lint/...`)
+- Test name: run a single test by name
+
+## Full Test Suite
+
+```bash
+make test
+```
+
+This runs:
+1. `go test -cover ./...` (all Go unit tests)
+2. Example lisp file tests (via `make -C _examples test`)
+
+## Targeted Tests
+
+### By package:
+```bash
+go test -v ./lisp/...
+go test -v ./parser/rdparser/...
+go test -v ./lint/...
+go test -v ./formatter/...
+go test -v ./diagnostic/...
+go test -v ./lisp/lisplib/libmath/...
+```
+
+### By test name:
+```bash
+go test -run TestFunctionName ./lisp/...
+go test -run TestMyLinter ./lint/...
+```
+
+### With coverage:
+```bash
+go test -cover ./...
+go test -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out  # Open coverage report
+```
+
+### With verbose output:
+```bash
+go test -v -run TestSpecificTest ./lisp/...
+```
+
+## Test Patterns in This Repo
+
+### Go unit tests (`_test.go`)
+Standard Go test files using `testify/assert`. Most tests use `elpstest.TestSuite` with `TestSequence` entries defining `{Expr, Result, Error, Output}` triples.
+
+### Lisp test files (`.lisp`)
+Executed via `elpstest.Runner` which loads and runs them as Go subtests. Use `testing` stdlib: `test`, `test-let`, `assert=`, `assert-equal`, `assert-nil`, `assert-error`.
+
+## On Failure
+
+Report which test failed, the full error output, and the file/line where the failure occurred. If the user is working on a change, suggest whether the failure is expected (test needs updating) or indicates a bug.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,69 @@
+# Verify CI Readiness
+
+Run the full verification pipeline matching the CI workflow. Use this before committing or creating a PR.
+
+## Pipeline
+
+Run these 6 steps in order. Stop and report on the first failure.
+
+### Step 1: Build
+
+```bash
+go build -o elps .
+```
+
+If this fails, there are compilation errors. Fix them before proceeding.
+
+### Step 2: Test
+
+```bash
+make test
+```
+
+Runs Go tests (`go test -cover ./...`) and example lisp files. All must pass.
+
+### Step 3: Static Analysis
+
+```bash
+golangci-lint run ./...
+```
+
+Fix any lint issues (includes gosec for security checks).
+
+### Step 4: Format Check
+
+```bash
+./elps fmt -l ./...
+```
+
+Lists files that need reformatting. If any are listed, run `./elps fmt ./...` to fix them, then re-verify.
+
+### Step 5: Lint Check
+
+```bash
+./elps lint ./...
+```
+
+Fix any ELPS linter diagnostics or suppress false positives with `; nolint:check-name`.
+
+### Step 6: Documentation Check
+
+```bash
+./elps doc -m
+```
+
+All builtins, special operators, macros, and library exports must have docstrings.
+
+## On Failure
+
+1. Report which step failed and the error output
+2. Fix the issue
+3. Re-run the full pipeline from the beginning (fixes can introduce new issues)
+4. Repeat until all 6 steps pass
+
+## Quick Mode
+
+For iterative development, run just the relevant subset:
+- Changed Go code: Steps 1-3
+- Changed `.lisp` files: Steps 2, 4-5
+- Added builtins/ops/macros: Steps 1-3, 6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,9 +111,32 @@ When adding a new builtin function, special operator, or macro:
 - **`set!` only mutates** existing bindings — it errors if the symbol is not already bound.
 - The `set-usage` linter flags repeated `set` on the same symbol, not every `set`.
 
-## Skills
+## Slash Commands
 
-Prescriptive workflows live in `.claude/skills/`. **Before starting a task, read the matching skill file and follow its workflow exactly.** Match tasks to skills by description:
+Invocable workflows live in `.claude/commands/`. Use these via `/project:<command>` in Claude Code:
+
+| Command | Description |
+|---------|-------------|
+| `/project:commit` | Create a well-formed commit with proper message conventions |
+| `/project:pr` | Ship changes — verify, push, create PR targeting `main` |
+| `/project:test` | Run tests (full suite or targeted by package/name) |
+| `/project:lint` | Run all linters (golangci-lint, elps fmt, elps lint, doc check) and fix issues |
+| `/project:verify` | Full CI gate — 6-step pipeline matching GitHub Actions |
+| `/project:implement` | Code change workflow — classify, branch, implement, test, verify |
+| `/project:add-builtin` | Add a new builtin function (register, docstring, tests) |
+| `/project:add-linter-check` | New lint analyzer — prescriptive 3-file-touch workflow |
+| `/project:add-stdlib-package` | New stdlib package — create, wire, test |
+| `/project:benchmark` | Before/after benchstat performance comparison |
+| `/project:pickup-issue` | Full lifecycle — GitHub issue to branch to PR |
+| `/project:audit` | Systematic multi-category codebase audit |
+| `/project:release` | Cut a new semver-tagged release |
+| `/project:review-pr` | Thorough code review of a pull request |
+
+Commands can chain: e.g., `/project:pickup-issue` uses `/project:implement` for the code, `/project:verify` before committing, and `/project:pr` to ship.
+
+## Skills (Reference)
+
+Detailed prescriptive workflows also live in `.claude/skills/` for auto-discovery. **Before starting a task, read the matching skill file and follow its workflow exactly.** Match tasks to skills by description:
 
 | Skill File | When to Use |
 |------------|-------------|


### PR DESCRIPTION
## Summary
- Adds 14 invocable slash commands in `.claude/commands/` covering routine development workflows
- These are proper Claude Code slash commands (invoked via `/project:<name>`) complementing the existing `.claude/skills/` reference docs
- Updates CLAUDE.md with a slash commands reference table

## Commands Added

| Command | Description |
|---------|-------------|
| `/project:commit` | Create a well-formed commit with proper message conventions |
| `/project:pr` | Ship changes -- verify, push, create PR targeting `main` |
| `/project:test` | Run tests (full suite or targeted by package/name) |
| `/project:lint` | Run all linters and fix issues |
| `/project:verify` | Full CI gate -- 6-step pipeline matching GitHub Actions |
| `/project:implement` | Code change workflow -- classify, branch, implement, test, verify |
| `/project:add-builtin` | Add a new builtin function (register, docstring, tests) |
| `/project:add-linter-check` | New lint analyzer -- prescriptive 3-file-touch workflow |
| `/project:add-stdlib-package` | New stdlib package -- create, wire, test |
| `/project:benchmark` | Before/after benchstat performance comparison |
| `/project:pickup-issue` | Full lifecycle -- GitHub issue to branch to PR |
| `/project:audit` | Systematic multi-category codebase audit |
| `/project:release` | Cut a new semver-tagged release |
| `/project:review-pr` | Thorough code review of a pull request |

All commands are repo-specific: they reference actual Makefile targets, CI steps, file locations, and coding conventions from this repo. Commands can chain (e.g., `/project:pickup-issue` uses `/project:implement`, `/project:verify`, and `/project:pr` internally).

## Test Plan
- [ ] Commands are discoverable in Claude Code via `/project:` tab completion
- [ ] No existing CI checks break (no code changes, only markdown)
- [ ] Each command references correct file paths and Makefile targets

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>