### PR TITLE
Fix stdlib LoadPackage not restoring previous package

### DIFF
--- a/lisp/lisplib/libbase64/libbase64.go
+++ b/lisp/lisplib/libbase64/libbase64.go
@@ -14,6 +14,8 @@ const DefaultPackageName = "base64"
 
 // LoadPackage adds the base64 package to env
 func LoadPackage(env *lisp.LEnv) *lisp.LVal {
+	prevPkg := env.Runtime.Package.Name
+	defer env.InPackage(lisp.Symbol(prevPkg))
 	name := lisp.Symbol(DefaultPackageName)
 	e := env.DefinePackage(name)
 	if !e.IsNil() {

--- a/lisp/lisplib/libgolang/libgolang.go
+++ b/lisp/lisplib/libgolang/libgolang.go
@@ -15,6 +15,8 @@ const DefaultPackageName = "golang"
 
 // LoadPackage adds the golang package to env
 func LoadPackage(env *lisp.LEnv) *lisp.LVal {
+	prevPkg := env.Runtime.Package.Name
+	defer env.InPackage(lisp.Symbol(prevPkg))
 	name := lisp.Symbol(DefaultPackageName)
 	e := env.DefinePackage(name)
 	if !e.IsNil() {

--- a/lisp/lisplib/libhelp/libhelp.go
+++ b/lisp/lisplib/libhelp/libhelp.go
@@ -115,6 +115,8 @@ func docstring(defn lisp.LBuiltinDef) string {
 
 // LoadPackage adds the help package to env
 func LoadPackage(env *lisp.LEnv) *lisp.LVal {
+	prevPkg := env.Runtime.Package.Name
+	defer env.InPackage(lisp.Symbol(prevPkg))
 	name := lisp.Symbol(DefaultPackageName)
 	e := env.DefinePackage(name)
 	if !e.IsNil() {

--- a/lisp/lisplib/libhelp/libhelp_test.go
+++ b/lisp/lisplib/libhelp/libhelp_test.go
@@ -385,6 +385,24 @@ func TestCheckMissing_ExcludesUserPackage(t *testing.T) {
 	}
 }
 
+func TestLoadPackage_RestoresPreviousPackage(t *testing.T) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	env.Runtime.Library = &lisp.RelativeFileSystemLibrary{}
+	rc := lisp.InitializeUserEnv(env)
+	require.True(t, rc.IsNil())
+
+	// Before LoadPackage, we should be in "user".
+	require.Equal(t, "user", env.Runtime.Package.Name)
+
+	rc = libhelp.LoadPackage(env)
+	require.True(t, rc.IsNil())
+
+	// After LoadPackage, we should still be in "user".
+	assert.Equal(t, "user", env.Runtime.Package.Name,
+		"LoadPackage should restore the previous package")
+}
+
 func TestCheckMissing_NoDuplicates(t *testing.T) {
 	env := newTestEnv(t)
 

--- a/lisp/lisplib/libjson/json.go
+++ b/lisp/lisplib/libjson/json.go
@@ -24,6 +24,8 @@ const DefaultPackageName = "json"
 
 // LoadPackage adds the json package to env
 func LoadPackage(env *lisp.LEnv) *lisp.LVal {
+	prevPkg := env.Runtime.Package.Name
+	defer env.InPackage(lisp.Symbol(prevPkg))
 	name := lisp.Symbol(DefaultPackageName)
 	e := env.DefinePackage(name)
 	if !e.IsNil() {

--- a/lisp/lisplib/libmath/libmath.go
+++ b/lisp/lisplib/libmath/libmath.go
@@ -14,6 +14,8 @@ const DefaultPackageName = "math"
 
 // LoadPackage adds the math package to env
 func LoadPackage(env *lisp.LEnv) *lisp.LVal {
+	prevPkg := env.Runtime.Package.Name
+	defer env.InPackage(lisp.Symbol(prevPkg))
 	name := lisp.Symbol(DefaultPackageName)
 	e := env.DefinePackage(name)
 	if !e.IsNil() {

--- a/lisp/lisplib/libregexp/libregexp.go
+++ b/lisp/lisplib/libregexp/libregexp.go
@@ -14,6 +14,8 @@ const DefaultPackageName = "regexp"
 
 // LoadPackage adds the regexp package to env
 func LoadPackage(env *lisp.LEnv) *lisp.LVal {
+	prevPkg := env.Runtime.Package.Name
+	defer env.InPackage(lisp.Symbol(prevPkg))
 	name := lisp.Symbol(DefaultPackageName)
 	e := env.DefinePackage(name)
 	if !e.IsNil() {

--- a/lisp/lisplib/libschema/libschema.go
+++ b/lisp/lisplib/libschema/libschema.go
@@ -55,6 +55,8 @@ const (
 
 // LoadPackage adds the schema package to env
 func LoadPackage(env *lisp.LEnv) *lisp.LVal {
+	prevPkg := env.Runtime.Package.Name
+	defer env.InPackage(lisp.Symbol(prevPkg))
 	name := lisp.Symbol(DefaultPackageName)
 	e := env.DefinePackage(name)
 	if !e.IsNil() {

--- a/lisp/lisplib/libstring/libstring.go
+++ b/lisp/lisplib/libstring/libstring.go
@@ -15,6 +15,8 @@ const DefaultPackageName = "string"
 
 // LoadPackage adds the string package to env
 func LoadPackage(env *lisp.LEnv) *lisp.LVal {
+	prevPkg := env.Runtime.Package.Name
+	defer env.InPackage(lisp.Symbol(prevPkg))
 	name := lisp.Symbol(DefaultPackageName)
 	e := env.DefinePackage(name)
 	if !e.IsNil() {

--- a/lisp/lisplib/libtesting/libtesting.go
+++ b/lisp/lisplib/libtesting/libtesting.go
@@ -16,6 +16,8 @@ const DefaultSuiteSymbol = "test-suite"
 
 // LoadPackage adds the testing package to env
 func LoadPackage(env *lisp.LEnv) *lisp.LVal {
+	prevPkg := env.Runtime.Package.Name
+	defer env.InPackage(lisp.Symbol(prevPkg))
 	name := lisp.Symbol(DefaultPackageName)
 	e := env.DefinePackage(name)
 	if !e.IsNil() {

--- a/lisp/lisplib/libtime/libtime.go
+++ b/lisp/lisplib/libtime/libtime.go
@@ -14,6 +14,8 @@ const DefaultPackageName = "time"
 
 // LoadPackage adds the time package to env
 func LoadPackage(env *lisp.LEnv) *lisp.LVal {
+	prevPkg := env.Runtime.Package.Name
+	defer env.InPackage(lisp.Symbol(prevPkg))
 	name := lisp.Symbol(DefaultPackageName)
 	e := env.DefinePackage(name)
 	if !e.IsNil() {


### PR DESCRIPTION
## Summary

- All 10 stdlib `LoadPackage` functions (`libhelp`, `libtime`, `libmath`, `libstring`, `libbase64`, `libjson`, `libregexp`, `libgolang`, `libtesting`, `libschema`) called `env.InPackage()` to switch into their own package but never restored the caller's package afterward.
- Added `defer env.InPackage(lisp.Symbol(prevPkg))` to each `LoadPackage` so the caller's active package is always restored.
- Added regression tests in both `libhelp_test.go` (direct test) and `lisplib_test.go` (comprehensive test covering all 10 packages).

Closes #99

## Test plan

- [x] New `TestLoadPackage_RestoresPreviousPackage` verifies `libhelp.LoadPackage` restores `user` package
- [x] New `TestLoadLibrary_EachPackageRestoresPrevious` verifies all 10 stdlib packages restore the previous package
- [x] Existing `TestNewDocEnv` confirms `LoadLibrary` still ends in `user` package
- [x] Full `make test` passes (Go tests + example lisp files)
- [x] `make static-checks` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)