### PR TITLE
Fix export-before-defun not recognized in prescan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ Functions return `*LVal`. Errors are LVal values with type `LError`. Check with 
 ## Additional Packages
 
 - **`formatter/`** — Source code formatter. Uses annotated AST with `LVal.Meta *SourceMeta`. Parser `preserveFormat` mode collects comments, brackets, newlines.
+- **`analysis/`** — Semantic analysis: scope building, symbol resolution, reference counting. `prescan()` uses a two-phase approach (definitions first, exports second) so `(export 'name)` before `(defun name ...)` works correctly.
 - **`lint/`** — Static analysis modeled after `go vet`. Each check is an `Analyzer` with a `Run func(pass *Pass) error`. Uses `Walk()`/`WalkSExprs()` for AST traversal, plus custom walkers for context-sensitive checks.
 - **`diagnostic/`** — Rust-style annotated source snippets for error and lint output. Zero dependencies on `lisp/`.
 

--- a/_examples/sicp/complex.lisp
+++ b/_examples/sicp/complex.lisp
@@ -115,28 +115,28 @@
     (:else (error 'invalid-argument "argument is not a complex number" z))))
 
 (export 'complex-add)
-(defun complex-add (z1 z2) ; nolint:unused-function
+(defun complex-add (z1 z2)
   (make-complex-from-real-imag (+ (complex-real-part z1)
                                   (complex-real-part z2))
                                (+ (complex-imag-part z1)
                                   (complex-imag-part z2))))
 
 (export 'complex-sub)
-(defun complex-sub (z1 z2) ; nolint:unused-function
+(defun complex-sub (z1 z2)
   (make-complex-from-real-imag (- (complex-real-part z1)
                                   (complex-real-part z2))
                                (- (complex-imag-part z1)
                                   (complex-imag-part z2))))
 
 (export 'complex-mul)
-(defun complex-mul (z1 z2) ; nolint:unused-function
+(defun complex-mul (z1 z2)
   (make-complex-from-mag-ang (* (complex-magnitude z1)
                                 (complex-magnitude z2))
                              (+ (complex-angle z1)
                                 (complex-angle z2))))
 
 (export 'complex-div)
-(defun complex-div (z1 z2) ; nolint:unused-function
+(defun complex-div (z1 z2)
   (make-complex-from-mag-ang (/ (complex-magnitude z1)
                                 (complex-magnitude z2))
                              (- (complex-angle z1)

--- a/_examples/sicp/stream.lisp
+++ b/_examples/sicp/stream.lisp
@@ -89,7 +89,7 @@
       (stream-for-each proc (stream-cdr s)))))
 
 (export 'stream-debug)
-(defun stream-debug (s) ; nolint:unused-function
+(defun stream-debug (s)
   (stream-for-each 'debug-print s))
 
 (export 'stream-cons)

--- a/_examples/user-defined-types/option_solved.lisp
+++ b/_examples/user-defined-types/option_solved.lisp
@@ -19,7 +19,7 @@
   (something (funcall fn (get-something v))))
 
 (export 'optional?)
-(defun optional? (v) (or (nothing? v) ; nolint:unused-function
+(defun optional? (v) (or (nothing? v)
                          (something? v)))
 
 (export 'lookup)

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -473,6 +473,14 @@ func TestAnalyze_Export(t *testing.T) {
 	assert.True(t, sym.Exported)
 }
 
+func TestAnalyze_ExportBeforeDefun(t *testing.T) {
+	// export before defun is a common ELPS convention — prescan must handle it.
+	result := parseAndAnalyze(t, "(export 'greet)\n(defun greet (name) name)")
+	sym := result.RootScope.LookupLocal("greet")
+	require.NotNil(t, sym)
+	assert.True(t, sym.Exported, "export before defun should mark greet as exported")
+}
+
 // --- Analyze: external symbols ---
 
 func TestAnalyze_ExternalSymbols(t *testing.T) {

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -478,7 +478,32 @@ func TestAnalyze_ExportBeforeDefun(t *testing.T) {
 	result := parseAndAnalyze(t, "(export 'greet)\n(defun greet (name) name)")
 	sym := result.RootScope.LookupLocal("greet")
 	require.NotNil(t, sym)
+	assert.Equal(t, SymFunction, sym.Kind, "greet should be registered as a function")
 	assert.True(t, sym.Exported, "export before defun should mark greet as exported")
+}
+
+func TestAnalyze_ExportBeforeDefun_Multiple(t *testing.T) {
+	source := "(export 'a)\n(export 'b)\n(defun a () 1)\n(defun b () 2)"
+	result := parseAndAnalyze(t, source)
+	for _, name := range []string{"a", "b"} {
+		sym := result.RootScope.LookupLocal(name)
+		require.NotNil(t, sym, "symbol %s should exist", name)
+		assert.True(t, sym.Exported, "%s should be exported", name)
+	}
+}
+
+func TestAnalyze_ExportBeforeDefmacro(t *testing.T) {
+	result := parseAndAnalyze(t, "(export 'my-macro)\n(defmacro my-macro (x) x)")
+	sym := result.RootScope.LookupLocal("my-macro")
+	require.NotNil(t, sym)
+	assert.Equal(t, SymMacro, sym.Kind)
+	assert.True(t, sym.Exported)
+}
+
+func TestAnalyze_ExportNonexistent(t *testing.T) {
+	result := parseAndAnalyze(t, "(export 'ghost)")
+	sym := result.RootScope.LookupLocal("ghost")
+	assert.Nil(t, sym, "export of undefined name should not create a symbol")
 }
 
 // --- Analyze: external symbols ---

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1657,6 +1657,14 @@ func TestUnusedFunction_Negative_Exported(t *testing.T) {
 	assertNoDiags(t, diags)
 }
 
+func TestUnusedFunction_Negative_ExportBeforeDefun(t *testing.T) {
+	// export before defun is a common ELPS convention — should not produce
+	// unused-function diagnostic.
+	source := "(export 'greet)\n(defun greet (name) name)"
+	diags := lintCheckSemantic(t, AnalyzerUnusedFunction, source)
+	assertNoDiags(t, diags)
+}
+
 func TestUnusedFunction_Negative_UnderscorePrefix(t *testing.T) {
 	source := `(defun _internal () 42)`
 	diags := lintCheckSemantic(t, AnalyzerUnusedFunction, source)


### PR DESCRIPTION
## Summary

Fixes #84.

- Split `analysis.prescan()` into two phases: Phase 1 registers all definitions (defun, defmacro, deftype, set, use-package, in-package), Phase 2 applies exports
- This ensures `(export 'name)` before `(defun name ...)` correctly marks the symbol as exported — a common ELPS convention documented in `docs/lang.md`
- Eliminates ~170 false-positive `unused-function` diagnostics in downstream projects

## Test plan

- [x] `TestAnalyze_ExportBeforeDefun` — verifies export before defun marks symbol as exported
- [x] `TestUnusedFunction_Negative_ExportBeforeDefun` — verifies no false positive lint diagnostic
- [x] Existing `TestAnalyze_Export` (export after defun) still passes
- [x] `make test` — full test suite passes
- [x] `make static-checks` — golangci-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>