### PR TITLE
Fix TOCTOU symlink race and EvalSymlinks error swallowing in LoadSource

### DIFF
--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -11,9 +11,10 @@ import (
 )
 
 var (
-	replJSON  bool
-	replBatch bool
-	replEval  string
+	replJSON    bool
+	replBatch   bool
+	replEval    string
+	replRootDir string
 )
 
 // replCmd represents the repl command
@@ -62,6 +63,9 @@ Example batch/JSON usage:
 			repl.WithJSON(jsonFlag),
 			repl.WithBatch(replBatch),
 		}
+		if replRootDir != "" {
+			opts = append(opts, repl.WithRootDir(replRootDir))
+		}
 		if replEval != "" {
 			opts = append(opts, repl.WithEval(replEval))
 		}
@@ -80,4 +84,6 @@ func init() {
 		"Alias for --batch")
 	replCmd.Flags().StringVarP(&replEval, "eval", "e", "",
 		"Evaluate a single expression, print result, and exit")
+	replCmd.Flags().StringVar(&replRootDir, "root-dir", "",
+		"Root directory for file access confinement (default: working directory)")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/lisplib"
@@ -15,6 +16,7 @@ import (
 var (
 	runExpression bool
 	runPrint      bool
+	runRootDir    string
 )
 
 // runCmd represents the run command
@@ -29,20 +31,39 @@ arguments are interpreted as Lisp expressions and evaluated directly.
 The runtime loads all standard library packages automatically. User code
 starts in the "user" package and can import other packages with use-package.
 
+File access is confined to the root directory (--root-dir, default: working
+directory). The load-file function can only read files within this tree.
+
 Examples:
   elps run hello.lisp              Run a source file
   elps run lib.lisp app.lisp       Load files in order (lib first)
   elps run -e '(+ 1 2)'            Evaluate an expression
   elps run -e -p '(* 6 7)'         Evaluate and print the result
+  elps run --root-dir /app scripts/main.lisp
 
 Exit codes:
   0  Success
   1  Runtime error (use elps lint to catch common mistakes before running)`,
 	Run: func(cmd *cobra.Command, args []string) {
+		rootDir := runRootDir
+		if rootDir == "" {
+			wd, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "cannot determine working directory: %v\n", err)
+				os.Exit(1)
+			}
+			rootDir = wd
+		}
+		rootDir, err := filepath.Abs(rootDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "cannot resolve root directory: %v\n", err)
+			os.Exit(1)
+		}
+
 		env := lisp.NewEnv(nil)
 		reader := parser.NewReader()
 		env.Runtime.Reader = reader
-		env.Runtime.Library = &lisp.RelativeFileSystemLibrary{}
+		env.Runtime.Library = &lisp.FSLibrary{FS: os.DirFS(rootDir)}
 		rc := lisp.InitializeUserEnv(env)
 		if !rc.IsNil() {
 			fmt.Fprintln(os.Stderr, rc)
@@ -59,13 +80,36 @@ Exit codes:
 			os.Exit(1)
 		}
 		for i := range args {
-			res := env.LoadFile(args[i])
+			arg, ferr := toRelativePath(rootDir, args[i])
+			if ferr != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", ferr)
+				os.Exit(1)
+			}
+			res := env.LoadFile(arg)
 			if res.Type == lisp.LError {
 				renderLispError(res, args[i])
 				os.Exit(1)
 			}
 		}
 	},
+}
+
+// toRelativePath converts a file path to be relative to rootDir.
+// Relative paths are returned as-is. Absolute paths within rootDir
+// are converted; absolute paths outside rootDir produce an error.
+func toRelativePath(rootDir, path string) (string, error) {
+	if !filepath.IsAbs(path) {
+		return path, nil
+	}
+	rel, err := filepath.Rel(rootDir, path)
+	if err != nil {
+		return "", fmt.Errorf("%s: cannot make relative to root directory %s: %w", path, rootDir, err)
+	}
+	// filepath.Rel can produce ".." components for paths outside rootDir.
+	if len(rel) >= 2 && rel[:2] == ".." {
+		return "", fmt.Errorf("%s: outside root directory %s", path, rootDir)
+	}
+	return rel, nil
 }
 
 func init() {
@@ -76,4 +120,6 @@ func init() {
 		"Interpret arguments as lisp expressions")
 	runCmd.Flags().BoolVarP(&runPrint, "print", "p", false,
 		"Print expression values to stdout")
+	runCmd.Flags().StringVar(&runRootDir, "root-dir", "",
+		"Root directory for file access confinement (default: working directory)")
 }

--- a/lisp/library_test.go
+++ b/lisp/library_test.go
@@ -110,6 +110,155 @@ func TestRootDirConfinement_BlocksSymlinksOutsideRoot(t *testing.T) {
 	assert.Equal(t, "(+ 2 3)", string(data))
 }
 
+func TestRootDirConfinement_ReadsResolvedPath(t *testing.T) {
+	// Verify that after confinement check, the file is read from the
+	// resolved (symlink-followed) path, not the original. This prevents
+	// TOCTOU races where a symlink target changes between resolution and read.
+	rootDir := t.TempDir()
+	subDir := filepath.Join(rootDir, "sub")
+	if err := os.Mkdir(subDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create real file inside the root.
+	realFile := filepath.Join(subDir, "real.lisp")
+	if err := os.WriteFile(realFile, []byte("(+ 10 20)"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create symlink inside root pointing to the real file (also inside root).
+	symlinkPath := filepath.Join(rootDir, "link.lisp")
+	if err := os.Symlink(realFile, symlinkPath); err != nil {
+		t.Skip("platform does not support symlinks")
+	}
+
+	lib := &lisp.RelativeFileSystemLibrary{RootDir: rootDir}
+	ctx := &testSourceContext{name: "test", loc: ""}
+
+	// The returned trueloc should be the resolved path, not the symlink.
+	_, trueloc, data, err := lib.LoadSource(ctx, symlinkPath)
+	assert.NoError(t, err, "symlink within root should be allowed")
+	assert.Equal(t, "(+ 10 20)", string(data))
+	// Resolve realFile too — on macOS, /var is a symlink to /private/var.
+	resolvedReal, rerr := filepath.EvalSymlinks(realFile)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	assert.Equal(t, resolvedReal, trueloc,
+		"trueloc should be the resolved (real) path, not the symlink")
+}
+
+func TestRootDirConfinement_EvalSymlinksErrorOnLoc(t *testing.T) {
+	// When RootDir is set and EvalSymlinks fails on loc (e.g., broken
+	// symlink), LoadSource must return an error instead of silently using
+	// the unresolved path.
+	rootDir := t.TempDir()
+
+	// Create a broken symlink (points to non-existent target).
+	brokenLink := filepath.Join(rootDir, "broken.lisp")
+	if err := os.Symlink(filepath.Join(rootDir, "nonexistent.lisp"), brokenLink); err != nil {
+		t.Skip("platform does not support symlinks")
+	}
+
+	lib := &lisp.RelativeFileSystemLibrary{RootDir: rootDir}
+	ctx := &testSourceContext{name: "test", loc: ""}
+
+	_, _, _, err := lib.LoadSource(ctx, brokenLink)
+	assert.Error(t, err, "broken symlink should produce an error when RootDir is set")
+	assert.Contains(t, err.Error(), "cannot resolve path")
+}
+
+func TestRootDirConfinement_EvalSymlinksErrorOnRoot(t *testing.T) {
+	// When RootDir points to a non-existent directory, LoadSource must
+	// return an error instead of silently using the unresolved path.
+	lib := &lisp.RelativeFileSystemLibrary{RootDir: "/nonexistent/root/dir"}
+	ctx := &testSourceContext{name: "test", loc: ""}
+
+	_, _, _, err := lib.LoadSource(ctx, "/some/file.lisp")
+	assert.Error(t, err, "non-existent RootDir should produce an error")
+	assert.Contains(t, err.Error(), "cannot resolve root directory")
+}
+
+func TestRootDirConfinement_BlocksSymlinkChain(t *testing.T) {
+	// Verify that symlink chains (link1 → link2 → outside) are blocked.
+	rootDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	outsideFile := filepath.Join(outsideDir, "secret.lisp")
+	if err := os.WriteFile(outsideFile, []byte("secret"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// link2 → outside file
+	link2 := filepath.Join(rootDir, "link2.lisp")
+	if err := os.Symlink(outsideFile, link2); err != nil {
+		t.Skip("platform does not support symlinks")
+	}
+	// link1 → link2 (chain: link1 → link2 → outside)
+	link1 := filepath.Join(rootDir, "link1.lisp")
+	if err := os.Symlink(link2, link1); err != nil {
+		t.Fatal(err)
+	}
+
+	lib := &lisp.RelativeFileSystemLibrary{RootDir: rootDir}
+	ctx := &testSourceContext{name: "test", loc: ""}
+
+	_, _, _, err := lib.LoadSource(ctx, link1)
+	assert.Error(t, err, "symlink chain escaping root should be blocked")
+	assert.Contains(t, err.Error(), "access denied")
+}
+
+func TestRootDirConfinement_BlocksSymlinkInParentDir(t *testing.T) {
+	// Verify that symlinked parent directories pointing outside root
+	// are detected and blocked.
+	rootDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	outsideFile := filepath.Join(outsideDir, "escape.lisp")
+	if err := os.WriteFile(outsideFile, []byte("escaped!"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create symlink where a path component points outside root.
+	linkDir := filepath.Join(rootDir, "link")
+	if err := os.Symlink(outsideDir, linkDir); err != nil {
+		t.Skip("platform does not support symlinks")
+	}
+
+	lib := &lisp.RelativeFileSystemLibrary{RootDir: rootDir}
+	ctx := &testSourceContext{name: "test", loc: ""}
+
+	_, _, _, err := lib.LoadSource(ctx, filepath.Join(linkDir, "escape.lisp"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "access denied")
+}
+
+func TestRootDirConfinement_PrefixBoundary(t *testing.T) {
+	// Verify that the confinement check is not fooled by paths that
+	// share a common prefix but are not within the root directory.
+	// E.g., root=/tmp/foo must not allow /tmp/foobar/file.lisp.
+	parentDir := t.TempDir()
+	rootDir := filepath.Join(parentDir, "root")
+	siblingDir := filepath.Join(parentDir, "rootextra")
+	if err := os.MkdirAll(rootDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(siblingDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	siblingFile := filepath.Join(siblingDir, "file.lisp")
+	if err := os.WriteFile(siblingFile, []byte("(+ 1 1)"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	lib := &lisp.RelativeFileSystemLibrary{RootDir: rootDir}
+	ctx := &testSourceContext{name: "test", loc: ""}
+
+	_, _, _, err := lib.LoadSource(ctx, siblingFile)
+	assert.Error(t, err, "file in sibling directory with shared prefix should be blocked")
+	assert.Contains(t, err.Error(), "access denied")
+}
+
 func TestFSLibrary_LoadsFile(t *testing.T) {
 	env := lisp.NewEnv(nil)
 	lerr := lisp.InitializeUserEnv(env)


### PR DESCRIPTION
## Summary

**Commit 1: Fix TOCTOU symlink race and EvalSymlinks error swallowing**
- Fix TOCTOU race: after resolving symlinks for confinement check, read from the **resolved** path instead of the original — prevents symlink swap between check and read
- Fix silent error swallowing: when `EvalSymlinks` fails on either the root directory or the target path, return an error instead of falling through with the unresolved path
- Add 6 regression tests: resolved-path reading, broken symlink, invalid root, symlink chains, parent-dir symlinks, prefix boundary

**Commit 2: Switch CLI to FSLibrary for filesystem confinement by default**
- `elps run` and `elps repl` now use `FSLibrary` (backed by `os.DirFS`) instead of `RelativeFileSystemLibrary`
- `load-file` is confined to the working directory tree by default — absolute paths and `..` traversal are rejected by the `fs.FS` contract
- New `--root-dir` flag on both commands to override the confinement root
- CLI file arguments with absolute paths are converted to relative paths within the root; paths outside produce a clear error

Closes #108

## Test plan

- [x] 6 new library confinement tests all pass
- [x] All existing confinement and FSLibrary tests pass
- [x] `make test` passes (Go tests + all example lisp files including `load-file` chains)
- [x] `make static-checks` passes (0 issues)
- [x] Smoke test: `elps run -e '(load-file "/etc/hosts")'` → blocked
- [x] Smoke test: `elps run -e '(load-file "../../../etc/hosts")'` → blocked
- [x] Smoke test: `elps run _examples/sicp/sicp.lisp` → works (relative paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)