### PR TITLE
Fix DAP step-into to use expression-level stepping

### DIFF
--- a/lisp/x/debugger/dapserver/translate.go
+++ b/lisp/x/debugger/dapserver/translate.go
@@ -42,14 +42,15 @@ func translateStackFrames(stack *lisp.CallStack, pausedExpr *lisp.LVal, sourceRo
 		}
 		// For the top frame (first appended), override with the paused
 		// expression's source to show where execution actually stopped.
+		// Always use the paused expression's file — when stepping into a
+		// function defined in a different file, the call frame still points
+		// to the caller's file, but we need to show the callee's source.
 		if len(frames) == 0 && pausedExpr != nil && pausedExpr.Source != nil {
 			sf.Line = pausedExpr.Source.Line
 			sf.Column = pausedExpr.Source.Col
-			if sf.Source == nil {
-				sf.Source = &dap.Source{
-					Name: pausedExpr.Source.File,
-					Path: resolveSourcePath(pausedExpr.Source.Path, pausedExpr.Source.File, sourceRoot),
-				}
+			sf.Source = &dap.Source{
+				Name: pausedExpr.Source.File,
+				Path: resolveSourcePath(pausedExpr.Source.Path, pausedExpr.Source.File, sourceRoot),
 			}
 			// Annotate with macro expansion name when paused inside a
 			// macro expansion, so the user can see which macro is active.

--- a/lisp/x/debugger/dapserver/translate_test.go
+++ b/lisp/x/debugger/dapserver/translate_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/x/debugger"
+	"github.com/luthersystems/elps/parser/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -66,6 +67,83 @@ func TestResolveSourcePath(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestTranslateStackFrames_CrossFileSource(t *testing.T) {
+	t.Parallel()
+	// When the paused expression is in a different file than the top call
+	// frame (e.g., stepping into a function defined in another file), the
+	// top frame should use the paused expression's file, not the caller's.
+	stack := &lisp.CallStack{
+		Frames: []lisp.CallFrame{
+			{
+				Source: &token.Location{
+					File: "caller.lisp",
+					Path: "caller.lisp",
+					Line: 10,
+					Col:  1,
+				},
+				Name:    "my-func",
+				Package: "user",
+			},
+		},
+	}
+
+	// Paused expression is in a different file.
+	pausedExpr := &lisp.LVal{
+		Type: lisp.LSExpr,
+		Source: &token.Location{
+			File: "callee.lisp",
+			Path: "callee.lisp",
+			Line: 3,
+			Col:  5,
+		},
+	}
+
+	frames := translateStackFrames(stack, pausedExpr, "/root")
+	require.Len(t, frames, 1)
+
+	// The top frame should reflect the paused expression's source file.
+	assert.Equal(t, "callee.lisp", frames[0].Source.Name,
+		"top frame source should use paused expression's file")
+	assert.Equal(t, "/root/callee.lisp", frames[0].Source.Path)
+	assert.Equal(t, 3, frames[0].Line)
+	assert.Equal(t, 5, frames[0].Column)
+}
+
+func TestTranslateStackFrames_SameFileOverride(t *testing.T) {
+	t.Parallel()
+	// Even when in the same file, the paused expression's line/col should
+	// override the frame's call-site location.
+	stack := &lisp.CallStack{
+		Frames: []lisp.CallFrame{
+			{
+				Source: &token.Location{
+					File: "test.lisp",
+					Path: "test.lisp",
+					Line: 1,
+					Col:  1,
+				},
+				Name:    "add",
+				Package: "user",
+			},
+		},
+	}
+
+	pausedExpr := &lisp.LVal{
+		Type: lisp.LSExpr,
+		Source: &token.Location{
+			File: "test.lisp",
+			Path: "test.lisp",
+			Line: 5,
+			Col:  10,
+		},
+	}
+
+	frames := translateStackFrames(stack, pausedExpr, "")
+	require.Len(t, frames, 1)
+	assert.Equal(t, 5, frames[0].Line, "top frame line should use paused expr's line")
+	assert.Equal(t, 10, frames[0].Column, "top frame column should use paused expr's col")
 }
 
 func TestTranslateVariables_WithRefAllocator(t *testing.T) {

--- a/lisp/x/debugger/dapserver/translate_test.go
+++ b/lisp/x/debugger/dapserver/translate_test.go
@@ -146,6 +146,31 @@ func TestTranslateStackFrames_SameFileOverride(t *testing.T) {
 	assert.Equal(t, 10, frames[0].Column, "top frame column should use paused expr's col")
 }
 
+func TestTranslateStackFrames_NilPausedExpr(t *testing.T) {
+	t.Parallel()
+	// When pausedExpr is nil, the frame's own source should be preserved.
+	stack := &lisp.CallStack{
+		Frames: []lisp.CallFrame{
+			{
+				Source: &token.Location{
+					File: "test.lisp",
+					Path: "test.lisp",
+					Line: 1,
+					Col:  1,
+				},
+				Name:    "fn",
+				Package: "user",
+			},
+		},
+	}
+
+	frames := translateStackFrames(stack, nil, "/root")
+	require.Len(t, frames, 1)
+	assert.Equal(t, "test.lisp", frames[0].Source.Name,
+		"should keep frame's own source when pausedExpr is nil")
+	assert.Equal(t, 1, frames[0].Line)
+}
+
 func TestTranslateVariables_WithRefAllocator(t *testing.T) {
 	nextRef := 5000
 	allocRef := func(v *lisp.LVal) int {

--- a/lisp/x/debugger/stepper_test.go
+++ b/lisp/x/debugger/stepper_test.go
@@ -328,6 +328,75 @@ func TestStepper_StepOver_InstructionGranularity_SameLine(t *testing.T) {
 	assert.Equal(t, StepNone, s.Mode())
 }
 
+// --- Expression-level stepping tests (Col + IsSExpr) ---
+
+// loce is a test helper for building StepLocation values with Col and IsSExpr.
+func loce(depth int, file string, line, col int, isSExpr bool) StepLocation {
+	return StepLocation{Depth: depth, File: file, Line: line, Col: col, IsSExpr: isSExpr}
+}
+
+func TestStepper_StepInto_LineGranularity_DifferentSExprSameLine(t *testing.T) {
+	t.Parallel()
+	s := NewStepper()
+	// Step issued at col 1 on an s-expression.
+	s.SetStepInto(loce(2, "test.lisp", 5, 1, true), "")
+
+	// Same line, different col, s-expression → pause (different expression).
+	assert.True(t, s.ShouldPause(loce(2, "test.lisp", 5, 10, true)))
+	assert.Equal(t, StepNone, s.Mode())
+}
+
+func TestStepper_StepInto_LineGranularity_AtomSameLine(t *testing.T) {
+	t.Parallel()
+	s := NewStepper()
+	// Step issued at col 1 on an s-expression.
+	s.SetStepInto(loce(2, "test.lisp", 5, 1, true), "")
+
+	// Same line, different col, atom → skip (atoms aren't interesting).
+	assert.False(t, s.ShouldPause(loce(2, "test.lisp", 5, 10, false)))
+	assert.Equal(t, StepInto, s.Mode())
+
+	// Same line, different col, s-expression → pause.
+	assert.True(t, s.ShouldPause(loce(2, "test.lisp", 5, 15, true)))
+	assert.Equal(t, StepNone, s.Mode())
+}
+
+func TestStepper_StepInto_LineGranularity_SameColSameLine(t *testing.T) {
+	t.Parallel()
+	s := NewStepper()
+	// Step issued at col 5 on an s-expression.
+	s.SetStepInto(loce(2, "test.lisp", 5, 5, true), "")
+
+	// Same line, same col → skip (same expression position).
+	assert.False(t, s.ShouldPause(loce(2, "test.lisp", 5, 5, true)))
+	assert.Equal(t, StepInto, s.Mode())
+}
+
+func TestStepper_StepInto_LineGranularity_ZeroColFallsBack(t *testing.T) {
+	t.Parallel()
+	s := NewStepper()
+	// Step issued with Col=0 (no column info).
+	s.SetStepInto(loce(2, "test.lisp", 5, 0, true), "")
+
+	// Same line, Col=0 → falls back to line-level behavior (skip).
+	assert.False(t, s.ShouldPause(loce(2, "test.lisp", 5, 0, true)))
+	assert.Equal(t, StepInto, s.Mode())
+
+	// Different line → pause.
+	assert.True(t, s.ShouldPause(loce(2, "test.lisp", 6, 0, true)))
+	assert.Equal(t, StepNone, s.Mode())
+}
+
+func TestStepper_StepInto_LineGranularity_ExprLevelEntersFunction(t *testing.T) {
+	t.Parallel()
+	s := NewStepper()
+	s.SetStepInto(loce(2, "test.lisp", 5, 1, true), "")
+
+	// Greater depth → pause (entered function body), regardless of col.
+	assert.True(t, s.ShouldPause(loce(3, "test.lisp", 5, 1, true)))
+	assert.Equal(t, StepNone, s.Mode())
+}
+
 // --- Macro expansion ID tests ---
 
 func TestStepper_StepInto_MacroID_PausesOnChange(t *testing.T) {

--- a/lisp/x/debugger/stepper_test.go
+++ b/lisp/x/debugger/stepper_test.go
@@ -387,6 +387,18 @@ func TestStepper_StepInto_LineGranularity_ZeroColFallsBack(t *testing.T) {
 	assert.Equal(t, StepNone, s.Mode())
 }
 
+func TestStepper_StepInto_LineGranularity_IncomingZeroColSkips(t *testing.T) {
+	t.Parallel()
+	s := NewStepper()
+	// Step issued with Col=5 (has column info).
+	s.SetStepInto(loce(2, "test.lisp", 5, 5, true), "")
+
+	// Incoming expression has Col=0 (unknown) — should skip since we can't
+	// confirm it's a different expression without column info.
+	assert.False(t, s.ShouldPause(loce(2, "test.lisp", 5, 0, true)))
+	assert.Equal(t, StepInto, s.Mode())
+}
+
 func TestStepper_StepInto_LineGranularity_ExprLevelEntersFunction(t *testing.T) {
 	t.Parallel()
 	s := NewStepper()


### PR DESCRIPTION
## Summary

Three related fixes for DAP debugger stepping:

- **Expression-level step-into**: Add `Col` and `IsSExpr` fields to `StepLocation`. Step-into now pauses on the next s-expression (skipping atoms) instead of the next source line, enabling proper debugging of `(foo (bar x))` patterns.
- **Breakpoint suppression for all resume actions**: Set `lastContinuedKey` for all step actions (not just continue), preventing the debugger from appearing stuck on breakpoints during stepping.
- **Cross-file source resolution**: Top stack frame always uses the paused expression's source file, fixing wrong-file display when stepping into functions defined in different files.

## Test plan

- [x] New unit tests for expression-level stepping in `stepper_test.go` (5 tests: different s-expr same line, atom same line, same col same line, zero col fallback, enters function)
- [x] New integration test for breakpoint suppression during step in `engine_test.go`
- [x] New unit tests for cross-file source resolution in `translate_test.go` (2 tests: cross-file, same-file override)
- [x] All existing tests pass (`make test`)
- [x] Static checks pass (`make static-checks`)

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)