### PR TITLE
Fix debug REPL bare expressions to evaluate in paused scope

### DIFF
--- a/docs/debugging-guide.md
+++ b/docs/debugging-guide.md
@@ -333,7 +333,7 @@ The CLI debug REPL (`elps debug --repl`) provides a GDB-style command interface.
 **Conventions:**
 
 - Empty input repeats the last command (GDB convention). Useful for repeated stepping.
-- Bare Lisp expressions (anything not matching a command) are evaluated in the paused scope. For example, typing `(+ x 1)` evaluates with the current local bindings.
+- Bare Lisp expressions (anything not matching a command) are evaluated in the paused scope with full access to local variables and function parameters. For example, if paused inside a function where `x=42`, typing `(+ x 1)` returns `43`.
 - Ctrl+C pauses a running program.
 
 **Example session:**

--- a/lisp/x/debugger/debugrepl/repl.go
+++ b/lisp/x/debugger/debugrepl/repl.go
@@ -472,7 +472,8 @@ func showHelp(w io.Writer) {
   quit (q)            End debug session
   help (h)            Show this help
 
-Lisp expressions are evaluated in the paused scope.
+Lisp expressions are evaluated in the paused scope
+(local variables and function parameters are visible).
 Empty input repeats the last command.`
 	fmt.Fprintln(w, help) //nolint:errcheck
 }


### PR DESCRIPTION
## Summary
- Fix `evalInContext` in the debug REPL to use the paused environment so bare Lisp expressions see local variables from the stopped scope
- Direct REPL eval output to the debug handler's stderr so results appear alongside debug command output
- Add `TestRunIntegration_BareExprInPausedScope` to verify bare expressions access paused-scope locals

Fixes #142

## Test plan
- [x] `go test ./lisp/x/debugger/debugrepl/...` passes
- [x] `make test` passes
- [x] New test verifies `(+ x 1)` evaluates to `43` when `x=42` in paused scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)