### PR TITLE
Issue #100: DAP debugger Phase 1 implementation

### DIFF
--- a/.github/workflows/elps.yml
+++ b/.github/workflows/elps.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Tests
         run: make test
 
+      - name: Race detection (debugger)
+        run: go test -race -count=1 ./lisp/x/debugger/...
+
       - name: Check formatting
         run: |
           go build -o elps .

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -1,0 +1,163 @@
+// Copyright © 2018 The ELPS authors
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/lisp/x/debugger"
+	"github.com/luthersystems/elps/lisp/x/debugger/dapserver"
+	"github.com/luthersystems/elps/parser"
+	"github.com/spf13/cobra"
+)
+
+var (
+	debugPort        int
+	debugStdio       bool
+	debugStopOnEntry bool
+	debugRootDir     string
+)
+
+var debugCmd = &cobra.Command{
+	Use:   "debug [flags] file.lisp",
+	Short: "Run a file under the DAP debugger",
+	Long: `Start a DAP (Debug Adapter Protocol) debug server for an ELPS source file.
+
+The debug server allows editors (VS Code, Neovim, Helix, etc.) to set
+breakpoints, step through code, and inspect variables using the standard
+Debug Adapter Protocol.
+
+Transport modes:
+  --port N     Listen for a DAP client on TCP port N (default: 4711)
+  --stdio      Use stdin/stdout for DAP communication (for editors that
+               launch the debug adapter as a child process)
+
+The --stop-on-entry flag pauses execution before the first expression,
+giving the editor time to set breakpoints.
+
+Examples:
+  elps debug myfile.lisp                     Debug with TCP on port 4711
+  elps debug --port 9229 myfile.lisp         Debug with TCP on port 9229
+  elps debug --stdio myfile.lisp             Debug with stdio transport
+  elps debug --stop-on-entry myfile.lisp     Pause at first expression`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rootDir := debugRootDir
+		if rootDir == "" {
+			wd, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "cannot determine working directory: %v\n", err)
+				os.Exit(1)
+			}
+			rootDir = wd
+		}
+		rootDir, err := filepath.Abs(rootDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "cannot resolve root directory: %v\n", err)
+			os.Exit(1)
+		}
+
+		file := args[0]
+		relFile, ferr := toRelativePath(rootDir, file)
+		if ferr != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", ferr)
+			os.Exit(1)
+		}
+
+		// Create the debugger engine.
+		dbg := debugger.New(
+			debugger.WithStopOnEntry(debugStopOnEntry),
+		)
+		dbg.Enable()
+
+		// Create the DAP server.
+		srv := dapserver.New(dbg)
+
+		// Wire the engine's event callback to send DAP events.
+		// This runs on the eval goroutine, so it must not block.
+		// The DAP server's handler will pick up stopped events
+		// directly from the engine.
+
+		// Set up the ELPS environment.
+		env := lisp.NewEnv(nil)
+		env.Runtime.Reader = parser.NewReader()
+		env.Runtime.Library = &lisp.FSLibrary{FS: os.DirFS(rootDir)}
+		env.Runtime.Debugger = dbg
+
+		rc := lisp.InitializeUserEnv(env)
+		if !rc.IsNil() {
+			fmt.Fprintln(os.Stderr, rc)
+			os.Exit(1)
+		}
+		rc = lisplib.LoadLibrary(env)
+		if !rc.IsNil() {
+			fmt.Fprintln(os.Stderr, rc)
+			os.Exit(1)
+		}
+		rc = env.InPackage(lisp.String(lisp.DefaultUserPackage))
+		if !rc.IsNil() {
+			fmt.Fprintln(os.Stderr, rc)
+			os.Exit(1)
+		}
+
+		// Start the eval goroutine.
+		evalDone := make(chan *lisp.LVal, 1)
+		go func() {
+			res := env.LoadFile(relFile)
+			evalDone <- res
+		}()
+
+		// Serve DAP.
+		if debugStdio {
+			log.Println("DAP debugger: using stdio transport")
+			if err := srv.ServeStdio(os.Stdin, os.Stdout); err != nil {
+				fmt.Fprintf(os.Stderr, "dap server error: %v\n", err)
+			}
+		} else {
+			addr := fmt.Sprintf("localhost:%d", debugPort)
+			ln, err := net.Listen("tcp", addr)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "cannot listen on %s: %v\n", addr, err)
+				os.Exit(1)
+			}
+			defer ln.Close() //nolint:errcheck
+			log.Printf("DAP debugger listening on %s", addr)
+			log.Println("Waiting for DAP client to connect...")
+
+			conn, err := ln.Accept()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "accept error: %v\n", err)
+				os.Exit(1)
+			}
+			if err := srv.ServeConn(conn); err != nil {
+				fmt.Fprintf(os.Stderr, "dap server error: %v\n", err)
+			}
+		}
+
+		// Wait for eval to finish and report any errors.
+		res := <-evalDone
+		if res.Type == lisp.LError {
+			renderLispError(res, file)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(debugCmd)
+
+	debugCmd.Flags().IntVar(&debugPort, "port", 4711,
+		"TCP port for DAP server (default: 4711)")
+	debugCmd.Flags().BoolVar(&debugStdio, "stdio", false,
+		"Use stdin/stdout for DAP communication")
+	debugCmd.Flags().BoolVar(&debugStopOnEntry, "stop-on-entry", false,
+		"Pause execution before the first expression")
+	debugCmd.Flags().StringVar(&debugRootDir, "root-dir", "",
+		"Root directory for file access confinement (default: working directory)")
+}

--- a/docs/plans/debugger-design.md
+++ b/docs/plans/debugger-design.md
@@ -1,0 +1,965 @@
+# ELPS Debugger Design Document
+
+**Date:** 2026-02-12
+**Status:** Draft / RFC
+**Author:** Claude (with Sam)
+**Related:** PR #21 (2020, never merged), `docs/plans/lsp-support-enhancements.md`
+
+---
+
+## 1. Context & Motivation
+
+PR #21 (2020) attempted to add a debugger with two backends: Delve and DAP.
+That code was never merged and no longer exists in the repo. This document
+revisits the idea with a modern lens, considering:
+
+- The current ELPS architecture (no debugger code exists today)
+- Modern tooling (DAP ecosystem maturation, editor landscape changes)
+- The **embedded use case** (substrate and similar Go applications hosting ELPS)
+- The non-negotiable requirement of **zero overhead on the production hot path**
+
+### 1.1 Why not Delve?
+
+Delve debugs **Go code**, not languages hosted on Go. It operates at the Go
+runtime level (goroutines, Go stack frames, Go variables). It cannot:
+
+- Set breakpoints on Lisp source lines
+- Step through Lisp expressions
+- Inspect Lisp variable bindings or the ELPS call stack
+- Understand ELPS packages, macros, or tail recursion
+
+Delve is the wrong tool. The 2020 PR's Delve backend panicked immediately
+because Delve doesn't understand the interpreter's virtual call stack. A
+debugger for ELPS must be **interpreter-level**, not runtime-level.
+
+### 1.2 Why DAP?
+
+The **Debug Adapter Protocol** (Microsoft, same lineage as LSP) is now the
+universal standard for editor-debugger communication:
+
+| Editor       | DAP Support | Notes |
+|-------------|-------------|-------|
+| VS Code     | Native      | DAP was designed for VS Code |
+| Neovim      | nvim-dap    | Mature plugin, widely used |
+| Helix       | Built-in    | Experimental but improving |
+| JetBrains   | LSP4IJ      | DAP client plugin (all IDEs), CLion native since 2025.3 |
+| Emacs       | dap-mode    | Stable, wraps DAP over LSP |
+| Zed         | Built-in    | DAP support added 2025 |
+
+**One DAP server = every editor.** This is the same bet LSP made for language
+servers, and it paid off.
+
+#### Go library: `google/go-dap` (v0.10.0)
+
+- Provides DAP **types and codec** (message encoding/decoding)
+- Does NOT provide a server framework (you build the TCP listener + handler)
+- Used by Delve's own DAP server as the codec layer
+- Apache 2.0 license, maintained by Google
+
+#### Precedent: Go-hosted interpreters with debuggers
+
+| Interpreter | Language | Debugger Approach |
+|------------|----------|-------------------|
+| **Yaegi**  | Go       | Internal `Debugger` type with SetBreakpoints, StepInto/Over/Out, Continue |
+| **Goja**   | JavaScript | DAP-compatible debugger with CLI frontend |
+| **GraalVM/Truffle** | Polyglot | Built-in DAP server, language-agnostic via AST tags |
+
+Yaegi's approach (internal debugger interface + DAP adapter) is closest to
+what ELPS should do.
+
+---
+
+## 2. Architecture Overview
+
+Two cleanly separated layers:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Editor / IDE                          │
+│              (VS Code, Neovim, etc.)                     │
+└────────────────────┬────────────────────────────────────┘
+                     │ DAP over TCP/stdio
+┌────────────────────▼────────────────────────────────────┐
+│              DAP Server (Layer 2)                        │
+│         lisp/x/debugger/dapserver/                       │
+│                                                          │
+│  - Listens on TCP or communicates via stdio              │
+│  - Translates DAP messages ↔ Debugger interface calls    │
+│  - Uses google/go-dap for codec                          │
+│  - Manages session lifecycle                             │
+└────────────────────┬────────────────────────────────────┘
+                     │ Go interface calls
+┌────────────────────▼────────────────────────────────────┐
+│           Debugger Engine (Layer 1)                      │
+│              lisp/debugger.go                            │
+│                                                          │
+│  - Debugger interface on Runtime                         │
+│  - Breakpoint storage & matching                         │
+│  - Step state machine (into/over/out/continue)           │
+│  - Variable inspection (scope walking)                   │
+│  - Expression evaluation in suspended context            │
+│  - Call stack translation                                │
+└────────────────────┬────────────────────────────────────┘
+                     │ Hook calls (nil-checked)
+┌────────────────────▼────────────────────────────────────┐
+│           ELPS Interpreter Core                          │
+│              lisp/env.go                                 │
+│                                                          │
+│  Eval() → EvalSExpr() → funCall() → call()              │
+│  (existing hot path, untouched when debugger is nil)     │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 2.1 Why two layers?
+
+**Layer 1 (Debugger Engine)** lives in the `lisp/` package (or a sub-package)
+and has zero external dependencies. It provides the core debugging primitives:
+pause, resume, step, breakpoints, inspect. This layer is usable by embedders
+who want programmatic debugging without DAP (e.g., a custom REPL debugger, a
+test harness, or a substrate-specific debug UI).
+
+**Layer 2 (DAP Server)** is an optional adapter in `lisp/x/debugger/` that
+translates between the DAP wire protocol and the Layer 1 interface. It depends
+on `google/go-dap` but the interpreter core does not.
+
+This separation means:
+- **Substrate** can embed Layer 1 without pulling in DAP dependencies
+- **The `elps` CLI** can start Layer 2 for editor integration
+- **Tests** can exercise Layer 1 without network/protocol overhead
+- **Future protocols** (if DAP is ever superseded) only replace Layer 2
+
+---
+
+## 3. Layer 1: Debugger Engine
+
+### 3.1 The Debugger interface
+
+```go
+// lisp/debugger.go
+
+// Debugger is called by the interpreter at key execution points.
+// When Runtime.Debugger is nil, these calls are never made (zero cost).
+type Debugger interface {
+    // OnEval is called before evaluating any expression.
+    // Returns true if the debugger wants execution to pause.
+    // The env provides access to scope, stack, and current package.
+    OnEval(env *LEnv, expr *LVal) bool
+
+    // OnFunCall is called before a function is invoked (after args are evaluated).
+    // fun is the function value, args is the evaluated argument list.
+    OnFunCall(env *LEnv, fun, args *LVal)
+
+    // OnFunReturn is called after a function returns.
+    // fun is the function, result is the return value.
+    OnFunReturn(env *LEnv, fun, result *LVal)
+
+    // WaitIfPaused blocks until the debugger allows execution to continue.
+    // Called when OnEval returns true.
+    // Returns the action to take (Continue, StepInto, StepOver, StepOut).
+    WaitIfPaused(env *LEnv, expr *LVal) DebugAction
+}
+
+type DebugAction int
+
+const (
+    DebugContinue DebugAction = iota
+    DebugStepInto
+    DebugStepOver
+    DebugStepOut
+)
+```
+
+### 3.2 Hook points in the interpreter
+
+Only **three** touch points in `env.go`:
+
+**Hook 1: `Eval()`** — expression-level granularity for line stepping
+
+```go
+func (env *LEnv) Eval(v *LVal) *LVal {
+    env.Loc = v.Source
+    if env.Runtime.Debugger != nil {  // nil check = zero cost when disabled
+        if env.Runtime.Debugger.OnEval(env, v) {
+            env.Runtime.Debugger.WaitIfPaused(env, v)
+        }
+    }
+    // ... existing eval logic unchanged ...
+}
+```
+
+**Hook 2: `funCall()`** — function entry (replaces/extends profiler hook)
+
+```go
+func (env *LEnv) funCall(fun, args *LVal) *LVal {
+    if env.Runtime.Debugger != nil {
+        env.Runtime.Debugger.OnFunCall(env, fun, args)
+    }
+    if env.Runtime.Profiler != nil {
+        defer env.trace(fun)()
+    }
+    // ... existing funCall logic unchanged ...
+}
+```
+
+**Hook 3: `funCall()` return path** — function exit
+
+```go
+    // At the end of funCall, before returning r:
+    if env.Runtime.Debugger != nil {
+        env.Runtime.Debugger.OnFunReturn(env, fun, r)
+    }
+    return r
+```
+
+### 3.3 Performance analysis: zero-cost when disabled
+
+The critical question: **does adding these hooks slow down production code?**
+
+When `Runtime.Debugger` is `nil`:
+- Each hook is a **nil pointer check** (`CMPQ $0, offset(reg)` + `JE`)
+- This is 1-2 nanoseconds, branch-predicted as not-taken
+- The Go compiler may even inline and optimize this away
+- Comparable to the existing `Runtime.Profiler != nil` check already in `funCall()`
+
+**Verification plan:** Run the existing benchmarks (`BenchmarkEnvFunCallBuiltin`,
+`BenchmarkEnvFunCallRecursion`, etc.) before and after, using `benchstat` to
+confirm no statistically significant regression. The benchmark CI
+(`.github/workflows/benchmark.yml`) will catch any drift.
+
+The `Eval()` hook is the most frequently called — every expression traversal
+hits it. But the nil check is effectively free on modern CPUs due to branch
+prediction. The Profiler hook already proves this pattern works in `funCall()`.
+
+### 3.4 Breakpoint storage
+
+```go
+// Breakpoint represents a location where execution should pause.
+type Breakpoint struct {
+    ID        int
+    File      string
+    Line      int
+    Condition string           // optional: Lisp expression to evaluate
+    HitCount  int              // how many times hit (for conditional breaks)
+    Enabled   bool
+}
+```
+
+Breakpoints are stored in the debugger engine (not on `Runtime`), indexed by
+`file:line` for O(1) lookup during `OnEval`. The `OnEval` implementation
+checks `expr.Source` against the breakpoint map.
+
+### 3.5 Step state machine
+
+The debugger engine tracks stepping state:
+
+```
+          ┌──────────┐
+          │  Running  │ ←── Continue command
+          └────┬─────┘
+               │ breakpoint hit / step complete
+          ┌────▼─────┐
+          │  Paused   │ ←── WaitIfPaused blocks here
+          └────┬─────┘
+               │ user command
+     ┌─────────┼──────────┬────────────┐
+     ▼         ▼          ▼            ▼
+  Continue  StepInto   StepOver    StepOut
+```
+
+**StepInto**: Pause on the next `OnEval` call regardless of depth.
+
+**StepOver**: Record current stack depth. Pause on next `OnEval` where
+stack depth <= recorded depth (i.e., don't descend into function calls).
+
+**StepOut**: Record current stack depth. Pause on next `OnEval` where
+stack depth < recorded depth (i.e., wait until current function returns).
+
+Stack depth is available via `len(env.Runtime.Stack.Frames)`.
+
+### 3.6 Variable inspection
+
+When paused, the debugger can inspect variables by walking the `LEnv` chain:
+
+```go
+// InspectScope returns all bindings visible from the given environment.
+func InspectScope(env *LEnv) []ScopeBinding {
+    var bindings []ScopeBinding
+    current := env
+    for current != nil {
+        for name, val := range current.Scope {
+            bindings = append(bindings, ScopeBinding{
+                Name:  name,
+                Value: val,
+                Env:   current,
+            })
+        }
+        current = current.Parent
+    }
+    return bindings
+}
+```
+
+This naturally produces scoped results: local bindings first, then enclosing
+scopes, then package globals.
+
+### 3.7 Expression evaluation in debug context
+
+When paused, users expect to evaluate expressions in the current context
+(the "Debug Console" / REPL). This is straightforward:
+
+```go
+// EvalInContext parses and evaluates an expression in the paused environment.
+func EvalInContext(env *LEnv, source string) *LVal {
+    expr, err := env.Runtime.Reader.Read("debug-eval", strings.NewReader(source))
+    if err != nil {
+        return env.ErrorConditionf("debug-eval", "%v", err)
+    }
+    return env.Eval(expr[0])
+}
+```
+
+The paused `env` already has the correct scope chain, package context, and
+runtime state. This is one of the advantages of an interpreter-level debugger.
+
+### 3.8 Tail recursion interaction
+
+ELPS performs tail recursion optimization (TRO) by collapsing stack frames.
+During debugging, TRO makes stepping confusing because the stack appears to
+"jump" when frames are elided.
+
+**Recommendation:** When a debugger is attached, disable TRO. This means:
+- The logical and physical stack heights are always equal
+- Step commands behave predictably
+- Stack frames are never elided
+
+Implementation: In `funCall()`, skip the `TerminalFID()` check when
+`Runtime.Debugger != nil`. This only affects debug sessions — production
+code retains TRO.
+
+**Trade-off:** Deeply recursive programs may hit the stack limit during
+debugging. This is acceptable and matches how most debuggers work (e.g.,
+Python's default recursion limit is much lower than production capacity).
+
+---
+
+## 4. Layer 2: DAP Server
+
+### 4.1 Package structure
+
+```
+lisp/x/debugger/
+    debugger.go          // Debugger engine implementation (Layer 1 impl)
+    breakpoint.go        // Breakpoint storage, matching, conditions
+    stepper.go           // Step state machine
+    inspector.go         // Scope/variable inspection
+    dapserver/
+        server.go        // TCP listener, session management
+        handler.go       // DAP message → Debugger method dispatch
+        translate.go     // ELPS types → DAP types (stack frames, variables, etc.)
+```
+
+### 4.2 DAP message handling
+
+The DAP server handles these key request types:
+
+| DAP Request | ELPS Action |
+|------------|-------------|
+| `initialize` | Declare capabilities (breakpoints, stepping, eval, etc.) |
+| `launch` | Start ELPS execution in a goroutine, attach debugger |
+| `attach` | Attach to an already-running embedded ELPS instance |
+| `setBreakpoints` | Update breakpoint map for a source file |
+| `configurationDone` | Begin/resume execution |
+| `continue` | Set action to DebugContinue, unblock WaitIfPaused |
+| `next` | StepOver |
+| `stepIn` | StepInto |
+| `stepOut` | StepOut |
+| `stackTrace` | Translate `Runtime.Stack.Frames` → DAP StackFrame[] |
+| `scopes` | Return Local / Package / Global scope references |
+| `variables` | Walk `env.Scope` for the requested scope reference |
+| `evaluate` | EvalInContext for debug console expressions |
+| `disconnect` | Detach debugger, resume execution |
+
+### 4.3 The `attach` use case (embedded/substrate/shirotester)
+
+This is the **critical differentiator** for ELPS. Most DAP servers only
+support `launch` (the debugger starts the program). ELPS must also support
+`attach` — connecting to an ELPS instance already running inside a Go
+application like substrate or shirotester.
+
+#### Does the embedder need its own debugger?
+
+**No.** The ELPS debugger is sufficient. Here's why:
+
+When an embedder (substrate, shirotester) registers custom builtins via
+`elpsutil.PackageLoader` or `env.AddBuiltins()`, those builtins are stored
+in the standard `Runtime.Registry` as regular `LFun` values. They are
+**indistinguishable from ELPS-defined functions** at the package registry
+level. The debugger sees them automatically:
+
+| What the embedder registers | What the debugger sees |
+|----------------------------|------------------------|
+| Custom builtin (Go func) | Call entry + exit, args, return value, package name |
+| Custom special op | Same as builtin — entry/exit/args/return |
+| Custom macro | Expansion result + post-expansion source locations |
+| `.lisp` library files | **Full debugging** — breakpoints, stepping, variable inspection |
+| Go native values (`LVal.Native`) | Type name only (opaque `interface{}`) |
+
+The key insight: **embedder-registered builtins are opaque at the Go boundary
+but fully visible at the Lisp boundary.** When a user steps through code that
+calls `substrate:do-something`, the debugger:
+
+1. Shows `substrate:do-something` in the call stack with source location
+2. Shows the evaluated arguments passed to it
+3. Steps OVER the Go implementation (cannot step into Go code)
+4. Shows the return value when it comes back
+5. Resumes stepping through the calling Lisp code
+
+This is the correct behavior — it matches how every language debugger handles
+FFI calls (Python's C extensions, Ruby's C gems, etc.).
+
+#### When would an embedder need to do extra work?
+
+Only in these optional, advanced cases:
+
+1. **Custom variable formatters.** If the embedder stores complex Go structs
+   in `LVal.Native`, the default debugger shows them as
+   `<native:*mypackage.MyStruct>`. The embedder could register a
+   `VariableFormatter` to provide richer display:
+
+   ```go
+   dbg.RegisterFormatter("*mypackage.MyStruct", func(v interface{}) string {
+       s := v.(*mypackage.MyStruct)
+       return fmt.Sprintf("{name: %q, count: %d}", s.Name, s.Count)
+   })
+   ```
+
+   This is Phase 3 / nice-to-have. The debugger works without it.
+
+2. **Source path mapping.** If the embedder loads `.lisp` files from embedded
+   resources (e.g., `//go:embed`) rather than the filesystem, breakpoints by
+   file path won't match. The embedder would need to provide a source mapper
+   so the DAP server can resolve `"substrate/lib/auth.lisp"` to the actual
+   embedded content. This is solvable via the existing `SourceLibrary`
+   interface.
+
+3. **Conditional debug activation.** In production, the embedder would NOT
+   attach a debugger (zero overhead). In development/test, a flag like
+   `--debug-port=4711` would activate it. This is just a configuration
+   concern — the embedder decides when to call `WithDebugger()`.
+
+#### Embedder integration API
+
+```go
+// In the host application (e.g., substrate or shirotester):
+
+env := lisp.NewEnv(nil)
+lisp.InitializeUserEnv(env)
+lisplib.LoadLibrary(env)
+
+// Register custom packages (these are automatically visible to debugger)
+rc := elpsutil.Load(env, elpsutil.PackageLoader(&substrate.CorePackage{}))
+rc = elpsutil.Load(env, elpsutil.PackageLoader(&substrate.AuthPackage{}))
+// ... more custom packages ...
+
+// Optionally attach debugger (e.g., behind a --debug flag)
+if debugMode {
+    dbg := debugger.New(env.Runtime)
+    server := dapserver.New(dbg, dapserver.Options{
+        Addr: fmt.Sprintf("localhost:%d", debugPort),
+    })
+    go server.ListenAndServe()
+    log.Printf("DAP debugger listening on %s", server.Addr())
+}
+
+// Continue normal execution — if debugger is attached, hooks are active;
+// if not, Runtime.Debugger is nil and there is zero overhead.
+env.LoadFile("main.lisp")
+```
+
+**Shirotester specifically:** Since shirotester runs ELPS-based tests, the
+debug flow would be: set breakpoints in `.lisp` test files, attach the
+debugger, run the test. The debugger pauses at breakpoints in the test code.
+Calls to shirotester's custom test builtins (assertions, setup/teardown)
+appear in the stack and can be stepped over. The `.lisp` test files
+themselves are fully debuggable — breakpoints, stepping, variable inspection
+all work. No changes to shirotester's builtin registration are needed.
+
+The embedder starts the DAP server in a goroutine. The editor connects to it.
+The debugger hooks pause execution when breakpoints are hit, and the DAP
+server communicates the state back to the editor.
+
+**Key constraint:** The ELPS execution and the DAP server communicate via
+channels. The execution goroutine blocks on `WaitIfPaused()` (which reads
+from a channel). The DAP server goroutine writes commands to that channel.
+This is thread-safe by design.
+
+### 4.4 The `launch` use case (CLI)
+
+For standalone ELPS files:
+
+```bash
+elps debug --dap --port 4711 myfile.lisp
+```
+
+The CLI creates the env, attaches the debugger, starts the DAP server, and
+waits for the editor to connect before executing `myfile.lisp`.
+
+---
+
+## 5. What the debugger CAN and CANNOT see
+
+### Can see (Lisp-level):
+- ELPS call stack (function names, source locations, packages)
+- Local variable bindings (via scope walking)
+- Package-level globals (including embedder-registered symbols)
+- Function formal parameters
+- Macro expansion results (post-expansion source locations)
+- Error condition stack (what's being handled by `handler-bind`)
+- Expression values at breakpoints
+- All packages in `Runtime.Registry` (including embedder-registered packages)
+- Embedder `.lisp` files loaded via `load-file` or `SourceLibrary`
+
+### Cannot see (Go-level):
+- Go goroutine state
+- Go variables inside builtin/special-op implementations
+- Internal LVal memory layout
+- The Go call stack beneath the interpreter
+- Native Go values beyond type name (opaque `interface{}` in `LVal.Native`)
+
+### Partial visibility (the embedder boundary):
+
+This is the most important section for substrate/shirotester users.
+
+- **Embedder Go builtins** (registered via `AddBuiltins`/`elpsutil`): The
+  debugger sees the call into the builtin and the return value, but cannot
+  step inside the Go implementation. The function appears in the call stack
+  with its registered name and package. Arguments are fully inspectable
+  (they're evaluated LVals). This is the expected behavior — identical to
+  how Python debuggers handle C extensions or how Java debuggers handle
+  JNI calls.
+
+- **Embedder `.lisp` files**: Fully debuggable. If substrate loads
+  `lib/auth.lisp` via `load-file` or a `SourceLibrary`, breakpoints,
+  stepping, and variable inspection all work. These are first-class ELPS
+  source — the debugger treats them identically to user code.
+
+- **Embedder special ops**: Same as builtins — entry/exit visible, internals
+  opaque. Arguments are NOT evaluated (that's what makes them special ops),
+  so the debugger shows the raw unevaluated forms.
+
+- **Embedder macros**: The debugger sees the expanded result. Source locations
+  on macro-generated code point to the call site (via `stampMacroExpansion`).
+  Stepping through macro-expanded code may feel surprising if the expansion
+  is complex, but breakpoints on the call site work correctly.
+
+- **`LVal.Native` values**: The debugger can show the Go type name
+  (`*substrate.Transaction`, `*shirotester.TestContext`, etc.) but cannot
+  inspect fields. The optional `VariableFormatter` extension (Phase 3) lets
+  embedders provide richer display for their native types.
+
+### What this means for embedders
+
+**The ELPS debugger is the only debugger needed.** Embedders do NOT need to:
+- Implement their own debugger
+- Register their builtins specially for debugging
+- Change their `PackageLoader` or `AddBuiltins` calls
+- Provide any debug-specific metadata
+
+Everything works out of the box because custom builtins are stored as regular
+`LFun` values in the package registry. The debugger discovers them through
+the same `Runtime.Registry` that `elps doc` and the linter already use.
+
+---
+
+## 6. Complexity Assessment
+
+### Estimated effort by component
+
+| Component | Files | Estimated LOC | Difficulty | Notes |
+|-----------|-------|---------------|------------|-------|
+| Debugger interface + hooks | 1-2 | ~80 | Low | 3 nil-checked hook points in env.go |
+| Breakpoint engine | 1 | ~150 | Low | Map lookup, condition eval |
+| Step state machine | 1 | ~200 | Medium | StepOver/StepOut need depth tracking |
+| Variable inspector | 1 | ~150 | Low | Scope chain walking |
+| Debug eval (REPL) | 0 | ~30 | Low | Reuses existing Eval + Reader |
+| DAP server scaffold | 2 | ~400 | Medium | TCP listener, session lifecycle |
+| DAP message handler | 1 | ~600 | Medium-High | ~15 request types to implement |
+| DAP type translation | 1 | ~200 | Medium | LVal → DAP Variable, Stack → DAP Frame |
+| CLI integration | 1 | ~80 | Low | `elps debug` command |
+| Tests | 3-4 | ~500 | Medium | Need mock debugger, DAP client tests |
+| **Total** | **~12** | **~2400** | **Medium** | |
+
+### Risk assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Hot path performance regression | Low | High | Benchmark CI, nil-check pattern proven by Profiler |
+| TRO disabling causes stack overflow in debug | Medium | Low | Configurable, increase stack limit in debug mode |
+| DAP protocol complexity (edge cases) | Medium | Medium | Start with VS Code only, add editors incrementally |
+| Thread safety between DAP server + eval | Low | High | Channel-based communication, single-writer |
+| Expression eval side effects in debug console | Medium | Medium | Document that debug eval can mutate state |
+| Breakpoint in macro expansion | Medium | Medium | Use post-expansion source locations (stampMacroExpansion) |
+
+### Phasing
+
+**Phase 1 — Minimum Viable Debugger (~1200 LOC)**
+- Debugger interface + hooks in env.go
+- Breakpoint engine (by file:line)
+- Continue + StepInto only
+- Variable inspection (locals + globals)
+- CLI `elps debug` with stdin/stdout DAP
+- VS Code launch configuration
+
+**Phase 2 — Full Stepping (~600 LOC)**
+- StepOver + StepOut
+- Conditional breakpoints
+- Function breakpoints (by name)
+- Debug eval (REPL in paused context)
+- `attach` mode for embedded use
+
+**Phase 3 — Polish (~600 LOC)**
+- Hit count breakpoints
+- Log points (print without pausing)
+- Exception breakpoints (break on LError)
+- Watch expressions
+- Source mapping for macro expansions
+- Editor-specific launch configs (Neovim, JetBrains)
+
+---
+
+## 7. Impact on Existing Code
+
+The debugger is designed to be **almost entirely additive**. No changes to the
+AST (`LVal`), parser, token system, package registry, call stack, or any
+existing interface. The core interpreter requires only **surgical, minimal
+modifications** to 3 existing files.
+
+### 7.1 Files that DO NOT change
+
+These files/structures are untouched. The debugger reads them but never
+modifies their definitions:
+
+| File/Structure | Why no change needed |
+|---------------|---------------------|
+| `lisp/lisp.go` — `LVal` struct | Debugger uses existing `Source *token.Location` for breakpoints and `Cells`/`Scope` for inspection. No new fields. |
+| `lisp/lisp.go` — `LType` enum | No new types. Debugger operates on existing types. |
+| `lisp/lisp.go` — `LFunData` | Already has `FID`, `Package`, `Builtin`, `Env` — everything the debugger needs to identify functions. |
+| `lisp/lisp.go` — `SourceMeta` | Formatter metadata. Irrelevant to debugger. |
+| `parser/` (all files) | Source locations are already tracked (`token.Location` with File, Line, Col). No parser changes needed. |
+| `parser/token/token.go` — `Location` | Already has File, Line, Col, Pos. Sufficient for breakpoint matching. |
+| `lisp/stack.go` — `CallStack`, `CallFrame` | Already has Source, FID, Package, Name, HeightLogical, Terminal, TROBlock. The debugger reads these, never extends them. |
+| `lisp/package.go` — `Package`, `PackageRegistry` | Debugger reads `pkg.Symbols` for variable inspection. No changes. |
+| `lisp/builtins.go` | All builtins unchanged. `debug-print` and `debug-stack` remain as-is. |
+| `lisp/op.go` | All special operators unchanged. |
+| `lisp/macro.go` | `stampMacroExpansion` already handles source locations. No changes. |
+| `lisp/profiler.go` — `Profiler` interface | Remains independent. Debugger is a separate concern. |
+| `lisp/error.go` | Error types and stack trace attachment unchanged. |
+| `formatter/` | Completely unrelated to runtime debugging. |
+| `lint/`, `analysis/` | Static analysis, unrelated to runtime. |
+| `elpsutil/` | Embedding helpers unchanged. |
+| `elpstest/` | Test framework unchanged. |
+
+### 7.2 Files that change (3 files, ~15 lines of modifications)
+
+#### `lisp/runtime.go` — Add one field
+
+```diff
+ type Runtime struct {
+     Registry       *PackageRegistry
+     Package        *Package
+     Stderr         io.Writer
+     Stack          *CallStack
+     Reader         Reader
+     Library        SourceLibrary
+     Profiler       Profiler
++    Debugger       Debugger          // nil = disabled (zero overhead)
+     MaxAlloc       int
+     conditionStack []*LVal
+     numenv         atomicCounter
+     numsym         atomicCounter
+ }
+```
+
+**Impact:** Adding a field to a struct. Zero risk. The field is `nil` by
+default (`StandardRuntime()` does not set it). No existing code references it.
+Size increase: 16 bytes per Runtime (one interface = pointer pair). There is
+exactly one Runtime per interpreter instance.
+
+#### `lisp/env.go` — Add nil-checked hooks at 3 points
+
+**Point 1: `Eval()` (line ~831)** — expression-level hook
+
+```diff
+ func (env *LEnv) Eval(v *LVal) *LVal {
+ eval:
+     if v.Spliced {
+         return env.Errorf("spliced value used as expression")
+     }
+     env.Loc = v.Source
++    if env.Runtime.Debugger != nil {
++        if env.Runtime.Debugger.OnEval(env, v) {
++            env.Runtime.Debugger.WaitIfPaused(env, v)
++        }
++    }
+     if v.Quoted {
+         return v
+     }
+```
+
+**Impact:** 4 lines added. When `Debugger` is nil, this is a single
+pointer comparison (`CMPQ $0, offset(reg)`) that the CPU branch-predicts
+as not-taken. Identical to the existing `Profiler != nil` pattern in
+`funCall()`. The `Eval` function is the hottest path — this is the change
+that matters most. Benchmark verification is mandatory.
+
+**Point 2: `funCall()` (line ~1034)** — function entry hook
+
+```diff
+ func (env *LEnv) funCall(fun, args *LVal) *LVal {
+     if fun.Type != LFun {
+         return env.Errorf("not a function: %v", fun.Type)
+     }
+     if fun.IsSpecialFun() {
+         return env.Errorf("not a regular function: %v", fun.FunType)
+     }
+
++    if env.Runtime.Debugger != nil {
++        env.Runtime.Debugger.OnFunCall(env, fun, args)
++    }
+     if env.Runtime.Profiler != nil {
+         defer env.trace(fun)()
+     }
+```
+
+**Impact:** 3 lines added, immediately before the existing Profiler check.
+Same nil-check pattern. Fires once per function call (not per expression).
+
+**Point 3: `funCall()` return path (line ~1079)** — function exit hook
+
+```diff
++    if env.Runtime.Debugger != nil {
++        env.Runtime.Debugger.OnFunReturn(env, fun, r)
++    }
+     return r
+ }
+```
+
+**Impact:** 3 lines added at the end of `funCall()`. Same nil-check pattern.
+
+**Point 4: TRO conditional disable (line ~1042)** — optional
+
+```diff
+-    npop := env.Runtime.Stack.TerminalFID(fun.FID())
++    var npop int
++    if env.Runtime.Debugger == nil {
++        npop = env.Runtime.Stack.TerminalFID(fun.FID())
++    }
+```
+
+**Impact:** Wraps existing TRO check in a nil guard. When debugger is nil,
+behavior is identical. When debugger is attached, TRO is disabled for
+predictable stepping. 2 lines changed.
+
+#### `lisp/config.go` — Add one Config function
+
+```diff
++// WithDebugger returns a Config that attaches a debugger to the runtime.
++// When a debugger is attached, tail recursion optimization is disabled
++// to provide predictable stepping behavior.
++func WithDebugger(d Debugger) Config {
++    return func(env *LEnv) *LVal {
++        env.Runtime.Debugger = d
++        return Nil()
++    }
++}
+```
+
+**Impact:** Purely additive. 7 lines. Follows the existing pattern
+(`WithReader`, `WithStderr`, `WithLibrary`, `WithMaximum*`).
+
+### 7.3 New files (purely additive)
+
+| File | Contents | Depends on |
+|------|----------|-----------|
+| `lisp/debugger.go` | `Debugger` interface, `DebugAction` enum, `Breakpoint` type | `lisp` package only (no new deps) |
+| `lisp/x/debugger/debugger.go` | Engine implementation | `lisp` |
+| `lisp/x/debugger/breakpoint.go` | Breakpoint storage + matching | `lisp`, `parser/token` |
+| `lisp/x/debugger/stepper.go` | Step state machine | `lisp` |
+| `lisp/x/debugger/inspector.go` | Scope/variable inspection | `lisp` |
+| `lisp/x/debugger/dapserver/server.go` | TCP listener | `google/go-dap` |
+| `lisp/x/debugger/dapserver/handler.go` | DAP message dispatch | `google/go-dap`, debugger engine |
+| `lisp/x/debugger/dapserver/translate.go` | ELPS→DAP type mapping | `google/go-dap`, `lisp` |
+| `cmd/debug.go` | `elps debug` CLI command | `lisp/x/debugger` |
+
+### 7.4 New dependency
+
+```
+google/go-dap v0.10.0
+```
+
+This dependency is **only imported by `lisp/x/debugger/dapserver/`**. The
+core `lisp/` package has zero new dependencies. An embedder that uses Layer 1
+(the `Debugger` interface) directly does not pull in `go-dap`.
+
+### 7.5 Summary: change surface
+
+```
+Existing code modified:    ~15 lines across 3 files
+Existing structs modified: 1 field added to Runtime (nil by default)
+AST changes:               NONE
+Parser changes:            NONE
+Token changes:             NONE
+Call stack changes:         NONE
+Package registry changes:  NONE
+Builtin changes:           NONE
+New external dependency:   1 (go-dap, isolated to dapserver/ subpackage)
+New files:                 ~10
+New LOC:                   ~2400
+```
+
+The debugger is essentially a **plugin that reads existing structures**. It
+adds one field to Runtime, adds nil-checked calls at 3 points in the eval
+loop, and everything else is new code in new files. If the debugger feature
+were ever removed, reverting those ~15 lines would leave the codebase exactly
+as it was.
+
+---
+
+## 8. Alternatives Considered
+
+### 8.1 Extend the Profiler interface instead of adding Debugger
+
+**Pros:** Reuses existing hook point, no new field on Runtime.
+**Cons:** Profiler semantics are wrong — Start/Stop is for timing, not
+pause/resume. Mixing concerns makes both profiling and debugging worse.
+A debugger needs to block execution; a profiler must never block.
+**Verdict:** Rejected. Keep Profiler and Debugger as separate concerns.
+
+### 8.2 Chrome DevTools Protocol (CDP) instead of DAP
+
+**Pros:** Rich, well-documented, good for web-based UIs.
+**Cons:** Designed for JavaScript/browser debugging, poor editor integration
+(no native support in VS Code for non-JS languages, no Neovim plugin).
+Much larger protocol surface area. No Go library ecosystem.
+**Verdict:** Rejected. DAP has better editor coverage.
+
+### 8.3 Custom protocol (like the 2020 PR's Delve approach)
+
+**Pros:** Maximum flexibility.
+**Cons:** Requires building editor extensions from scratch for every editor.
+Enormous maintenance burden. The 2020 PR required a custom VS Code extension.
+**Verdict:** Rejected. DAP eliminates this entire class of work.
+
+### 8.4 GDB/MI protocol
+
+**Pros:** Supported by older tools.
+**Cons:** Legacy protocol, poor editor support outside GDB frontends,
+designed for native code debugging. Declining ecosystem.
+**Verdict:** Rejected.
+
+### 8.5 No debugger — just improve debug-print/debug-stack
+
+**Pros:** Zero complexity.
+**Cons:** Doesn't solve the actual problem. Printf debugging is the baseline,
+not the goal. Modern developers expect breakpoint/step/inspect workflows.
+**Verdict:** Rejected as the sole approach, but `debug-print` and
+`debug-stack` remain useful as lightweight alternatives.
+
+---
+
+## 9. Interaction with Existing Systems
+
+### 9.1 Profiler
+
+The Debugger and Profiler are independent. Both can be active simultaneously:
+- Profiler fires in `funCall()` via `defer env.trace(fun)()`
+- Debugger fires in `Eval()` via `OnEval()` and in `funCall()` via `OnFunCall()`
+- No ordering dependency between them
+
+### 9.2 LSP
+
+The LSP support enhancements (`docs/plans/lsp-support-enhancements.md`) and
+the debugger are complementary:
+- LSP provides editing features (completion, diagnostics, go-to-definition)
+- Debugger provides runtime features (breakpoints, stepping, inspection)
+- They share no state and can be developed independently
+- The LSP's semantic analyzer (P3) could eventually provide richer variable
+  type information to the debugger, but this is not required for v1
+
+### 9.3 Formatter and Linter
+
+No interaction. The debugger operates at runtime, not on static source.
+
+### 9.4 Error handling (handler-bind / rethrow)
+
+The debugger can provide "break on exception" functionality by hooking into
+the condition system. When `opHandlerBind` pushes to `Runtime.conditionStack`,
+the debugger can optionally pause. This is a Phase 3 feature.
+
+---
+
+## 10. Configuration API
+
+```go
+// Config function for embedders
+func WithDebugger(d Debugger) Config {
+    return func(env *LEnv) *LVal {
+        env.Runtime.Debugger = d
+        return Nil()
+    }
+}
+
+// Usage:
+env := lisp.NewEnv(nil)
+dbg := debugger.New()
+lisp.InitializeUserEnv(env, lisp.WithDebugger(dbg))
+```
+
+This follows the established Config pattern (`WithReader`, `WithStderr`,
+`WithLibrary`). The debugger is optional and nil by default.
+
+---
+
+## 11. Open Questions
+
+1. **Should the debugger disable TRO globally or per-session?** If globally,
+   it simplifies the implementation but means attaching a debugger changes
+   execution behavior. Per-session would require tracking which call chains
+   are being debugged.
+
+2. **Should `OnEval` fire for every expression or only expressions with
+   source locations?** Synthetic expressions (from macro expansion with
+   `Pos < 0`) may not be meaningful to step through. Filtering them reduces
+   overhead but may miss debugging opportunities.
+
+3. **Should the DAP server support both TCP and stdio?** VS Code typically
+   launches the debug adapter as a child process (stdio). Embedded attach
+   requires TCP. Supporting both is straightforward but adds complexity.
+
+4. **Should debug eval be sandboxed?** Evaluating expressions in the debug
+   console can mutate program state (e.g., `(set! x 42)`). Some debuggers
+   prevent mutations; others allow them. ELPS should probably allow them
+   (REPL philosophy) but document the risk.
+
+5. **Goroutine model for the DAP server?** The Delve DAP server uses a
+   single-client model (restart for each session). This is simpler and
+   sufficient for v1.
+
+---
+
+## 12. Summary
+
+| Aspect | Decision |
+|--------|----------|
+| Protocol | DAP (Debug Adapter Protocol) |
+| Go library | `google/go-dap` v0.10.0 (codec only) |
+| Architecture | Two layers: internal Debugger interface + DAP adapter |
+| Hook mechanism | Nil-checked calls in Eval() and funCall() |
+| Hot path cost | Zero when debugger is nil (branch-predicted nil check) |
+| Embedded support | `attach` mode via WithDebugger() Config |
+| CLI support | `elps debug --dap` command |
+| Editor coverage | VS Code (Phase 1), Neovim/JetBrains/Helix (Phase 3) |
+| Total estimated LOC | ~2400 across ~12 files |
+| Overall difficulty | Medium — no novel algorithms, well-trodden patterns |
+| Biggest risk | DAP protocol edge cases in message handler |
+| Biggest win | One implementation serves every editor |

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/google/go-dap v0.12.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-dap v0.12.0 h1:rVcjv3SyMIrpaOoTAdFDyHs99CwVOItIJGKLQFQhNeM=
+github.com/google/go-dap v0.12.0/go.mod h1:tNjCASCm5cqePi/RVXXWEVqtnNLV1KTWtYOqu6rZNzc=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/lisp/config.go
+++ b/lisp/config.go
@@ -94,3 +94,13 @@ func WithMaxAlloc(n int) Config {
 		return Nil()
 	}
 }
+
+// WithDebugger returns a Config that attaches a debugger to the runtime.
+// When a debugger is attached, tail recursion optimization is disabled to
+// provide predictable stepping behavior and stack traces.
+func WithDebugger(d Debugger) Config {
+	return func(env *LEnv) *LVal {
+		env.Runtime.Debugger = d
+		return Nil()
+	}
+}

--- a/lisp/debugger.go
+++ b/lisp/debugger.go
@@ -1,0 +1,71 @@
+// Copyright © 2018 The ELPS authors
+
+package lisp
+
+// Debugger is called by the interpreter at key execution points to support
+// breakpoints, stepping, and variable inspection. When Runtime.Debugger is
+// nil, no hook calls are made and there is zero overhead on the hot path.
+//
+// Hook calls use a two-check gate pattern:
+//
+//	if d := env.Runtime.Debugger; d != nil && d.IsEnabled() { ... }
+//
+// The nil check is free (branch-predicted not-taken). IsEnabled allows a
+// debugger to remain attached but dormant, further reducing overhead when
+// not actively debugging.
+type Debugger interface {
+	// IsEnabled returns true when the debugger is actively debugging.
+	// A dormant debugger (attached but not yet activated) returns false,
+	// allowing the interpreter to skip all other hook calls.
+	IsEnabled() bool
+
+	// OnEval is called before evaluating any expression with a real source
+	// location (v.Source != nil). Synthetic expressions from macro expansion
+	// are skipped.
+	// Returns true if the debugger wants execution to pause (breakpoint hit
+	// or step complete).
+	OnEval(env *LEnv, expr *LVal) bool
+
+	// WaitIfPaused blocks until the debugger allows execution to continue.
+	// Called when OnEval returns true. The eval goroutine blocks here while
+	// the DAP server goroutine processes user commands.
+	// Returns the action to take after resuming.
+	WaitIfPaused(env *LEnv, expr *LVal) DebugAction
+
+	// OnFunEntry is called when a function is entered, after formal
+	// parameters have been bound in the function's lexical environment.
+	// env is the caller's environment; fenv is the function's environment
+	// with parameter bindings in scope. For builtins (which have no lexical
+	// env), this hook is not called.
+	OnFunEntry(env *LEnv, fun *LVal, fenv *LEnv)
+
+	// OnFunReturn is called after a function returns.
+	// fun is the function value, result is the return value.
+	OnFunReturn(env *LEnv, fun, result *LVal)
+
+	// OnError is called when an error condition is created (in
+	// ErrorCondition and ErrorConditionf). Returns true if the debugger
+	// wants execution to pause (exception breakpoint). When true, the
+	// interpreter calls WaitIfPaused with the error value.
+	OnError(env *LEnv, lerr *LVal) bool
+}
+
+// DebugAction represents the action the interpreter should take after
+// the debugger resumes execution from a paused state.
+type DebugAction int
+
+const (
+	// DebugContinue resumes execution until the next breakpoint.
+	DebugContinue DebugAction = iota
+
+	// DebugStepInto pauses on the next OnEval call regardless of depth.
+	DebugStepInto
+
+	// DebugStepOver pauses on the next OnEval call at the same or
+	// lesser stack depth (does not descend into function calls).
+	DebugStepOver
+
+	// DebugStepOut pauses on the next OnEval call at a lesser stack
+	// depth (waits until the current function returns).
+	DebugStepOut
+)

--- a/lisp/runtime.go
+++ b/lisp/runtime.go
@@ -30,7 +30,8 @@ type Runtime struct {
 	Reader                 Reader
 	Library                SourceLibrary
 	Profiler               Profiler
-	MaxAlloc               int // Per-operation allocation size cap (0 = use default). Not cumulative.
+	Debugger               Debugger // nil = disabled (zero overhead on hot path)
+	MaxAlloc               int      // Per-operation allocation size cap (0 = use default). Not cumulative.
 	MaxMacroExpansionDepth int // Maximum macro expansion iterations (0 = use default).
 	conditionStack         []*LVal
 	numenv                 atomicCounter

--- a/lisp/x/debugger/breakpoint.go
+++ b/lisp/x/debugger/breakpoint.go
@@ -1,0 +1,206 @@
+// Copyright © 2018 The ELPS authors
+
+package debugger
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// Breakpoint represents a location where execution should pause.
+type Breakpoint struct {
+	ID        int
+	File      string
+	Line      int
+	Condition string // optional: Lisp expression to evaluate
+	Enabled   bool
+}
+
+// key returns the file:line key used for map indexing.
+func (bp *Breakpoint) key() string {
+	return breakpointKey(bp.File, bp.Line)
+}
+
+func breakpointKey(file string, line int) string {
+	return fmt.Sprintf("%s:%d", file, line)
+}
+
+// ExceptionBreakMode controls when the debugger pauses on exceptions.
+type ExceptionBreakMode int
+
+const (
+	// ExceptionBreakNever disables exception breakpoints.
+	ExceptionBreakNever ExceptionBreakMode = iota
+	// ExceptionBreakAll pauses on all exceptions.
+	ExceptionBreakAll
+	// ExceptionBreakUncaught pauses only on uncaught exceptions (not yet implemented).
+	ExceptionBreakUncaught
+)
+
+// BreakpointStore manages breakpoints indexed by file:line for O(1) lookup.
+// All methods are safe for concurrent use from the DAP server goroutine
+// while the eval goroutine reads via Match.
+type BreakpointStore struct {
+	mu             sync.RWMutex
+	byKey          map[string]*Breakpoint
+	nextID         int
+	exceptionBreak ExceptionBreakMode
+}
+
+// NewBreakpointStore returns an empty breakpoint store.
+func NewBreakpointStore() *BreakpointStore {
+	return &BreakpointStore{
+		byKey: make(map[string]*Breakpoint),
+	}
+}
+
+// Set adds or replaces a breakpoint at the given file:line. Returns the
+// breakpoint with its assigned ID.
+func (s *BreakpointStore) Set(file string, line int, condition string) *Breakpoint {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := breakpointKey(file, line)
+	bp, exists := s.byKey[key]
+	if exists {
+		bp.Condition = condition
+		bp.Enabled = true
+		return bp
+	}
+	s.nextID++
+	bp = &Breakpoint{
+		ID:        s.nextID,
+		File:      file,
+		Line:      line,
+		Condition: condition,
+		Enabled:   true,
+	}
+	s.byKey[key] = bp
+	return bp
+}
+
+// Remove removes the breakpoint at file:line. Returns true if it existed.
+func (s *BreakpointStore) Remove(file string, line int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := breakpointKey(file, line)
+	_, ok := s.byKey[key]
+	if ok {
+		delete(s.byKey, key)
+	}
+	return ok
+}
+
+// ClearFile removes all breakpoints for the given file.
+func (s *BreakpointStore) ClearFile(file string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prefix := file + ":"
+	for key := range s.byKey {
+		if strings.HasPrefix(key, prefix) {
+			delete(s.byKey, key)
+		}
+	}
+}
+
+// SetForFile replaces all breakpoints in a file. This implements the DAP
+// setBreakpoints semantics (full replacement, not incremental).
+func (s *BreakpointStore) SetForFile(file string, lines []int, conditions []string) []*Breakpoint {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Remove old breakpoints for this file.
+	prefix := file + ":"
+	for key := range s.byKey {
+		if strings.HasPrefix(key, prefix) {
+			delete(s.byKey, key)
+		}
+	}
+	// Add new ones.
+	result := make([]*Breakpoint, len(lines))
+	for i, line := range lines {
+		s.nextID++
+		cond := ""
+		if i < len(conditions) {
+			cond = conditions[i]
+		}
+		bp := &Breakpoint{
+			ID:        s.nextID,
+			File:      file,
+			Line:      line,
+			Condition: cond,
+			Enabled:   true,
+		}
+		s.byKey[bp.key()] = bp
+		result[i] = bp
+	}
+	return result
+}
+
+// Match returns the breakpoint at the given source location, or nil.
+func (s *BreakpointStore) Match(src *token.Location) *Breakpoint {
+	if src == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	key := breakpointKey(src.File, src.Line)
+	bp, ok := s.byKey[key]
+	if !ok || !bp.Enabled {
+		return nil
+	}
+	return bp
+}
+
+// SetExceptionBreak sets the exception breakpoint mode.
+func (s *BreakpointStore) SetExceptionBreak(mode ExceptionBreakMode) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.exceptionBreak = mode
+}
+
+// ExceptionBreak returns the current exception breakpoint mode.
+func (s *BreakpointStore) ExceptionBreak() ExceptionBreakMode {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.exceptionBreak
+}
+
+// EvalCondition evaluates a breakpoint's condition expression in the
+// given environment. Returns true if the condition is satisfied (or if
+// there is no condition). The evaluatingCondition flag on the engine
+// must be set before calling this to prevent re-entrancy.
+func EvalCondition(env *lisp.LEnv, condition string) bool {
+	if condition == "" {
+		return true
+	}
+	if env.Runtime.Reader == nil {
+		return true
+	}
+	exprs, err := env.Runtime.Reader.Read("bp-condition", strings.NewReader(condition))
+	if err != nil || len(exprs) == 0 {
+		return true // condition failed to parse — treat as unconditional
+	}
+	result := env.Eval(exprs[0])
+	// ELPS falsiness: nil, errors, and the false symbol are all falsey.
+	if result.IsNil() || result.Type == lisp.LError {
+		return false
+	}
+	if result.Type == lisp.LSymbol && result.Str == lisp.FalseSymbol {
+		return false
+	}
+	return true
+}
+
+// All returns all breakpoints in the store.
+func (s *BreakpointStore) All() []*Breakpoint {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]*Breakpoint, 0, len(s.byKey))
+	for _, bp := range s.byKey {
+		result = append(result, bp)
+	}
+	return result
+}

--- a/lisp/x/debugger/breakpoint_test.go
+++ b/lisp/x/debugger/breakpoint_test.go
@@ -1,0 +1,130 @@
+package debugger
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBreakpointStore_SetAndMatch(t *testing.T) {
+	store := NewBreakpointStore()
+
+	bp := store.Set("test.lisp", 10, "")
+	assert.Equal(t, 1, bp.ID)
+	assert.Equal(t, "test.lisp", bp.File)
+	assert.Equal(t, 10, bp.Line)
+	assert.True(t, bp.Enabled)
+
+	// Match with matching location.
+	loc := &token.Location{File: "test.lisp", Line: 10}
+	matched := store.Match(loc)
+	assert.NotNil(t, matched)
+	assert.Equal(t, bp.ID, matched.ID)
+
+	// No match on different line.
+	loc2 := &token.Location{File: "test.lisp", Line: 11}
+	assert.Nil(t, store.Match(loc2))
+
+	// No match on different file.
+	loc3 := &token.Location{File: "other.lisp", Line: 10}
+	assert.Nil(t, store.Match(loc3))
+
+	// Nil source returns nil.
+	assert.Nil(t, store.Match(nil))
+}
+
+func TestBreakpointStore_Remove(t *testing.T) {
+	store := NewBreakpointStore()
+	store.Set("test.lisp", 10, "")
+
+	ok := store.Remove("test.lisp", 10)
+	assert.True(t, ok)
+
+	loc := &token.Location{File: "test.lisp", Line: 10}
+	assert.Nil(t, store.Match(loc))
+
+	// Removing non-existent breakpoint returns false.
+	ok = store.Remove("test.lisp", 10)
+	assert.False(t, ok)
+}
+
+func TestBreakpointStore_SetForFile(t *testing.T) {
+	store := NewBreakpointStore()
+
+	// Set initial breakpoints.
+	store.Set("test.lisp", 5, "")
+	store.Set("test.lisp", 10, "")
+	store.Set("other.lisp", 15, "")
+
+	// Replace all breakpoints for test.lisp.
+	bps := store.SetForFile("test.lisp", []int{20, 25}, []string{"(> x 5)", ""})
+	assert.Len(t, bps, 2)
+	assert.Equal(t, 20, bps[0].Line)
+	assert.Equal(t, "(> x 5)", bps[0].Condition)
+	assert.Equal(t, 25, bps[1].Line)
+	assert.Empty(t, bps[1].Condition)
+
+	// Old breakpoints in test.lisp are gone.
+	loc5 := &token.Location{File: "test.lisp", Line: 5}
+	assert.Nil(t, store.Match(loc5))
+	loc10 := &token.Location{File: "test.lisp", Line: 10}
+	assert.Nil(t, store.Match(loc10))
+
+	// New breakpoints are active.
+	loc20 := &token.Location{File: "test.lisp", Line: 20}
+	assert.NotNil(t, store.Match(loc20))
+
+	// Other file is unaffected.
+	loc15 := &token.Location{File: "other.lisp", Line: 15}
+	assert.NotNil(t, store.Match(loc15))
+}
+
+func TestBreakpointStore_ClearFile(t *testing.T) {
+	store := NewBreakpointStore()
+	store.Set("test.lisp", 5, "")
+	store.Set("test.lisp", 10, "")
+	store.Set("other.lisp", 15, "")
+
+	store.ClearFile("test.lisp")
+	assert.Nil(t, store.Match(&token.Location{File: "test.lisp", Line: 5}))
+	assert.Nil(t, store.Match(&token.Location{File: "test.lisp", Line: 10}))
+	assert.NotNil(t, store.Match(&token.Location{File: "other.lisp", Line: 15}))
+}
+
+func TestBreakpointStore_ExceptionBreak(t *testing.T) {
+	store := NewBreakpointStore()
+	assert.Equal(t, ExceptionBreakNever, store.ExceptionBreak())
+
+	store.SetExceptionBreak(ExceptionBreakAll)
+	assert.Equal(t, ExceptionBreakAll, store.ExceptionBreak())
+
+	store.SetExceptionBreak(ExceptionBreakNever)
+	assert.Equal(t, ExceptionBreakNever, store.ExceptionBreak())
+}
+
+func TestBreakpointStore_All(t *testing.T) {
+	store := NewBreakpointStore()
+	store.Set("a.lisp", 1, "")
+	store.Set("b.lisp", 2, "")
+
+	all := store.All()
+	assert.Len(t, all, 2)
+}
+
+func TestBreakpointStore_IDsAreUnique(t *testing.T) {
+	store := NewBreakpointStore()
+	bp1 := store.Set("test.lisp", 1, "")
+	bp2 := store.Set("test.lisp", 2, "")
+	assert.NotEqual(t, bp1.ID, bp2.ID)
+}
+
+func TestBreakpointStore_SetUpdatesExisting(t *testing.T) {
+	store := NewBreakpointStore()
+	bp1 := store.Set("test.lisp", 10, "")
+	bp2 := store.Set("test.lisp", 10, "(> x 5)")
+
+	// Same breakpoint ID, updated condition.
+	assert.Equal(t, bp1.ID, bp2.ID)
+	assert.Equal(t, "(> x 5)", bp2.Condition)
+}

--- a/lisp/x/debugger/dapserver/handler.go
+++ b/lisp/x/debugger/dapserver/handler.go
@@ -1,0 +1,389 @@
+// Copyright © 2018 The ELPS authors
+
+package dapserver
+
+import (
+	"log"
+	"sync"
+
+	"github.com/google/go-dap"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/x/debugger"
+)
+
+// scopeRef constants encode scope type into variable references.
+// The frame index is embedded: ref = base + frameIndex.
+const (
+	scopeLocalBase   = 1000
+	scopePackageBase = 3000
+)
+
+// handler dispatches incoming DAP messages to the appropriate method.
+type handler struct {
+	server *Server
+	engine *debugger.Engine
+
+	mu          sync.Mutex
+	initialized bool
+	launched    bool
+
+	// frameEnvs caches the environments for each stack frame when paused.
+	// Indexed by frame ID (1-based, most recent first).
+	frameEnvs map[int]*lisp.LEnv
+}
+
+func newHandler(s *Server, e *debugger.Engine) *handler {
+	h := &handler{
+		server: s,
+		engine: e,
+	}
+	// Wire the engine's event callback to forward stopped events to the DAP client.
+	e.SetEventCallback(func(evt debugger.Event) {
+		if evt.Type == debugger.EventStopped {
+			var bpIDs []int
+			if evt.BP != nil {
+				bpIDs = []int{evt.BP.ID}
+			}
+			h.sendStoppedEvent(evt.Reason, bpIDs)
+		}
+	})
+	return h
+}
+
+// send sends a DAP message and logs any write error.
+func (h *handler) send(msg dap.Message) {
+	if err := h.server.send(msg); err != nil {
+		log.Printf("dap: send error: %v", err)
+	}
+}
+
+func (h *handler) handle(msg dap.Message) {
+	switch req := msg.(type) {
+	case *dap.InitializeRequest:
+		h.onInitialize(req)
+	case *dap.SetBreakpointsRequest:
+		h.onSetBreakpoints(req)
+	case *dap.SetExceptionBreakpointsRequest:
+		h.onSetExceptionBreakpoints(req)
+	case *dap.ConfigurationDoneRequest:
+		h.onConfigurationDone(req)
+	case *dap.ThreadsRequest:
+		h.onThreads(req)
+	case *dap.StackTraceRequest:
+		h.onStackTrace(req)
+	case *dap.ScopesRequest:
+		h.onScopes(req)
+	case *dap.VariablesRequest:
+		h.onVariables(req)
+	case *dap.ContinueRequest:
+		h.onContinue(req)
+	case *dap.NextRequest:
+		h.onNext(req)
+	case *dap.StepInRequest:
+		h.onStepIn(req)
+	case *dap.StepOutRequest:
+		h.onStepOut(req)
+	case *dap.EvaluateRequest:
+		h.onEvaluate(req)
+	case *dap.DisconnectRequest:
+		h.onDisconnect(req)
+	default:
+		log.Printf("dap: unhandled message type: %T", msg)
+	}
+}
+
+func (h *handler) onInitialize(req *dap.InitializeRequest) {
+	h.mu.Lock()
+	h.initialized = true
+	h.mu.Unlock()
+
+	resp := &dap.InitializeResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+	resp.Body = dap.Capabilities{
+		SupportsConfigurationDoneRequest:  true,
+		SupportsConditionalBreakpoints:    true,
+		SupportsEvaluateForHovers:         true,
+		SupportTerminateDebuggee:          true,
+		ExceptionBreakpointFilters: []dap.ExceptionBreakpointsFilter{
+			{
+				Filter:  "all",
+				Label:   "All Exceptions",
+				Default: false,
+			},
+		},
+	}
+	h.send(resp)
+
+	// Send initialized event to tell the client it can send configuration.
+	h.send(&dap.InitializedEvent{
+		Event: h.newEvent("initialized"),
+	})
+}
+
+func (h *handler) onSetBreakpoints(req *dap.SetBreakpointsRequest) {
+	file := req.Arguments.Source.Path
+	if file == "" {
+		file = req.Arguments.Source.Name
+	}
+
+	lines := make([]int, len(req.Arguments.Breakpoints))
+	conditions := make([]string, len(req.Arguments.Breakpoints))
+	for i, bp := range req.Arguments.Breakpoints {
+		lines[i] = bp.Line
+		conditions[i] = bp.Condition
+	}
+
+	bps := h.engine.Breakpoints().SetForFile(file, lines, conditions)
+
+	resp := &dap.SetBreakpointsResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+	resp.Body.Breakpoints = translateBreakpoints(bps)
+	h.send(resp)
+}
+
+func (h *handler) onSetExceptionBreakpoints(req *dap.SetExceptionBreakpointsRequest) {
+	mode := debugger.ExceptionBreakNever
+	for _, filter := range req.Arguments.Filters {
+		if filter == "all" {
+			mode = debugger.ExceptionBreakAll
+		}
+	}
+	h.engine.Breakpoints().SetExceptionBreak(mode)
+
+	resp := &dap.SetExceptionBreakpointsResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+	h.send(resp)
+}
+
+func (h *handler) onConfigurationDone(req *dap.ConfigurationDoneRequest) {
+	resp := &dap.ConfigurationDoneResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+	h.send(resp)
+
+	h.mu.Lock()
+	h.launched = true
+	h.mu.Unlock()
+}
+
+func (h *handler) onThreads(req *dap.ThreadsRequest) {
+	resp := &dap.ThreadsResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+	resp.Body.Threads = []dap.Thread{
+		{Id: elpsThreadID, Name: "ELPS Main"},
+	}
+	h.send(resp)
+}
+
+func (h *handler) onStackTrace(req *dap.StackTraceRequest) {
+	env, _ := h.engine.PausedState()
+
+	resp := &dap.StackTraceResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+
+	if env == nil {
+		h.send(resp)
+		return
+	}
+
+	frames := translateStackFrames(env.Runtime.Stack)
+	resp.Body.TotalFrames = len(frames)
+
+	// Apply paging.
+	start := req.Arguments.StartFrame
+	if start > len(frames) {
+		start = len(frames)
+	}
+	end := len(frames)
+	if req.Arguments.Levels > 0 && start+req.Arguments.Levels < end {
+		end = start + req.Arguments.Levels
+	}
+	resp.Body.StackFrames = frames[start:end]
+
+	// Cache frame environments for variable inspection.
+	h.cacheFrameEnvs(env)
+
+	h.send(resp)
+}
+
+// cacheFrameEnvs walks up the env parent chain and maps frame IDs to envs.
+// This is a simplification: we map the paused env to frame 1 (top of stack).
+// For deeper frames, we walk up the parent chain, which approximates the
+// lexical scopes at each call depth.
+func (h *handler) cacheFrameEnvs(env *lisp.LEnv) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.frameEnvs = make(map[int]*lisp.LEnv)
+	nframes := len(env.Runtime.Stack.Frames)
+	current := env
+	for i := 0; i < nframes && current != nil; i++ {
+		h.frameEnvs[i+1] = current // 1-based frame IDs
+		current = current.Parent
+	}
+}
+
+func (h *handler) onScopes(req *dap.ScopesRequest) {
+	resp := &dap.ScopesResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+
+	frameID := req.Arguments.FrameId
+	resp.Body.Scopes = []dap.Scope{
+		{
+			Name:               "Local",
+			VariablesReference: scopeLocalBase + frameID,
+			Expensive:          false,
+		},
+		{
+			Name:               "Package",
+			VariablesReference: scopePackageBase + frameID,
+			Expensive:          true,
+		},
+	}
+	h.send(resp)
+}
+
+func (h *handler) onVariables(req *dap.VariablesRequest) {
+	resp := &dap.VariablesResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+
+	ref := req.Arguments.VariablesReference
+	var bindings []debugger.ScopeBinding
+
+	switch {
+	case ref >= scopePackageBase:
+		frameID := ref - scopePackageBase
+		env := h.getFrameEnv(frameID)
+		if env != nil && env.Runtime.Package != nil {
+			// Show package-level symbols.
+			pkg := env.Runtime.Package
+			for name := range pkg.Symbols {
+				v := pkg.Get(lisp.Symbol(name))
+				if v.Type != lisp.LError {
+					bindings = append(bindings, debugger.ScopeBinding{Name: name, Value: v})
+				}
+			}
+		}
+	case ref >= scopeLocalBase:
+		frameID := ref - scopeLocalBase
+		env := h.getFrameEnv(frameID)
+		if env != nil {
+			bindings = debugger.InspectLocals(env)
+		}
+	}
+
+	resp.Body.Variables = translateVariables(bindings)
+	h.send(resp)
+}
+
+func (h *handler) getFrameEnv(frameID int) *lisp.LEnv {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.frameEnvs == nil {
+		return nil
+	}
+	return h.frameEnvs[frameID]
+}
+
+func (h *handler) onContinue(req *dap.ContinueRequest) {
+	resp := &dap.ContinueResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+	resp.Body.AllThreadsContinued = true
+	h.send(resp)
+	h.engine.Resume()
+}
+
+func (h *handler) onNext(req *dap.NextRequest) {
+	resp := &dap.NextResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+	h.send(resp)
+	h.engine.StepOver()
+}
+
+func (h *handler) onStepIn(req *dap.StepInRequest) {
+	resp := &dap.StepInResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+	h.send(resp)
+	h.engine.StepInto()
+}
+
+func (h *handler) onStepOut(req *dap.StepOutRequest) {
+	resp := &dap.StepOutResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+	h.send(resp)
+	h.engine.StepOut()
+}
+
+func (h *handler) onEvaluate(req *dap.EvaluateRequest) {
+	resp := &dap.EvaluateResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+
+	env, _ := h.engine.PausedState()
+	if env == nil {
+		resp.Success = false
+		resp.Message = "not paused"
+		h.send(resp)
+		return
+	}
+
+	// Use the frame env if specified.
+	if req.Arguments.FrameId > 0 {
+		if fenv := h.getFrameEnv(req.Arguments.FrameId); fenv != nil {
+			env = fenv
+		}
+	}
+
+	result := debugger.EvalInContext(env, req.Arguments.Expression)
+	if result != nil && result.Type == lisp.LError {
+		resp.Success = false
+		resp.Message = debugger.FormatValue(result)
+	} else {
+		resp.Body.Result = debugger.FormatValue(result)
+		resp.Body.Type = lvalTypeName(result)
+	}
+	h.send(resp)
+}
+
+func (h *handler) onDisconnect(req *dap.DisconnectRequest) {
+	resp := &dap.DisconnectResponse{}
+	resp.Response = h.newResponse(req.Seq, req.Command)
+	h.send(resp)
+
+	h.engine.Disconnect()
+
+	// Send terminated event.
+	h.send(&dap.TerminatedEvent{
+		Event: h.newEvent("terminated"),
+	})
+	h.server.close()
+}
+
+// sendStoppedEvent sends a DAP stopped event to the client.
+func (h *handler) sendStoppedEvent(reason debugger.StopReason, bpIDs []int) {
+	evt := &dap.StoppedEvent{
+		Event: h.newEvent("stopped"),
+	}
+	evt.Body.Reason = string(reason)
+	evt.Body.ThreadId = elpsThreadID
+	evt.Body.AllThreadsStopped = true
+	if len(bpIDs) > 0 {
+		evt.Body.HitBreakpointIds = bpIDs
+	}
+	h.send(evt)
+}
+
+// --- helpers ---
+
+func (h *handler) newResponse(reqSeq int, command string) dap.Response {
+	return dap.Response{
+		ProtocolMessage: dap.ProtocolMessage{Seq: h.server.nextSeq(), Type: "response"},
+		RequestSeq:      reqSeq,
+		Success:         true,
+		Command:         command,
+	}
+}
+
+func (h *handler) newEvent(event string) dap.Event {
+	return dap.Event{
+		ProtocolMessage: dap.ProtocolMessage{Seq: h.server.nextSeq(), Type: "event"},
+		Event:           event,
+	}
+}

--- a/lisp/x/debugger/dapserver/handler_test.go
+++ b/lisp/x/debugger/dapserver/handler_test.go
@@ -1,0 +1,222 @@
+package dapserver
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/go-dap"
+	"github.com/luthersystems/elps/lisp/x/debugger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDAPServer_InitializeAndDisconnect(t *testing.T) {
+	e := debugger.New()
+	e.Enable()
+	srv := New(e)
+
+	// Use a net.Pipe to simulate a DAP client/server connection.
+	client, server := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	go func() {
+		_ = srv.ServeConn(server)
+	}()
+
+	reader := bufio.NewReader(client)
+
+	// Send Initialize request.
+	sendDAPRequest(t, client, &dap.InitializeRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: 1, Type: "request"},
+			Command:         "initialize",
+		},
+		Arguments: dap.InitializeRequestArguments{
+			AdapterID:     "elps",
+			LinesStartAt1: true,
+		},
+	})
+
+	// Read Initialize response.
+	msg1, err := dap.ReadProtocolMessage(reader)
+	require.NoError(t, err)
+	initResp, ok := msg1.(*dap.InitializeResponse)
+	require.True(t, ok, "expected InitializeResponse, got %T", msg1)
+	assert.True(t, initResp.Success)
+	assert.True(t, initResp.Body.SupportsConditionalBreakpoints)
+
+	// Read Initialized event.
+	msg2, err := dap.ReadProtocolMessage(reader)
+	require.NoError(t, err)
+	_, ok = msg2.(*dap.InitializedEvent)
+	assert.True(t, ok, "expected InitializedEvent, got %T", msg2)
+
+	// Send Disconnect request.
+	sendDAPRequest(t, client, &dap.DisconnectRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: 2, Type: "request"},
+			Command:         "disconnect",
+		},
+	})
+
+	// Read Disconnect response.
+	msg3, err := dap.ReadProtocolMessage(reader)
+	require.NoError(t, err)
+	disconnResp, ok := msg3.(*dap.DisconnectResponse)
+	require.True(t, ok, "expected DisconnectResponse, got %T", msg3)
+	assert.True(t, disconnResp.Success)
+
+	// Read Terminated event.
+	msg4, err := dap.ReadProtocolMessage(reader)
+	require.NoError(t, err)
+	_, ok = msg4.(*dap.TerminatedEvent)
+	assert.True(t, ok, "expected TerminatedEvent, got %T", msg4)
+}
+
+func TestDAPServer_SetBreakpoints(t *testing.T) {
+	e := debugger.New()
+	e.Enable()
+	srv := New(e)
+
+	client, server := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	go func() {
+		_ = srv.ServeConn(server)
+	}()
+
+	reader := bufio.NewReader(client)
+
+	// Initialize.
+	sendDAPRequest(t, client, &dap.InitializeRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: 1, Type: "request"},
+			Command:         "initialize",
+		},
+	})
+	readDAPMessage(t, reader) // InitializeResponse
+	readDAPMessage(t, reader) // InitializedEvent
+
+	// Set breakpoints.
+	sendDAPRequest(t, client, &dap.SetBreakpointsRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: 2, Type: "request"},
+			Command:         "setBreakpoints",
+		},
+		Arguments: dap.SetBreakpointsArguments{
+			Source: dap.Source{Path: "test.lisp"},
+			Breakpoints: []dap.SourceBreakpoint{
+				{Line: 5, Condition: "(> x 10)"},
+				{Line: 10},
+			},
+		},
+	})
+
+	msg := readDAPMessage(t, reader)
+	bpResp, ok := msg.(*dap.SetBreakpointsResponse)
+	require.True(t, ok, "expected SetBreakpointsResponse, got %T", msg)
+	assert.True(t, bpResp.Success)
+	assert.Len(t, bpResp.Body.Breakpoints, 2)
+	assert.Equal(t, 5, bpResp.Body.Breakpoints[0].Line)
+	assert.True(t, bpResp.Body.Breakpoints[0].Verified)
+	assert.Equal(t, 10, bpResp.Body.Breakpoints[1].Line)
+
+	// Verify breakpoints are in the engine.
+	all := e.Breakpoints().All()
+	assert.Len(t, all, 2)
+
+	// Cleanup.
+	sendDAPRequest(t, client, &dap.DisconnectRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: 3, Type: "request"},
+			Command:         "disconnect",
+		},
+	})
+	readDAPMessage(t, reader)
+	readDAPMessage(t, reader)
+}
+
+func TestDAPServer_Threads(t *testing.T) {
+	e := debugger.New()
+	e.Enable()
+	srv := New(e)
+
+	client, server := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	go func() {
+		_ = srv.ServeConn(server)
+	}()
+
+	reader := bufio.NewReader(client)
+
+	// Initialize.
+	sendDAPRequest(t, client, &dap.InitializeRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: 1, Type: "request"},
+			Command:         "initialize",
+		},
+	})
+	readDAPMessage(t, reader)
+	readDAPMessage(t, reader)
+
+	// Request threads.
+	sendDAPRequest(t, client, &dap.ThreadsRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: 2, Type: "request"},
+			Command:         "threads",
+		},
+	})
+
+	msg := readDAPMessage(t, reader)
+	threadsResp, ok := msg.(*dap.ThreadsResponse)
+	require.True(t, ok, "expected ThreadsResponse, got %T", msg)
+	assert.Len(t, threadsResp.Body.Threads, 1)
+	assert.Equal(t, elpsThreadID, threadsResp.Body.Threads[0].Id)
+	assert.Equal(t, "ELPS Main", threadsResp.Body.Threads[0].Name)
+
+	// Cleanup.
+	sendDAPRequest(t, client, &dap.DisconnectRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: 3, Type: "request"},
+			Command:         "disconnect",
+		},
+	})
+	readDAPMessage(t, reader)
+	readDAPMessage(t, reader)
+}
+
+// --- helpers ---
+
+func sendDAPRequest(t *testing.T, w io.Writer, msg dap.Message) {
+	t.Helper()
+	err := dap.WriteProtocolMessage(w, msg)
+	require.NoError(t, err)
+}
+
+func readDAPMessage(t *testing.T, r *bufio.Reader) dap.Message {
+	t.Helper()
+	done := make(chan dap.Message, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		msg, err := dap.ReadProtocolMessage(r)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		done <- msg
+	}()
+	select {
+	case msg := <-done:
+		return msg
+	case err := <-errCh:
+		t.Fatalf("error reading DAP message: %v", err)
+		return nil
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout reading DAP message")
+		return nil
+	}
+}

--- a/lisp/x/debugger/dapserver/server.go
+++ b/lisp/x/debugger/dapserver/server.go
@@ -1,0 +1,163 @@
+// Copyright © 2018 The ELPS authors
+
+// Package dapserver implements a DAP (Debug Adapter Protocol) server for
+// the ELPS debugger engine. It translates between the DAP wire protocol
+// and the debugger.Engine interface.
+//
+// The server supports two transport modes:
+//   - TCP: Primary mode for embedded/attached debugging. The server listens
+//     on a TCP port and accepts a single client connection.
+//   - Stdio: For CLI use (e.g., "elps debug --stdio"). The server reads
+//     from stdin and writes to stdout, as expected by editors like VS Code
+//     when launching a debug adapter as a child process.
+package dapserver
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/google/go-dap"
+	"github.com/luthersystems/elps/lisp/x/debugger"
+)
+
+// Server is a DAP protocol server that wraps a debugger Engine.
+type Server struct {
+	engine *debugger.Engine
+
+	mu     sync.Mutex
+	seq    int
+	writer io.Writer
+	reader *bufio.Reader
+
+	// done is closed when the server should stop processing messages.
+	done chan struct{}
+}
+
+// New creates a new DAP server wrapping the given debugger engine.
+func New(engine *debugger.Engine) *Server {
+	s := &Server{
+		engine: engine,
+		done:   make(chan struct{}),
+	}
+	return s
+}
+
+// ServeConn serves DAP messages on a single connection. It blocks until
+// the connection is closed or a disconnect request is received.
+func (s *Server) ServeConn(conn io.ReadWriteCloser) error {
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+	s.mu.Lock()
+	s.writer = conn
+	s.reader = bufio.NewReader(conn)
+	s.mu.Unlock()
+
+	// Register event callback so the engine notifies us of state changes.
+	s.engine.Breakpoints() // ensure initialized
+	handler := newHandler(s, s.engine)
+
+	for {
+		select {
+		case <-s.done:
+			return nil
+		default:
+		}
+
+		msg, err := dap.ReadProtocolMessage(s.reader)
+		if err != nil {
+			select {
+			case <-s.done:
+				return nil
+			default:
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			}
+		}
+
+		handler.handle(msg)
+	}
+}
+
+// ServeTCP listens on the given address and serves a single DAP client.
+// It blocks until the client disconnects.
+func (s *Server) ServeTCP(addr string) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	defer ln.Close() //nolint:errcheck // best-effort cleanup
+	return s.ServeListener(ln)
+}
+
+// ServeListener accepts a single connection from the listener and serves
+// DAP messages on it.
+func (s *Server) ServeListener(ln net.Listener) error {
+	conn, err := ln.Accept()
+	if err != nil {
+		return err
+	}
+	return s.ServeConn(conn)
+}
+
+// ServeStdio serves DAP messages on the given reader and writer,
+// typically os.Stdin and os.Stdout.
+func (s *Server) ServeStdio(r io.Reader, w io.Writer) error {
+	s.mu.Lock()
+	s.writer = w
+	s.reader = bufio.NewReader(r)
+	s.mu.Unlock()
+
+	handler := newHandler(s, s.engine)
+
+	for {
+		select {
+		case <-s.done:
+			return nil
+		default:
+		}
+
+		msg, err := dap.ReadProtocolMessage(s.reader)
+		if err != nil {
+			select {
+			case <-s.done:
+				return nil
+			default:
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			}
+		}
+
+		handler.handle(msg)
+	}
+}
+
+// send writes a DAP protocol message to the client.
+// The caller is responsible for setting the Seq field before calling send
+// (via the newResponse/newEvent helpers which call nextSeq).
+func (s *Server) send(msg dap.Message) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return dap.WriteProtocolMessage(s.writer, msg)
+}
+
+// nextSeq returns the next sequence number for outgoing messages.
+func (s *Server) nextSeq() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seq++
+	return s.seq
+}
+
+// close signals the server to stop processing messages.
+func (s *Server) close() {
+	select {
+	case <-s.done:
+	default:
+		close(s.done)
+	}
+}

--- a/lisp/x/debugger/dapserver/testdata/simple.lisp
+++ b/lisp/x/debugger/dapserver/testdata/simple.lisp
@@ -1,0 +1,5 @@
+; simple.lisp — minimal test program for debugger integration tests.
+(defun add (a b)
+  (+ a b))
+
+(add 1 2)

--- a/lisp/x/debugger/dapserver/translate.go
+++ b/lisp/x/debugger/dapserver/translate.go
@@ -1,0 +1,76 @@
+// Copyright © 2018 The ELPS authors
+
+package dapserver
+
+import (
+	"github.com/google/go-dap"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/x/debugger"
+)
+
+// elpsThreadID is the single thread ID used for ELPS (single-threaded interpreter).
+const elpsThreadID = 1
+
+// translateStackFrames converts ELPS CallStack frames to DAP StackFrame objects.
+// Frames are returned in reverse order (most recent first), matching DAP convention.
+func translateStackFrames(stack *lisp.CallStack) []dap.StackFrame {
+	if stack == nil || len(stack.Frames) == 0 {
+		return nil
+	}
+	frames := make([]dap.StackFrame, 0, len(stack.Frames))
+	for i := len(stack.Frames) - 1; i >= 0; i-- {
+		f := &stack.Frames[i]
+		sf := dap.StackFrame{
+			Id:   i + 1, // 1-based IDs
+			Name: f.QualifiedFunName(),
+		}
+		if f.Source != nil {
+			sf.Source = &dap.Source{
+				Name: f.Source.File,
+				Path: f.Source.Path,
+			}
+			sf.Line = f.Source.Line
+			sf.Column = f.Source.Col
+		}
+		frames = append(frames, sf)
+	}
+	return frames
+}
+
+// translateVariables converts scope bindings to DAP Variable objects.
+func translateVariables(bindings []debugger.ScopeBinding) []dap.Variable {
+	vars := make([]dap.Variable, len(bindings))
+	for i, b := range bindings {
+		vars[i] = dap.Variable{
+			Name:  b.Name,
+			Value: debugger.FormatValue(b.Value),
+			Type:  lvalTypeName(b.Value),
+		}
+	}
+	return vars
+}
+
+// lvalTypeName returns a human-readable type name for an LVal.
+func lvalTypeName(v *lisp.LVal) string {
+	if v == nil {
+		return "nil"
+	}
+	return v.Type.String()
+}
+
+// translateBreakpoints converts engine breakpoints to DAP Breakpoint objects.
+func translateBreakpoints(bps []*debugger.Breakpoint) []dap.Breakpoint {
+	result := make([]dap.Breakpoint, len(bps))
+	for i, bp := range bps {
+		result[i] = dap.Breakpoint{
+			Id:       bp.ID,
+			Verified: true,
+			Source: &dap.Source{
+				Name: bp.File,
+				Path: bp.File,
+			},
+			Line: bp.Line,
+		}
+	}
+	return result
+}

--- a/lisp/x/debugger/engine.go
+++ b/lisp/x/debugger/engine.go
@@ -1,0 +1,354 @@
+// Copyright © 2018 The ELPS authors
+
+// Package debugger implements the ELPS debugger engine (Layer 1).
+// It provides breakpoint management, stepping, variable inspection,
+// and debug evaluation without any external protocol dependencies.
+//
+// The engine implements the lisp.Debugger interface and communicates
+// with external consumers (such as a DAP server) through event
+// callbacks and a channel-based pause/resume mechanism.
+//
+// Concurrency model: The ELPS eval goroutine calls the Debugger hook
+// methods (OnEval, WaitIfPaused, etc.). When paused, it blocks on a
+// channel. The external consumer (DAP server goroutine) sends commands
+// via Resume/StepInto/StepOver/StepOut. This is thread-safe by design.
+package debugger
+
+import (
+	"sync"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// EventType identifies the kind of debug event.
+type EventType int
+
+const (
+	// EventStopped indicates execution has paused (breakpoint, step, exception).
+	EventStopped EventType = iota
+	// EventContinued indicates execution has resumed.
+	EventContinued
+	// EventExited indicates the program has finished.
+	EventExited
+	// EventOutput indicates the program produced output.
+	EventOutput
+)
+
+// StopReason describes why execution paused.
+type StopReason string
+
+const (
+	StopBreakpoint StopReason = "breakpoint"
+	StopStep       StopReason = "step"
+	StopException  StopReason = "exception"
+	StopEntry      StopReason = "entry"
+	StopPause      StopReason = "pause"
+)
+
+// Event is sent to the event callback when the debugger state changes.
+type Event struct {
+	Type   EventType
+	Reason StopReason
+	Env    *lisp.LEnv
+	Expr   *lisp.LVal
+	BP     *Breakpoint // non-nil for breakpoint stops
+}
+
+// EventCallback is called when the debugger state changes. It runs on
+// the eval goroutine, so it must not block.
+type EventCallback func(Event)
+
+// Engine implements lisp.Debugger and provides the core debugging
+// primitives: breakpoints, stepping, variable inspection, and debug eval.
+type Engine struct {
+	breakpoints *BreakpointStore
+	stepper     *Stepper
+	onEvent     EventCallback
+
+	mu                  sync.Mutex
+	enabled             bool
+	stopOnEntry         bool
+	evaluatingCondition bool   // re-entrancy guard for conditional breakpoints
+	lastContinuedKey    string // suppress breakpoint re-hit after continue on same line
+
+	// pauseCh is used by the eval goroutine to block in WaitIfPaused.
+	// The DAP server sends DebugAction values to resume execution.
+	pauseCh chan lisp.DebugAction
+
+	// pausedEnv/pausedExpr hold the state when paused, protected by mu.
+	pausedEnv  *lisp.LEnv
+	pausedExpr *lisp.LVal
+}
+
+// Verify Engine implements lisp.Debugger at compile time.
+var _ lisp.Debugger = (*Engine)(nil)
+
+// Option configures an Engine.
+type Option func(*Engine)
+
+// WithEventCallback sets the function called on debugger state changes.
+func WithEventCallback(cb EventCallback) Option {
+	return func(e *Engine) {
+		e.onEvent = cb
+	}
+}
+
+// WithStopOnEntry makes the debugger pause before the first expression.
+func WithStopOnEntry(stop bool) Option {
+	return func(e *Engine) {
+		e.stopOnEntry = stop
+	}
+}
+
+// New creates a new debugger engine.
+func New(opts ...Option) *Engine {
+	e := &Engine{
+		breakpoints: NewBreakpointStore(),
+		stepper:     NewStepper(),
+		pauseCh:     make(chan lisp.DebugAction, 1),
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// Breakpoints returns the breakpoint store for external management
+// (e.g., by a DAP server handling setBreakpoints requests).
+func (e *Engine) Breakpoints() *BreakpointStore {
+	return e.breakpoints
+}
+
+// SetEventCallback sets or replaces the event callback. It is safe to call
+// after construction (e.g., when a DAP handler wires itself up).
+func (e *Engine) SetEventCallback(cb EventCallback) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.onEvent = cb
+}
+
+// Enable activates the debugger. Hook calls are only made when enabled.
+func (e *Engine) Enable() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.enabled = true
+}
+
+// Disable deactivates the debugger without detaching it.
+func (e *Engine) Disable() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.enabled = false
+}
+
+// IsEnabled implements lisp.Debugger.
+func (e *Engine) IsEnabled() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.enabled
+}
+
+// IsPaused returns true if the eval goroutine is currently blocked in
+// WaitIfPaused.
+func (e *Engine) IsPaused() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.pausedEnv != nil
+}
+
+// PausedState returns the env and expr where execution is paused, or
+// nil if not paused.
+func (e *Engine) PausedState() (*lisp.LEnv, *lisp.LVal) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.pausedEnv, e.pausedExpr
+}
+
+// OnEval implements lisp.Debugger. Called before each expression with
+// a real source location.
+func (e *Engine) OnEval(env *lisp.LEnv, expr *lisp.LVal) bool {
+	e.mu.Lock()
+	if e.evaluatingCondition {
+		e.mu.Unlock()
+		return false
+	}
+
+	// Clear lastContinuedKey when we move to a different source line.
+	// This allows breakpoints to re-fire when the program loops back.
+	if e.lastContinuedKey != "" && expr.Source != nil {
+		key := breakpointKey(expr.Source.File, expr.Source.Line)
+		if key != e.lastContinuedKey {
+			e.lastContinuedKey = ""
+		}
+	}
+
+	// Check stop-on-entry (first expression only).
+	if e.stopOnEntry {
+		e.stopOnEntry = false
+		e.mu.Unlock()
+		return true
+	}
+	e.mu.Unlock()
+
+	// Check stepping.
+	depth := len(env.Runtime.Stack.Frames)
+	if e.stepper.ShouldPause(depth) {
+		return true
+	}
+
+	// Check breakpoints.
+	bp := e.breakpoints.Match(expr.Source)
+	if bp == nil {
+		return false
+	}
+
+	// Suppress re-hit on the same line after continue.
+	e.mu.Lock()
+	if e.lastContinuedKey == bp.key() {
+		e.mu.Unlock()
+		return false
+	}
+	e.mu.Unlock()
+
+	// Evaluate condition if present.
+	if bp.Condition != "" {
+		e.mu.Lock()
+		e.evaluatingCondition = true
+		e.mu.Unlock()
+		result := EvalCondition(env, bp.Condition)
+		e.mu.Lock()
+		e.evaluatingCondition = false
+		e.mu.Unlock()
+		if !result {
+			return false
+		}
+	}
+	return true
+}
+
+// WaitIfPaused implements lisp.Debugger. Blocks the eval goroutine
+// until the DAP server sends a resume command.
+func (e *Engine) WaitIfPaused(env *lisp.LEnv, expr *lisp.LVal) lisp.DebugAction {
+	// Determine stop reason.
+	reason := StopStep
+	bp := e.breakpoints.Match(expr.Source)
+	if bp != nil {
+		reason = StopBreakpoint
+	}
+	if expr.Type == lisp.LError {
+		reason = StopException
+	}
+
+	e.mu.Lock()
+	if e.stopOnEntry {
+		reason = StopEntry
+		e.stopOnEntry = false
+	}
+	e.pausedEnv = env
+	e.pausedExpr = expr
+	e.mu.Unlock()
+
+	// Notify the DAP server that we're paused.
+	e.mu.Lock()
+	cb := e.onEvent
+	e.mu.Unlock()
+	if cb != nil {
+		cb(Event{
+			Type:   EventStopped,
+			Reason: reason,
+			Env:    env,
+			Expr:   expr,
+			BP:     bp,
+		})
+	}
+
+	// Block until a resume command arrives.
+	action := <-e.pauseCh
+
+	e.mu.Lock()
+	e.pausedEnv = nil
+	e.pausedExpr = nil
+	e.mu.Unlock()
+
+	// On continue, suppress breakpoint re-hit on the same source line.
+	if action == lisp.DebugContinue && expr.Source != nil {
+		e.mu.Lock()
+		e.lastContinuedKey = breakpointKey(expr.Source.File, expr.Source.Line)
+		e.mu.Unlock()
+	}
+
+	// Configure stepper based on action.
+	depth := len(env.Runtime.Stack.Frames)
+	switch action {
+	case lisp.DebugStepInto:
+		e.stepper.SetStepInto()
+	case lisp.DebugStepOver:
+		e.stepper.SetStepOver(depth)
+	case lisp.DebugStepOut:
+		e.stepper.SetStepOut(depth)
+	default:
+		e.stepper.Reset()
+	}
+
+	// Notify continued.
+	e.mu.Lock()
+	cb = e.onEvent
+	e.mu.Unlock()
+	if cb != nil {
+		cb(Event{Type: EventContinued})
+	}
+	return action
+}
+
+// OnFunEntry implements lisp.Debugger.
+func (e *Engine) OnFunEntry(env *lisp.LEnv, fun *lisp.LVal, fenv *lisp.LEnv) {
+	// Currently used for stack tracking. Future: function breakpoints.
+}
+
+// OnFunReturn implements lisp.Debugger.
+func (e *Engine) OnFunReturn(env *lisp.LEnv, fun, result *lisp.LVal) {
+	// Currently a no-op. Future: watch expressions on return values.
+}
+
+// OnError implements lisp.Debugger. Called when an error condition is
+// created. Returns true if execution should pause.
+func (e *Engine) OnError(env *lisp.LEnv, lerr *lisp.LVal) bool {
+	e.mu.Lock()
+	if e.evaluatingCondition {
+		e.mu.Unlock()
+		return false
+	}
+	e.mu.Unlock()
+	return e.breakpoints.ExceptionBreak() == ExceptionBreakAll
+}
+
+// Resume sends a Continue action to the paused eval goroutine.
+func (e *Engine) Resume() {
+	e.pauseCh <- lisp.DebugContinue
+}
+
+// StepInto sends a StepInto action to the paused eval goroutine.
+func (e *Engine) StepInto() {
+	e.pauseCh <- lisp.DebugStepInto
+}
+
+// StepOver sends a StepOver action to the paused eval goroutine.
+func (e *Engine) StepOver() {
+	e.pauseCh <- lisp.DebugStepOver
+}
+
+// StepOut sends a StepOut action to the paused eval goroutine.
+func (e *Engine) StepOut() {
+	e.pauseCh <- lisp.DebugStepOut
+}
+
+// Disconnect atomically disables the debugger and resumes execution if paused.
+func (e *Engine) Disconnect() {
+	e.mu.Lock()
+	e.enabled = false
+	paused := e.pausedEnv != nil
+	e.mu.Unlock()
+	if paused {
+		e.Resume()
+	}
+}

--- a/lisp/x/debugger/engine_test.go
+++ b/lisp/x/debugger/engine_test.go
@@ -1,0 +1,237 @@
+package debugger
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestEnv creates a minimal ELPS environment for testing.
+func newTestEnv(t *testing.T, dbg *Engine) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	env.Runtime.Debugger = dbg
+	rc := lisp.InitializeUserEnv(env)
+	require.True(t, rc.IsNil(), "InitializeUserEnv failed: %v", rc)
+	rc = lisplib.LoadLibrary(env)
+	require.True(t, rc.IsNil(), "LoadLibrary failed: %v", rc)
+	rc = env.InPackage(lisp.String(lisp.DefaultUserPackage))
+	require.True(t, rc.IsNil(), "InPackage failed: %v", rc)
+	return env
+}
+
+func TestEngine_IsEnabled(t *testing.T) {
+	e := New()
+	assert.False(t, e.IsEnabled())
+
+	e.Enable()
+	assert.True(t, e.IsEnabled())
+
+	e.Disable()
+	assert.False(t, e.IsEnabled())
+}
+
+func TestEngine_BreakpointPauseAndResume(t *testing.T) {
+	var events []Event
+	var mu sync.Mutex
+
+	e := New(WithEventCallback(func(evt Event) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, evt)
+	}))
+	e.Enable()
+
+	env := newTestEnv(t, e)
+
+	// Set a breakpoint — we'll use source name "test" with line 1.
+	e.Breakpoints().Set("test", 1, "")
+
+	// Eval in a goroutine since it will pause.
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", "(+ 1 2)")
+		resultCh <- res
+	}()
+
+	// Wait for the engine to pause (event callback fires).
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not pause")
+
+	// Verify stopped event was sent.
+	mu.Lock()
+	assert.True(t, len(events) > 0)
+	assert.Equal(t, EventStopped, events[0].Type)
+	mu.Unlock()
+
+	// Resume execution.
+	e.Resume()
+
+	// Wait for result.
+	select {
+	case res := <-resultCh:
+		assert.Equal(t, lisp.LInt, res.Type)
+		assert.Equal(t, 3, res.Int)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for eval result")
+	}
+}
+
+func TestEngine_StepInto(t *testing.T) {
+	e := New(WithStopOnEntry(true))
+	e.Enable()
+	env := newTestEnv(t, e)
+
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", "(+ 1 2)")
+		resultCh <- res
+	}()
+
+	// Should stop on entry.
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not stop on entry")
+
+	// Step into.
+	e.StepInto()
+
+	// Should pause again on the next expression.
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not pause after step")
+
+	// Continue to finish.
+	e.Resume()
+
+	select {
+	case res := <-resultCh:
+		assert.NotEqual(t, lisp.LError, res.Type, "unexpected error: %v", res)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for eval result")
+	}
+}
+
+func TestEngine_ExceptionBreakpoint(t *testing.T) {
+	e := New()
+	e.Enable()
+	e.Breakpoints().SetExceptionBreak(ExceptionBreakAll)
+
+	env := newTestEnv(t, e)
+
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		// This triggers an error through env.ErrorCondition, which has the debugger hook.
+		res := env.LoadString("test", `(error 'test-error "deliberate error")`)
+		resultCh <- res
+	}()
+
+	// Should pause on the error.
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not pause on exception")
+
+	// Resume to let the error propagate.
+	e.Resume()
+
+	select {
+	case res := <-resultCh:
+		assert.Equal(t, lisp.LError, res.Type)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for eval result")
+	}
+}
+
+func TestEngine_Disconnect(t *testing.T) {
+	e := New(WithStopOnEntry(true))
+	e.Enable()
+	env := newTestEnv(t, e)
+
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", "(+ 1 2)")
+		resultCh <- res
+	}()
+
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Disconnect should resume and disable.
+	e.Disconnect()
+
+	select {
+	case res := <-resultCh:
+		assert.Equal(t, lisp.LInt, res.Type)
+		assert.Equal(t, 3, res.Int)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout after disconnect")
+	}
+
+	assert.False(t, e.IsEnabled())
+}
+
+func TestEngine_DisabledHooksAreSkipped(t *testing.T) {
+	e := New()
+	// NOT enabled — hooks should all be no-ops.
+
+	env := newTestEnv(t, e)
+
+	// This should run without any debugging interference.
+	res := env.LoadString("test", "(+ 1 2)")
+	assert.Equal(t, lisp.LInt, res.Type)
+	assert.Equal(t, 3, res.Int)
+}
+
+func TestEngine_ConditionalBreakpoint(t *testing.T) {
+	e := New()
+	e.Enable()
+
+	env := newTestEnv(t, e)
+
+	// Set a breakpoint with a condition that evaluates to false.
+	e.Breakpoints().Set("test", 1, "false")
+
+	// Should NOT pause because condition is false.
+	res := env.LoadString("test", "(+ 1 2)")
+	assert.Equal(t, lisp.LInt, res.Type)
+	assert.Equal(t, 3, res.Int)
+}
+
+func TestEngine_ConditionalBreakpoint_True(t *testing.T) {
+	e := New()
+	e.Enable()
+
+	env := newTestEnv(t, e)
+
+	// Set a breakpoint with a condition that evaluates to true.
+	e.Breakpoints().Set("test", 1, "true")
+
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", "(+ 1 2)")
+		resultCh <- res
+	}()
+
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not pause on true condition")
+
+	e.Resume()
+
+	select {
+	case res := <-resultCh:
+		assert.Equal(t, lisp.LInt, res.Type)
+		assert.Equal(t, 3, res.Int)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+}

--- a/lisp/x/debugger/engine_test.go
+++ b/lisp/x/debugger/engine_test.go
@@ -66,9 +66,9 @@ func TestEngine_BreakpointPauseAndResume(t *testing.T) {
 		return e.IsPaused()
 	}, 2*time.Second, 10*time.Millisecond, "engine did not pause")
 
-	// Verify stopped event was sent.
+	// Verify exactly one stopped event was sent.
 	mu.Lock()
-	assert.True(t, len(events) > 0)
+	assert.Equal(t, 1, len(events))
 	assert.Equal(t, EventStopped, events[0].Type)
 	mu.Unlock()
 
@@ -114,14 +114,24 @@ func TestEngine_StepInto(t *testing.T) {
 
 	select {
 	case res := <-resultCh:
-		assert.NotEqual(t, lisp.LError, res.Type, "unexpected error: %v", res)
+		assert.Equal(t, lisp.LInt, res.Type, "expected int result, got %v", res)
+		assert.Equal(t, 3, res.Int)
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for eval result")
 	}
 }
 
 func TestEngine_ExceptionBreakpoint(t *testing.T) {
-	e := New()
+	var stopReason StopReason
+	var mu sync.Mutex
+
+	e := New(WithEventCallback(func(evt Event) {
+		if evt.Type == EventStopped {
+			mu.Lock()
+			stopReason = evt.Reason
+			mu.Unlock()
+		}
+	}))
 	e.Enable()
 	e.Breakpoints().SetExceptionBreak(ExceptionBreakAll)
 
@@ -138,6 +148,11 @@ func TestEngine_ExceptionBreakpoint(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return e.IsPaused()
 	}, 2*time.Second, 10*time.Millisecond, "engine did not pause on exception")
+
+	// Verify stop reason is exception.
+	mu.Lock()
+	assert.Equal(t, StopException, stopReason, "expected exception stop reason")
+	mu.Unlock()
 
 	// Resume to let the error propagate.
 	e.Resume()
@@ -231,6 +246,313 @@ func TestEngine_ConditionalBreakpoint_True(t *testing.T) {
 	case res := <-resultCh:
 		assert.Equal(t, lisp.LInt, res.Type)
 		assert.Equal(t, 3, res.Int)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestEngine_StepOver(t *testing.T) {
+	e := New(WithStopOnEntry(true))
+	e.Enable()
+	env := newTestEnv(t, e)
+
+	// A program with a function call — step over should skip into f's body.
+	program := `(defun f (x) (+ x 1)) (f 10)`
+
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", program)
+		resultCh <- res
+	}()
+
+	// Stop on entry.
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not stop on entry")
+
+	// Step over — should pause again at the same depth (next top-level expr).
+	e.StepOver()
+
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not pause after step over")
+
+	// Resume to finish.
+	e.Resume()
+
+	select {
+	case res := <-resultCh:
+		assert.Equal(t, lisp.LInt, res.Type, "expected int result, got %v", res)
+		assert.Equal(t, 11, res.Int)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for eval result")
+	}
+}
+
+func TestEngine_StepOut(t *testing.T) {
+	e := New()
+	e.Enable()
+	env := newTestEnv(t, e)
+
+	// A program with a function call. Set breakpoint inside the function body
+	// so we're at a non-zero stack depth when paused.
+	program := `(defun f (x) (+ x 1)) (f 10)`
+	// The breakpoint is on line 1 where all expressions reside. When the
+	// interpreter enters function f and evaluates (+ x 1), it will hit this.
+	e.Breakpoints().Set("test", 1, "")
+
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", program)
+		resultCh <- res
+	}()
+
+	// Wait for first breakpoint hit.
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not pause at breakpoint")
+
+	// Resume past the first hit (e.g., defun definition).
+	e.Resume()
+
+	// Wait for next pause (should be inside f's body at deeper stack depth).
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not pause again")
+
+	// Step out — should pause at a lesser depth (back to caller).
+	e.StepOut()
+
+	// Should pause again after returning from f.
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not pause after step out")
+
+	// Resume to finish.
+	e.Resume()
+
+	// Keep resuming any additional breakpoint hits until program completes.
+	resumeDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-resumeDone:
+				return
+			case <-ticker.C:
+				if e.IsPaused() {
+					e.Resume()
+				}
+			}
+		}
+	}()
+
+	select {
+	case res := <-resultCh:
+		close(resumeDone)
+		assert.Equal(t, lisp.LInt, res.Type, "expected int result, got %v", res)
+		assert.Equal(t, 11, res.Int)
+	case <-time.After(5 * time.Second):
+		close(resumeDone)
+		if e.IsPaused() {
+			e.Resume()
+		}
+		t.Fatal("timeout waiting for eval result")
+	}
+}
+
+func TestEngine_ConditionalBreakpoint_ErrorInCondition(t *testing.T) {
+	// Regression: a conditional breakpoint whose condition errors should NOT
+	// deadlock. The re-entrancy guard should prevent OnError from re-entering
+	// the breakpoint check. The condition errors → treated as "not met" → no pause.
+	e := New()
+	e.Enable()
+	e.Breakpoints().SetExceptionBreak(ExceptionBreakAll)
+	// Use unbound symbol as condition — this produces an error through env.Errorf.
+	e.Breakpoints().Set("test", 1, "undefined-sym-xyz")
+
+	env := newTestEnv(t, e)
+
+	// Run in a goroutine to avoid hanging if the re-entrancy guard fails.
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", "(+ 1 2)")
+		resultCh <- res
+	}()
+
+	select {
+	case res := <-resultCh:
+		assert.Equal(t, lisp.LInt, res.Type, "expected int result, got %v", res)
+		assert.Equal(t, 3, res.Int)
+	case <-time.After(5 * time.Second):
+		if e.IsPaused() {
+			e.Resume()
+		}
+		t.Fatal("re-entrancy guard failed: engine deadlocked on error in condition")
+	}
+}
+
+func TestEngine_BreakpointInLoop(t *testing.T) {
+	// Verify that the lastContinuedKey suppression doesn't prevent a
+	// breakpoint from re-firing on subsequent recursive iterations.
+	// We use recursion because each recursive call evaluates the function body
+	// starting at a different line than the breakpoint, which clears
+	// lastContinuedKey between hits.
+	var hitCount int
+	var mu sync.Mutex
+
+	e := New(WithEventCallback(func(evt Event) {
+		if evt.Type == EventStopped && evt.Reason == StopBreakpoint {
+			mu.Lock()
+			hitCount++
+			mu.Unlock()
+		}
+	}))
+	e.Enable()
+
+	env := newTestEnv(t, e)
+
+	// Multi-line recursive program.
+	// Line 1: defun
+	// Line 2: if test
+	// Line 3: base case
+	// Line 4: recursive call (breakpoint here)
+	// Line 5: initial call
+	program := "(defun loop-fn (n total)\n" +
+		"  (if (<= n 0)\n" +
+		"    total\n" +
+		"    (loop-fn (- n 1) (+ total 1))))\n" +
+		"(loop-fn 3 0)"
+	// Breakpoint on line 4 — the recursive call. Each recursion re-enters
+	// the function body at line 2, clearing lastContinuedKey before line 4
+	// is reached again.
+	e.Breakpoints().Set("test", 4, "")
+
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", program)
+		resultCh <- res
+	}()
+
+	// Wait for first hit to confirm breakpoint works.
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not pause at first breakpoint")
+	e.Resume()
+
+	// Keep resuming until the program finishes or we've seen enough hits.
+	for range 20 {
+		time.Sleep(100 * time.Millisecond)
+		if e.IsPaused() {
+			e.Resume()
+		}
+	}
+
+	select {
+	case <-resultCh:
+		// Program completed.
+	case <-time.After(5 * time.Second):
+		if e.IsPaused() {
+			e.Resume()
+		}
+		t.Fatal("timeout waiting for eval result")
+	}
+
+	mu.Lock()
+	count := hitCount
+	mu.Unlock()
+	assert.Equal(t, 3, count, "breakpoint should fire exactly 3 times (once per recursive call where n > 0)")
+}
+
+func TestEngine_PausedState(t *testing.T) {
+	e := New(WithStopOnEntry(true))
+	e.Enable()
+	env := newTestEnv(t, e)
+
+	// Before pausing, PausedState should return nil.
+	pEnv, pExpr := e.PausedState()
+	assert.Nil(t, pEnv)
+	assert.Nil(t, pExpr)
+
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", "(+ 1 2)")
+		resultCh <- res
+	}()
+
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// While paused, PausedState should return non-nil values with source info.
+	pEnv, pExpr = e.PausedState()
+	assert.NotNil(t, pEnv, "expected non-nil env while paused")
+	require.NotNil(t, pExpr, "expected non-nil expr while paused")
+	require.NotNil(t, pExpr.Source, "expected source location on paused expr")
+	assert.Equal(t, "test", pExpr.Source.File, "expected paused expr from test source")
+
+	e.Resume()
+
+	select {
+	case <-resultCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	// After resume, PausedState should return nil again.
+	pEnv, pExpr = e.PausedState()
+	assert.Nil(t, pEnv)
+	assert.Nil(t, pExpr)
+}
+
+func TestEngine_OnFunEntryReturn(t *testing.T) {
+	// OnFunEntry and OnFunReturn are currently no-ops but must not interfere
+	// with program execution when the debugger is enabled.
+	e := New()
+	e.Enable()
+	env := newTestEnv(t, e)
+
+	// Run a program with function calls — the interpreter calls OnFunEntry/OnFunReturn.
+	res := env.LoadString("test", `(defun add (a b) (+ a b)) (add 10 20)`)
+	assert.Equal(t, lisp.LInt, res.Type, "expected int result, got %v", res)
+	assert.Equal(t, 30, res.Int)
+}
+
+func TestEngine_SetEventCallback(t *testing.T) {
+	var called bool
+	var mu sync.Mutex
+
+	e := New(WithStopOnEntry(true))
+	e.Enable()
+
+	// Replace the callback after construction.
+	e.SetEventCallback(func(evt Event) {
+		mu.Lock()
+		defer mu.Unlock()
+		called = true
+	})
+
+	env := newTestEnv(t, e)
+
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", "(+ 1 2)")
+		resultCh <- res
+	}()
+
+	require.Eventually(t, func() bool {
+		return e.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	assert.True(t, called, "replacement callback should have fired")
+	mu.Unlock()
+
+	e.Resume()
+
+	select {
+	case <-resultCh:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout")
 	}

--- a/lisp/x/debugger/inspector.go
+++ b/lisp/x/debugger/inspector.go
@@ -1,0 +1,146 @@
+// Copyright © 2018 The ELPS authors
+
+package debugger
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// ScopeBinding represents a single variable binding in a scope.
+type ScopeBinding struct {
+	Name  string
+	Value *lisp.LVal
+}
+
+// InspectLocals returns the local variable bindings from the given
+// environment's immediate scope (not parent scopes). Bindings are
+// returned sorted by name.
+func InspectLocals(env *lisp.LEnv) []ScopeBinding {
+	if env == nil {
+		return nil
+	}
+	bindings := make([]ScopeBinding, 0, len(env.Scope))
+	for name, val := range env.Scope {
+		bindings = append(bindings, ScopeBinding{Name: name, Value: val})
+	}
+	sort.Slice(bindings, func(i, j int) bool {
+		return bindings[i].Name < bindings[j].Name
+	})
+	return bindings
+}
+
+// InspectScope returns all bindings visible from the given environment,
+// walking up the parent chain. Local bindings shadow parent bindings.
+// Bindings are returned sorted by name.
+func InspectScope(env *lisp.LEnv) []ScopeBinding {
+	if env == nil {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var bindings []ScopeBinding
+	current := env
+	for current != nil {
+		for name, val := range current.Scope {
+			if !seen[name] {
+				seen[name] = true
+				bindings = append(bindings, ScopeBinding{Name: name, Value: val})
+			}
+		}
+		current = current.Parent
+	}
+	sort.Slice(bindings, func(i, j int) bool {
+		return bindings[i].Name < bindings[j].Name
+	})
+	return bindings
+}
+
+// FormatValue returns a human-readable string representation of an LVal,
+// suitable for display in a debugger variables view.
+func FormatValue(v *lisp.LVal) string {
+	if v == nil {
+		return "<nil>"
+	}
+	switch v.Type {
+	case lisp.LInt:
+		return fmt.Sprintf("%d", v.Int)
+	case lisp.LFloat:
+		return fmt.Sprintf("%g", v.Float)
+	case lisp.LString:
+		return fmt.Sprintf("%q", v.Str)
+	case lisp.LSymbol:
+		return v.Str
+	case lisp.LSExpr:
+		if v.IsNil() {
+			return "()"
+		}
+		return formatList(v)
+	case lisp.LFun:
+		name := v.Str
+		if name == "" && v.FunData() != nil {
+			name = v.FunData().FID
+		}
+		switch {
+		case v.IsMacro():
+			return fmt.Sprintf("<macro %s>", name)
+		case v.IsSpecialOp():
+			return fmt.Sprintf("<special-op %s>", name)
+		default:
+			return fmt.Sprintf("<function %s>", name)
+		}
+	case lisp.LError:
+		return fmt.Sprintf("<error: %s>", v.Str)
+	case lisp.LNative:
+		if v.Native == nil {
+			return "<native nil>"
+		}
+		return fmt.Sprintf("<native %T>", v.Native)
+	case lisp.LTaggedVal:
+		return fmt.Sprintf("<tagged %s>", v.Str)
+	case lisp.LArray:
+		return fmt.Sprintf("<array len=%d>", v.Len())
+	case lisp.LSortMap:
+		return fmt.Sprintf("<sorted-map len=%d>", v.Len())
+	case lisp.LQSymbol:
+		return fmt.Sprintf("'%s", v.Str)
+	case lisp.LBytes:
+		return fmt.Sprintf("<bytes len=%d>", len(v.Bytes()))
+	default:
+		return fmt.Sprintf("<%s>", v.Type)
+	}
+}
+
+func formatList(v *lisp.LVal) string {
+	if v.Len() > 10 {
+		return fmt.Sprintf("(%d elements)", v.Len())
+	}
+	var parts []string
+	for _, cell := range v.Cells {
+		parts = append(parts, FormatValue(cell))
+	}
+	open, close := "(", ")"
+	if v.Quoted {
+		open, close = "[", "]"
+	}
+	return open + strings.Join(parts, " ") + close
+}
+
+// EvalInContext parses and evaluates an expression in the paused
+// environment. This allows the debug console to inspect and mutate
+// state. Returns the result or an error LVal.
+func EvalInContext(env *lisp.LEnv, source string) *lisp.LVal {
+	if env.Runtime.Reader == nil {
+		return env.Errorf("no reader for debug evaluation")
+	}
+	exprs, err := env.Runtime.Reader.Read("debug-eval", strings.NewReader(source))
+	if err != nil {
+		return env.Errorf("debug eval parse error: %v", err)
+	}
+	if len(exprs) == 0 {
+		return lisp.Nil()
+	}
+	return env.Eval(exprs[0])
+}

--- a/lisp/x/debugger/inspector_test.go
+++ b/lisp/x/debugger/inspector_test.go
@@ -1,0 +1,99 @@
+package debugger
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectLocals(t *testing.T) {
+	parent := lisp.NewEnv(nil)
+	parent.Put(lisp.Symbol("x"), lisp.Int(42))
+
+	child := lisp.NewEnv(parent)
+	child.Put(lisp.Symbol("y"), lisp.String("hello"))
+	child.Put(lisp.Symbol("z"), lisp.Float(3.14))
+
+	locals := InspectLocals(child)
+	assert.Len(t, locals, 2)
+	// Sorted by name.
+	assert.Equal(t, "y", locals[0].Name)
+	assert.Equal(t, "z", locals[1].Name)
+
+	// InspectLocals does NOT include parent bindings.
+	names := make(map[string]bool)
+	for _, b := range locals {
+		names[b.Name] = true
+	}
+	assert.False(t, names["x"])
+}
+
+func TestInspectScope(t *testing.T) {
+	parent := lisp.NewEnv(nil)
+	parent.Put(lisp.Symbol("x"), lisp.Int(42))
+
+	child := lisp.NewEnv(parent)
+	child.Put(lisp.Symbol("y"), lisp.String("hello"))
+
+	scope := InspectScope(child)
+	assert.Len(t, scope, 2)
+
+	names := make(map[string]bool)
+	for _, b := range scope {
+		names[b.Name] = true
+	}
+	assert.True(t, names["x"])
+	assert.True(t, names["y"])
+}
+
+func TestInspectScope_Shadowing(t *testing.T) {
+	parent := lisp.NewEnv(nil)
+	parent.Put(lisp.Symbol("x"), lisp.Int(1))
+
+	child := lisp.NewEnv(parent)
+	child.Put(lisp.Symbol("x"), lisp.Int(2))
+
+	scope := InspectScope(child)
+	// x appears once (child shadows parent).
+	xCount := 0
+	var xVal *lisp.LVal
+	for _, b := range scope {
+		if b.Name == "x" {
+			xCount++
+			xVal = b.Value
+		}
+	}
+	assert.Equal(t, 1, xCount)
+	require.NotNil(t, xVal)
+	assert.Equal(t, 2, xVal.Int)
+}
+
+func TestInspectLocals_Nil(t *testing.T) {
+	assert.Nil(t, InspectLocals(nil))
+	assert.Nil(t, InspectScope(nil))
+}
+
+func TestFormatValue(t *testing.T) {
+	tests := []struct {
+		name string
+		val  *lisp.LVal
+		want string
+	}{
+		{"nil val", nil, "<nil>"},
+		{"int", lisp.Int(42), "42"},
+		{"float", lisp.Float(3.14), "3.14"},
+		{"string", lisp.String("hello"), `"hello"`},
+		{"symbol", lisp.Symbol("foo"), "foo"},
+		{"nil list", lisp.Nil(), "()"},
+		{"true", lisp.Symbol("true"), "true"},
+		{"false", lisp.Symbol("false"), "false"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatValue(tt.val)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/lisp/x/debugger/stepper.go
+++ b/lisp/x/debugger/stepper.go
@@ -1,0 +1,91 @@
+// Copyright © 2018 The ELPS authors
+
+package debugger
+
+// StepMode represents the current stepping behavior.
+type StepMode int
+
+const (
+	// StepNone means no stepping is active (free-running).
+	StepNone StepMode = iota
+	// StepInto pauses on the next OnEval call regardless of depth.
+	StepInto
+	// StepOver pauses on the next OnEval where stack depth <= recorded depth.
+	StepOver
+	// StepOut pauses on the next OnEval where stack depth < recorded depth.
+	StepOut
+)
+
+// Stepper implements the step state machine. It tracks the step mode and
+// the reference stack depth to determine when stepping should pause.
+//
+// Thread safety: Stepper is NOT safe for concurrent use. All access must
+// occur on the eval goroutine. The write path (SetStep*/Reset) runs inside
+// WaitIfPaused after the channel receive, and the read path (ShouldPause)
+// runs in OnEval before the next pause — both on the eval goroutine.
+type Stepper struct {
+	mode  StepMode
+	depth int // stack depth when step command was issued
+}
+
+// NewStepper returns a stepper in the StepNone state.
+func NewStepper() *Stepper {
+	return &Stepper{}
+}
+
+// Mode returns the current step mode.
+func (s *Stepper) Mode() StepMode {
+	return s.mode
+}
+
+// Reset clears the stepper to StepNone (free-running).
+func (s *Stepper) Reset() {
+	s.mode = StepNone
+	s.depth = 0
+}
+
+// SetStepInto configures the stepper to pause on the next OnEval.
+func (s *Stepper) SetStepInto() {
+	s.mode = StepInto
+	s.depth = 0
+}
+
+// SetStepOver configures the stepper to pause on the next OnEval at the
+// same or lesser stack depth.
+func (s *Stepper) SetStepOver(currentDepth int) {
+	s.mode = StepOver
+	s.depth = currentDepth
+}
+
+// SetStepOut configures the stepper to pause on the next OnEval at a
+// lesser stack depth (i.e., after the current function returns).
+func (s *Stepper) SetStepOut(currentDepth int) {
+	s.mode = StepOut
+	s.depth = currentDepth
+}
+
+// ShouldPause returns true if the stepper should cause a pause at the
+// given stack depth. After returning true, the stepper resets to StepNone.
+func (s *Stepper) ShouldPause(currentDepth int) bool {
+	switch s.mode {
+	case StepNone:
+		return false
+	case StepInto:
+		s.mode = StepNone
+		return true
+	case StepOver:
+		if currentDepth <= s.depth {
+			s.mode = StepNone
+			return true
+		}
+		return false
+	case StepOut:
+		if currentDepth < s.depth {
+			s.mode = StepNone
+			return true
+		}
+		return false
+	default:
+		return false
+	}
+}

--- a/lisp/x/debugger/stepper_test.go
+++ b/lisp/x/debugger/stepper_test.go
@@ -1,0 +1,71 @@
+package debugger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStepper_InitialState(t *testing.T) {
+	s := NewStepper()
+	assert.Equal(t, StepNone, s.Mode())
+	assert.False(t, s.ShouldPause(0))
+	assert.False(t, s.ShouldPause(5))
+}
+
+func TestStepper_StepInto(t *testing.T) {
+	s := NewStepper()
+	s.SetStepInto()
+	assert.Equal(t, StepInto, s.Mode())
+
+	// Should pause on any depth.
+	assert.True(t, s.ShouldPause(0))
+	// After pausing, mode resets.
+	assert.Equal(t, StepNone, s.Mode())
+	assert.False(t, s.ShouldPause(0))
+}
+
+func TestStepper_StepOver(t *testing.T) {
+	s := NewStepper()
+	s.SetStepOver(3) // Step issued at depth 3
+
+	// Deeper than 3: don't pause (inside a function call).
+	assert.False(t, s.ShouldPause(4))
+	assert.False(t, s.ShouldPause(5))
+
+	// Same depth: pause.
+	assert.True(t, s.ShouldPause(3))
+	assert.Equal(t, StepNone, s.Mode())
+}
+
+func TestStepper_StepOver_LesserDepth(t *testing.T) {
+	s := NewStepper()
+	s.SetStepOver(3)
+
+	// Lesser depth (returned from function): also pauses.
+	assert.True(t, s.ShouldPause(2))
+	assert.Equal(t, StepNone, s.Mode())
+}
+
+func TestStepper_StepOut(t *testing.T) {
+	s := NewStepper()
+	s.SetStepOut(3) // Step issued at depth 3
+
+	// Same depth: don't pause (still in current function).
+	assert.False(t, s.ShouldPause(3))
+
+	// Deeper: don't pause.
+	assert.False(t, s.ShouldPause(4))
+
+	// Lesser depth (returned): pause.
+	assert.True(t, s.ShouldPause(2))
+	assert.Equal(t, StepNone, s.Mode())
+}
+
+func TestStepper_Reset(t *testing.T) {
+	s := NewStepper()
+	s.SetStepInto()
+	s.Reset()
+	assert.Equal(t, StepNone, s.Mode())
+	assert.False(t, s.ShouldPause(0))
+}

--- a/lisp/x/debugger/stepper_test.go
+++ b/lisp/x/debugger/stepper_test.go
@@ -69,3 +69,31 @@ func TestStepper_Reset(t *testing.T) {
 	assert.Equal(t, StepNone, s.Mode())
 	assert.False(t, s.ShouldPause(0))
 }
+
+func TestStepper_StepOut_DepthZero(t *testing.T) {
+	s := NewStepper()
+	s.SetStepOut(0) // Step out issued at depth 0
+
+	// Can't go shallower than 0, so depth 0 should not pause (need depth < 0).
+	assert.False(t, s.ShouldPause(0))
+	// Still in StepOut mode since we haven't satisfied the condition.
+	assert.Equal(t, StepOut, s.Mode())
+}
+
+func TestStepper_StepOver_DepthZero(t *testing.T) {
+	s := NewStepper()
+	s.SetStepOver(0) // Step over issued at depth 0
+
+	// Same depth 0 should pause (depth <= recorded depth).
+	assert.True(t, s.ShouldPause(0))
+	assert.Equal(t, StepNone, s.Mode())
+}
+
+func TestStepper_StepInto_NonZeroDepth(t *testing.T) {
+	s := NewStepper()
+	s.SetStepInto()
+
+	// StepInto pauses at any depth, not just depth 0.
+	assert.True(t, s.ShouldPause(42))
+	assert.Equal(t, StepNone, s.Mode())
+}


### PR DESCRIPTION
## Summary

- Adds DAP (Debug Adapter Protocol) based debugger support to ELPS (Issue #100)
- Updates design document (`docs/plans/debugger-design.md`) with all resolved architectural decisions
- Implements Phase 1: interface, hooks, engine, DAP server, CLI command, and tests

### Architecture

**Two-layer design:**
- **Layer 1** (`lisp/x/debugger/`): Debugger engine with zero external dependencies. Breakpoint store, step state machine, variable inspector, channel-based pause/resume.
- **Layer 2** (`lisp/x/debugger/dapserver/`): DAP protocol server using `google/go-dap`. TCP and stdio transports.

**Key design decisions:**
- Two-check gate: `d != nil && d.IsEnabled()` — nil check is free, IsEnabled allows dormant debugger
- TRO globally disabled when debugger is attached (nil check, not IsEnabled)
- OnFunEntry at `call()` post-bind provides `fenv` with parameter bindings
- Re-entrancy guard prevents infinite loops during conditional breakpoint evaluation
- `lastContinuedKey` suppresses breakpoint re-hit on same source line after Continue

### New files
| File | Purpose |
|------|---------|
| `lisp/debugger.go` | `Debugger` interface, `DebugAction` enum |
| `lisp/x/debugger/engine.go` | Core engine implementing `lisp.Debugger` |
| `lisp/x/debugger/breakpoint.go` | Breakpoint store with file:line index |
| `lisp/x/debugger/stepper.go` | Step state machine (Into/Over/Out) |
| `lisp/x/debugger/inspector.go` | Variable extraction from LEnv scopes |
| `lisp/x/debugger/dapserver/server.go` | TCP + stdio DAP transport |
| `lisp/x/debugger/dapserver/handler.go` | DAP message dispatch |
| `lisp/x/debugger/dapserver/translate.go` | ELPS types → DAP types |
| `cmd/debug.go` | `elps debug` CLI command |

### Modified files
| File | Change |
|------|--------|
| `lisp/runtime.go` | Added `Debugger Debugger` field |
| `lisp/config.go` | Added `WithDebugger` config option |
| `lisp/env.go` | 5 hook points: OnEval, TRO suppression, OnFunEntry, OnFunReturn, OnError |
| `docs/plans/debugger-design.md` | Updated with resolved decisions |

## Test plan

- [x] 63 tests across 5 test files (breakpoint, stepper, inspector, engine, DAP server)
- [x] `make test` passes — all existing tests unaffected
- [x] `make static-checks` passes — 0 lint issues
- [x] `go build ./...` compiles cleanly
- [x] Debugger engine coverage: 97.9%
- [x] DAP server coverage: 82.9%
- [x] `go test -race` passes — 0 data races
- [x] File-based integration test: `TestDAPServer_FileDebugSession` loads `testdata/simple.lisp` via FSLibrary, exercises full DAP lifecycle
- [x] Benchmark regression check: zero allocation overhead from debugger hooks, CI workflow runs benchstat on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)