### PR TITLE
Add DAP variable regex filter for sorted maps

### DIFF
--- a/docs/debugging-guide.md
+++ b/docs/debugging-guide.md
@@ -14,6 +14,7 @@ ELPS ships with a full-featured debugger that supports two modes of operation:
 | Stepping granularity        | Line + instruction      | Line                 |
 | Smart step-in targets       | Yes                     | No                   |
 | Variable inspection         | Local, Package, Macro   | Locals               |
+| Variable filtering          | `/filter <regex>`       | No                   |
 | Custom scope providers      | Yes                     | No                   |
 | Watch expressions           | Yes                     | No                   |
 | Debug console / eval        | Yes                     | Yes (bare exprs)     |
@@ -416,6 +417,17 @@ Structured values (lists, arrays, sorted-maps, tagged values) are expandable in 
 The debug console evaluates Lisp expressions in the paused scope. Supports multi-expression input with progn semantics (the result of the last expression is returned). Auto-complete is available for symbols in scope.
 
 Watch expressions are re-evaluated automatically each time execution pauses.
+
+**Debug console commands:**
+
+| Command            | Description                                          |
+|--------------------|------------------------------------------------------|
+| `/filter <regex>`  | Filter sorted-map entries by key (regex match)       |
+| `/filter`          | Clear the active filter (show all entries)            |
+
+The `/filter` command is useful for large sorted-maps with many keys. The regex matches against the formatted key name (e.g., `"apple"` for string keys, `:foo` for keywords). The filter applies to all sorted-map expansions in the Variables panel and persists across step/continue until cleared.
+
+When the client supports `InvalidatedEvent`, the Variables panel refreshes automatically after a filter change.
 
 ## Embedding the Debugger
 


### PR DESCRIPTION
## Summary

- Add `/filter <regex>` debug console command to filter sorted-map entries by key in the Variables pane
- Large sorted maps (100+ keys) require manual scrolling since VS Code doesn't auto-paginate named variables — this gives users a way to narrow down what's shown
- Uses standard DAP `InvalidatedEvent` to refresh the Variables pane when the filter changes
- Zero VS Code extension changes required — works within standard DAP protocol

Closes #149

## Implementation

- **handler.go**: `mapKeyFilter *regexp.Regexp` field (session-level, persists across resume), `handleFilterCommand()` intercepts `/filter` in `onEvaluate`, `sendInvalidatedVariables()` sends refresh event when client supports it
- **translate.go**: `expandVariable()` takes `mapKeyFilter` param, filters `LSortMap` entries by matching against formatted key name
- **debugging-guide.md**: Documents the `/filter` command in the debug console section and feature comparison table

## Test plan

- [x] Unit tests: filter with matches, no matches, nil filter, empty map, non-map types ignored
- [x] Integration tests: set/clear lifecycle, invalid regex error, InvalidatedEvent sent when supported, no event when unsupported, pagination after filter
- [x] QA review: strengthened tests for state corruption on invalid regex, pagination value assertion, negative assertions for excluded entries
- [x] `go test ./lisp/x/debugger/dapserver/...` — all pass
- [x] `make test` — full suite passes
- [x] `make static-checks` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)