### PR TITLE
Add DAP macro source mapping for step-into visibility (#128)

### DIFF
--- a/lisp/macro_expansion_test.go
+++ b/lisp/macro_expansion_test.go
@@ -1,0 +1,136 @@
+package lisp
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStampMacroExpansion_NoContext(t *testing.T) {
+	// Without a context (no debugger), MacroExpansion should remain nil.
+	callSite := &token.Location{File: "test.lisp", Line: 5, Col: 1}
+	rt := StandardRuntime()
+
+	inner := Symbol("+")
+	// Give it a synthetic source (Pos < 0).
+	inner.Source = nativeSource()
+	expr := SExpr([]*LVal{inner, Int(1), Int(2)})
+	expr.Source = nativeSource()
+
+	stampMacroExpansion(expr, callSite, nil, rt)
+
+	// Source should be stamped.
+	assert.Equal(t, callSite, expr.Source)
+	assert.Equal(t, callSite, inner.Source)
+
+	// MacroExpansion should remain nil.
+	assert.Nil(t, expr.MacroExpansion)
+	assert.Nil(t, inner.MacroExpansion)
+}
+
+func TestStampMacroExpansion_WithContext(t *testing.T) {
+	// With a context (debugger attached), MacroExpansion should be populated
+	// on nodes that get stamped (synthetic source) and have unique IDs.
+	callSite := &token.Location{File: "test.lisp", Line: 5, Col: 1}
+	rt := StandardRuntime()
+	ctx := &MacroExpansionContext{
+		CallSite: callSite,
+		Name:     "lisp:defun",
+		Args:     []*LVal{Symbol("my-fn"), SExpr([]*LVal{Symbol("x")})},
+	}
+
+	inner := Symbol("+")
+	inner.Source = nativeSource()
+	arg1 := Int(1)
+	arg1.Source = nativeSource()
+	arg2 := Int(2)
+	arg2.Source = nativeSource()
+	expr := SExpr([]*LVal{inner, arg1, arg2})
+	expr.Source = nativeSource()
+
+	stampMacroExpansion(expr, callSite, ctx, rt)
+
+	// All nodes should have MacroExpansion set.
+	require.NotNil(t, expr.MacroExpansion)
+	require.NotNil(t, inner.MacroExpansion)
+	require.NotNil(t, arg1.MacroExpansion)
+	require.NotNil(t, arg2.MacroExpansion)
+
+	// All nodes should share the same context.
+	assert.Equal(t, ctx, expr.MacroExpansion.MacroExpansionContext)
+	assert.Equal(t, ctx, inner.MacroExpansion.MacroExpansionContext)
+
+	// All IDs should be unique and monotonically increasing.
+	ids := []int64{
+		expr.MacroExpansion.ID,
+		inner.MacroExpansion.ID,
+		arg1.MacroExpansion.ID,
+		arg2.MacroExpansion.ID,
+	}
+	for i := 1; i < len(ids); i++ {
+		assert.Greater(t, ids[i], ids[i-1], "IDs should be monotonically increasing")
+	}
+}
+
+func TestStampMacroExpansion_PreservesRealSource(t *testing.T) {
+	// Nodes with valid source locations (from parser) should not be stamped.
+	callSite := &token.Location{File: "test.lisp", Line: 5, Col: 1}
+	realSource := &token.Location{File: "test.lisp", Line: 10, Col: 3, Pos: 42}
+	rt := StandardRuntime()
+	ctx := &MacroExpansionContext{
+		CallSite: callSite,
+		Name:     "lisp:defun",
+	}
+
+	// Node with real source (from unquote).
+	node := Symbol("x")
+	node.Source = realSource
+
+	// Node with synthetic source.
+	synth := Symbol("+")
+	synth.Source = nativeSource()
+
+	expr := SExpr([]*LVal{synth, node})
+	expr.Source = nativeSource()
+
+	stampMacroExpansion(expr, callSite, ctx, rt)
+
+	// Real source node should keep its source and have NO MacroExpansion.
+	assert.Equal(t, realSource, node.Source)
+	assert.Nil(t, node.MacroExpansion)
+
+	// Synthetic nodes should be stamped.
+	assert.Equal(t, callSite, synth.Source)
+	require.NotNil(t, synth.MacroExpansion)
+	assert.Equal(t, "lisp:defun", synth.MacroExpansion.Name)
+}
+
+func TestStampMacroExpansion_SkipsSingletonNil(t *testing.T) {
+	// Singleton nil (empty SExpr) must not be mutated.
+	callSite := &token.Location{File: "test.lisp", Line: 5, Col: 1}
+	rt := StandardRuntime()
+	ctx := &MacroExpansionContext{
+		CallSite: callSite,
+		Name:     "lisp:defun",
+	}
+
+	nilVal := Nil() // singleton
+
+	stampMacroExpansion(nilVal, callSite, ctx, rt)
+
+	// Should NOT have been stamped.
+	assert.Nil(t, nilVal.MacroExpansion)
+}
+
+func TestRuntimeMacroExpSeq(t *testing.T) {
+	rt := StandardRuntime()
+	id1 := rt.nextMacroExpID()
+	id2 := rt.nextMacroExpID()
+	id3 := rt.nextMacroExpID()
+
+	assert.Equal(t, int64(1), id1)
+	assert.Equal(t, int64(2), id2)
+	assert.Equal(t, int64(3), id3)
+}

--- a/lisp/runtime.go
+++ b/lisp/runtime.go
@@ -36,6 +36,7 @@ type Runtime struct {
 	conditionStack         []*LVal
 	numenv                 atomicCounter
 	numsym                 atomicCounter
+	macroExpSeq            int64 // monotonic counter for MacroExpansionInfo.ID
 }
 
 // MaxAllocBytes returns the effective per-operation allocation size cap.
@@ -152,6 +153,13 @@ func (r *Runtime) getEnvID() uint {
 
 func (r *Runtime) gensym() uint {
 	return r.numsym.Add(1)
+}
+
+// nextMacroExpID returns the next unique macro expansion node ID.
+// Only called when a debugger is attached.
+func (r *Runtime) nextMacroExpID() int64 {
+	r.macroExpSeq++
+	return r.macroExpSeq
 }
 
 // sourceContext uses the CallStack to determine the location/name of the

--- a/lisp/x/debugger/dapserver/translate.go
+++ b/lisp/x/debugger/dapserver/translate.go
@@ -51,6 +51,11 @@ func translateStackFrames(stack *lisp.CallStack, pausedExpr *lisp.LVal, sourceRo
 					Path: resolveSourcePath(pausedExpr.Source.Path, pausedExpr.Source.File, sourceRoot),
 				}
 			}
+			// Annotate with macro expansion name when paused inside a
+			// macro expansion, so the user can see which macro is active.
+			if pausedExpr.MacroExpansion != nil && pausedExpr.MacroExpansion.MacroExpansionContext != nil {
+				sf.Name = sf.Name + " [macro: " + pausedExpr.MacroExpansion.Name + "]"
+			}
 		}
 		frames = append(frames, sf)
 	}

--- a/lisp/x/debugger/inspector.go
+++ b/lisp/x/debugger/inspector.go
@@ -117,6 +117,34 @@ func InspectFunctionLocals(env *lisp.LEnv) []ScopeBinding {
 	return bindings
 }
 
+// InspectMacroExpansion returns scope bindings representing the macro
+// expansion context: macro name, call-site arguments paired with their
+// positional index, and the call-site location. Returns nil if the
+// expression has no macro expansion info.
+func InspectMacroExpansion(expr *lisp.LVal) []ScopeBinding {
+	if expr == nil || expr.MacroExpansion == nil {
+		return nil
+	}
+	ctx := expr.MacroExpansion.MacroExpansionContext
+	if ctx == nil {
+		return nil
+	}
+	bindings := []ScopeBinding{
+		{Name: "(macro)", Value: lisp.String(ctx.Name)},
+	}
+	for i, arg := range ctx.Args {
+		name := fmt.Sprintf("arg[%d]", i)
+		bindings = append(bindings, ScopeBinding{Name: name, Value: arg})
+	}
+	if ctx.CallSite != nil {
+		bindings = append(bindings, ScopeBinding{
+			Name:  "(call-site)",
+			Value: lisp.String(ctx.CallSite.String()),
+		})
+	}
+	return bindings
+}
+
 // FormatValue returns a human-readable string representation of an LVal,
 // suitable for display in a debugger variables view.
 func FormatValue(v *lisp.LVal) string {

--- a/lisp/x/debugger/stepper.go
+++ b/lisp/x/debugger/stepper.go
@@ -16,6 +16,16 @@ const (
 	StepOut
 )
 
+// StepLocation describes a source location for stepping operations.
+// Using a struct (rather than positional arguments) keeps the API stable
+// when new fields are added.
+type StepLocation struct {
+	Depth   int    // stack depth
+	File    string // source file
+	Line    int    // source line
+	MacroID int64  // macro expansion node ID (0 = not in expansion)
+}
+
 // Stepper implements the step state machine. It tracks the step mode and
 // the reference stack depth to determine when stepping should pause.
 //
@@ -25,10 +35,8 @@ const (
 // runs in OnEval before the next pause — both on the eval goroutine.
 type Stepper struct {
 	mode        StepMode
-	depth       int    // stack depth when step command was issued
-	granularity string // "instruction" for expression-level, anything else for line-level
-	startFile   string // file where step was issued
-	startLine   int    // line where step was issued
+	granularity string       // "instruction" for expression-level, anything else for line-level
+	start       StepLocation // location when step command was issued
 }
 
 // NewStepper returns a stepper in the StepNone state.
@@ -44,49 +52,45 @@ func (s *Stepper) Mode() StepMode {
 // Reset clears the stepper to StepNone (free-running).
 func (s *Stepper) Reset() {
 	s.mode = StepNone
-	s.depth = 0
 	s.granularity = ""
-	s.startFile = ""
-	s.startLine = 0
+	s.start = StepLocation{}
 }
 
 // SetStepInto configures the stepper to pause on the next OnEval.
 // For line-level granularity (the default), it skips pauses on the same
-// source line unless the stack depth increased (entered a function body).
+// source line unless the stack depth increased (entered a function body)
+// or the macro expansion ID changed (progress within a macro expansion).
 // For "instruction" granularity, it pauses on every expression.
-func (s *Stepper) SetStepInto(currentDepth int, granularity, file string, line int) {
+func (s *Stepper) SetStepInto(loc StepLocation, granularity string) {
 	s.mode = StepInto
-	s.depth = currentDepth
 	s.granularity = granularity
-	s.startFile = file
-	s.startLine = line
+	s.start = loc
 }
 
 // SetStepOver configures the stepper to pause on the next OnEval at the
 // same or lesser stack depth.
 // For line-level granularity (the default), it additionally skips pauses
-// on the same source line. For "instruction" granularity, it pauses on
-// every expression at the appropriate depth.
-func (s *Stepper) SetStepOver(currentDepth int, granularity, file string, line int) {
+// on the same source line (macro ID changes are ignored — step-over treats
+// entire macro expansions as same-line). For "instruction" granularity,
+// it pauses on every expression at the appropriate depth.
+func (s *Stepper) SetStepOver(loc StepLocation, granularity string) {
 	s.mode = StepOver
-	s.depth = currentDepth
 	s.granularity = granularity
-	s.startFile = file
-	s.startLine = line
+	s.start = loc
 }
 
 // SetStepOut configures the stepper to pause on the next OnEval at a
 // lesser stack depth (i.e., after the current function returns).
 func (s *Stepper) SetStepOut(currentDepth int) {
 	s.mode = StepOut
-	s.depth = currentDepth
+	s.start = StepLocation{Depth: currentDepth}
 }
 
 // Depth returns the reference stack depth recorded when the step command
 // was issued. Used by Engine to detect the step-out condition in
 // OnFunReturn (before the frame is popped).
 func (s *Stepper) Depth() int {
-	return s.depth
+	return s.start.Depth
 }
 
 // ShouldPausePostCall returns true if a step-out should pause after a
@@ -96,7 +100,7 @@ func (s *Stepper) Depth() int {
 // flows back through the call chain without visiting any new expressions
 // at a lesser depth. After returning true, the stepper resets to StepNone.
 func (s *Stepper) ShouldPausePostCall(currentDepth int) bool {
-	if s.mode == StepOut && currentDepth < s.depth {
+	if s.mode == StepOut && currentDepth < s.start.Depth {
 		s.mode = StepNone
 		return true
 	}
@@ -112,49 +116,58 @@ func (s *Stepper) isLineGranularity() bool {
 
 // isSameLine returns true if the given file and line match the step origin.
 func (s *Stepper) isSameLine(file string, line int) bool {
-	return file == s.startFile && line == s.startLine
+	return file == s.start.File && line == s.start.Line
 }
 
 // ShouldPause returns true if the stepper should cause a pause at the
-// given stack depth and source location. After returning true, the stepper
-// resets to StepNone.
+// given location. After returning true, the stepper resets to StepNone.
 //
 // For line-level granularity (the default), StepInto and StepOver skip
 // pauses on the same source line unless the stack depth increased (entered
-// a function body). For "instruction" granularity, the original per-expression
-// behavior is preserved.
-func (s *Stepper) ShouldPause(currentDepth int, file string, line int) bool {
+// a function body). StepInto additionally pauses when the macro expansion
+// ID changed on the same line (progress within a macro expansion).
+// StepOver ignores macro ID changes (treats entire expansion as same-line).
+// For "instruction" granularity, the original per-expression behavior is
+// preserved.
+func (s *Stepper) ShouldPause(loc StepLocation) bool {
 	switch s.mode {
 	case StepNone:
 		return false
 	case StepInto:
-		if s.isLineGranularity() && s.isSameLine(file, line) && currentDepth <= s.depth {
-			// Same line, same or lesser depth — skip (sub-expression on same line).
-			// But if depth increased, we entered a function body → pause.
+		if s.isLineGranularity() && s.isSameLine(loc.File, loc.Line) && loc.Depth <= s.start.Depth {
+			// Same line, same or lesser depth. For step-into, check if
+			// the macro expansion ID changed — if so, the debugger has
+			// made progress within a macro expansion and should pause.
+			if loc.MacroID != s.start.MacroID {
+				s.mode = StepNone
+				return true
+			}
+			// Same macro ID (or both zero) — skip sub-expression.
 			return false
 		}
 		s.mode = StepNone
 		return true
 	case StepOver:
-		if currentDepth > s.depth {
+		if loc.Depth > s.start.Depth {
 			// Deeper than step origin — inside a called function, skip.
 			return false
 		}
-		if currentDepth < s.depth {
+		if loc.Depth < s.start.Depth {
 			// Returned to a shallower depth — always pause regardless of
 			// line, as the enclosing call completed.
 			s.mode = StepNone
 			return true
 		}
-		// currentDepth == s.depth: same depth as step origin.
-		if s.isLineGranularity() && s.isSameLine(file, line) {
+		// loc.Depth == s.start.Depth: same depth as step origin.
+		if s.isLineGranularity() && s.isSameLine(loc.File, loc.Line) {
 			// Same line, same depth — skip same-line sub-expressions.
+			// Step-over intentionally ignores macro ID changes.
 			return false
 		}
 		s.mode = StepNone
 		return true
 	case StepOut:
-		if currentDepth < s.depth {
+		if loc.Depth < s.start.Depth {
 			s.mode = StepNone
 			return true
 		}


### PR DESCRIPTION
## Summary

- Adds `MacroExpansionInfo` to `LVal` with unique monotonic IDs per expansion node, enabling the debugger's line-level stepper to detect progress within macro-expanded code (previously all sub-expressions shared the same call-site location and were skipped)
- Refactors `Stepper` API to use a `StepLocation` struct instead of positional arguments for stable, extensible public API
- Adds "Macro Expansion" scope in DAP variables panel showing macro name and call-site arguments, plus `[macro: name]` annotation on stack frames

## Design decisions

- **Zero production overhead**: `MacroExpansionInfo` is only allocated when `Runtime.Debugger != nil`. In production, every `LVal.MacroExpansion` stays `nil` — the only cost is an 8-byte nil pointer in the struct.
- **Step-into vs step-over**: Step-into pauses when macro ID changes on the same line (expansion progress). Step-over ignores macro ID changes (treats entire expansion as same-line). This preserves the existing step-over behavior of skipping macro expansions.
- **`StepLocation` struct**: Replaces 5+ positional arguments with a struct so future additions don't break the API.

## Test plan

- [x] `TestStampMacroExpansion_NoContext` — no MacroExpansion when context is nil
- [x] `TestStampMacroExpansion_WithContext` — unique sequential IDs, shared context
- [x] `TestStampMacroExpansion_PreservesRealSource` — unquote nodes untouched
- [x] `TestStampMacroExpansion_SkipsSingletonNil` — singleton safety
- [x] `TestRuntimeMacroExpSeq` — monotonic counter
- [x] `TestStepper_StepInto_MacroID_PausesOnChange` — step-into pauses on macro ID change
- [x] `TestStepper_StepInto_MacroID_ZeroToNonZero` — entering expansion from non-expansion
- [x] `TestStepper_StepOver_MacroID_IgnoresChange` — step-over ignores macro IDs
- [x] `TestInspectMacroExpansion_WithContext` — inspector returns correct bindings
- [x] All existing stepper, engine, and DAP tests pass with struct API
- [x] `make test` — all Go + lisp tests pass
- [x] `make static-checks` — golangci-lint clean (0 issues)
- [x] `elps doc -m` — no missing docstrings

🤖 Generated with [Claude Code](https://claude.com/claude-code)