### PR TITLE
Fix DAP handler to respect client stopOnEntry preference

### DIFF
--- a/lisp/x/debugger/dapserver/handler_test.go
+++ b/lisp/x/debugger/dapserver/handler_test.go
@@ -481,24 +481,17 @@ func readDAPMessage(t *testing.T, r *bufio.Reader) dap.Message {
 	}
 }
 
-// tryReadDAPMessage attempts to read a DAP message within the given timeout.
-// Returns the message and true if one was received, or nil and false if the
-// timeout elapsed without receiving a message.
-func tryReadDAPMessage(r *bufio.Reader, timeout time.Duration) (dap.Message, bool) {
-	done := make(chan dap.Message, 1)
-	go func() {
-		msg, err := dap.ReadProtocolMessage(r)
-		if err != nil {
-			return
-		}
-		done <- msg
-	}()
-	select {
-	case msg := <-done:
-		return msg, true
-	case <-time.After(timeout):
+// tryReadDAPMessage attempts to read a DAP message within the given timeout
+// using a connection deadline (no leaked goroutines). The conn must be the
+// underlying net.Conn for the bufio.Reader.
+func tryReadDAPMessage(conn net.Conn, r *bufio.Reader, timeout time.Duration) (dap.Message, bool) {
+	_ = conn.SetReadDeadline(time.Now().Add(timeout))
+	msg, err := dap.ReadProtocolMessage(r)
+	_ = conn.SetReadDeadline(time.Time{}) // clear deadline
+	if err != nil {
 		return nil, false
 	}
+	return msg, true
 }
 
 // dapTestSession reduces boilerplate for DAP protocol tests.
@@ -582,6 +575,12 @@ func (s *dapTestSession) continueExec() {
 		Arguments: dap.ContinueArguments{ThreadId: elpsThreadID},
 	})
 	s.read() // ContinueResponse
+}
+
+// tryRead attempts to read a DAP message within the given timeout.
+// Returns the message and true if received, or nil and false on timeout.
+func (s *dapTestSession) tryRead(timeout time.Duration) (dap.Message, bool) {
+	return tryReadDAPMessage(s.client, s.reader, timeout)
 }
 
 func (s *dapTestSession) disconnect() {
@@ -3130,8 +3129,9 @@ func TestDAPServer_StopOnEntry_AttachTrue(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "engine did not stop on entry")
 
 	stoppedMsg := s.read()
-	_, ok = stoppedMsg.(*dap.StoppedEvent)
+	stoppedEvent, ok := stoppedMsg.(*dap.StoppedEvent)
 	require.True(t, ok, "expected StoppedEvent, got %T", stoppedMsg)
+	assert.Equal(t, "entry", stoppedEvent.Body.Reason, "stopOnEntry should produce entry reason")
 
 	// Continue to let the program finish.
 	s.continueExec()
@@ -3170,6 +3170,11 @@ func TestDAPServer_StopOnEntry_AttachFalse(t *testing.T) {
 	require.True(t, ok, "expected AttachResponse, got %T", msg)
 
 	s.configDone()
+
+	// Verify no StoppedEvent was sent after configurationDone.
+	if msg2, ok2 := s.tryRead(200 * time.Millisecond); ok2 {
+		t.Fatalf("expected no StoppedEvent, but got %T", msg2)
+	}
 
 	// Launch program -- engine should NOT stop on entry because client
 	// said stopOnEntry: false.
@@ -3217,6 +3222,11 @@ func TestDAPServer_StopOnEntry_AttachAbsent(t *testing.T) {
 
 	s.configDone()
 
+	// Verify no StoppedEvent was sent after configurationDone.
+	if msg2, ok2 := s.tryRead(200 * time.Millisecond); ok2 {
+		t.Fatalf("expected no StoppedEvent, but got %T", msg2)
+	}
+
 	// Launch program -- engine should NOT stop on entry because the
 	// default for stopOnEntry is false.
 	env := newDAPTestEnv(t, s.engine)
@@ -3238,5 +3248,165 @@ func TestDAPServer_StopOnEntry_AttachAbsent(t *testing.T) {
 	// Verify engine is not paused.
 	assert.False(t, s.engine.IsPaused(), "engine should not be paused after absent stopOnEntry")
 
+	s.disconnect()
+}
+
+// TestParseStopOnEntry verifies the parseStopOnEntry helper handles all JSON
+// edge cases correctly, defaulting to false per DAP spec.
+func TestParseStopOnEntry(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args json.RawMessage
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty_object", json.RawMessage(`{}`), false},
+		{"true", json.RawMessage(`{"stopOnEntry":true}`), true},
+		{"false", json.RawMessage(`{"stopOnEntry":false}`), false},
+		{"malformed_json", json.RawMessage(`{invalid}`), false},
+		{"extra_fields", json.RawMessage(`{"stopOnEntry":true,"other":"field"}`), true},
+		{"empty_bytes", json.RawMessage(``), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseStopOnEntry(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestDAPServer_StopOnEntry_LaunchTrue verifies that launch with
+// stopOnEntry:true sends a stopped event on entry.
+func TestDAPServer_StopOnEntry_LaunchTrue(t *testing.T) {
+	t.Parallel()
+	s := setupDAPSession(t, debugger.WithStopOnEntry(true))
+
+	args, err := json.Marshal(map[string]any{"stopOnEntry": true})
+	require.NoError(t, err)
+	s.send(&dap.LaunchRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "launch",
+		},
+		Arguments: json.RawMessage(args),
+	})
+	msg := s.read()
+	_, ok := msg.(*dap.LaunchResponse)
+	require.True(t, ok, "expected LaunchResponse, got %T", msg)
+
+	s.configDone()
+
+	env := newDAPTestEnv(t, s.engine)
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", "(+ 1 2)")
+		resultCh <- res
+	}()
+
+	require.Eventually(t, func() bool {
+		return s.engine.IsPaused()
+	}, 2*time.Second, 10*time.Millisecond, "engine did not stop on entry")
+
+	stoppedMsg := s.read()
+	stoppedEvent, ok := stoppedMsg.(*dap.StoppedEvent)
+	require.True(t, ok, "expected StoppedEvent, got %T", stoppedMsg)
+	assert.Equal(t, "entry", stoppedEvent.Body.Reason, "stopOnEntry should produce entry reason")
+
+	s.continueExec()
+
+	select {
+	case res := <-resultCh:
+		assert.Equal(t, lisp.LInt, res.Type)
+		assert.Equal(t, 3, res.Int)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for program result")
+	}
+
+	s.disconnect()
+}
+
+// TestDAPServer_StopOnEntry_LaunchFalse verifies that launch with
+// stopOnEntry:false resumes silently.
+func TestDAPServer_StopOnEntry_LaunchFalse(t *testing.T) {
+	t.Parallel()
+	s := setupDAPSession(t, debugger.WithStopOnEntry(true))
+
+	args, err := json.Marshal(map[string]any{"stopOnEntry": false})
+	require.NoError(t, err)
+	s.send(&dap.LaunchRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "launch",
+		},
+		Arguments: json.RawMessage(args),
+	})
+	msg := s.read()
+	_, ok := msg.(*dap.LaunchResponse)
+	require.True(t, ok, "expected LaunchResponse, got %T", msg)
+
+	s.configDone()
+
+	if msg2, ok2 := s.tryRead(200 * time.Millisecond); ok2 {
+		t.Fatalf("expected no StoppedEvent, but got %T", msg2)
+	}
+
+	env := newDAPTestEnv(t, s.engine)
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", "(+ 1 2)")
+		resultCh <- res
+	}()
+
+	select {
+	case res := <-resultCh:
+		assert.Equal(t, lisp.LInt, res.Type, "expected int result")
+		assert.Equal(t, 3, res.Int)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: program did not complete -- engine likely paused on entry when it should not have")
+	}
+
+	assert.False(t, s.engine.IsPaused(), "engine should not be paused after stopOnEntry:false")
+	s.disconnect()
+}
+
+// TestDAPServer_StopOnEntry_LaunchAbsent verifies that launch without
+// stopOnEntry defaults to not stopping (per DAP spec).
+func TestDAPServer_StopOnEntry_LaunchAbsent(t *testing.T) {
+	t.Parallel()
+	s := setupDAPSession(t, debugger.WithStopOnEntry(true))
+
+	s.send(&dap.LaunchRequest{
+		Request: dap.Request{
+			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
+			Command:         "launch",
+		},
+	})
+	msg := s.read()
+	_, ok := msg.(*dap.LaunchResponse)
+	require.True(t, ok, "expected LaunchResponse, got %T", msg)
+
+	s.configDone()
+
+	if msg2, ok2 := s.tryRead(200 * time.Millisecond); ok2 {
+		t.Fatalf("expected no StoppedEvent, but got %T", msg2)
+	}
+
+	env := newDAPTestEnv(t, s.engine)
+	resultCh := make(chan *lisp.LVal, 1)
+	go func() {
+		res := env.LoadString("test", "(+ 1 2)")
+		resultCh <- res
+	}()
+
+	select {
+	case res := <-resultCh:
+		assert.Equal(t, lisp.LInt, res.Type, "expected int result")
+		assert.Equal(t, 3, res.Int)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: program did not complete -- engine likely paused on entry when it should not have")
+	}
+
+	assert.False(t, s.engine.IsPaused(), "engine should not be paused after absent stopOnEntry")
 	s.disconnect()
 }

--- a/lisp/x/debugger/engine.go
+++ b/lisp/x/debugger/engine.go
@@ -137,6 +137,17 @@ func WithStopOnEntry(stop bool) Option {
 	}
 }
 
+// SetStopOnEntry overrides the stop-on-entry flag at runtime. This allows
+// a DAP handler to reflect the client's stopOnEntry preference, which may
+// differ from the embedder's WithStopOnEntry option. It is safe to call
+// before evaluation starts. If called while the engine is already paused on
+// entry, the caller must also Resume the engine to unblock it.
+func (e *Engine) SetStopOnEntry(stop bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.stopOnEntry = stop
+}
+
 // WithSourceRoot sets an absolute directory path used to resolve relative
 // Source.Path values into absolute paths. This allows DAP clients (VS Code)
 // to open source files from stack frames. Embedders should pass the root


### PR DESCRIPTION
## Summary

Fixes #120 — The DAP handler always stopped on entry regardless of whether the client requested it.

### Root Cause

Three issues combined:
1. `onAttach` discarded the request body entirely — never read `stopOnEntry`
2. `onLaunch` did the same
3. `onConfigurationDone` always sent a stopped event if the engine was paused, regardless of client preference

### Fix

1. Added `parseStopOnEntry()` helper that extracts the boolean from JSON request arguments (defaults to `false` per DAP spec)
2. `onAttach` and `onLaunch` now parse `stopOnEntry` and call `engine.SetStopOnEntry()` immediately to override the engine flag before the eval goroutine starts
3. `onConfigurationDone` now checks the client preference — if `stopOnEntry: false` (or absent), resumes the engine silently instead of sending a stopped event

### Files Changed

- `lisp/x/debugger/engine.go` — Added `SetStopOnEntry(bool)` method
- `lisp/x/debugger/dapserver/handler.go` — Parse `stopOnEntry` in onAttach/onLaunch, conditional logic in onConfigurationDone, `parseStopOnEntry()` helper
- `lisp/x/debugger/dapserver/handler_test.go` — Three new tests covering true/false/absent scenarios

## Test plan

- [x] `TestDAPServer_StopOnEntry_AttachTrue` — client sends `stopOnEntry: true`, verifies stopped event
- [x] `TestDAPServer_StopOnEntry_AttachFalse` — client sends `stopOnEntry: false`, verifies program runs without pausing
- [x] `TestDAPServer_StopOnEntry_AttachAbsent` — no `stopOnEntry` field, verifies default behavior is to NOT stop (per DAP spec)
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)