### PR TITLE
Add ScopeProvider interface for custom variable scopes (#127)

### DIFF
--- a/lisp/x/debugger/scope_provider.go
+++ b/lisp/x/debugger/scope_provider.go
@@ -1,0 +1,32 @@
+// Copyright © 2018 The ELPS authors
+
+package debugger
+
+import "github.com/luthersystems/elps/lisp"
+
+// ScopeProvider supplies a custom variable scope visible in the debugger's
+// Variables panel (e.g., "State DB" in VS Code). Embedders implement this
+// interface and register providers via WithScopeProviders or
+// RegisterScopeProvider on the Engine.
+//
+// The Variables method is called on the DAP server goroutine while the
+// interpreter is paused — it must not resume execution or modify engine state.
+type ScopeProvider interface {
+	// Name returns the scope label displayed in the debugger UI.
+	Name() string
+	// Expensive indicates whether the scope should be fetched lazily.
+	Expensive() bool
+	// Variables returns the variables to display for this scope.
+	// The env is the paused interpreter environment.
+	Variables(env *lisp.LEnv) []ScopeVariable
+}
+
+// ScopeVariable represents a single variable in a custom scope. Values are
+// strings (not LVal) because custom scopes often expose non-LVal data such
+// as raw database entries.
+type ScopeVariable struct {
+	Name     string          // display name
+	Value    string          // display value
+	Type     string          // optional type annotation
+	Children []ScopeVariable // expandable sub-variables (nil = leaf)
+}


### PR DESCRIPTION
Closes #127

## Summary
- Adds `ScopeProvider` interface and `ScopeVariable` type for embedders to register custom variable scopes in the debugger's Variables panel
- Engine gains `WithScopeProviders()` option, `RegisterScopeProvider()` method, and `ScopeProviders()` accessor
- DAP handler appends custom scopes after Local/Package, supports nested drill-down into `ScopeVariable.Children`, and cleans up refs on continue

## Test plan
- [x] `TestEngine_ScopeProviders` — option, runtime registration, defensive copy, combined
- [x] `TestDAPServer_CustomScopeProvider` — full flow with env capture, 3-level nesting drill-down
- [x] `TestDAPServer_CustomScopeProvider_Cleanup` — verifies old child refs invalidated after continue
- [x] `TestDAPServer_MultipleScopeProviders` — two providers with correct isolation
- [x] `TestDAPServer_CustomScopeProvider_Empty` — empty provider returns scope with valid ref
- [x] `make test` — full suite passes
- [x] `make static-checks` — golangci-lint clean

---
*Local tests passed. Security review completed. QA professor review completed.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>