### PR TITLE
Add defmacro docstrings, SymbolDocs fallback, and docs guide

### DIFF
--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -559,6 +559,7 @@ func walkRethrowNode(node *lisp.LVal, handlerDepth int, report func(*lisp.LVal))
 var implicitPrognForms = map[string]int{
 	"lambda":        2, // (lambda (formals) body...)
 	"defun":         3, // (defun name (formals) body...)
+	"defmacro":      3, // (defmacro name (formals) body...)
 	"let":           2, // (let (bindings) body...)
 	"let*":          2, // (let* (bindings) body...)
 	"flet":          2, // (flet (bindings) body...)
@@ -575,7 +576,7 @@ var implicitPrognForms = map[string]int{
 var AnalyzerUnnecessaryProgn = &Analyzer{
 	Name:     "unnecessary-progn",
 	Severity: SeverityInfo,
-	Doc:      "Warn when `progn` wraps the body of a form that already supports multiple expressions.\n\nForms like `defun`, `lambda`, `let`, and others evaluate their body as an implicit progn. Wrapping the body in an explicit `(progn ...)` is redundant. This does not flag `progn` inside `if` branches or `defmacro`, where it is needed.",
+	Doc:      "Warn when `progn` wraps the body of a form that already supports multiple expressions.\n\nForms like `defun`, `defmacro`, `lambda`, `let`, and others evaluate their body as an implicit progn. Wrapping the body in an explicit `(progn ...)` is redundant. This does not flag `progn` inside `if` branches, where it is needed.",
 	Run: func(pass *Pass) error {
 		WalkSExprs(pass.Exprs, func(sexpr *lisp.LVal, depth int) {
 			head := HeadSymbol(sexpr)

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -860,11 +860,12 @@ func TestUnnecessaryProgn_Negative_IfElseBranch(t *testing.T) {
 	assertNoDiags(t, diags)
 }
 
-func TestUnnecessaryProgn_Negative_Defmacro(t *testing.T) {
-	// defmacro only takes a single body expression, so progn IS needed
+func TestUnnecessaryProgn_Positive_Defmacro(t *testing.T) {
+	// defmacro now supports multiple body expressions, so progn is redundant
 	source := `(defmacro m (x) (progn (print x) x))`
 	diags := lintCheck(t, AnalyzerUnnecessaryProgn, source)
-	assertNoDiags(t, diags)
+	assert.Len(t, diags, 1)
+	assertHasDiag(t, diags, "progn is unnecessary in defmacro body")
 }
 
 func TestUnnecessaryProgn_Negative_MultipleBodyExprs(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #102.

- **defmacro docstrings**: Change `defmacro` formals from fixed 3-arg to variadic body (matching `defun`), enabling inline docstrings like `(defmacro m (x) "Doc." (list '+ x 1))`
- **SymbolDocs fallback**: `CheckMissing` and `renderFun` now check `pkg.SymbolDocs` when `v.Docstring()` is empty, so functions documented via `set` with trailing docstrings are recognized
- **Linter update**: Add `defmacro` to `implicitPrognForms` (progn is now redundant in defmacro body), update analyzer doc
- **Language guide**: Add a "Documentation" section to `docs/lang.md` (`elps doc --guide`) covering function/macro docstrings, variable docs, package docs, Go builtin docs, and viewing docs

## Test plan
- [x] `make test` — all Go + lisp tests pass
- [x] `make static-checks` — 0 issues
- [x] `./elps doc -m` — no missing docs
- [x] New tests: `TestDefmacroDocstring`, `TestCheckMissing_FunWithSymbolDocs`, `TestCheckMissing_DefmacroDocstring`, `TestRenderFun_SymbolDocsFallback`
- [x] Updated test: `TestUnnecessaryProgn_Positive_Defmacro` (was negative, now expects diagnostic)
- [x] Backward compatible: existing single-expression `defmacro` calls unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)