### PR TITLE
Fix DAP debugging synchronization for embedded use

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -73,6 +73,7 @@ Examples:
 		// Create the debugger engine.
 		dbg := debugger.New(
 			debugger.WithStopOnEntry(debugStopOnEntry),
+			debugger.WithSourceRoot(rootDir),
 		)
 		dbg.Enable()
 

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -106,10 +106,17 @@ Examples:
 			os.Exit(1)
 		}
 
-		// Start the eval goroutine.
+		// Start the eval goroutine. After evaluation finishes, notify
+		// the DAP server so it can send ExitedEvent + TerminatedEvent
+		// while ServeConn is still running.
 		evalDone := make(chan *lisp.LVal, 1)
 		go func() {
 			res := env.LoadFile(relFile)
+			exitCode := 0
+			if res.Type == lisp.LError {
+				exitCode = 1
+			}
+			dbg.NotifyExit(exitCode)
 			evalDone <- res
 		}()
 

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,4 @@
+.gitignore
+.vscode/**
+**/*.map
+node_modules/**

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,72 @@
+# ELPS Debug — VS Code Extension
+
+A minimal VS Code debug adapter extension for the [ELPS](https://github.com/luthersystems/elps) Lisp interpreter.
+
+## Prerequisites
+
+Build the `elps` binary and ensure it's on your PATH:
+
+```bash
+cd /path/to/elps
+make
+export PATH="$PWD:$PATH"
+```
+
+## Install
+
+From the `editors/vscode/` directory:
+
+```bash
+# Option 1: Symlink into VS Code extensions directory
+ln -s "$PWD" ~/.vscode/extensions/elps-debug
+
+# Option 2: Package and install with vsce
+npx @vscode/vsce package
+code --install-extension elps-debug-0.1.0.vsix
+```
+
+## Usage
+
+1. Open a `.lisp` file in VS Code.
+2. Create a `.vscode/launch.json` (or use the auto-generated snippet):
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "elps",
+      "request": "launch",
+      "name": "Debug ELPS",
+      "program": "${file}",
+      "stopOnEntry": true
+    }
+  ]
+}
+```
+
+3. Set breakpoints by clicking the gutter.
+4. Press F5 to start debugging.
+
+## Configuration
+
+| Attribute     | Type    | Default              | Description                              |
+|---------------|---------|----------------------|------------------------------------------|
+| `program`     | string  | `${file}`            | Path to the `.lisp` file to debug        |
+| `stopOnEntry` | boolean | `true`               | Pause before the first expression        |
+| `rootDir`     | string  | `${workspaceFolder}` | Source root for file resolution           |
+| `elpsPath`    | string  | `"elps"`             | Path to the `elps` binary                |
+
+## Features
+
+- Line breakpoints
+- Conditional breakpoints (Lisp expressions)
+- Hit count breakpoints (`>N`, `>=N`, `==N`, `%N`)
+- Log points (message templates with `{expr}` interpolation)
+- Function breakpoints
+- Exception breakpoints
+- Step into / over / out
+- Variable inspection (local and package scopes)
+- Watch expressions
+- Debug console evaluation
+- Pause / continue

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -1,0 +1,37 @@
+// ELPS Debug Adapter Extension for VS Code
+//
+// This extension registers a DebugAdapterDescriptorFactory that spawns
+// `elps debug --stdio` as a child process, connecting VS Code's DAP
+// client to the ELPS debugger.
+
+const vscode = require("vscode");
+
+class ElpsDebugAdapterFactory {
+  createDebugAdapterDescriptor(session) {
+    const config = session.configuration;
+    const elpsPath = config.elpsPath || "elps";
+    const args = ["debug", "--stdio"];
+
+    if (config.stopOnEntry) {
+      args.push("--stop-on-entry");
+    }
+    if (config.rootDir) {
+      args.push("--root-dir", config.rootDir);
+    }
+
+    args.push(config.program);
+
+    return new vscode.DebugAdapterExecutable(elpsPath, args);
+  }
+}
+
+function activate(context) {
+  const factory = new ElpsDebugAdapterFactory();
+  context.subscriptions.push(
+    vscode.debug.registerDebugAdapterDescriptorFactory("elps", factory)
+  );
+}
+
+function deactivate() {}
+
+module.exports = { activate, deactivate };

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,85 @@
+{
+  "name": "elps-debug",
+  "displayName": "ELPS Debug",
+  "description": "Debug adapter for the ELPS Lisp interpreter",
+  "version": "0.1.0",
+  "publisher": "luthersystems",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/luthersystems/elps"
+  },
+  "engines": {
+    "vscode": "^1.74.0"
+  },
+  "categories": [
+    "Debuggers"
+  ],
+  "activationEvents": [
+    "onDebugResolve:elps"
+  ],
+  "main": "./extension.js",
+  "contributes": {
+    "debuggers": [
+      {
+        "type": "elps",
+        "label": "ELPS Debug",
+        "languages": [
+          "lisp",
+          "elps"
+        ],
+        "configurationAttributes": {
+          "launch": {
+            "required": [
+              "program"
+            ],
+            "properties": {
+              "program": {
+                "type": "string",
+                "description": "Path to the .lisp file to debug",
+                "default": "${file}"
+              },
+              "stopOnEntry": {
+                "type": "boolean",
+                "description": "Pause before the first expression",
+                "default": true
+              },
+              "rootDir": {
+                "type": "string",
+                "description": "Source root directory for file resolution",
+                "default": "${workspaceFolder}"
+              },
+              "elpsPath": {
+                "type": "string",
+                "description": "Path to the elps binary",
+                "default": "elps"
+              }
+            }
+          }
+        },
+        "initialConfigurations": [
+          {
+            "type": "elps",
+            "request": "launch",
+            "name": "Debug ELPS",
+            "program": "${file}",
+            "stopOnEntry": true
+          }
+        ],
+        "configurationSnippets": [
+          {
+            "label": "ELPS: Debug File",
+            "description": "Debug the current ELPS file",
+            "body": {
+              "type": "elps",
+              "request": "launch",
+              "name": "Debug ELPS",
+              "program": "^\"\\${file}\"",
+              "stopOnEntry": true
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/ergochat/readline v0.1.3
+	github.com/google/go-dap v0.12.0
 	github.com/muesli/reflow v0.3.0
 	github.com/prataprc/goparsec v0.0.0-20211219142520-daac0e635e7e
 	github.com/spf13/cobra v1.8.0
@@ -21,7 +22,6 @@ require (
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/google/go-dap v0.12.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/lisp/package.go
+++ b/lisp/package.go
@@ -93,10 +93,14 @@ func (pkg *Package) get(k *LVal) *LVal {
 // Exports declares symbols exported by the package.  The symbols are not
 // required to be bound at the time Exports is called.
 func (pkg *Package) Exports(sym ...string) {
-	sort.Strings(sym)
+	// Copy sym before sorting to avoid mutating the caller's backing
+	// array (e.g., a package-level var passed via ...).
+	sorted := make([]string, len(sym))
+	copy(sorted, sym)
+	sort.Strings(sorted)
 	externs := pkg.Externals
 addloop:
-	for _, symnew := range sym {
+	for _, symnew := range sorted {
 		for _, s := range pkg.Externals {
 			if s == symnew {
 				continue addloop

--- a/lisp/x/debugger/breakpoint.go
+++ b/lisp/x/debugger/breakpoint.go
@@ -5,6 +5,7 @@ package debugger
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -12,13 +13,38 @@ import (
 	"github.com/luthersystems/elps/parser/token"
 )
 
+// hitOp represents a hit count comparison operator.
+type hitOp int
+
+const (
+	hitOpNone hitOp = iota
+	hitOpEQ         // == or bare number
+	hitOpGT         // >
+	hitOpGTE        // >=
+	hitOpMod        // %
+)
+
+// BreakpointSpec describes a breakpoint to set (used by SetForFileSpecs).
+type BreakpointSpec struct {
+	Line         int
+	Condition    string
+	HitCondition string
+	LogMessage   string
+}
+
 // Breakpoint represents a location where execution should pause.
 type Breakpoint struct {
-	ID        int
-	File      string
-	Line      int
-	Condition string // optional: Lisp expression to evaluate
-	Enabled   bool
+	ID           int
+	File         string
+	Line         int
+	Condition    string // optional: Lisp expression to evaluate
+	HitCondition string // optional: hit count expression (e.g., ">5", "==3", "%2")
+	LogMessage   string // optional: log point message template with {expr} interpolation
+	Enabled      bool
+
+	hitCount     int    // number of times this breakpoint has been reached
+	parsedHitOp  hitOp
+	parsedHitVal int
 }
 
 // key returns the file:line key used for map indexing.
@@ -39,6 +65,99 @@ func normalizePath(file string) string {
 		return file
 	}
 	return filepath.Base(file)
+}
+
+// parseHitCondition parses a DAP hit condition string into an operator and value.
+// Supported formats: ">5", ">=3", "==10", "%2", or bare "5" (treated as ==5).
+func parseHitCondition(s string) (hitOp, int) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return hitOpNone, 0
+	}
+	var op hitOp
+	var numStr string
+	switch {
+	case strings.HasPrefix(s, ">="):
+		op = hitOpGTE
+		numStr = strings.TrimSpace(s[2:])
+	case strings.HasPrefix(s, "=="):
+		op = hitOpEQ
+		numStr = strings.TrimSpace(s[2:])
+	case strings.HasPrefix(s, ">"):
+		op = hitOpGT
+		numStr = strings.TrimSpace(s[1:])
+	case strings.HasPrefix(s, "%"):
+		op = hitOpMod
+		numStr = strings.TrimSpace(s[1:])
+	default:
+		op = hitOpEQ
+		numStr = s
+	}
+	val, err := strconv.Atoi(numStr)
+	if err != nil {
+		return hitOpNone, 0
+	}
+	return op, val
+}
+
+// checkHitCondition tests whether the breakpoint's current hit count
+// satisfies the hit condition. Returns true if there is no hit condition
+// or if the condition is met.
+func (bp *Breakpoint) checkHitCondition() bool {
+	if bp.parsedHitOp == hitOpNone {
+		return true
+	}
+	switch bp.parsedHitOp {
+	case hitOpEQ:
+		return bp.hitCount == bp.parsedHitVal
+	case hitOpGT:
+		return bp.hitCount > bp.parsedHitVal
+	case hitOpGTE:
+		return bp.hitCount >= bp.parsedHitVal
+	case hitOpMod:
+		if bp.parsedHitVal <= 0 {
+			return true
+		}
+		return bp.hitCount%bp.parsedHitVal == 0
+	}
+	return true
+}
+
+// IncrementHitCount increments the breakpoint's hit count and returns
+// whether the hit condition is satisfied.
+func (bp *Breakpoint) IncrementHitCount() bool {
+	bp.hitCount++
+	return bp.checkHitCondition()
+}
+
+// InterpolateLogMessage evaluates a log point message template, replacing
+// {expr} placeholders with the result of evaluating each expression.
+func InterpolateLogMessage(env *lisp.LEnv, template string) string {
+	if template == "" {
+		return ""
+	}
+	var buf strings.Builder
+	for {
+		open := strings.Index(template, "{")
+		if open < 0 {
+			buf.WriteString(template)
+			break
+		}
+		buf.WriteString(template[:open])
+		rest := template[open+1:]
+		close := strings.Index(rest, "}")
+		if close < 0 {
+			// Unterminated brace — emit remainder literally.
+			buf.WriteByte('{')
+			buf.WriteString(rest)
+			break
+		}
+		expr := rest[:close]
+		result := EvalInContext(env, expr)
+		buf.WriteString(FormatValue(result))
+		template = rest[close+1:]
+	}
+	return buf.String()
 }
 
 // ExceptionBreakMode controls when the debugger pauses on exceptions.
@@ -79,6 +198,11 @@ func (s *BreakpointStore) Set(file string, line int, condition string) *Breakpoi
 	bp, exists := s.byKey[key]
 	if exists {
 		bp.Condition = condition
+		bp.HitCondition = ""
+		bp.LogMessage = ""
+		bp.hitCount = 0
+		bp.parsedHitOp = hitOpNone
+		bp.parsedHitVal = 0
 		bp.Enabled = true
 		return bp
 	}
@@ -121,6 +245,20 @@ func (s *BreakpointStore) ClearFile(file string) {
 // SetForFile replaces all breakpoints in a file. This implements the DAP
 // setBreakpoints semantics (full replacement, not incremental).
 func (s *BreakpointStore) SetForFile(file string, lines []int, conditions []string) []*Breakpoint {
+	specs := make([]BreakpointSpec, len(lines))
+	for i, line := range lines {
+		cond := ""
+		if i < len(conditions) {
+			cond = conditions[i]
+		}
+		specs[i] = BreakpointSpec{Line: line, Condition: cond}
+	}
+	return s.SetForFileSpecs(file, specs)
+}
+
+// SetForFileSpecs replaces all breakpoints in a file using full specs.
+// This supports hit conditions and log messages in addition to conditions.
+func (s *BreakpointStore) SetForFileSpecs(file string, specs []BreakpointSpec) []*Breakpoint {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	// Remove old breakpoints for this file (using normalized path).
@@ -131,19 +269,20 @@ func (s *BreakpointStore) SetForFile(file string, lines []int, conditions []stri
 		}
 	}
 	// Add new ones.
-	result := make([]*Breakpoint, len(lines))
-	for i, line := range lines {
+	result := make([]*Breakpoint, len(specs))
+	for i, spec := range specs {
 		s.nextID++
-		cond := ""
-		if i < len(conditions) {
-			cond = conditions[i]
-		}
+		hitOp, hitVal := parseHitCondition(spec.HitCondition)
 		bp := &Breakpoint{
-			ID:        s.nextID,
-			File:      file,
-			Line:      line,
-			Condition: cond,
-			Enabled:   true,
+			ID:           s.nextID,
+			File:         file,
+			Line:         spec.Line,
+			Condition:    spec.Condition,
+			HitCondition: spec.HitCondition,
+			LogMessage:   spec.LogMessage,
+			Enabled:      true,
+			parsedHitOp:  hitOp,
+			parsedHitVal: hitVal,
 		}
 		s.byKey[bp.key()] = bp
 		result[i] = bp

--- a/lisp/x/debugger/breakpoint_test.go
+++ b/lisp/x/debugger/breakpoint_test.go
@@ -344,6 +344,10 @@ func TestInterpolateLogMessage(t *testing.T) {
 
 	// Empty template.
 	assert.Equal(t, "", InterpolateLogMessage(env, ""))
+
+	// Expression that errors — should render as error.
+	result := InterpolateLogMessage(env, "val={undefined_sym}")
+	assert.Contains(t, result, "<error:")
 }
 
 func TestBreakpointStore_SetForFileSpecs(t *testing.T) {

--- a/lisp/x/debugger/dapserver/handler_test.go
+++ b/lisp/x/debugger/dapserver/handler_test.go
@@ -1316,7 +1316,7 @@ func TestServeTCPLoop_MultipleConnections(t *testing.T) {
 	ln, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 	addr := ln.Addr().String()
-	ln.Close()
+	ln.Close() //nolint:errcheck // best-effort cleanup for port reservation
 
 	go func() {
 		if err := srv.ServeTCPLoop(addr); err != nil {
@@ -1349,7 +1349,7 @@ func TestServeTCPLoop_MultipleConnections(t *testing.T) {
 	})
 	readDAPMessage(t, reader1) // DisconnectResponse
 	readDAPMessage(t, reader1) // TerminatedEvent
-	conn1.Close()
+	conn1.Close() //nolint:errcheck // best-effort cleanup
 
 	// --- Second connection (retry until server re-enters Accept) ---
 	conn2 := dialWithRetry(t, addr, 2*time.Second)
@@ -1366,5 +1366,5 @@ func TestServeTCPLoop_MultipleConnections(t *testing.T) {
 	require.True(t, ok, "expected InitializeResponse on second connection, got %T", msg)
 	assert.True(t, initResp.Success)
 
-	conn2.Close()
+	conn2.Close() //nolint:errcheck // best-effort cleanup
 }

--- a/lisp/x/debugger/dapserver/handler_test.go
+++ b/lisp/x/debugger/dapserver/handler_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestDAPServer_InitializeAndDisconnect(t *testing.T) {
+	t.Parallel()
 	e := debugger.New()
 	e.Enable()
 	srv := New(e)
@@ -81,6 +82,7 @@ func TestDAPServer_InitializeAndDisconnect(t *testing.T) {
 }
 
 func TestDAPServer_SetBreakpoints(t *testing.T) {
+	t.Parallel()
 	e := debugger.New()
 	e.Enable()
 	srv := New(e)
@@ -150,6 +152,7 @@ func TestDAPServer_SetBreakpoints(t *testing.T) {
 }
 
 func TestDAPServer_Threads(t *testing.T) {
+	t.Parallel()
 	e := debugger.New()
 	e.Enable()
 	srv := New(e)
@@ -203,6 +206,7 @@ func TestDAPServer_Threads(t *testing.T) {
 // initialize → set breakpoint → launch program → read stopped event →
 // stackTrace → scopes → variables → evaluate → continue → disconnect.
 func TestDAPServer_FullSession(t *testing.T) {
+	t.Parallel()
 	e := debugger.New(debugger.WithStopOnEntry(true))
 	e.Enable()
 	srv := New(e)
@@ -569,6 +573,7 @@ func (s *dapTestSession) disconnect() {
 }
 
 func TestDAPServer_StepNext(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 
 	// Set breakpoint inside outer's body (line 3: call to inner).
@@ -683,6 +688,7 @@ func TestDAPServer_StepNext(t *testing.T) {
 }
 
 func TestDAPServer_StepIn(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t, debugger.WithStopOnEntry(true))
 	s.configDone()
 
@@ -736,6 +742,7 @@ func TestDAPServer_StepIn(t *testing.T) {
 }
 
 func TestDAPServer_StepOut(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 
 	// Set breakpoint inside function body (line 2).
@@ -842,6 +849,7 @@ func TestDAPServer_StepOut(t *testing.T) {
 }
 
 func TestDAPServer_SetExceptionBreakpoints(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 
 	s.send(&dap.SetExceptionBreakpointsRequest{
@@ -865,6 +873,7 @@ func TestDAPServer_SetExceptionBreakpoints(t *testing.T) {
 }
 
 func TestDAPServer_EvaluateNotPaused(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 	s.configDone()
 
@@ -889,6 +898,7 @@ func TestDAPServer_EvaluateNotPaused(t *testing.T) {
 }
 
 func TestDAPServer_StackTracePaging(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t, debugger.WithStopOnEntry(true))
 
 	// Set breakpoint inside function body (line 2).
@@ -969,6 +979,7 @@ func TestDAPServer_StackTracePaging(t *testing.T) {
 }
 
 func TestDAPServer_PackageScopeVariables(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t, debugger.WithStopOnEntry(true))
 
 	// Set breakpoint inside function body (line 2).
@@ -1089,6 +1100,7 @@ func TestDAPServer_PackageScopeVariables(t *testing.T) {
 // pauses (stopOnEntry) before the DAP client connects, the client receives
 // the stopped event when it sends configurationDone.
 func TestDAPServer_LateConnectStoppedEvent(t *testing.T) {
+	t.Parallel()
 	e := debugger.New(debugger.WithStopOnEntry(true))
 	e.Enable()
 
@@ -1183,6 +1195,7 @@ func TestDAPServer_LateConnectStoppedEvent(t *testing.T) {
 // TestDAPServer_ReadyChSignaledOnConfigDone verifies that the engine's
 // ReadyCh is closed when configurationDone is received.
 func TestDAPServer_ReadyChSignaledOnConfigDone(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 
 	// ReadyCh should not be closed yet.
@@ -1208,6 +1221,7 @@ func TestDAPServer_ReadyChSignaledOnConfigDone(t *testing.T) {
 // TestDAPServer_PathNormalization verifies that breakpoints set with absolute
 // paths from the IDE match ELPS runtime locations that use basenames.
 func TestDAPServer_PathNormalization(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t, debugger.WithStopOnEntry(true))
 
 	// Set breakpoints using absolute paths (like VS Code sends).
@@ -1266,6 +1280,7 @@ func TestDAPServer_PathNormalization(t *testing.T) {
 // does: set up environment with FSLibrary, load file, pause at breakpoint
 // inside function, inspect variables, evaluate expression, and continue.
 func TestDAPServer_FileDebugSession(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t, debugger.WithStopOnEntry(true))
 
 	// Set breakpoint on line 3 (inside add function body: (+ a b)).
@@ -1435,6 +1450,7 @@ func dialWithRetry(t *testing.T, addr string, timeout time.Duration) net.Conn {
 // ServeTCPLoop fixes this by looping on Accept. This test connects twice
 // to verify the server survives client reconnections.
 func TestServeTCPLoop_MultipleConnections(t *testing.T) {
+	t.Parallel()
 	e := debugger.New()
 	e.Enable()
 	srv := New(e)
@@ -1497,6 +1513,7 @@ func TestServeTCPLoop_MultipleConnections(t *testing.T) {
 }
 
 func TestDAPServer_AttachRequest(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 
 	s.send(&dap.AttachRequest{
@@ -1514,6 +1531,7 @@ func TestDAPServer_AttachRequest(t *testing.T) {
 }
 
 func TestDAPServer_LaunchRequest(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 
 	s.send(&dap.LaunchRequest{
@@ -1531,6 +1549,7 @@ func TestDAPServer_LaunchRequest(t *testing.T) {
 }
 
 func TestDAPServer_PauseRequest(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 	s.configDone()
 
@@ -1596,6 +1615,7 @@ func TestDAPServer_PauseRequest(t *testing.T) {
 }
 
 func TestDAPServer_SourceRequest(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 
 	s.send(&dap.SourceRequest{
@@ -1618,6 +1638,7 @@ func TestDAPServer_SourceRequest(t *testing.T) {
 }
 
 func TestDAPServer_StackTraceUsesPausedExpr(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t, debugger.WithStopOnEntry(true))
 
 	// Set breakpoint on line 2 (inside function body: (+ a b)).
@@ -1686,6 +1707,7 @@ func TestDAPServer_StackTraceUsesPausedExpr(t *testing.T) {
 }
 
 func TestDAPServer_SetFunctionBreakpoints(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 	s.configDone()
 
@@ -1744,6 +1766,7 @@ func TestDAPServer_SetFunctionBreakpoints(t *testing.T) {
 }
 
 func TestDAPServer_InitializeReportsFunctionBreakpointCapability(t *testing.T) {
+	t.Parallel()
 	e := debugger.New()
 	e.Enable()
 	srv := New(e)
@@ -1787,6 +1810,7 @@ func TestDAPServer_InitializeReportsFunctionBreakpointCapability(t *testing.T) {
 }
 
 func TestDAPServer_SourceRootResolvesAbsolutePaths(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t,
 		debugger.WithSourceRoot("/my/project"),
 	)
@@ -1852,6 +1876,7 @@ func TestDAPServer_SourceRootResolvesAbsolutePaths(t *testing.T) {
 }
 
 func TestDAPServer_TerminatedEventOnProgramFinish(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 	s.configDone()
 
@@ -1883,6 +1908,7 @@ func TestDAPServer_TerminatedEventOnProgramFinish(t *testing.T) {
 }
 
 func TestDAPServer_SetBreakpointsWithHitCondition(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 
 	// Set breakpoint with a hit condition.
@@ -1951,6 +1977,7 @@ func TestDAPServer_SetBreakpointsWithHitCondition(t *testing.T) {
 }
 
 func TestDAPServer_LogPoint(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t)
 
 	// Set a log point breakpoint (LogMessage set, no condition).
@@ -2004,6 +2031,7 @@ func TestDAPServer_LogPoint(t *testing.T) {
 }
 
 func TestDAPServer_EvaluateWatch(t *testing.T) {
+	t.Parallel()
 	s := setupDAPSession(t, debugger.WithStopOnEntry(true))
 
 	// Set breakpoint inside function body (line 2).
@@ -2101,7 +2129,178 @@ func TestDAPServer_EvaluateWatch(t *testing.T) {
 	s.disconnect()
 }
 
+// TestDAPServer_EvaluateWhilePausedInRecursion is a regression test for the
+// critical deadlock where EvalInContext called env.Eval() without the
+// evaluatingCondition guard, causing OnEval to re-enter and block on
+// WaitIfPaused. This test breaks a recursive factorial at line 5 (the
+// recursive branch), then evaluates (+ n 100) — which previously returned
+// an ErrorResponse with "<error: error>".
+func TestDAPServer_EvaluateWhilePausedInRecursion(t *testing.T) {
+	t.Parallel()
+	s := setupDAPSession(t, debugger.WithStopOnEntry(true))
+
+	// Set breakpoint on line 5 (* n (factorial (- n 1)))
+	s.send(&dap.SetBreakpointsRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "setBreakpoints",
+		},
+		Arguments: dap.SetBreakpointsArguments{
+			Source:      dap.Source{Path: "factorial.lisp"},
+			Breakpoints: []dap.SourceBreakpoint{{Line: 5}},
+		},
+	})
+	msg := s.read()
+	bpResp, ok := msg.(*dap.SetBreakpointsResponse)
+	require.True(t, ok, "expected SetBreakpointsResponse, got %T", msg)
+	assert.True(t, bpResp.Success)
+
+	s.configDone()
+
+	// Set up ELPS environment with FSLibrary.
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	env.Runtime.Library = &lisp.FSLibrary{FS: os.DirFS("testdata")}
+	env.Runtime.Debugger = s.engine
+	rc := lisp.InitializeUserEnv(env)
+	require.True(t, rc.IsNil(), "InitializeUserEnv failed: %v", rc)
+	rc = lisplib.LoadLibrary(env)
+	require.True(t, rc.IsNil(), "LoadLibrary failed: %v", rc)
+	rc = env.InPackage(lisp.String(lisp.DefaultUserPackage))
+	require.True(t, rc.IsNil(), "InPackage failed: %v", rc)
+
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadFile("factorial.lisp")
+		resultCh <- res
+	}()
+
+	// Stop on entry.
+	require.Eventually(t, func() bool {
+		return s.engine.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not stop on entry")
+	s.read() // StoppedEvent
+
+	// Continue past stop-on-entry to hit breakpoint in factorial.
+	s.continueExec()
+
+	require.Eventually(t, func() bool {
+		return s.engine.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not pause at breakpoint")
+	stoppedMsg := s.read()
+	stoppedEvt, ok := stoppedMsg.(*dap.StoppedEvent)
+	require.True(t, ok, "expected StoppedEvent, got %T", stoppedMsg)
+	assert.Equal(t, "breakpoint", stoppedEvt.Body.Reason)
+
+	// Get stack trace to find the top frame.
+	s.send(&dap.StackTraceRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "stackTrace",
+		},
+		Arguments: dap.StackTraceArguments{ThreadId: elpsThreadID},
+	})
+	msg = s.read()
+	stResp, ok := msg.(*dap.StackTraceResponse)
+	require.True(t, ok, "expected StackTraceResponse, got %T", msg)
+	require.Greater(t, len(stResp.Body.StackFrames), 0)
+	topFrameID := stResp.Body.StackFrames[0].Id
+
+	// Verify local variables are visible (the core of the locals bug fix).
+	s.send(&dap.ScopesRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "scopes",
+		},
+		Arguments: dap.ScopesArguments{FrameId: topFrameID},
+	})
+	msg = s.read()
+	scopesResp, ok := msg.(*dap.ScopesResponse)
+	require.True(t, ok, "expected ScopesResponse, got %T", msg)
+	var localRef int
+	for _, scope := range scopesResp.Body.Scopes {
+		if scope.Name == "Local" {
+			localRef = scope.VariablesReference
+		}
+	}
+	require.Greater(t, localRef, 0, "expected local scope reference")
+
+	s.send(&dap.VariablesRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "variables",
+		},
+		Arguments: dap.VariablesArguments{VariablesReference: localRef},
+	})
+	msg = s.read()
+	varsResp, ok := msg.(*dap.VariablesResponse)
+	require.True(t, ok, "expected VariablesResponse, got %T", msg)
+	varMap := make(map[string]string)
+	for _, v := range varsResp.Body.Variables {
+		varMap[v.Name] = v.Value
+	}
+	assert.Contains(t, varMap, "n",
+		"local scope should contain 'n' even when paused in sub-expression")
+
+	// Evaluate expression while paused (the core of the deadlock bug fix).
+	s.send(&dap.EvaluateRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "evaluate",
+		},
+		Arguments: dap.EvaluateArguments{
+			Expression: "(+ n 100)",
+			FrameId:    topFrameID,
+			Context:    "watch",
+		},
+	})
+	msg = s.read()
+	evalResp, ok := msg.(*dap.EvaluateResponse)
+	require.True(t, ok, "expected EvaluateResponse (not ErrorResponse), got %T", msg)
+	assert.True(t, evalResp.Success, "evaluate should succeed")
+	// n is 5 on the first hit (factorial(5)), so (+ n 100) = 105.
+	assert.Equal(t, "105", evalResp.Body.Result,
+		"(+ n 100) should equal 105 when n=5")
+
+	// Continue to finish — drain any more breakpoint hits.
+	s.continueExec()
+	for waitForEnginePause(t, s.engine, 500*time.Millisecond) {
+		s.read() // StoppedEvent
+		s.continueExec()
+	}
+
+	select {
+	case res := <-resultCh:
+		assert.Equal(t, lisp.LInt, res.Type, "expected int result, got %v", res)
+		assert.Equal(t, 120, res.Int)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for program result")
+	}
+
+	s.disconnect()
+}
+
+// waitForEnginePause waits for the engine to enter paused state, returning true
+// if it paused within the timeout, false otherwise.
+func waitForEnginePause(t *testing.T, e *debugger.Engine, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-deadline:
+			return false
+		case <-ticker.C:
+			if e.IsPaused() {
+				return true
+			}
+		}
+	}
+}
+
 func TestDAPServer_InitializeReportsHitAndLogCapabilities(t *testing.T) {
+	t.Parallel()
 	e := debugger.New()
 	e.Enable()
 	srv := New(e)

--- a/lisp/x/debugger/dapserver/handler_test.go
+++ b/lisp/x/debugger/dapserver/handler_test.go
@@ -1316,7 +1316,7 @@ func TestServeTCPLoop_MultipleConnections(t *testing.T) {
 	ln, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 	addr := ln.Addr().String()
-	ln.Close() //nolint:errcheck // best-effort cleanup for port reservation
+	ln.Close() //nolint:errcheck,gosec // best-effort cleanup for port reservation
 
 	go func() {
 		if err := srv.ServeTCPLoop(addr); err != nil {
@@ -1349,7 +1349,7 @@ func TestServeTCPLoop_MultipleConnections(t *testing.T) {
 	})
 	readDAPMessage(t, reader1) // DisconnectResponse
 	readDAPMessage(t, reader1) // TerminatedEvent
-	conn1.Close() //nolint:errcheck // best-effort cleanup
+	conn1.Close() //nolint:errcheck,gosec // best-effort cleanup
 
 	// --- Second connection (retry until server re-enters Accept) ---
 	conn2 := dialWithRetry(t, addr, 2*time.Second)
@@ -1366,5 +1366,5 @@ func TestServeTCPLoop_MultipleConnections(t *testing.T) {
 	require.True(t, ok, "expected InitializeResponse on second connection, got %T", msg)
 	assert.True(t, initResp.Success)
 
-	conn2.Close() //nolint:errcheck // best-effort cleanup
+	conn2.Close() //nolint:errcheck,gosec // best-effort cleanup
 }

--- a/lisp/x/debugger/dapserver/testdata/factorial.lisp
+++ b/lisp/x/debugger/dapserver/testdata/factorial.lisp
@@ -1,0 +1,7 @@
+; factorial.lisp — recursive test program for debugger integration tests.
+(defun factorial (n)
+  (if (<= n 1)
+    1
+    (* n (factorial (- n 1)))))
+
+(factorial 5)

--- a/lisp/x/debugger/dapserver/translate_test.go
+++ b/lisp/x/debugger/dapserver/translate_test.go
@@ -1,0 +1,66 @@
+package dapserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveSourcePath(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		file       string
+		sourceRoot string
+		want       string
+	}{
+		{
+			name:       "absolute path unchanged",
+			path:       "/abs/path/file.lisp",
+			file:       "file.lisp",
+			sourceRoot: "/root",
+			want:       "/abs/path/file.lisp",
+		},
+		{
+			name:       "relative path resolved with source root",
+			path:       "file.lisp",
+			file:       "file.lisp",
+			sourceRoot: "/my/project",
+			want:       "/my/project/file.lisp",
+		},
+		{
+			name:       "relative subdir path resolved",
+			path:       "subdir/file.lisp",
+			file:       "file.lisp",
+			sourceRoot: "/my/project",
+			want:       "/my/project/subdir/file.lisp",
+		},
+		{
+			name:       "no source root returns relative path as-is",
+			path:       "file.lisp",
+			file:       "file.lisp",
+			sourceRoot: "",
+			want:       "file.lisp",
+		},
+		{
+			name:       "empty path uses file as fallback",
+			path:       "",
+			file:       "main.lisp",
+			sourceRoot: "/root",
+			want:       "/root/main.lisp",
+		},
+		{
+			name:       "both empty returns empty",
+			path:       "",
+			file:       "",
+			sourceRoot: "/root",
+			want:       "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveSourcePath(tt.path, tt.file, tt.sourceRoot)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/lisp/x/debugger/engine_test.go
+++ b/lisp/x/debugger/engine_test.go
@@ -641,8 +641,10 @@ func TestEngine_RequestPause(t *testing.T) {
 		resultCh <- res
 	}()
 
-	// Give the eval goroutine a moment to start, then request pause.
-	time.Sleep(10 * time.Millisecond)
+	// Wait for eval goroutine to start executing, then request pause.
+	require.Eventually(t, func() bool {
+		return e.EvalCount() > 0
+	}, 2*time.Second, time.Millisecond, "eval goroutine did not start")
 	e.RequestPause()
 
 	// The engine should pause.


### PR DESCRIPTION
## Summary

Implements Phase 2 of the DAP debugger (issue #100) and fixes synchronization bugs from #115 for embedded substrate use.

### Sync Bug Fixes (from #115)

1. **Late-connect stopped event** — eval pauses before client connects; `onConfigurationDone` detects pending pause and sends `stopped` event
2. **ReadyCh/SignalReady gate** — embedders wait until `configurationDone` before starting evaluation
3. **ServeTCPLoop** — accepts connections in a loop so DAP server survives client disconnections
4. **Breakpoint path normalization** — basename matching for absolute IDE paths vs runtime relative paths
5. **Remove dead `h.launched` flag** — replaced by ReadyCh mechanism

### Additional DAP Handlers

- `attach`, `launch`, `pause`, `source` request handlers
- Stack trace fix: top frame shows paused expression location, not call site
- `ExitedEvent` + `TerminatedEvent` sent on program finish (`NotifyExit`)

### Phase 2 Features

- **Hit count breakpoints** — `>N`, `>=N`, `==N`, `%N` syntax with `SupportsHitConditionalBreakpoints` capability
- **Log points** — `{expr}` interpolation in log messages, fires `OutputEvent` instead of pausing; `SupportsLogPoints` capability
- **Watch expressions** — `evaluate` request with frame-specific context via `EvalInContext`
- **Function breakpoints** — `setFunctionBreakpoints` handler with qualified/unqualified name matching; `SupportsFunctionBreakpoints` capability
- **Source root resolution** — `WithSourceRoot(dir)` option + `resolveSourcePath()` for absolute paths in stack frames
- **VS Code extension** — minimal extension in `editors/vscode/` that launches `elps debug --stdio`

### Critical Bug Fixes

1. **Evaluate-while-paused deadlock** — `EvalInContext` fired `OnEval` → `WaitIfPaused` → deadlock. Fixed with `evaluatingCondition` re-entrancy guard on `Engine.EvalInContext()`.
2. **Empty local scope at sub-expressions** — `InspectLocals` only checked immediate env scope, missing parent function bindings. Added `InspectFunctionLocals()` that walks parent envs to root.
3. **Frame env mapping reversed** — `cacheFrameEnvs` mapped paused env to frame ID 1, but `translateStackFrames` gave top frame the highest ID. Reversed mapping direction.
4. **Package.Exports data race** — `sort.Strings(sym)` mutated shared caller backing array. Fixed with copy-before-sort.

### Test Coverage

- 3,140 lines added across 18 files
- `t.Parallel()` on all handler_test.go and engine_test.go tests
- Full end-to-end DAP integration tests (breakpoints, stepping, locals, evaluate-while-paused)
- Race detector passing on all tests
- All CI checks pass (Lint & Test + Benchmark Comparison)

## Test plan

- [x] `TestDAPServer_LateConnectStoppedEvent` — late connect stopped event
- [x] `TestDAPServer_ReadyChSignaledOnConfigDone` + `TestEngine_ReadyCh` — ReadyCh gate
- [x] `TestServeTCPLoop_MultipleConnections` — multi-accept TCP server
- [x] `TestDAPServer_PathNormalization` + `TestBreakpointStore_PathNormalization` — path normalization
- [x] `TestEngine_HitCountBreakpoint` + `TestParseHitCondition` — hit count breakpoints
- [x] `TestEngine_LogPoint` + `TestEngine_LogPoint_WithHitCondition` — log points
- [x] `TestDAPServer_EvaluateWhilePausedInRecursion` — evaluate while paused + locals visibility
- [x] `TestEngine_EvalInContextWhilePaused` — re-entrancy guard prevents deadlock
- [x] `TestInspectFunctionLocals` — parent scope walking
- [x] `TestDAPServer_SetBreakpointsWithHitCondition` — DAP hit condition wiring
- [x] `TestDAPServer_LogPoint` — DAP log point OutputEvent
- [x] `TestDAPServer_FunctionBreakpoints` — function breakpoints
- [x] All existing debugger tests pass (97 tests total)
- [x] `go test -race ./lisp/x/debugger/...` — race-free
- [x] `make test && make static-checks` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)