### PR TITLE
Fix semantic lint false positives (#89, #91)

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -476,6 +476,42 @@ func TestAnalyze_HandlerBind_MultipleClauses(t *testing.T) {
 	}
 }
 
+func TestAnalyze_HandlerBind_BodyStillAnalyzed(t *testing.T) {
+	// Ensure that body forms inside handler-bind ARE still analyzed.
+	// An undefined symbol in the body should be flagged as unresolved.
+	result := parseAndAnalyze(t, `
+(handler-bind
+  ((condition (lambda (e) e)))
+  (undefined-body-call 1 2))`)
+	found := false
+	for _, u := range result.Unresolved {
+		if u.Name == "undefined-body-call" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"undefined symbol in handler-bind body should be flagged as unresolved")
+}
+
+func TestAnalyze_HandlerBind_HandlerBodyStillAnalyzed(t *testing.T) {
+	// Ensure handler lambda bodies ARE analyzed — undefined symbols inside
+	// handler lambdas should be flagged.
+	result := parseAndAnalyze(t, `
+(handler-bind
+  ((condition (lambda (e) (undefined-handler-call e))))
+  (+ 1 2))`)
+	found := false
+	for _, u := range result.Unresolved {
+		if u.Name == "undefined-handler-call" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"undefined symbol in handler-bind handler body should be flagged as unresolved")
+}
+
 // --- Analyze: test-let / test-let* ---
 
 func TestAnalyze_TestLet_BindingsResolved(t *testing.T) {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1593,6 +1593,19 @@ func TestUndefinedSymbol_HasNotes(t *testing.T) {
 	assert.NotEmpty(t, diags[0].Notes)
 }
 
+func TestUndefinedSymbol_Negative_HandlerBindConditionType(t *testing.T) {
+	// Condition types in handler-bind clauses are not variable references.
+	source := `(defun safe-op ()
+  (handler-bind
+    ((condition (lambda (&rest e) (debug-print "caught" e) ())))
+    (/ 1 0)))`
+	diags := lintCheckSemantic(t, AnalyzerUndefinedSymbol, source)
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, "condition",
+			"condition type in handler-bind should not be flagged")
+	}
+}
+
 // --- unused-variable ---
 
 func TestUnusedVariable_Positive_LetBinding(t *testing.T) {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1889,6 +1889,34 @@ func TestUserArity_Negative_ExternalSymbol(t *testing.T) {
 	assertNoDiags(t, diags)
 }
 
+func TestUserArity_Negative_LetStarShadow(t *testing.T) {
+	// When let* shadows a defun with a variable binding, user-arity should
+	// not check the call against the defun's signature (issue #91).
+	source := `(defun register (name) name)
+(defun call-handler ()
+  (let* ([register (lambda (a b c) (list a b c))])
+    (register 1 2 3)))`
+	diags := lintCheckSemantic(t, AnalyzerUserArity, source)
+	assertNoDiags(t, diags)
+}
+
+func TestUserArity_Negative_LetShadow(t *testing.T) {
+	// Same as above but with let (not let*).
+	source := `(defun foo (x) (+ x 1))
+(let ([foo (lambda (a b) (+ a b))])
+  (foo 1 2))`
+	diags := lintCheckSemantic(t, AnalyzerUserArity, source)
+	assertNoDiags(t, diags)
+}
+
+func TestUserArity_Negative_LambdaParamShadow(t *testing.T) {
+	// Lambda parameter shadows a defun — should skip arity check.
+	source := `(defun register (name) name)
+(lambda (register) (register 1 2 3))`
+	diags := lintCheckSemantic(t, AnalyzerUserArity, source)
+	assertNoDiags(t, diags)
+}
+
 // --- unused-nolint ---
 
 func TestUnusedNolint_Unused(t *testing.T) {

--- a/lisp/lisplib/libjson/libjson_test.lisp
+++ b/lisp/lisplib/libjson/libjson_test.lisp
@@ -87,10 +87,10 @@
 
 (test "unmarshal-syntax-error"
   (assert-string= "syntax-error"
-                  (handler-bind ([json:syntax-error (lambda (c _) "syntax-error")])
+                  (handler-bind ([json:syntax-error (lambda (_c _) "syntax-error")])
                     (json:load-string "{false:true}")))
   (assert-string= "ok-json"
-                  (handler-bind ([json:syntax-error (lambda (c _) "syntax-error")])
+                  (handler-bind ([json:syntax-error (lambda (_c _) "syntax-error")])
                     (json:load-string "\"ok-json\""))))
 
 (benchmark-simple "load-object"


### PR DESCRIPTION
## Summary
- **#89**: Fix `handler-bind` condition types flagged as `undefined-symbol` — the first element of each handler-bind clause is a condition type name (data), not a variable reference; `analyzeHandlerBind` now skips resolving condition type names
- **#91**: Fix `user-arity` false positive when `let`/`let*`/`lambda` shadows a `defun` — build a set of locally-shadowed function names and skip arity checks for those names
- **#90**: Added regression tests for labels scope resolution — confirmed not a linter bug (substrate code was using `let*` with lambdas instead of `labels` for recursive bindings)

## Test plan
- [x] All existing tests pass (`make test`)
- [x] Static checks pass (`make static-checks`)
- [x] New analysis tests: handler-bind condition types (3 tests), labels scope (6 tests)
- [x] New lint tests: handler-bind undefined-symbol (1), labels undefined-symbol (3), user-arity shadow (3)
- [x] Substrate confirms #90 resolved by their code fix, not a linter bug

---
*Local tests passed. Security review completed (lint/analysis only — no security-sensitive changes). QA professor review pending.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)