### PR TITLE
parser: add fault-tolerant parsing for LSP error recovery

### DIFF
--- a/lsp/diagnostics.go
+++ b/lsp/diagnostics.go
@@ -108,7 +108,7 @@ func (s *Server) analyzeAndPublish(doc *Document) {
 
 	// Snapshot document fields under the lock.
 	doc.mu.Lock()
-	parseErr := doc.parseErr
+	parseErrors := doc.parseErrors
 	content := doc.Content
 	docAnalysis := doc.analysis
 	uri := doc.URI
@@ -117,7 +117,7 @@ func (s *Server) analyzeAndPublish(doc *Document) {
 	var diags []protocol.Diagnostic
 
 	// Report parse errors as diagnostics.
-	if parseErr != nil {
+	for _, parseErr := range parseErrors {
 		diags = append(diags, protocol.Diagnostic{
 			Range:    parseErrorRange(parseErr),
 			Severity: severity(protocol.DiagnosticSeverityError),

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -199,7 +199,10 @@ func TestDocumentParseError(t *testing.T) {
 	store := NewDocumentStore()
 	doc := store.Open("file:///test.lisp", 1, "(defun add (x y")
 	require.NotNil(t, doc)
-	assert.NotEmpty(t, doc.parseErrors)
+	require.Len(t, doc.parseErrors, 1)
+	var ev *lisp.ErrorVal
+	require.ErrorAs(t, doc.parseErrors[0], &ev)
+	assert.Equal(t, lisp.CondUnmatchedSyntax, ev.Condition())
 }
 
 func TestDocumentFaultTolerantParse(t *testing.T) {
@@ -207,8 +210,10 @@ func TestDocumentFaultTolerantParse(t *testing.T) {
 	// Two valid expressions followed by an incomplete one.
 	doc := store.Open("file:///test.lisp", 1, "(defun a () 1)\n(defun b () 2)\n(incomplete")
 	require.NotNil(t, doc)
-	assert.NotEmpty(t, doc.parseErrors, "should record parse error")
+	require.Len(t, doc.parseErrors, 1, "should record one parse error")
 	assert.Len(t, doc.ast, 2, "should recover the two valid expressions")
+	assert.Equal(t, "(defun a () 1)", doc.ast[0].String())
+	assert.Equal(t, "(defun b () 2)", doc.ast[1].String())
 }
 
 // --- Diagnostics tests ---
@@ -342,7 +347,7 @@ func TestDocumentFaultTolerantRecoveryBeyondError(t *testing.T) {
 	// Mismatched bracket in middle, valid code AFTER the error is recovered.
 	doc := store.Open("file:///test.lisp", 1, "(defun a () 1)\n(broken]\n(defun b () 2)")
 	require.NotNil(t, doc)
-	assert.NotEmpty(t, doc.parseErrors, "should record parse error")
+	require.Len(t, doc.parseErrors, 1, "should record one parse error")
 	assert.Len(t, doc.ast, 2, "should recover both valid expressions around the error")
 	assert.Equal(t, "(defun a () 1)", doc.ast[0].String())
 	assert.Equal(t, "(defun b () 2)", doc.ast[1].String())
@@ -364,14 +369,17 @@ func TestDiagnosticsMultipleParseErrors(t *testing.T) {
 	require.Len(t, *captured, 1)
 	pub := (*captured)[0]
 
-	// Count parse error diagnostics.
-	var parseCount int
+	// Collect parse error diagnostics.
+	var parseDiags []protocol.Diagnostic
 	for _, d := range pub.Diagnostics {
 		if d.Source != nil && *d.Source == "elps" {
-			parseCount++
+			parseDiags = append(parseDiags, d)
 		}
 	}
-	assert.Equal(t, 2, parseCount, "should publish one diagnostic per parse error")
+	require.Len(t, parseDiags, 2, "should publish one diagnostic per parse error")
+	// The two errors are on different lines; verify distinct positions.
+	assert.NotEqual(t, parseDiags[0].Range.Start.Line, parseDiags[1].Range.Start.Line,
+		"two errors on different lines should have different diagnostic positions")
 }
 
 // --- Hover tests ---

--- a/parser/rdparser/bench_test.go
+++ b/parser/rdparser/bench_test.go
@@ -3,12 +3,15 @@
 package rdparser_test
 
 import (
+	"bytes"
+	"os"
 	"path/filepath"
 	"sort"
 	"testing"
 
 	"github.com/luthersystems/elps/elpstest"
 	"github.com/luthersystems/elps/parser/rdparser"
+	"github.com/luthersystems/elps/parser/token"
 )
 
 const fixtureDir = "../../_examples/sicp"
@@ -21,5 +24,30 @@ func BenchmarkParser(b *testing.B) {
 	sort.Strings(files) // should be redundant
 	for _, path := range files {
 		b.Run(filepath.Base(path), elpstest.BenchmarkParse(path, rdparser.NewReader))
+	}
+}
+
+func BenchmarkParserFaultTolerant(b *testing.B) {
+	files, err := filepath.Glob(filepath.Join(fixtureDir, "*.lisp"))
+	if err != nil {
+		b.Fatalf("Failed to list test fixtures: %v", err)
+	}
+	sort.Strings(files)
+	for _, path := range files {
+		b.Run(filepath.Base(path), func(b *testing.B) {
+			buf, err := os.ReadFile(path) //#nosec G304
+			if err != nil {
+				b.Fatalf("Unable to read source file %v: %v", path, err)
+			}
+			b.SetBytes(int64(len(buf)))
+			for i := 0; i < b.N; i++ {
+				s := token.NewScanner("test", bytes.NewReader(buf))
+				p := rdparser.New(s)
+				result := p.ParseProgramFaultTolerant()
+				if len(result.Errors) > 0 {
+					b.Fatalf("Parse failure: %v", result.Errors[0])
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Add `ParseProgramFaultTolerant()` to `rdparser` that recovers from parse errors and continues parsing, returning a partial AST alongside all collected errors (capped at 50)
- Switch the LSP to use this method, eliminating the double-parse workaround and reporting multiple parse errors as diagnostics
- Purely additive to the parser — no existing functions modified, zero performance impact on `ParseProgram()`

Closes #145

## Test plan

- [x] 13 fault-tolerant parser tests: no errors, error in middle, start, end, stray closers, mismatched brackets, multiple errors, only errors, empty input, error positions, error limit, unclosed bracket behavior, scan error recovery
- [x] Benchmark: `BenchmarkParserFaultTolerant` matches `BenchmarkParser` on valid input (no overhead)
- [x] LSP tests: `TestDocumentFaultTolerantRecoveryBeyondError`, `TestDiagnosticsMultipleParseErrors`
- [x] Full suite: `make test && make static-checks` pass with 0 issues
- [x] Security review: no issues found

---
*Local tests passed. Security review completed.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>