### PR TITLE
Add DAP completions request for debug console auto-complete

### DIFF
--- a/lisp/x/debugger/complete.go
+++ b/lisp/x/debugger/complete.go
@@ -1,0 +1,157 @@
+// Copyright © 2018 The ELPS authors
+
+package debugger
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// CompletionCandidate represents a single auto-complete suggestion.
+type CompletionCandidate struct {
+	Label  string // symbol name (possibly qualified with package prefix)
+	Type   string // "variable", "function", "keyword", "module"
+	Detail string // e.g. package name or "<builtin>"
+}
+
+// CompleteInContext returns completion candidates for the given prefix
+// in the context of env. It collects candidates from function locals,
+// current package symbols, qualified package symbols, package names,
+// exported symbols from used packages, and keywords.
+//
+// An empty prefix returns no candidates (matches REPL behavior).
+func CompleteInContext(env *lisp.LEnv, prefix string) []CompletionCandidate {
+	if prefix == "" || env == nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var candidates []CompletionCandidate
+
+	add := func(label, typ, detail string) {
+		if seen[label] {
+			return
+		}
+		seen[label] = true
+		candidates = append(candidates, CompletionCandidate{
+			Label:  label,
+			Type:   typ,
+			Detail: detail,
+		})
+	}
+
+	// 1. Function locals — walk up env chain, stopping before root.
+	locals := InspectFunctionLocals(env)
+	for _, b := range locals {
+		if strings.HasPrefix(b.Name, prefix) {
+			add(b.Name, lvalCompletionType(b.Value), "local")
+		}
+	}
+
+	// 2. Current package symbols.
+	if pkg := env.Runtime.Package; pkg != nil {
+		for name, val := range pkg.Symbols {
+			if strings.HasPrefix(name, prefix) {
+				add(name, lvalCompletionType(val), pkg.Name)
+			}
+		}
+	}
+
+	// 3. Qualified package completion and package name completion.
+	if env.Runtime.Registry != nil {
+		for pkgName, pkg := range env.Runtime.Registry.Packages {
+			qualPrefix := pkgName + ":"
+			if strings.HasPrefix(prefix, qualPrefix) {
+				// Prefix contains "pkg:" — complete within that package's exports.
+				symPrefix := prefix[len(qualPrefix):]
+				for _, ext := range pkg.Externals {
+					if strings.HasPrefix(ext, symPrefix) {
+						name := qualPrefix + ext
+						typ := "function"
+						if val, ok := pkg.Symbols[ext]; ok {
+							typ = lvalCompletionType(val)
+						}
+						add(name, typ, pkgName)
+					}
+				}
+			} else if strings.HasPrefix(qualPrefix, prefix) {
+				// Prefix matches start of package name — suggest "pkg:".
+				add(qualPrefix, "module", pkgName)
+			}
+
+			// 4. Unqualified exported symbols from all packages.
+			for _, ext := range pkg.Externals {
+				if strings.HasPrefix(ext, prefix) {
+					typ := "function"
+					if val, ok := pkg.Symbols[ext]; ok {
+						typ = lvalCompletionType(val)
+					}
+					add(ext, typ, pkgName)
+				}
+			}
+		}
+	}
+
+	// 5. Keyword completion — when prefix starts with ":".
+	if strings.HasPrefix(prefix, ":") {
+		collectKeywords(env, prefix, add)
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].Label < candidates[j].Label
+	})
+	return candidates
+}
+
+// ExtractPrefix extracts the completion prefix from text at the given
+// column position. Column is 1-based (DAP convention). The prefix is
+// the word being typed, walking backward from the cursor to whitespace
+// or an open paren.
+func ExtractPrefix(text string, column int) string {
+	// Convert 1-based column to 0-based index.
+	pos := column - 1
+	if pos < 0 {
+		pos = 0
+	}
+	if pos > len(text) {
+		pos = len(text)
+	}
+
+	start := pos
+	for start > 0 {
+		ch := text[start-1]
+		if ch == ' ' || ch == '\t' || ch == '(' || ch == '\n' {
+			break
+		}
+		start--
+	}
+	return text[start:pos]
+}
+
+// lvalCompletionType maps an LVal to a completion type string.
+func lvalCompletionType(v *lisp.LVal) string {
+	if v == nil {
+		return "variable"
+	}
+	if v.Type == lisp.LFun {
+		return "function"
+	}
+	return "variable"
+}
+
+// collectKeywords scans package symbol tables for keyword-like symbols
+// (names starting with ":") and adds them as candidates.
+func collectKeywords(env *lisp.LEnv, prefix string, add func(string, string, string)) {
+	if env.Runtime.Registry == nil {
+		return
+	}
+	for _, pkg := range env.Runtime.Registry.Packages {
+		for name := range pkg.Symbols {
+			if strings.HasPrefix(name, prefix) && strings.HasPrefix(name, ":") {
+				add(name, "keyword", pkg.Name)
+			}
+		}
+	}
+}

--- a/lisp/x/debugger/complete_test.go
+++ b/lisp/x/debugger/complete_test.go
@@ -1,0 +1,177 @@
+package debugger
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompleteInContext_EmptyPrefix(t *testing.T) {
+	env := newInspectorTestEnv(t)
+	candidates := CompleteInContext(env, "")
+	assert.Nil(t, candidates, "empty prefix should return no candidates")
+}
+
+func TestCompleteInContext_NilEnv(t *testing.T) {
+	candidates := CompleteInContext(nil, "foo")
+	assert.Nil(t, candidates, "nil env should return no candidates")
+}
+
+func TestCompleteInContext_Locals(t *testing.T) {
+	env := newInspectorTestEnv(t)
+
+	// Create a child env with local bindings (simulating being inside a function).
+	child := lisp.NewEnv(env)
+	child.Runtime = env.Runtime
+	child.Put(lisp.Symbol("my-local-var"), lisp.Int(42))
+	child.Put(lisp.Symbol("my-local-fn"), lisp.Fun("my-local-fn", lisp.Formals("x"), func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+		return lisp.Nil()
+	}))
+
+	candidates := CompleteInContext(child, "my-local")
+	require.True(t, len(candidates) >= 2, "expected at least 2 candidates, got %d", len(candidates))
+
+	labels := candidateLabels(candidates)
+	assert.Contains(t, labels, "my-local-var")
+	assert.Contains(t, labels, "my-local-fn")
+
+	// Check types.
+	for _, c := range candidates {
+		if c.Label == "my-local-var" {
+			assert.Equal(t, "variable", c.Type)
+			assert.Equal(t, "local", c.Detail)
+		}
+		if c.Label == "my-local-fn" {
+			assert.Equal(t, "function", c.Type)
+			assert.Equal(t, "local", c.Detail)
+		}
+	}
+}
+
+func TestCompleteInContext_PackageSymbols(t *testing.T) {
+	env := newInspectorTestEnv(t)
+
+	// Define a function in the current package.
+	EvalInContext(env, "(defun my-test-func (x) (+ x 1))")
+
+	candidates := CompleteInContext(env, "my-test")
+	require.NotEmpty(t, candidates)
+
+	labels := candidateLabels(candidates)
+	assert.Contains(t, labels, "my-test-func")
+}
+
+func TestCompleteInContext_QualifiedCompletion(t *testing.T) {
+	env := newInspectorTestEnv(t)
+
+	// "string:" should complete exported symbols from the string package.
+	candidates := CompleteInContext(env, "string:jo")
+	labels := candidateLabels(candidates)
+	assert.Contains(t, labels, "string:join", "expected string:join in qualified completions")
+}
+
+func TestCompleteInContext_PackageNameCompletion(t *testing.T) {
+	env := newInspectorTestEnv(t)
+
+	// "stri" should suggest "string:" as a package prefix.
+	candidates := CompleteInContext(env, "stri")
+	labels := candidateLabels(candidates)
+	assert.Contains(t, labels, "string:", "expected string: package completion")
+
+	// Verify the type is "module".
+	for _, c := range candidates {
+		if c.Label == "string:" {
+			assert.Equal(t, "module", c.Type)
+		}
+	}
+}
+
+func TestCompleteInContext_ExportedUnqualified(t *testing.T) {
+	env := newInspectorTestEnv(t)
+
+	// Built-in symbols from the lisp package (e.g., "set") should be
+	// completable without qualification since the user package uses lisp.
+	candidates := CompleteInContext(env, "defu")
+	labels := candidateLabels(candidates)
+	assert.Contains(t, labels, "defun", "expected defun in unqualified completions")
+}
+
+func TestCompleteInContext_Dedup(t *testing.T) {
+	env := newInspectorTestEnv(t)
+
+	// Create a local that shadows a package symbol.
+	child := lisp.NewEnv(env)
+	child.Runtime = env.Runtime
+	child.Put(lisp.Symbol("set"), lisp.Int(99))
+
+	candidates := CompleteInContext(child, "set")
+	// Count how many times "set" appears.
+	count := 0
+	for _, c := range candidates {
+		if c.Label == "set" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "set should appear exactly once (dedup)")
+}
+
+func TestCompleteInContext_SortedAlphabetically(t *testing.T) {
+	env := newInspectorTestEnv(t)
+
+	child := lisp.NewEnv(env)
+	child.Runtime = env.Runtime
+	child.Put(lisp.Symbol("zeta-var"), lisp.Int(1))
+	child.Put(lisp.Symbol("alpha-var"), lisp.Int(2))
+	child.Put(lisp.Symbol("mid-var"), lisp.Int(3))
+
+	// Use a prefix that won't match builtins but will match all three.
+	// Actually, let's use a unique prefix.
+	child.Put(lisp.Symbol("xcv-z"), lisp.Int(1))
+	child.Put(lisp.Symbol("xcv-a"), lisp.Int(2))
+	child.Put(lisp.Symbol("xcv-m"), lisp.Int(3))
+
+	candidates := CompleteInContext(child, "xcv-")
+	require.Len(t, candidates, 3)
+	assert.Equal(t, "xcv-a", candidates[0].Label)
+	assert.Equal(t, "xcv-m", candidates[1].Label)
+	assert.Equal(t, "xcv-z", candidates[2].Label)
+}
+
+func TestExtractPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		column int
+		want   string
+	}{
+		{"simple word", "hello", 6, "hello"},
+		{"mid word", "hello", 4, "hel"},
+		{"after paren", "(defun", 7, "defun"},
+		{"after space", "foo bar", 8, "bar"},
+		{"empty", "", 1, ""},
+		{"column 1", "x", 1, ""},
+		{"column 2", "x", 2, "x"},
+		{"nested paren", "(+ (str", 8, "str"},
+		{"keyword", ":key", 5, ":key"},
+		{"qualified", "string:join", 12, "string:join"},
+		{"column beyond text", "abc", 10, "abc"},
+		{"column zero", "abc", 0, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractPrefix(tt.text, tt.column)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// candidateLabels returns just the labels from a candidate slice.
+func candidateLabels(candidates []CompletionCandidate) []string {
+	labels := make([]string, len(candidates))
+	for i, c := range candidates {
+		labels[i] = c.Label
+	}
+	return labels
+}


### PR DESCRIPTION
## Summary
- Implement DAP `completions` request so VS Code shows auto-complete suggestions in the debug console, watch panel, and hover tooltips while paused at a breakpoint
- Shared `CompleteInContext` infrastructure in `lisp/x/debugger/complete.go` — reusable by future CLI debug REPL (#134)
- Candidate sources: function locals, current package symbols, qualified package exports (e.g. `string:join`), package name prefixes, unqualified exports, and keywords

Closes #135

## Files changed
| File | Change |
|------|--------|
| `lisp/x/debugger/complete.go` | **New.** `CompletionCandidate`, `CompleteInContext()`, `ExtractPrefix()` |
| `lisp/x/debugger/complete_test.go` | **New.** 9 unit tests for completion logic + prefix extraction |
| `lisp/x/debugger/dapserver/handler.go` | Add `onCompletions`, capability flag, switch case |
| `lisp/x/debugger/dapserver/handler_test.go` | 3 DAP integration tests for completions |

## Test plan
- [x] `go test ./lisp/x/debugger/...` — unit tests for CompleteInContext and ExtractPrefix
- [x] `go test ./lisp/x/debugger/dapserver/...` — DAP integration tests (paused completions, not-paused returns empty, capability declared)
- [x] `make test` — full test suite passes
- [x] `make static-checks` — golangci-lint clean
- [ ] Manual: launch `elps debug` with VS Code, pause at breakpoint, type in debug console and verify completions appear

---
*Local tests passed. Security review completed — read-only completion logic, no input evaluation.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>