### PR TITLE
Fix LoadLocation fallback passing wrong file to Reader

### DIFF
--- a/lisp/env.go
+++ b/lisp/env.go
@@ -259,7 +259,7 @@ func (env *LEnv) LoadLocation(name string, loc string, r io.Reader) *LVal {
 
 	reader, ok := env.Runtime.Reader.(LocationReader)
 	if !ok {
-		return env.Load(name, r)
+		return env.Load(loc, r)
 	}
 	exprs, err := reader.ReadLocation(name, loc, r)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #119 — DAP stack frames reported the wrong source file for code loaded via `(load ...)`.

### Root Cause

`LoadLocation` in `lisp/env.go` has a fallback path when the `Reader` doesn't implement `LocationReader`. The fallback called `env.Load(name, r)` where `name` is the *loading* file (e.g., `init.lisp`), not `loc` — the actual file being loaded (e.g., `organisation.lisp`). All parsed expressions then got the wrong `Source.File`, causing the DAP server's `resolveSourcePath` to report the loading file in stack frames.

### Fix

One-word change: `env.Load(name, r)` → `env.Load(loc, r)` in the fallback path.

### Files Changed

- `lisp/env.go` — Fix fallback path in `LoadLocation`
- `lisp/loader_test.go` — Regression test `TestLoadLocation_fallbackUsesLoc`

## Test plan

- [x] Regression test: `plainReader` wrapper forces fallback path, asserts `Read()` receives `loc` not `name`
- [x] Test confirmed to fail before fix, pass after
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)