### PR TITLE
Fix lint false positives and add severity-based exit codes

### DIFF
--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -635,6 +635,7 @@ var AnalyzerUnnecessaryProgn = &Analyzer{
 var AnalyzerUnusedVariable = &Analyzer{
 	Name:     "unused-variable",
 	Severity: SeverityWarning,
+	Semantic: true,
 	Doc:      "Warn about variables and parameters that are defined but never referenced.\n\nRequires semantic analysis (--workspace flag). Skips variables with underscore prefix (conventional \"ignored\" marker) and top-level (global scope) variables.",
 	Run: func(pass *Pass) error {
 		if pass.Semantics == nil {
@@ -670,6 +671,7 @@ var AnalyzerUnusedVariable = &Analyzer{
 var AnalyzerUnusedFunction = &Analyzer{
 	Name:     "unused-function",
 	Severity: SeverityWarning,
+	Semantic: true,
 	Doc:      "Warn about top-level functions and macros that are defined but never referenced.\n\nRequires semantic analysis (--workspace flag). Exported symbols and functions with underscore prefix are excluded.",
 	Run: func(pass *Pass) error {
 		if pass.Semantics == nil {
@@ -710,6 +712,7 @@ var AnalyzerUnusedFunction = &Analyzer{
 var AnalyzerShadowing = &Analyzer{
 	Name:     "shadowing",
 	Severity: SeverityInfo,
+	Semantic: true,
 	Doc:      "Report when a local binding shadows a name from an enclosing scope.\n\nRequires semantic analysis (--workspace flag). Shadowing is valid but can cause confusion, especially when it hides a builtin or outer variable.",
 	Run: func(pass *Pass) error {
 		if pass.Semantics == nil {
@@ -748,6 +751,7 @@ var AnalyzerShadowing = &Analyzer{
 var AnalyzerUserArity = &Analyzer{
 	Name:     "user-arity",
 	Severity: SeverityError,
+	Semantic: true,
 	Doc:      "Check argument counts for calls to user-defined functions and macros.\n\nRequires semantic analysis (--workspace flag). Only checks calls to functions with known signatures (Source != nil). Complements builtin-arity which covers builtins.",
 	Run: func(pass *Pass) error {
 		if pass.Semantics == nil {
@@ -835,6 +839,7 @@ func sourceString(loc *token.Location) string {
 var AnalyzerUndefinedSymbol = &Analyzer{
 	Name:     "undefined-symbol",
 	Severity: SeverityError,
+	Semantic: true,
 	Doc:      "Report symbols that cannot be resolved in any enclosing scope.\n\nRequires semantic analysis (--workspace flag). Keywords and qualified symbols are excluded. Builtins, special operators, and macros are pre-populated.",
 	Run: func(pass *Pass) error {
 		if pass.Semantics == nil {


### PR DESCRIPTION
## Summary
- **#95**: Fix `unused-nolint` false positives — nolint directives targeting semantic-only analyzers (e.g. `unused-function`, `user-arity`) no longer fire spurious "unused" warnings in syntactic mode (no `--workspace`). Also fixes `--checks` filtering causing valid analyzer names to be flagged as "unknown".
- **#96**: Add `--fail-on` flag to `elps lint` — exit code now respects diagnostic severity. Default `--fail-on=error` means only error-level diagnostics cause exit 1; warnings and info are reported but don't fail CI. Use `--fail-on=warning` or `--fail-on=info` for stricter thresholds.
- Adds `Semantic bool` field to `Analyzer` struct, exported `ParseSeverity()`, `MaxSeverity()`, `ShouldFail()` helpers for embedders.

Closes #95, closes #96.

## Test plan
- [x] 9 new tests for semantic nolint handling (syntactic mode skip, mixed directives, --checks filtering)
- [x] 15 new tests for severity helpers (ParseSeverity, MaxSeverity, ShouldFail — all threshold combinations)
- [x] All existing lint tests pass (no regressions)
- [x] `make test` passes (Go tests + example lisp files)
- [x] `make static-checks` clean (golangci-lint)

---
*Local tests passed. Security review completed (low risk — linter-only changes). QA professor review pending.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>