### PR TITLE
Add parser depth limit, macro expansion depth limit, and MaxAlloc enforcement

### DIFF
--- a/lisp/alloc_test.go
+++ b/lisp/alloc_test.go
@@ -14,7 +14,7 @@ func TestAllocLimits(t *testing.T) {
 			// Normal usage: verify correct content, not just length.
 			{`(make-sequence 0 5)`, `'(0 1 2 3 4)`, ""},
 			// Exceeding the default limit (10Mi elements) must produce an error.
-			{`(make-sequence 0 20000000)`, `test:1:1: lisp:make-sequence: make-sequence would exceed maximum allocation size (10485760 elements)`, ""},
+			{`(make-sequence 0 20000000)`, `test:1:1: lisp:make-sequence: allocation size 10485761 exceeds maximum (10485760)`, ""},
 		}},
 	}
 	elpstest.RunTestSuite(t, tests)

--- a/lisp/config.go
+++ b/lisp/config.go
@@ -74,3 +74,23 @@ func WithLibrary(l SourceLibrary) Config {
 		return Nil()
 	}
 }
+
+// WithMaxMacroExpansionDepth returns a Config that limits the number of
+// successive macro expansions during evaluation.  This prevents infinite
+// macro expansion from exhausting memory.
+func WithMaxMacroExpansionDepth(n int) Config {
+	return func(env *LEnv) *LVal {
+		env.Runtime.MaxMacroExpansionDepth = n
+		return Nil()
+	}
+}
+
+// WithMaxAlloc returns a Config that sets the per-operation allocation size
+// cap (in bytes for strings, in elements for sequences).  This limits the
+// output size of any single builtin call, not cumulative memory usage.
+func WithMaxAlloc(n int) Config {
+	return func(env *LEnv) *LVal {
+		env.Runtime.MaxAlloc = n
+		return Nil()
+	}
+}

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -864,6 +864,7 @@ func (env *LEnv) Eval(v *LVal) (result *LVal) {
 			result = env.Errorf("internal error (recovered panic): %v", r)
 		}
 	}()
+	macroDepth := 0
 eval:
 	if v.Spliced {
 		return env.Errorf("spliced value used as expression")
@@ -905,6 +906,10 @@ eval:
 		if res.Type == LMarkMacExpand {
 			// A macro was just expanded and returned an unevaluated
 			// expression.  We have to evaluate the result before we return.
+			macroDepth++
+			if macroDepth > env.Runtime.MaxMacroExpansions() {
+				return env.Errorf("macro expansion depth exceeded (%d expansions)", macroDepth)
+			}
 			v = res.Cells[0]
 			goto eval
 		}

--- a/lisp/eval_safety_test.go
+++ b/lisp/eval_safety_test.go
@@ -255,3 +255,360 @@ func TestMakeByteSeqOnInvalidType(t *testing.T) {
 		t.Errorf("wrong error message: %s", msg)
 	}
 }
+
+// --- Allocation limit tests (HC-2) ---
+//
+// Each CheckAlloc call site is tested with:
+//   1. An "exceeds" case that verifies the exact error message (size + limit).
+//   2. A "within limit" case that verifies the operation succeeds and returns
+//      the correct result.
+
+func TestCheckAllocConcatString(t *testing.T) {
+	t.Parallel()
+	t.Run("exceeds", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 100
+		a := String(strings.Repeat("a", 60))
+		b := String(strings.Repeat("b", 60))
+		args := SExpr([]*LVal{Symbol("string"), a, b})
+		result := builtinConcatString(env, args)
+		msg := requireLError(t, result)
+		if !strings.Contains(msg, "allocation size 120 exceeds maximum (100)") {
+			t.Errorf("wrong error: %s", msg)
+		}
+	})
+	t.Run("within limit", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 100
+		a := String("hello")
+		b := String(" world")
+		args := SExpr([]*LVal{Symbol("string"), a, b})
+		result := builtinConcatString(env, args)
+		if result.Type == LError {
+			t.Fatalf("unexpected error: %v", result)
+		}
+		if result.Str != "hello world" {
+			t.Errorf("expected 'hello world', got %q", result.Str)
+		}
+	})
+}
+
+func TestCheckAllocConcatBytes(t *testing.T) {
+	t.Parallel()
+	t.Run("exceeds", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 5
+		a := Bytes([]byte{1, 2, 3})
+		b := Bytes([]byte{4, 5, 6})
+		args := SExpr([]*LVal{Symbol("bytes"), a, b})
+		result := builtinConcatBytes(env, args)
+		msg := requireLError(t, result)
+		if !strings.Contains(msg, "allocation size 6 exceeds maximum (5)") {
+			t.Errorf("wrong error: %s", msg)
+		}
+	})
+	t.Run("within limit", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 10
+		a := Bytes([]byte{1, 2})
+		b := Bytes([]byte{3, 4})
+		args := SExpr([]*LVal{Symbol("bytes"), a, b})
+		result := builtinConcatBytes(env, args)
+		if result.Type == LError {
+			t.Fatalf("unexpected error: %v", result)
+		}
+		if len(result.Bytes()) != 4 {
+			t.Errorf("expected 4 bytes, got %d", len(result.Bytes()))
+		}
+	})
+}
+
+func TestCheckAllocConcatSeq(t *testing.T) {
+	t.Parallel()
+	t.Run("exceeds", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 3
+		a := QExpr([]*LVal{Int(1), Int(2)})
+		b := QExpr([]*LVal{Int(3), Int(4)})
+		args := SExpr([]*LVal{Symbol("list"), a, b})
+		result := builtinConcatSeq(env, args)
+		msg := requireLError(t, result)
+		if !strings.Contains(msg, "allocation size 4 exceeds maximum (3)") {
+			t.Errorf("wrong error: %s", msg)
+		}
+	})
+	t.Run("within limit", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 10
+		a := QExpr([]*LVal{Int(1)})
+		b := QExpr([]*LVal{Int(2)})
+		args := SExpr([]*LVal{Symbol("list"), a, b})
+		result := builtinConcatSeq(env, args)
+		if result.Type == LError {
+			t.Fatalf("unexpected error: %v", result)
+		}
+		if result.Len() != 2 {
+			t.Errorf("expected 2 elements, got %d", result.Len())
+		}
+	})
+}
+
+func TestCheckAllocAppend(t *testing.T) {
+	t.Parallel()
+	t.Run("exceeds", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 5
+		seq := QExpr([]*LVal{Int(1), Int(2), Int(3)})
+		args := SExpr([]*LVal{Symbol("list"), seq, Int(4), Int(5), Int(6)})
+		result := builtinAppend(env, args)
+		msg := requireLError(t, result)
+		if !strings.Contains(msg, "allocation size 6 exceeds maximum (5)") {
+			t.Errorf("wrong error: %s", msg)
+		}
+	})
+	t.Run("within limit", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 10
+		seq := QExpr([]*LVal{Int(1), Int(2)})
+		args := SExpr([]*LVal{Symbol("list"), seq, Int(3)})
+		result := builtinAppend(env, args)
+		if result.Type == LError {
+			t.Fatalf("unexpected error: %v", result)
+		}
+		if result.Len() != 3 {
+			t.Errorf("expected 3 elements, got %d", result.Len())
+		}
+	})
+}
+
+func TestCheckAllocAppendBytes(t *testing.T) {
+	t.Parallel()
+	t.Run("exceeds", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 3
+		b := Bytes([]byte{1, 2})
+		args := SExpr([]*LVal{Symbol("bytes"), b, Int(3), Int(4)})
+		result := builtinAppend_Bytes(env, args)
+		msg := requireLError(t, result)
+		if !strings.Contains(msg, "allocation size 4 exceeds maximum (3)") {
+			t.Errorf("wrong error: %s", msg)
+		}
+	})
+	t.Run("within limit", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 10
+		b := Bytes([]byte{1, 2})
+		args := SExpr([]*LVal{Symbol("bytes"), b, Int(3)})
+		result := builtinAppend_Bytes(env, args)
+		if result.Type == LError {
+			t.Fatalf("unexpected error: %v", result)
+		}
+		if len(result.Bytes()) != 3 {
+			t.Errorf("expected 3 bytes, got %d", len(result.Bytes()))
+		}
+	})
+}
+
+func TestCheckAllocAppendMutate(t *testing.T) {
+	t.Parallel()
+	t.Run("exceeds", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 3
+		vec := Array(QExpr([]*LVal{Int(2)}), []*LVal{Int(1), Int(2)})
+		args := SExpr([]*LVal{vec, Int(3), Int(4)})
+		result := builtinAppendMutate(env, args)
+		msg := requireLError(t, result)
+		if !strings.Contains(msg, "allocation size 4 exceeds maximum (3)") {
+			t.Errorf("wrong error: %s", msg)
+		}
+	})
+	t.Run("within limit", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 10
+		vec := Array(QExpr([]*LVal{Int(2)}), []*LVal{Int(1), Int(2)})
+		args := SExpr([]*LVal{vec, Int(3)})
+		result := builtinAppendMutate(env, args)
+		if result.Type == LError {
+			t.Fatalf("unexpected error: %v", result)
+		}
+		if result.Len() != 3 {
+			t.Errorf("expected 3 elements, got %d", result.Len())
+		}
+	})
+}
+
+func TestCheckAllocZip(t *testing.T) {
+	t.Parallel()
+	t.Run("exceeds", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 3
+		// zip 'list [1 2] [3 4] → 2*2=4 elements total
+		a := QExpr([]*LVal{Int(1), Int(2)})
+		b := QExpr([]*LVal{Int(3), Int(4)})
+		args := SExpr([]*LVal{Symbol("list"), a, b})
+		result := builtinZip(env, args)
+		msg := requireLError(t, result)
+		if !strings.Contains(msg, "allocation size 4 exceeds maximum (3)") {
+			t.Errorf("wrong error: %s", msg)
+		}
+	})
+	t.Run("within limit", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 10
+		a := QExpr([]*LVal{Int(1)})
+		b := QExpr([]*LVal{Int(2)})
+		args := SExpr([]*LVal{Symbol("list"), a, b})
+		result := builtinZip(env, args)
+		if result.Type == LError {
+			t.Fatalf("unexpected error: %v", result)
+		}
+		if result.Len() != 1 {
+			t.Errorf("expected 1 element, got %d", result.Len())
+		}
+	})
+}
+
+func TestCheckAllocReverse(t *testing.T) {
+	t.Parallel()
+	t.Run("exceeds", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 2
+		seq := QExpr([]*LVal{Int(1), Int(2), Int(3)})
+		args := SExpr([]*LVal{Symbol("list"), seq})
+		result := builtinReverse(env, args)
+		msg := requireLError(t, result)
+		if !strings.Contains(msg, "allocation size 3 exceeds maximum (2)") {
+			t.Errorf("wrong error: %s", msg)
+		}
+	})
+	t.Run("within limit", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 10
+		seq := QExpr([]*LVal{Int(1), Int(2), Int(3)})
+		args := SExpr([]*LVal{Symbol("list"), seq})
+		result := builtinReverse(env, args)
+		if result.Type == LError {
+			t.Fatalf("unexpected error: %v", result)
+		}
+		if result.Len() != 3 {
+			t.Errorf("expected 3 elements, got %d", result.Len())
+		}
+		// Verify reversed order.
+		if result.Cells[0].Int != 3 || result.Cells[2].Int != 1 {
+			t.Errorf("expected reversed [3 2 1], got %v", result)
+		}
+	})
+}
+
+func TestCheckAllocMap(t *testing.T) {
+	t.Parallel()
+	t.Run("exceeds", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 2
+		// map needs a function — use the identity function.
+		identity := env.Lambda(
+			SExpr([]*LVal{Symbol("x")}),
+			[]*LVal{Symbol("x")},
+		)
+		seq := QExpr([]*LVal{Int(1), Int(2), Int(3)})
+		args := SExpr([]*LVal{Symbol("list"), identity, seq})
+		result := builtinMap(env, args)
+		msg := requireLError(t, result)
+		if !strings.Contains(msg, "allocation size 3 exceeds maximum (2)") {
+			t.Errorf("wrong error: %s", msg)
+		}
+	})
+	t.Run("within limit", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxAlloc = 10
+		identity := env.Lambda(
+			SExpr([]*LVal{Symbol("x")}),
+			[]*LVal{Symbol("x")},
+		)
+		seq := QExpr([]*LVal{Int(1), Int(2)})
+		args := SExpr([]*LVal{Symbol("list"), identity, seq})
+		result := builtinMap(env, args)
+		if result.Type == LError {
+			t.Fatalf("unexpected error: %v", result)
+		}
+		if result.Len() != 2 {
+			t.Errorf("expected 2 elements, got %d", result.Len())
+		}
+	})
+}
+
+// --- Macro expansion depth limit tests (HC-9) ---
+
+func TestMacroExpansionDepthLimit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("infinite expansion caught", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxMacroExpansionDepth = 10
+
+		env.AddMacros(true, &langBuiltin{
+			name:    "infinite-macro",
+			formals: Formals(VarArgSymbol, "args"),
+			fun: func(env *LEnv, args *LVal) *LVal {
+				return SExpr([]*LVal{Symbol("infinite-macro")})
+			},
+			docs: "test macro that expands infinitely",
+		})
+
+		result := env.Eval(SExpr([]*LVal{Symbol("infinite-macro")}))
+		msg := requireLError(t, result)
+		// The counter increments before the check, so the first failure is at
+		// macroDepth = 11 (one past the limit of 10).
+		if !strings.Contains(msg, "macro expansion depth exceeded (11 expansions)") {
+			t.Errorf("error should report exactly 11 expansions, got: %s", msg)
+		}
+	})
+
+	t.Run("finite expansion within limit succeeds", func(t *testing.T) {
+		t.Parallel()
+		env := initSafetyTestEnv(t)
+		env.Runtime.MaxMacroExpansionDepth = 10
+
+		// A macro that expands to (countdown N-1) until N=0, then to 42.
+		// With N=5, it re-expands 5 times, well within the limit of 10.
+		env.AddMacros(true, &langBuiltin{
+			name:    "countdown",
+			formals: Formals("n"),
+			fun: func(env *LEnv, args *LVal) *LVal {
+				n := args.Cells[0]
+				if n.Type != LInt || n.Int <= 0 {
+					return Int(42)
+				}
+				return SExpr([]*LVal{Symbol("countdown"), Int(n.Int - 1)})
+			},
+			docs: "test macro that expands N times then terminates",
+		})
+
+		result := env.Eval(SExpr([]*LVal{Symbol("countdown"), Int(5)}))
+		if result.Type == LError {
+			t.Fatalf("expected success for 5 expansions within limit 10, got error: %v", result)
+		}
+		if result.Type != LInt || result.Int != 42 {
+			t.Errorf("expected 42, got: %v", result)
+		}
+	})
+}

--- a/lisp/runtime.go
+++ b/lisp/runtime.go
@@ -12,27 +12,61 @@ import (
 // Runtime is an object underlying a family of tree of LEnv values.  It is
 // responsible for holding shared environment state, generating identifiers,
 // and writing debugging output to a stream (typically os.Stderr).
+//
+// Concurrency: Runtime and its associated LEnv tree are NOT safe for
+// concurrent use from multiple goroutines.  All calls to Eval, Load, and
+// any other methods that read or mutate Runtime or LEnv state must be
+// serialized by the caller.  To evaluate ELPS code concurrently, create a
+// separate Runtime (and LEnv tree) per goroutine.
+//
+// The only thread-safe operations are GenEnvID and GenSym, which use atomic
+// counters internally.  All other fields — including Registry, Package,
+// Stack, conditionStack, and the LEnv Scope maps — are unprotected.
 type Runtime struct {
-	Registry       *PackageRegistry
-	Package        *Package
-	Stderr         io.Writer
-	Stack          *CallStack
-	Reader         Reader
-	Library        SourceLibrary
-	Profiler       Profiler
-	MaxAlloc       int // Maximum single allocation size in bytes (0 = use default).
-	conditionStack []*LVal
-	numenv         atomicCounter
-	numsym         atomicCounter
+	Registry               *PackageRegistry
+	Package                *Package
+	Stderr                 io.Writer
+	Stack                  *CallStack
+	Reader                 Reader
+	Library                SourceLibrary
+	Profiler               Profiler
+	MaxAlloc               int // Per-operation allocation size cap (0 = use default). Not cumulative.
+	MaxMacroExpansionDepth int // Maximum macro expansion iterations (0 = use default).
+	conditionStack         []*LVal
+	numenv                 atomicCounter
+	numsym                 atomicCounter
 }
 
-// MaxAllocBytes returns the effective maximum single allocation size.
+// MaxAllocBytes returns the effective per-operation allocation size cap.
+// Each builtin that allocates a buffer or sequence checks its output size
+// against this limit independently — it is NOT a cumulative memory tracker.
 // If MaxAlloc is zero, DefaultMaxAlloc is returned.
 func (r *Runtime) MaxAllocBytes() int {
 	if r.MaxAlloc > 0 {
 		return r.MaxAlloc
 	}
 	return DefaultMaxAlloc
+}
+
+// MaxMacroExpansions returns the effective maximum macro expansion depth.
+// If MaxMacroExpansionDepth is zero, DefaultMaxMacroExpansionDepth is returned.
+func (r *Runtime) MaxMacroExpansions() int {
+	if r.MaxMacroExpansionDepth > 0 {
+		return r.MaxMacroExpansionDepth
+	}
+	return DefaultMaxMacroExpansionDepth
+}
+
+// CheckAlloc returns a non-empty error message if n exceeds the per-operation
+// allocation size cap.  This is a point-in-time check for a single operation,
+// not a cumulative memory tracker.  Callers should use this before allocating
+// buffers or sequences whose size is determined by user input.
+func (r *Runtime) CheckAlloc(n int) string {
+	max := r.MaxAllocBytes()
+	if n > max {
+		return fmt.Sprintf("allocation size %d exceeds maximum (%d)", n, max)
+	}
+	return ""
 }
 
 // PushCondition pushes an error onto the condition stack, making it available
@@ -61,11 +95,18 @@ func (r *Runtime) CurrentCondition() *LVal {
 	return r.conditionStack[n-1]
 }
 
-// DefaultMaxAlloc is the maximum size of a single allocation (in bytes for
-// strings, in elements for sequences) allowed by builtins like string:repeat
-// and make-sequence. This prevents memory exhaustion from untrusted input.
-// Applications can override this via Runtime.MaxAlloc.
+// DefaultMaxAlloc is the per-operation allocation size cap (in bytes for
+// strings, in elements for sequences) enforced by builtins like concat,
+// append, map, zip, reverse, make-sequence, and JSON load.  Each operation
+// checks its own output size independently — this is not a cumulative memory
+// budget.  It prevents a single malicious or accidental call from exhausting
+// memory.  Applications can override this via Runtime.MaxAlloc.
 const DefaultMaxAlloc = 10 * 1024 * 1024 // 10 million (bytes or elements)
+
+// DefaultMaxMacroExpansionDepth is the maximum number of successive macro
+// expansions allowed before Eval returns an error.  This prevents infinite
+// macro expansion from exhausting memory or running forever.
+const DefaultMaxMacroExpansionDepth = 1000
 
 // Default stack depth limits. These match the values used by the test harness
 // and provide protection against unbounded recursion exhausting the Go


### PR DESCRIPTION
## Summary

Addresses four findings from the failure mode analysis in #104:

- **HC-3**: Add parser depth limit (`DefaultMaxParseDepth = 10000`) to prevent goroutine stack overflow from deeply nested input — converts a fatal unrecoverable crash into a parse error
- **HC-9**: Add macro expansion depth limit (`DefaultMaxMacroExpansionDepth = 1000`) to prevent infinite macro expansion in both the `Eval` loop and `builtinMacroExpand`
- **HC-10**: Document `Runtime`'s single-threaded concurrency contract in godoc
- **HC-2**: Enforce `MaxAlloc` across all allocation-heavy builtins — `concat` (string/bytes/seq), `append`, `append!`, `zip`, `reverse`, `map`, `make-sequence`, and JSON `load-bytes`/`load-string`

All guards use `Runtime.CheckAlloc()` — a single integer comparison in the happy path with zero extra allocations. Benchstat confirms no measurable performance impact.

Closes #105

## Test plan

- [x] `TestParseDepthLimit` — boundary tests (at limit succeeds, limit+1 fails, bracket list variant)
- [x] `TestMacroExpansionDepthLimit` — infinite expansion caught with exact count, finite expansion within limit succeeds
- [x] 9 `TestCheckAlloc*` tests covering all guarded builtins, each with "exceeds" and "within limit" subtests
- [x] `TestLoadMaxAllocArray` / `TestLoadMaxAllocMap` — JSON allocation limits
- [x] `make test` passes (Go tests + example lisp files)
- [x] `make static-checks` — 0 issues
- [x] Benchstat: no statistically significant regression (p>0.15 on all benchmarks)

---
*Local tests passed. Security review completed.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>