### PR TITLE
DAP debugger: variable expansion, source serving, formatters, editor configs

### DIFF
--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -1,0 +1,61 @@
+# ELPS DAP for Emacs
+
+Requires [dap-mode](https://emacs-lsp.github.io/dap-mode/).
+
+## Configuration
+
+Add to your Emacs config:
+
+```elisp
+(require 'dap-mode)
+
+;; Register the ELPS debug adapter.
+(dap-register-debug-provider
+ "elps"
+ (lambda (conf)
+   (plist-put conf :dap-server-path '("elps" "debug" "--stdio"))
+   conf))
+
+;; Launch configuration.
+(dap-register-debug-template
+ "ELPS: Debug File"
+ (list :type "elps"
+       :request "launch"
+       :name "Debug ELPS"
+       :program "${file}"
+       :stopOnEntry t))
+
+;; Attach configuration (connect to running DAP server).
+(dap-register-debug-template
+ "ELPS: Attach"
+ (list :type "elps"
+       :request "attach"
+       :name "Attach to ELPS"
+       :host "localhost"
+       :port 4711))
+```
+
+## Attach Mode
+
+For attach mode, configure the debug provider to connect via TCP:
+
+```elisp
+(dap-register-debug-provider
+ "elps-attach"
+ (lambda (conf)
+   (let ((host (or (plist-get conf :host) "localhost"))
+         (port (or (plist-get conf :port) 4711)))
+     (plist-put conf :dap-server-host host)
+     (plist-put conf :dap-server-port port)
+     conf)))
+```
+
+## Usage
+
+1. `M-x dap-debug` — select "ELPS: Debug File" or "ELPS: Attach"
+2. `M-x dap-breakpoint-toggle` — toggle breakpoint on current line
+3. `M-x dap-continue` — continue execution
+4. `M-x dap-next` — step over
+5. `M-x dap-step-in` — step into
+6. `M-x dap-step-out` — step out
+7. `M-x dap-eval` — evaluate expression in debug console

--- a/editors/helix/README.md
+++ b/editors/helix/README.md
@@ -1,0 +1,44 @@
+# ELPS DAP for Helix
+
+Requires Helix 24.03+ with DAP support.
+
+## Configuration
+
+Add to `.helix/languages.toml` in your project or `~/.config/helix/languages.toml`:
+
+```toml
+[language-server.elps-dap]
+command = "elps"
+args = ["debug", "--stdio"]
+
+[[language]]
+name = "lisp"
+file-types = ["lisp", "elps"]
+debugger = { command = "elps", args = ["debug", "--stdio"], name = "elps" }
+
+[language.debugger.templates]
+name = "launch"
+request = "launch"
+completion = [{ name = "program", completion = "filename" }]
+
+[[language.debugger.templates.args]]
+program = "{0}"
+stopOnEntry = true
+```
+
+## Attach Mode
+
+For connecting to a running DAP server, Helix does not natively support
+TCP attach. Use the launch configuration to spawn the debugger, or use
+Neovim/VS Code for attach workflows.
+
+## Usage
+
+1. Open a `.lisp` file
+2. `:debug` to start debugging
+3. Use `<space>g` prefix for debug commands:
+   - `<space>gb` — toggle breakpoint
+   - `<space>gc` — continue
+   - `<space>gn` — step over
+   - `<space>gi` — step in
+   - `<space>go` — step out

--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -1,0 +1,49 @@
+# ELPS DAP for JetBrains IDEs
+
+Requires the [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) plugin
+which includes DAP client support.
+
+## Setup
+
+1. Install the **LSP4IJ** plugin from the JetBrains Marketplace
+2. Go to **Settings > Languages & Frameworks > LSP4IJ > DAP**
+3. Add a new DAP server configuration:
+
+| Field | Value |
+|-------|-------|
+| Name | ELPS Debug |
+| Command | `elps debug --stdio` |
+| File types | `*.lisp`, `*.elps` |
+
+## Launch Configuration
+
+Create a Run Configuration:
+
+1. **Run > Edit Configurations > + > DAP**
+2. Set:
+   - **DAP Server**: ELPS Debug
+   - **Request**: launch
+   - **Program**: `$FilePath$`
+   - **Stop on Entry**: true
+
+## Attach Configuration
+
+To connect to a running ELPS DAP server:
+
+1. **Run > Edit Configurations > + > DAP**
+2. Set:
+   - **DAP Server**: ELPS Debug
+   - **Request**: attach
+   - **Host**: localhost
+   - **Port**: 4711
+
+Start the DAP server in your Go application, then run the attach
+configuration in the IDE.
+
+## Alternative: External Tool
+
+If LSP4IJ is not available, you can configure ELPS as an External Tool:
+
+1. **Settings > Tools > External Tools > +**
+2. Set **Program** to `elps`, **Arguments** to `debug --stdio $FilePath$`
+3. Use this for non-DAP debugging (output only, no breakpoints)

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -1,0 +1,67 @@
+# ELPS DAP for Neovim
+
+Requires [nvim-dap](https://github.com/mfussenegger/nvim-dap).
+
+## Launch Mode (spawn child process)
+
+```lua
+local dap = require('dap')
+
+dap.adapters.elps = {
+  type = 'executable',
+  command = 'elps',
+  args = { 'debug', '--stdio' },
+}
+
+dap.configurations.lisp = {
+  {
+    type = 'elps',
+    request = 'launch',
+    name = 'Debug ELPS',
+    program = '${file}',
+    stopOnEntry = true,
+  },
+}
+```
+
+## Attach Mode (connect to running DAP server)
+
+Start the DAP server in your application:
+
+```go
+listener, _ := net.Listen("tcp", ":4711")
+conn, _ := listener.Accept()
+srv := dapserver.New(engine)
+srv.ServeConn(conn)
+```
+
+Then configure nvim-dap to connect:
+
+```lua
+dap.adapters.elps_attach = {
+  type = 'server',
+  host = '127.0.0.1',
+  port = 4711,
+}
+
+dap.configurations.lisp = {
+  {
+    type = 'elps_attach',
+    request = 'attach',
+    name = 'Attach to ELPS',
+  },
+}
+```
+
+## File Type Detection
+
+Add to your Neovim config:
+
+```lua
+vim.filetype.add({
+  extension = {
+    lisp = 'lisp',
+    elps = 'lisp',
+  },
+})
+```

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -1,14 +1,24 @@
 // ELPS Debug Adapter Extension for VS Code
 //
-// This extension registers a DebugAdapterDescriptorFactory that spawns
-// `elps debug --stdio` as a child process, connecting VS Code's DAP
-// client to the ELPS debugger.
+// This extension registers a DebugAdapterDescriptorFactory that handles
+// two modes:
+// - launch: spawns `elps debug --stdio` as a child process
+// - attach: connects to a running DAP server over TCP
 
 const vscode = require("vscode");
 
 class ElpsDebugAdapterFactory {
   createDebugAdapterDescriptor(session) {
     const config = session.configuration;
+
+    // Attach mode: connect to an already-running DAP server over TCP.
+    if (config.request === "attach") {
+      const host = config.host || "localhost";
+      const port = config.port || 4711;
+      return new vscode.DebugAdapterServer(port, host);
+    }
+
+    // Launch mode: spawn the elps binary as a child process.
     const elpsPath = config.elpsPath || "elps";
     const args = ["debug", "--stdio"];
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -55,6 +55,20 @@
                 "default": "elps"
               }
             }
+          },
+          "attach": {
+            "properties": {
+              "host": {
+                "type": "string",
+                "description": "Host of the running DAP server",
+                "default": "localhost"
+              },
+              "port": {
+                "type": "number",
+                "description": "Port of the running DAP server",
+                "default": 4711
+              }
+            }
           }
         },
         "initialConfigurations": [
@@ -64,6 +78,13 @@
             "name": "Debug ELPS",
             "program": "${file}",
             "stopOnEntry": true
+          },
+          {
+            "type": "elps",
+            "request": "attach",
+            "name": "Attach to ELPS",
+            "host": "localhost",
+            "port": 4711
           }
         ],
         "configurationSnippets": [
@@ -76,6 +97,17 @@
               "name": "Debug ELPS",
               "program": "^\"\\${file}\"",
               "stopOnEntry": true
+            }
+          },
+          {
+            "label": "ELPS: Attach to Server",
+            "description": "Attach to a running ELPS DAP server",
+            "body": {
+              "type": "elps",
+              "request": "attach",
+              "name": "Attach to ELPS",
+              "host": "localhost",
+              "port": 4711
             }
           }
         ]

--- a/lisp/debugger.go
+++ b/lisp/debugger.go
@@ -43,6 +43,12 @@ type Debugger interface {
 	// fun is the function value, result is the return value.
 	OnFunReturn(env *LEnv, fun, result *LVal)
 
+	// AfterFunCall is called in Eval after EvalSExpr returns, giving the
+	// debugger a chance to pause at the call-site expression when the
+	// stack depth has decreased (step-out from tail position). Returns
+	// true if execution should pause.
+	AfterFunCall(env *LEnv) bool
+
 	// OnError is called when an error condition is created (in
 	// ErrorCondition and ErrorConditionf). Returns true if the debugger
 	// wants execution to pause (exception breakpoint). When true, the

--- a/lisp/library.go
+++ b/lisp/library.go
@@ -39,6 +39,14 @@ type SourceContext interface {
 	Location() string
 }
 
+// NewSourceContext creates a SourceContext with the given name and location.
+// This is useful for callers that need to construct a SourceContext for
+// SourceLibrary.LoadSource calls outside of normal evaluation flow (e.g.,
+// DAP source request handlers).
+func NewSourceContext(name, loc string) SourceContext {
+	return &sourceContext{name: name, loc: loc}
+}
+
 type sourceContext struct {
 	name string
 	loc  string

--- a/lisp/x/debugger/dapserver/handler_test.go
+++ b/lisp/x/debugger/dapserver/handler_test.go
@@ -2,10 +2,12 @@ package dapserver
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"net"
 	"os"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/google/go-dap"
@@ -570,6 +572,84 @@ func (s *dapTestSession) disconnect() {
 	})
 	s.read() // DisconnectResponse
 	s.read() // TerminatedEvent
+}
+
+// stackTrace requests a stack trace and returns the response.
+func (s *dapTestSession) stackTrace() *dap.StackTraceResponse {
+	s.send(&dap.StackTraceRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "stackTrace",
+		},
+		Arguments: dap.StackTraceArguments{ThreadId: elpsThreadID},
+	})
+	msg := s.read()
+	resp, ok := msg.(*dap.StackTraceResponse)
+	require.True(s.t, ok, "expected StackTraceResponse, got %T", msg)
+	return resp
+}
+
+// scopes requests scopes for a frame and returns the local scope ref.
+func (s *dapTestSession) localScopeRef(frameID int) int {
+	s.send(&dap.ScopesRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "scopes",
+		},
+		Arguments: dap.ScopesArguments{FrameId: frameID},
+	})
+	msg := s.read()
+	scopesResp, ok := msg.(*dap.ScopesResponse)
+	require.True(s.t, ok, "expected ScopesResponse, got %T", msg)
+	for _, sc := range scopesResp.Body.Scopes {
+		if sc.Name == "Local" {
+			return sc.VariablesReference
+		}
+	}
+	s.t.Fatal("no local scope found")
+	return 0
+}
+
+// variables requests variables for a given reference and returns the response.
+func (s *dapTestSession) variables(ref int) []dap.Variable {
+	s.send(&dap.VariablesRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "variables",
+		},
+		Arguments: dap.VariablesArguments{VariablesReference: ref},
+	})
+	msg := s.read()
+	varsResp, ok := msg.(*dap.VariablesResponse)
+	require.True(s.t, ok, "expected VariablesResponse, got %T", msg)
+	return varsResp.Body.Variables
+}
+
+// varNames returns a list of variable names for debug output.
+func varNames(vars []dap.Variable) []string {
+	names := make([]string, len(vars))
+	for i, v := range vars {
+		names[i] = fmt.Sprintf("%s=%s", v.Name, v.Value)
+	}
+	return names
+}
+
+// evaluate sends an evaluate request and returns the response.
+func (s *dapTestSession) evaluate(expr string, frameID int) *dap.EvaluateResponse {
+	s.send(&dap.EvaluateRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "evaluate",
+		},
+		Arguments: dap.EvaluateArguments{
+			Expression: expr,
+			FrameId:    frameID,
+		},
+	})
+	msg := s.read()
+	evalResp, ok := msg.(*dap.EvaluateResponse)
+	require.True(s.t, ok, "expected EvaluateResponse, got %T", msg)
+	return evalResp
 }
 
 func TestDAPServer_StepNext(t *testing.T) {
@@ -2341,4 +2421,350 @@ func TestDAPServer_InitializeReportsHitAndLogCapabilities(t *testing.T) {
 	})
 	readDAPMessage(t, reader) // DisconnectResponse
 	readDAPMessage(t, reader) // TerminatedEvent
+}
+
+// TestDAPServer_VariableExpansion verifies that structured types (lists)
+// return non-zero VariablesReference and that requesting children returns
+// the individual elements.
+func TestDAPServer_VariableExpansion(t *testing.T) {
+	t.Parallel()
+	s := setupDAPSession(t)
+
+	// Breakpoint on line 3 (+ a b) inside the function body.
+	// The function receives a list, sorted-map, and evaluates expressions.
+	s.send(&dap.SetBreakpointsRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "setBreakpoints",
+		},
+		Arguments: dap.SetBreakpointsArguments{
+			Source:      dap.Source{Path: "test"},
+			Breakpoints: []dap.SourceBreakpoint{{Line: 3}},
+		},
+	})
+	s.read() // SetBreakpointsResponse
+	s.configDone()
+
+	env := newDAPTestEnv(t, s.engine)
+	resultCh := make(chan *lisp.LVal, 1)
+	// Simple program: function receives a list and map, breakpoint on line 3.
+	program := "(defun inspect-vars (items m)\n" +
+		"  (let ((x (car items)))\n" +
+		"    (+ x 1)))\n" + // line 3: breakpoint
+		"(inspect-vars (list 10 20 30) (sorted-map \"a\" 1 \"b\" 2))"
+	go func() {
+		resultCh <- env.LoadString("test", program)
+	}()
+
+	require.Eventually(t, func() bool {
+		return s.engine.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond)
+	s.read() // StoppedEvent
+
+	// Get stack trace and local variables.
+	stResp := s.stackTrace()
+	require.Greater(t, len(stResp.Body.StackFrames), 0)
+	topFrame := stResp.Body.StackFrames[0].Id
+	localRef := s.localScopeRef(topFrame)
+	vars := s.variables(localRef)
+
+	// Find variables — items (list), m (sorted-map), x (scalar).
+	varMap := make(map[string]dap.Variable)
+	for _, v := range vars {
+		varMap[v.Name] = v
+	}
+
+	// --- List expansion ---
+	listVar, ok := varMap["items"]
+	require.True(t, ok, "should find items variable, got vars: %v", varNames(vars))
+	assert.Greater(t, listVar.VariablesReference, 0,
+		"list should have expandable children")
+	children := s.variables(listVar.VariablesReference)
+	require.Len(t, children, 3, "list should have 3 elements")
+	assert.Equal(t, "[0]", children[0].Name)
+	assert.Equal(t, "10", children[0].Value)
+	assert.Equal(t, "[1]", children[1].Name)
+	assert.Equal(t, "20", children[1].Value)
+	assert.Equal(t, "[2]", children[2].Name)
+	assert.Equal(t, "30", children[2].Value)
+
+	// --- Sorted-map expansion ---
+	mapVar, ok := varMap["m"]
+	require.True(t, ok, "should find m variable, got vars: %v", varNames(vars))
+	assert.Greater(t, mapVar.VariablesReference, 0,
+		"sorted-map should have expandable children")
+	mapChildren := s.variables(mapVar.VariablesReference)
+	require.Len(t, mapChildren, 2, "sorted-map should have 2 entries")
+	mapVals := make(map[string]string)
+	for _, ch := range mapChildren {
+		mapVals[ch.Name] = ch.Value
+	}
+	assert.Equal(t, "1", mapVals[`"a"`], "map key 'a' should have value 1")
+	assert.Equal(t, "2", mapVals[`"b"`], "map key 'b' should have value 2")
+
+	// --- Scalar should NOT be expandable ---
+	xVar, ok := varMap["x"]
+	require.True(t, ok, "should find x variable")
+	assert.Equal(t, 0, xVar.VariablesReference,
+		"scalar should not be expandable")
+
+	// Continue and finish.
+	s.continueExec()
+	select {
+	case <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+	s.disconnect()
+}
+
+// TestDAPServer_EvaluateResultExpansion verifies that evaluate results for
+// structured types return a non-zero VariablesReference for drill-down.
+func TestDAPServer_EvaluateResultExpansion(t *testing.T) {
+	t.Parallel()
+	s := setupDAPSession(t)
+
+	// Set breakpoint inside function body so we have stack frames.
+	s.send(&dap.SetBreakpointsRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "setBreakpoints",
+		},
+		Arguments: dap.SetBreakpointsArguments{
+			Source:      dap.Source{Path: "test"},
+			Breakpoints: []dap.SourceBreakpoint{{Line: 2}},
+		},
+	})
+	s.read() // SetBreakpointsResponse
+	s.configDone()
+
+	env := newDAPTestEnv(t, s.engine)
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		resultCh <- env.LoadString("test", "(defun f (x)\n  (+ x 1))\n(f 10)")
+	}()
+
+	require.Eventually(t, func() bool {
+		return s.engine.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond)
+	s.read() // StoppedEvent
+
+	stResp := s.stackTrace()
+	require.Greater(t, len(stResp.Body.StackFrames), 0)
+	topFrame := stResp.Body.StackFrames[0].Id
+
+	// Evaluate a list expression — result should be expandable.
+	evalResp := s.evaluate("(list 1 2 3)", topFrame)
+	assert.True(t, evalResp.Success, "evaluate should succeed")
+	assert.Greater(t, evalResp.Body.VariablesReference, 0,
+		"list evaluate result should be expandable")
+
+	// Expand the result's children.
+	children := s.variables(evalResp.Body.VariablesReference)
+	require.Len(t, children, 3)
+	assert.Equal(t, "[0]", children[0].Name)
+	assert.Equal(t, "1", children[0].Value)
+
+	// Evaluate a scalar — result should NOT be expandable.
+	scalarResp := s.evaluate("42", topFrame)
+	assert.True(t, scalarResp.Success)
+	assert.Equal(t, 0, scalarResp.Body.VariablesReference,
+		"scalar evaluate result should not be expandable")
+
+	s.continueExec()
+	select {
+	case <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+	s.disconnect()
+}
+
+// TestDAPServer_SourceByPath verifies that the source request handler
+// can serve source content from a configured SourceLibrary.
+func TestDAPServer_SourceByPath(t *testing.T) {
+	t.Parallel()
+	content := "; hello from embedded source\n(+ 1 2)\n"
+	fs := fstest.MapFS{
+		"hello.lisp": &fstest.MapFile{Data: []byte(content)},
+	}
+	s := setupDAPSession(t, debugger.WithSourceLibrary(&lisp.FSLibrary{FS: fs}))
+	s.configDone()
+
+	// Request source by path.
+	s.send(&dap.SourceRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "source",
+		},
+		Arguments: dap.SourceArguments{
+			Source: &dap.Source{Path: "hello.lisp"},
+		},
+	})
+	msg := s.read()
+	srcResp, ok := msg.(*dap.SourceResponse)
+	require.True(t, ok, "expected SourceResponse, got %T", msg)
+	assert.True(t, srcResp.Success)
+	assert.Equal(t, content, srcResp.Body.Content)
+	assert.Equal(t, "text/x-lisp", srcResp.Body.MimeType)
+
+	s.disconnect()
+}
+
+// TestDAPServer_SourceByReference verifies that source content can be
+// served by reference ID for virtual sources.
+func TestDAPServer_SourceByReference(t *testing.T) {
+	t.Parallel()
+	s := setupDAPSession(t)
+	s.configDone()
+
+	// Allocate a source reference.
+	content := "(defun hello () (print \"hi\"))\n"
+	ref := s.engine.AllocSourceRef("virtual.lisp", content)
+
+	// Request source by reference.
+	s.send(&dap.SourceRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "source",
+		},
+		Arguments: dap.SourceArguments{
+			SourceReference: ref,
+		},
+	})
+	msg := s.read()
+	srcResp, ok := msg.(*dap.SourceResponse)
+	require.True(t, ok, "expected SourceResponse, got %T", msg)
+	assert.True(t, srcResp.Success)
+	assert.Equal(t, content, srcResp.Body.Content)
+	assert.Equal(t, "text/x-lisp", srcResp.Body.MimeType)
+
+	s.disconnect()
+}
+
+// TestDAPServer_SourceNotAvailable verifies that the source request handler
+// returns an error when no source library is configured and no ref matches.
+func TestDAPServer_SourceNotAvailable(t *testing.T) {
+	t.Parallel()
+	s := setupDAPSession(t)
+	s.configDone()
+
+	s.send(&dap.SourceRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "source",
+		},
+		Arguments: dap.SourceArguments{
+			Source: &dap.Source{Path: "nonexistent.lisp"},
+		},
+	})
+	msg := s.read()
+	// go-dap deserializes responses with Success=false as ErrorResponse.
+	errResp, ok := msg.(*dap.ErrorResponse)
+	require.True(t, ok, "expected ErrorResponse, got %T", msg)
+	assert.False(t, errResp.Success)
+	assert.Equal(t, "source not available", errResp.Message)
+
+	s.disconnect()
+}
+
+// TestDAPServer_VariableFormatterNative verifies that custom native type
+// formatters are wired through the DAP Variables response. A native
+// value in scope should display using the registered formatter's output.
+func TestDAPServer_VariableFormatterNative(t *testing.T) {
+	t.Parallel()
+
+	type myStruct struct {
+		Name string
+		Age  int
+	}
+	typeName := fmt.Sprintf("%T", myStruct{})
+
+	s := setupDAPSession(t, debugger.WithFormatters(map[string]debugger.VariableFormatter{
+		typeName: debugger.FormatterFunc(func(v any) string {
+			ms, ok := v.(myStruct)
+			if !ok {
+				return "<unknown>"
+			}
+			return fmt.Sprintf("Person(%s, %d)", ms.Name, ms.Age)
+		}),
+	}))
+
+	// Breakpoint on line 2 inside function body.
+	s.send(&dap.SetBreakpointsRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "setBreakpoints",
+		},
+		Arguments: dap.SetBreakpointsArguments{
+			Source:      dap.Source{Path: "test"},
+			Breakpoints: []dap.SourceBreakpoint{{Line: 2}},
+		},
+	})
+	s.read() // SetBreakpointsResponse
+	s.configDone()
+
+	// Create an env that puts a native value into scope before evaluation.
+	env := newDAPTestEnv(t, s.engine)
+	env.Put(lisp.Symbol("person"), lisp.Native(myStruct{Name: "Alice", Age: 30}))
+
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		// Line 1: defun with person in scope via closure
+		// Line 2: breakpoint fires here — person visible as local
+		resultCh <- env.LoadString("test", "(defun check ()\n  person)\n(check)")
+	}()
+
+	require.Eventually(t, func() bool {
+		return s.engine.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond)
+	s.read() // StoppedEvent
+
+	// Request stack trace → scopes → variables through the DAP protocol.
+	stResp := s.stackTrace()
+	require.Greater(t, len(stResp.Body.StackFrames), 0)
+
+	// Evaluate the native value through the DAP evaluate handler.
+	evalResp := s.evaluate("person", stResp.Body.StackFrames[0].Id)
+	assert.True(t, evalResp.Success)
+	assert.Equal(t, "Person(Alice, 30)", evalResp.Body.Result,
+		"evaluate should use registered formatter for native value")
+
+	s.continueExec()
+	select {
+	case <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+	s.disconnect()
+}
+
+// TestDAPServer_SourceLibraryMissing verifies that when a SourceLibrary
+// is configured but the requested file does not exist, the error response
+// is returned instead of crashing.
+func TestDAPServer_SourceLibraryMissing(t *testing.T) {
+	t.Parallel()
+	fs := fstest.MapFS{
+		"exists.lisp": &fstest.MapFile{Data: []byte("(+ 1 2)")},
+	}
+	s := setupDAPSession(t, debugger.WithSourceLibrary(&lisp.FSLibrary{FS: fs}))
+	s.configDone()
+
+	// Request a file that does NOT exist in the library.
+	s.send(&dap.SourceRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "source",
+		},
+		Arguments: dap.SourceArguments{
+			Source: &dap.Source{Path: "nonexistent.lisp"},
+		},
+	})
+	msg := s.read()
+	errResp, ok := msg.(*dap.ErrorResponse)
+	require.True(t, ok, "expected ErrorResponse, got %T", msg)
+	assert.False(t, errResp.Success)
+	assert.Equal(t, "source not available", errResp.Message)
+
+	s.disconnect()
 }

--- a/lisp/x/debugger/dapserver/testdata/structured.lisp
+++ b/lisp/x/debugger/dapserver/testdata/structured.lisp
@@ -2,10 +2,8 @@
 (defun test-structured ()
   (let ((my-list (list 10 20 30))
         (my-map (sorted-map "a" 1 "b" 2))
-        (my-array (make-array 3)))
-    (aset my-array 0 "x")
-    (aset my-array 1 "y")
-    (aset my-array 2 "z")
+        (my-array (vector "x" "y" "z")))
+    (debug-print my-map my-array)
     my-list))
 
 (test-structured)

--- a/lisp/x/debugger/dapserver/testdata/structured.lisp
+++ b/lisp/x/debugger/dapserver/testdata/structured.lisp
@@ -1,0 +1,11 @@
+; structured.lisp — test program with structured types for variable expansion tests.
+(defun test-structured ()
+  (let ((my-list (list 10 20 30))
+        (my-map (sorted-map "a" 1 "b" 2))
+        (my-array (make-array 3)))
+    (aset my-array 0 "x")
+    (aset my-array 1 "y")
+    (aset my-array 2 "z")
+    my-list))
+
+(test-structured)

--- a/lisp/x/debugger/dapserver/translate_test.go
+++ b/lisp/x/debugger/dapserver/translate_test.go
@@ -3,7 +3,10 @@ package dapserver
 import (
 	"testing"
 
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/x/debugger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveSourcePath(t *testing.T) {
@@ -63,4 +66,98 @@ func TestResolveSourcePath(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestTranslateVariables_WithRefAllocator(t *testing.T) {
+	nextRef := 5000
+	allocRef := func(v *lisp.LVal) int {
+		if v != nil && v.Type == lisp.LSExpr && !v.IsNil() {
+			nextRef++
+			return nextRef
+		}
+		return 0
+	}
+
+	bindings := []debugger.ScopeBinding{
+		{Name: "x", Value: lisp.Int(42)},
+		{Name: "items", Value: lisp.SExpr([]*lisp.LVal{lisp.Int(1), lisp.Int(2)})},
+	}
+
+	vars := translateVariables(bindings, allocRef, nil)
+	require.Len(t, vars, 2)
+
+	assert.Equal(t, "x", vars[0].Name)
+	assert.Equal(t, "42", vars[0].Value)
+	assert.Equal(t, 0, vars[0].VariablesReference, "scalar should have ref=0")
+
+	assert.Equal(t, "items", vars[1].Name)
+	assert.Equal(t, "(1 2)", vars[1].Value)
+	assert.Greater(t, vars[1].VariablesReference, 0, "list should have expandable ref")
+}
+
+func TestExpandVariable_List(t *testing.T) {
+	list := lisp.SExpr([]*lisp.LVal{lisp.Int(10), lisp.String("hi"), lisp.Float(3.14)})
+	noRef := func(v *lisp.LVal) int { return 0 }
+
+	children := expandVariable(list, noRef, nil)
+	require.Len(t, children, 3)
+	assert.Equal(t, "[0]", children[0].Name)
+	assert.Equal(t, "10", children[0].Value)
+	assert.Equal(t, "[1]", children[1].Name)
+	assert.Equal(t, `"hi"`, children[1].Value)
+	assert.Equal(t, "[2]", children[2].Name)
+	assert.Equal(t, "3.14", children[2].Value)
+}
+
+func TestExpandVariable_SortedMap(t *testing.T) {
+	m := lisp.SortedMap()
+	m.MapSet(lisp.String("alpha"), lisp.Int(1))
+	m.MapSet(lisp.String("beta"), lisp.Int(2))
+	noRef := func(v *lisp.LVal) int { return 0 }
+
+	children := expandVariable(m, noRef, nil)
+	require.Len(t, children, 2)
+
+	vals := make(map[string]string)
+	for _, ch := range children {
+		vals[ch.Name] = ch.Value
+	}
+	assert.Equal(t, "1", vals[`"alpha"`])
+	assert.Equal(t, "2", vals[`"beta"`])
+}
+
+func TestExpandVariable_Array(t *testing.T) {
+	arr := lisp.Array(nil, []*lisp.LVal{lisp.String("a"), lisp.String("b")})
+	noRef := func(v *lisp.LVal) int { return 0 }
+
+	children := expandVariable(arr, noRef, nil)
+	require.Len(t, children, 2)
+	assert.Equal(t, "[0]", children[0].Name)
+	assert.Equal(t, `"a"`, children[0].Value)
+	assert.Equal(t, "[1]", children[1].Name)
+	assert.Equal(t, `"b"`, children[1].Value)
+}
+
+func TestExpandVariable_TaggedVal(t *testing.T) {
+	inner := lisp.Int(42)
+	tagged := &lisp.LVal{Type: lisp.LTaggedVal, Str: "my-type", Cells: []*lisp.LVal{inner}}
+	noRef := func(v *lisp.LVal) int { return 0 }
+
+	children := expandVariable(tagged, noRef, nil)
+	require.Len(t, children, 1)
+	assert.Equal(t, "data", children[0].Name)
+	assert.Equal(t, "42", children[0].Value)
+}
+
+func TestExpandVariable_NativeNilEngine(t *testing.T) {
+	native := lisp.Native(struct{ X int }{X: 42})
+	noRef := func(v *lisp.LVal) int { return 0 }
+
+	children := expandVariable(native, noRef, nil)
+	assert.Nil(t, children, "LNative with nil engine should return nil children")
+}
+
+func TestExpandVariable_Nil(t *testing.T) {
+	assert.Nil(t, expandVariable(nil, func(v *lisp.LVal) int { return 0 }, nil))
+	assert.Nil(t, expandVariable(lisp.Int(42), func(v *lisp.LVal) int { return 0 }, nil))
 }


### PR DESCRIPTION
## Summary

- **Variable expansion**: Lists, sorted-maps, arrays, tagged values, and native Go types are now expandable in the debugger variables pane. Uses lazy reference allocation with per-pause lifecycle (references cleared on continue/step).
- **VariableFormatter API**: New `VariableFormatter` interface on the engine layer lets embedders customize how `LNative` values display and what children they expose. Includes `FormatterFunc` convenience adapter.
- **Source request handler**: `onSource` now serves file content via `SourceLibrary` (for `go:embed` files) or integer source references. Returns `text/x-lisp` MIME type.
- **VS Code attach mode**: Extension now supports `request: "attach"` for connecting to a running DAP server over TCP (host/port configurable).
- **Editor documentation**: Added setup guides for Neovim (nvim-dap), Helix, Emacs (dap-mode), and JetBrains (LSP4IJ).
- **Fix step-out from tail-position functions** (closes #118): Step-out from a function in tail position previously ran to completion. Added a post-call check in `Eval()` and an `OnFunReturn` pre-detection flag so the debugger pauses at the call-site expression when the stack depth decreases.

## Test plan

- [x] `make test` — all Go tests and lisp examples pass
- [x] `make static-checks` — 0 lint issues
- [x] `go test -race ./lisp/x/debugger/...` — no data races
- [x] New handler tests: variable expansion, sorted-map expansion, evaluate result expansion, formatter integration, source by path/reference/missing
- [x] New translate tests: ref allocator wiring, expand list/map/array/tagged/nil/native-nil-engine
- [x] New engine tests: formatter registration, source ref registry, source library, step-out tail position
- [x] New stepper tests: `ShouldPausePostCall` (5 subtests), `Depth` accessor
- [x] New inspector tests: FormatValueWith, FormatterFunc adapter
- [x] Handler test: `TestDAPServer_StepOutTailPosition` updated from documenting known limitation to asserting correct behavior
- [x] QA professor reviewed — critical and major findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)