### PR TITLE
Fix handler-bind condition types reported as undefined

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -340,6 +340,20 @@ func TestAnalyze_HandlerBind(t *testing.T) {
 	}
 }
 
+func TestAnalyze_HandlerBind_ConditionTypeNotUndefined(t *testing.T) {
+	// The condition type name in handler-bind bindings is a runtime matcher,
+	// not a variable reference. It should not be flagged as undefined.
+	result := parseAndAnalyze(t, `
+(defun safe-divide (a b)
+  (handler-bind
+    ((condition (lambda (c) (debug-print "caught" c) 0)))
+    (/ a b)))`)
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "condition", u.Name,
+			"condition type name in handler-bind should not be flagged as undefined")
+	}
+}
+
 // --- Analyze: test-let / test-let* ---
 
 func TestAnalyze_TestLet_BindingsResolved(t *testing.T) {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1569,6 +1569,17 @@ func TestUndefinedSymbol_Negative_TrueFalse(t *testing.T) {
 	assertNoDiags(t, diags)
 }
 
+func TestUndefinedSymbol_Negative_HandlerBindConditionType(t *testing.T) {
+	// Condition type names in handler-bind bindings are runtime matchers,
+	// not variable references.
+	source := `(defun safe-divide (a b)
+  (handler-bind
+    ((condition (lambda (c) c)))
+    (/ a b)))`
+	diags := lintCheckSemantic(t, AnalyzerUndefinedSymbol, source)
+	assertNoDiags(t, diags)
+}
+
 func TestUndefinedSymbol_Negative_NoSemantics(t *testing.T) {
 	// Without semantic analysis, should be a no-op
 	diags := lintCheck(t, AnalyzerUndefinedSymbol, `(unknown-fn 1 2)`)

--- a/lisp/lisplib/libjson/libjson_test.lisp
+++ b/lisp/lisplib/libjson/libjson_test.lisp
@@ -87,10 +87,10 @@
 
 (test "unmarshal-syntax-error"
   (assert-string= "syntax-error"
-                  (handler-bind ([json:syntax-error (lambda (c _) "syntax-error")])
+                  (handler-bind ([json:syntax-error (lambda (_c _) "syntax-error")])
                     (json:load-string "{false:true}")))
   (assert-string= "ok-json"
-                  (handler-bind ([json:syntax-error (lambda (c _) "syntax-error")])
+                  (handler-bind ([json:syntax-error (lambda (_c _) "syntax-error")])
                     (json:load-string "\"ok-json\""))))
 
 (benchmark-simple "load-object"


### PR DESCRIPTION
## Summary

Fixes #85 (handler-bind part).

- `analyzeHandlerBind` was walking all children including condition type names in binding pairs like `(condition handler-fn)`. The condition type is a runtime matcher, not a variable reference — it should be skipped.
- Split analysis to skip the first element of each binding pair and only analyze handler functions + body forms.
- The prefix lambda `%` issue from #85 could not be reproduced — the analysis correctly handles `#^(* % 2)` and the lint test passes without changes.

## Test plan

- [x] `TestAnalyze_HandlerBind_ConditionTypeNotUndefined` — verifies condition type not flagged
- [x] `TestUndefinedSymbol_Negative_HandlerBindConditionType` — lint integration test
- [x] Existing `TestAnalyze_HandlerBind` (lambda param `c` resolved) still passes
- [x] `make test` — full suite passes
- [x] `make static-checks` — golangci-lint clean
- [x] `./elps lint --workspace=. ./...` — no false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>