### PR TITLE
Add branch guard to PR skill and create lessons file

### DIFF
--- a/.claude/skills/pickup-issue/SKILL.md
+++ b/.claude/skills/pickup-issue/SKILL.md
@@ -38,7 +38,7 @@ git pull origin main
 git checkout -b issue-<N>/<short-description>
 ```
 
-Use the issue number in the branch name for traceability.
+Use the issue number in the branch name for traceability. **Never commit or push directly to main** — all work must happen on a feature branch.
 
 ### 4. Plan the Implementation
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -16,7 +16,19 @@ gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'
 
 This is typically `main`.
 
-### 2. Fetch and Rebase
+### 2. Guard: Verify Not on Main
+
+```bash
+current=$(git branch --show-current)
+if [ "$current" = "main" ] || [ "$current" = "master" ]; then
+  echo "ERROR: On $current — create a feature branch first"
+  exit 1
+fi
+```
+
+**STOP** if on main/master. Create a feature branch before proceeding. Never push directly to the default branch.
+
+### 3. Fetch and Rebase
 
 ```bash
 git fetch origin
@@ -25,17 +37,17 @@ git rebase origin/<base-branch>
 
 If there are conflicts, resolve them before proceeding.
 
-### 3. Run Full Verification
+### 4. Run Full Verification
 
 Run the complete `/verify` pipeline (all 6 steps). If any step fails, stop and fix before creating the PR.
 
-### 4. Push
+### 5. Push
 
 ```bash
 git push -u origin <current-branch>
 ```
 
-### 5. Create the PR
+### 6. Create the PR
 
 ```bash
 gh pr create --title "<concise title>" --body "$(cat <<'EOF'
@@ -57,7 +69,7 @@ EOF
 )"
 ```
 
-### 6. Report
+### 7. Report
 
 Return the PR URL so the user can review it.
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,7 @@
+# Lessons Learned
+
+Patterns and mistakes to avoid. Review at the start of each session.
+
+**[2026-02-11] Git Workflow:** Committed directly to main after switching branches mid-session. `git checkout main && git pull` followed by work left me on main without creating a feature branch. Always verify `git branch --show-current` before committing. The PR skill now includes a mandatory branch guard (Step 2).
+
+**[2026-02-11] CI Cascading Effects:** Fixing a false-positive analyzer (handler-bind condition types) surfaced new true-positive warnings in test files (`libjson_test.lisp`). When fixing an analyzer that was previously skipping nodes, check whether the fix reveals new legitimate diagnostics in the repo's own files and fix those in the same PR.


### PR DESCRIPTION
## Summary

- Add mandatory branch guard (Step 2) to `/pr` skill — verifies not on main/master before pushing
- Reinforce "never push to main" in `/pickup-issue` skill's branch creation step
- Create `tasks/lessons.md` to track workflow mistakes and patterns

## Context

During #85 fix, a commit was accidentally pushed to main after `git checkout main && git pull` left the session on main without creating a feature branch. This adds a hard guard to prevent recurrence.

## Test plan

- [x] PR skill has new Step 2 with branch guard
- [x] pickup-issue skill reinforces branch requirement
- [x] lessons.md records the mistake and pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>