### PR TITLE
Add LintCommand/DocCommand factories for embedder CLI reuse

### DIFF
--- a/cmd/doc_test.go
+++ b/cmd/doc_test.go
@@ -1,0 +1,77 @@
+// Copyright © 2024 The ELPS authors
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDocCommand_DefaultFlags(t *testing.T) {
+	cmd := DocCommand()
+	assert.Equal(t, "doc [flags] QUERY", cmd.Use)
+
+	for _, name := range []string{"package", "source-file", "list-packages", "missing", "guide"} {
+		assert.NotNil(t, cmd.Flags().Lookup(name), "missing flag: %s", name)
+	}
+}
+
+func TestDocCommand_WithEnvInjectsEnv(t *testing.T) {
+	// Build an env with a custom package.
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	env.Runtime.Library = &lisp.RelativeFileSystemLibrary{}
+	env.Runtime.Stderr = &bytes.Buffer{}
+	lisp.InitializeUserEnv(env)
+	lisplib.LoadLibrary(env)
+
+	env.DefinePackage(lisp.Symbol("mypkg"))
+	env.InPackage(lisp.Symbol("mypkg"))
+	env.AddBuiltins(true, &testBuiltin{
+		name:    "my-helper",
+		formals: lisp.QExpr([]*lisp.LVal{lisp.Symbol("x")}),
+	})
+	env.InPackage(lisp.String(lisp.DefaultUserPackage))
+
+	var cfg cmdConfig
+	WithEnv(env)(&cfg)
+
+	assert.Same(t, env, cfg.env,
+		"WithEnv should store the env in cmdConfig")
+
+	// Verify the custom package is accessible via the env's registry.
+	pkg, ok := env.Runtime.Registry.Packages["mypkg"]
+	assert.True(t, ok, "mypkg should be registered")
+	assert.Contains(t, pkg.Externals, "my-helper",
+		"my-helper should be exported from mypkg")
+}
+
+func TestDocCommand_WithRegistryMergesIntoDocEnv(t *testing.T) {
+	// Build a standalone registry with a custom package.
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	env.Runtime.Library = &lisp.RelativeFileSystemLibrary{}
+	env.Runtime.Stderr = &bytes.Buffer{}
+	lisp.InitializeUserEnv(env)
+
+	env.DefinePackage(lisp.Symbol("custpkg"))
+	env.InPackage(lisp.Symbol("custpkg"))
+	env.AddBuiltins(true, &testBuiltin{
+		name:    "cust-fn",
+		formals: lisp.QExpr([]*lisp.LVal{lisp.Symbol("x")}),
+	})
+	env.InPackage(lisp.String(lisp.DefaultUserPackage))
+
+	var cfg cmdConfig
+	WithRegistry(env.Runtime.Registry)(&cfg)
+
+	assert.Same(t, env.Runtime.Registry, cfg.resolveRegistry(),
+		"resolveRegistry should return the injected registry")
+	assert.NotNil(t, cfg.registry.Packages["custpkg"],
+		"custpkg should be in the registry")
+}

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -1,0 +1,107 @@
+// Copyright © 2024 The ELPS authors
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLintCommand_DefaultFlags(t *testing.T) {
+	cmd := LintCommand()
+	assert.Equal(t, "lint [flags] [files...]", cmd.Use)
+
+	// All expected flags should exist
+	for _, name := range []string{"json", "checks", "list", "exclude", "workspace", "no-workspace"} {
+		assert.NotNil(t, cmd.Flags().Lookup(name), "missing flag: %s", name)
+	}
+}
+
+func TestLintCommand_WithRegistryInjectsRegistry(t *testing.T) {
+	// Build an env with a custom package "testpkg" exporting "custom-fn".
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	env.Runtime.Library = &lisp.RelativeFileSystemLibrary{}
+	env.Runtime.Stderr = &bytes.Buffer{}
+	lisp.InitializeUserEnv(env)
+	lisplib.LoadLibrary(env)
+
+	env.DefinePackage(lisp.Symbol("testpkg"))
+	env.InPackage(lisp.Symbol("testpkg"))
+	env.AddBuiltins(true, &testBuiltin{
+		name:    "custom-fn",
+		formals: lisp.QExpr([]*lisp.LVal{lisp.Symbol("x")}),
+	})
+	env.InPackage(lisp.String(lisp.DefaultUserPackage))
+
+	reg := env.Runtime.Registry
+
+	// Write a lisp file that uses testpkg:custom-fn.
+	dir := t.TempDir()
+	src := `(use-package 'testpkg)
+(testpkg:custom-fn 42)
+`
+	lispFile := filepath.Join(dir, "test.lisp")
+	require.NoError(t, os.WriteFile(lispFile, []byte(src), 0o600))
+
+	// Create the lint command with the registry injected.
+	cmd := LintCommand(WithRegistry(reg))
+	cmd.SetArgs([]string{"--workspace", dir, lispFile})
+
+	// Capture stdout/stderr — we just want to verify no exit(1).
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	// The command calls os.Exit on diagnostics, so we can't call Execute()
+	// directly in-process. Instead, verify the factory wiring by checking
+	// that resolveRegistry returns the expected registry.
+	var cfg cmdConfig
+	WithRegistry(reg)(&cfg)
+	assert.Same(t, reg, cfg.resolveRegistry(),
+		"WithRegistry should inject the registry")
+}
+
+func TestLintCommand_WithEnvResolvesRegistry(t *testing.T) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+
+	var cfg cmdConfig
+	WithEnv(env)(&cfg)
+
+	assert.Same(t, env.Runtime.Registry, cfg.resolveRegistry(),
+		"WithEnv should resolve to the env's registry")
+}
+
+func TestLintCommand_WithEnvPreferredOverRegistry(t *testing.T) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+
+	otherReg := lisp.NewRegistry()
+
+	var cfg cmdConfig
+	WithEnv(env)(&cfg)
+	WithRegistry(otherReg)(&cfg)
+
+	assert.Same(t, env.Runtime.Registry, cfg.resolveRegistry(),
+		"env's registry should take precedence over explicit registry")
+}
+
+// testBuiltin is a minimal LBuiltinDef for test fixtures.
+type testBuiltin struct {
+	name    string
+	formals *lisp.LVal
+}
+
+func (b *testBuiltin) Name() string              { return b.name }
+func (b *testBuiltin) Formals() *lisp.LVal        { return b.formals }
+func (b *testBuiltin) Eval(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal { return lisp.Nil() }
+func (b *testBuiltin) Docstring() string           { return "test builtin" }

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -1,0 +1,38 @@
+// Copyright © 2024 The ELPS authors
+
+package cmd
+
+import "github.com/luthersystems/elps/lisp"
+
+// Option configures an exported command factory (LintCommand, DocCommand).
+type Option func(*cmdConfig)
+
+type cmdConfig struct {
+	registry *lisp.PackageRegistry
+	env      *lisp.LEnv
+}
+
+// WithRegistry injects a PackageRegistry for semantic analysis. The
+// registry's Go-registered builtins, special ops, and macros are merged
+// with stdlib symbols so that the linter recognises embedder-provided
+// functions.
+func WithRegistry(reg *lisp.PackageRegistry) Option {
+	return func(c *cmdConfig) { c.registry = reg }
+}
+
+// WithEnv injects a fully configured LEnv. For the doc command this is
+// the environment used for documentation queries. For the lint command
+// the env's Runtime.Registry is used for semantic analysis.
+func WithEnv(env *lisp.LEnv) Option {
+	return func(c *cmdConfig) { c.env = env }
+}
+
+// resolveRegistry returns the best available registry from the options.
+// If an env was provided its registry is preferred, falling back to an
+// explicitly supplied registry.
+func (c *cmdConfig) resolveRegistry() *lisp.PackageRegistry {
+	if c.env != nil {
+		return c.env.Runtime.Registry
+	}
+	return c.registry
+}


### PR DESCRIPTION
## Summary
- Refactors `cmd/lint.go` and `cmd/doc.go` from package-level command vars to exported `LintCommand()`/`DocCommand()` factory functions that accept functional options (`WithRegistry`, `WithEnv`)
- Embedders (e.g. shirotester) can now reuse the full `elps lint` and `elps doc` cobra commands — with all flags, output modes, and diagnostic rendering — while injecting their Go-registered builtins for accurate semantic analysis and documentation
- Updates `docs/embed.md` with embedder usage guide and API reference table

## Test Plan
- [x] `make test` passes
- [x] `make static-checks` passes (golangci-lint, 0 issues)
- [x] `./elps fmt -l ./...` reports no changes
- [x] `./elps doc -m` reports no missing docs
- [x] New tests in `cmd/lint_test.go` and `cmd/doc_test.go` verify option wiring, flag registration, and registry resolution precedence

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)