### PR TITLE
lsp: fix hover, completion, diagnostics, and dedup (#162-#165)

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -32,6 +32,7 @@ type ExternalSymbol struct {
 	Package   string
 	Signature *Signature
 	Source    *token.Location
+	DocString string
 }
 
 // Result holds the output of semantic analysis.
@@ -59,6 +60,7 @@ func Analyze(exprs []*lisp.LVal, cfg *Config) *Result {
 			Kind:      ext.Kind,
 			Source:    ext.Source,
 			Signature: ext.Signature,
+			DocString: ext.DocString,
 			Exported:  true,
 			External:  true,
 		})

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -170,6 +170,7 @@ func (a *analyzer) prescanUsePackage(expr *lisp.LVal, scope *Scope) {
 			Kind:      ext.Kind,
 			Source:    ext.Source,
 			Signature: ext.Signature,
+			DocString: ext.DocString,
 			Exported:  true,
 			External:  true,
 		}
@@ -206,6 +207,7 @@ func (a *analyzer) prescanInPackage(expr *lisp.LVal, scope *Scope) {
 				Kind:      ext.Kind,
 				Source:    ext.Source,
 				Signature: ext.Signature,
+				DocString: ext.DocString,
 				Exported:  true,
 				External:  true,
 			}

--- a/analysis/stdlib.go
+++ b/analysis/stdlib.go
@@ -21,8 +21,9 @@ func ExtractPackageExports(reg *lisp.PackageRegistry) map[string][]ExternalSymbo
 				continue
 			}
 			sym := ExternalSymbol{
-				Name:    extName,
-				Package: name,
+				Name:      extName,
+				Package:   name,
+				DocString: val.Docstring(),
 			}
 			sym.Kind, sym.Signature = classifyLVal(val)
 			syms = append(syms, sym)

--- a/analysis/stdlib_test.go
+++ b/analysis/stdlib_test.go
@@ -79,3 +79,22 @@ func TestExtractPackageExports_PackageField(t *testing.T) {
 		}
 	}
 }
+
+func TestExtractPackageExports_DocString(t *testing.T) {
+	reg := loadedRegistry()
+	exports := ExtractPackageExports(reg)
+	require.NotNil(t, exports)
+
+	// Find a builtin with a known docstring (e.g. "map" in the lisp package).
+	lispPkg, ok := exports["lisp"]
+	require.True(t, ok, "lisp package should have exports")
+
+	found := false
+	for _, sym := range lispPkg {
+		if sym.DocString != "" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "at least one lisp package export should have a docstring")
+}

--- a/analysis/stdlib_test.go
+++ b/analysis/stdlib_test.go
@@ -85,16 +85,21 @@ func TestExtractPackageExports_DocString(t *testing.T) {
 	exports := ExtractPackageExports(reg)
 	require.NotNil(t, exports)
 
-	// Find a builtin with a known docstring (e.g. "map" in the lisp package).
-	lispPkg, ok := exports["lisp"]
-	require.True(t, ok, "lisp package should have exports")
+	// Pin a specific known symbol and verify its docstring content.
+	testingPkg, ok := exports["testing"]
+	require.True(t, ok, "testing package should have exports")
 
-	found := false
-	for _, sym := range lispPkg {
-		if sym.DocString != "" {
-			found = true
-			break
-		}
+	symByName := make(map[string]ExternalSymbol)
+	for _, sym := range testingPkg {
+		symByName[sym.Name] = sym
 	}
-	assert.True(t, found, "at least one lisp package export should have a docstring")
+	assertEq, ok := symByName["assert-equal"]
+	require.True(t, ok, "testing package should export assert-equal")
+	assert.Contains(t, assertEq.DocString, "structurally equal",
+		"assert-equal docstring should describe structural equality")
+
+	assertNil, ok := symByName["assert-nil"]
+	require.True(t, ok, "testing package should export assert-nil")
+	assert.Contains(t, assertNil.DocString, "nil",
+		"assert-nil docstring should mention nil")
 }

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -19,40 +19,35 @@ import (
 //
 // Files that fail to parse are silently skipped (fault tolerant).
 func ScanWorkspace(root string) ([]ExternalSymbol, error) {
-	var syms []ExternalSymbol
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return nil // skip unreadable dirs
-		}
-		if info.IsDir() {
-			return nil
-		}
-		if filepath.Ext(path) != ".lisp" {
-			return nil
-		}
-		fileSrc, err := os.ReadFile(path) //nolint:gosec // CLI tool reads user-specified files
-		if err != nil {
-			return nil // skip unreadable files
-		}
-		fileSyms := scanFile(fileSrc, path)
-		syms = append(syms, fileSyms...)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return syms, nil
+	globals, _, err := ScanWorkspaceFull(root)
+	return globals, err
 }
 
 // ScanWorkspacePackages is like ScanWorkspace but returns a map of
 // package name to exported symbols, suitable for use as Config.PackageExports.
 func ScanWorkspacePackages(root string) (map[string][]ExternalSymbol, error) {
+	_, pkgs, err := ScanWorkspaceFull(root)
+	return pkgs, err
+}
+
+// ScanWorkspaceFull walks a directory tree in a single pass, parsing all
+// .lisp files and extracting both global symbols and package exports.
+// It skips hidden directories (names starting with '.') and node_modules.
+//
+// Files that fail to parse are silently skipped (fault tolerant).
+func ScanWorkspaceFull(root string) ([]ExternalSymbol, map[string][]ExternalSymbol, error) {
+	var globals []ExternalSymbol
 	pkgs := make(map[string][]ExternalSymbol)
+
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return nil
+			return nil // skip unreadable dirs
 		}
 		if info.IsDir() {
+			name := info.Name()
+			if shouldSkipDir(name) {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if filepath.Ext(path) != ".lisp" {
@@ -60,8 +55,13 @@ func ScanWorkspacePackages(root string) (map[string][]ExternalSymbol, error) {
 		}
 		fileSrc, readErr := os.ReadFile(path) //nolint:gosec // CLI tool reads user-specified files
 		if readErr != nil {
-			return nil
+			return nil // skip unreadable files
 		}
+
+		// Parse once and extract both globals and packages.
+		fileGlobals := scanFile(fileSrc, path)
+		globals = append(globals, fileGlobals...)
+
 		filePkgs := scanFilePackages(fileSrc, path)
 		for pkg, syms := range filePkgs {
 			pkgs[pkg] = append(pkgs[pkg], syms...)
@@ -69,9 +69,20 @@ func ScanWorkspacePackages(root string) (map[string][]ExternalSymbol, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return pkgs, nil
+	return globals, pkgs, nil
+}
+
+// shouldSkipDir returns true for directories that should not be walked.
+func shouldSkipDir(name string) bool {
+	if len(name) > 0 && name[0] == '.' {
+		return true
+	}
+	if name == "node_modules" {
+		return true
+	}
+	return false
 }
 
 // scanFile parses a single file and extracts top-level definitions and
@@ -231,11 +242,22 @@ func scanDefun(expr *lisp.LVal, kind SymbolKind) *ExternalSymbol {
 	if formalsVal.Type != lisp.LSExpr {
 		return nil
 	}
+
+	// Extract docstring: (defun name (args) "docstring" body...)
+	var docStr string
+	if astutil.ArgCount(expr) >= 3 && expr.Cells[3].Type == lisp.LString {
+		// Only treat as docstring if there's at least one body form after it.
+		if astutil.ArgCount(expr) >= 4 {
+			docStr = expr.Cells[3].Str
+		}
+	}
+
 	return &ExternalSymbol{
 		Name:      nameVal.Str,
 		Kind:      kind,
 		Signature: signatureFromFormals(formalsVal),
 		Source:    nameVal.Source,
+		DocString: docStr,
 	}
 }
 

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -75,7 +75,12 @@ func ScanWorkspaceFull(root string) ([]ExternalSymbol, map[string][]ExternalSymb
 }
 
 // shouldSkipDir returns true for directories that should not be walked.
+// It skips hidden directories (e.g. .git, .vscode) and node_modules,
+// but not "." or ".." which represent the current/parent directory.
 func shouldSkipDir(name string) bool {
+	if name == "." || name == ".." {
+		return false
+	}
 	if len(name) > 0 && name[0] == '.' {
 		return true
 	}

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -163,3 +163,111 @@ func TestScanWorkspace_DefmacroExported(t *testing.T) {
 	assert.Equal(t, "when", syms[0].Name)
 	assert.Equal(t, SymMacro, syms[0].Kind)
 }
+
+func TestScanWorkspace_DocStringExtracted(t *testing.T) {
+	dir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(dir, "lib.lisp"), []byte(`
+(defun greet (name)
+  "Say hello to someone."
+  (concat "Hello, " name))
+(export 'greet)
+`), 0600)
+	require.NoError(t, err)
+
+	syms, err := ScanWorkspace(dir)
+	require.NoError(t, err)
+
+	require.Len(t, syms, 1)
+	assert.Equal(t, "greet", syms[0].Name)
+	assert.Equal(t, "Say hello to someone.", syms[0].DocString)
+}
+
+func TestScanWorkspace_NoDocStringWhenNoBody(t *testing.T) {
+	dir := t.TempDir()
+
+	// A function with only a string (constant function) has no docstring.
+	err := os.WriteFile(filepath.Join(dir, "lib.lisp"), []byte(`
+(defun version () "1.0.0")
+(export 'version)
+`), 0600)
+	require.NoError(t, err)
+
+	syms, err := ScanWorkspace(dir)
+	require.NoError(t, err)
+
+	require.Len(t, syms, 1)
+	assert.Equal(t, "version", syms[0].Name)
+	assert.Empty(t, syms[0].DocString, "string-only body should not be treated as docstring")
+}
+
+func TestScanWorkspaceFull_SkipsHiddenDirs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a hidden directory with a lisp file.
+	hiddenDir := filepath.Join(dir, ".git")
+	err := os.MkdirAll(hiddenDir, 0750)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(hiddenDir, "config.lisp"), []byte(`
+(defun hidden-fn () 42)
+(export 'hidden-fn)
+`), 0600)
+	require.NoError(t, err)
+
+	// Create a node_modules directory.
+	nmDir := filepath.Join(dir, "node_modules")
+	err = os.MkdirAll(nmDir, 0750)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(nmDir, "dep.lisp"), []byte(`
+(defun dep-fn () 42)
+(export 'dep-fn)
+`), 0600)
+	require.NoError(t, err)
+
+	// Create a visible file.
+	err = os.WriteFile(filepath.Join(dir, "lib.lisp"), []byte(`
+(defun visible-fn () 42)
+(export 'visible-fn)
+`), 0600)
+	require.NoError(t, err)
+
+	globals, pkgs, err := ScanWorkspaceFull(dir)
+	require.NoError(t, err)
+
+	names := make(map[string]bool)
+	for _, s := range globals {
+		names[s.Name] = true
+	}
+	for _, syms := range pkgs {
+		for _, s := range syms {
+			names[s.Name] = true
+		}
+	}
+
+	assert.True(t, names["visible-fn"], "visible file should be scanned")
+	assert.False(t, names["hidden-fn"], "hidden directory files should be skipped")
+	assert.False(t, names["dep-fn"], "node_modules files should be skipped")
+}
+
+func TestScanWorkspaceFull_CombinedResults(t *testing.T) {
+	dir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(dir, "lib.lisp"), []byte(`
+(in-package 'mylib)
+(defun helper (x) (+ x 1))
+(export 'helper)
+`), 0600)
+	require.NoError(t, err)
+
+	globals, pkgs, err := ScanWorkspaceFull(dir)
+	require.NoError(t, err)
+
+	// Globals should contain the exported symbol.
+	assert.Len(t, globals, 1)
+	assert.Equal(t, "helper", globals[0].Name)
+
+	// Package exports should group by package.
+	require.Contains(t, pkgs, "mylib")
+	assert.Len(t, pkgs["mylib"], 1)
+	assert.Equal(t, "helper", pkgs["mylib"][0].Name)
+}

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -263,11 +263,15 @@ func TestScanWorkspaceFull_CombinedResults(t *testing.T) {
 	require.NoError(t, err)
 
 	// Globals should contain the exported symbol.
-	assert.Len(t, globals, 1)
+	require.Len(t, globals, 1)
 	assert.Equal(t, "helper", globals[0].Name)
+	assert.Equal(t, SymFunction, globals[0].Kind)
 
-	// Package exports should group by package.
+	// Package exports should group by package with Package field set.
 	require.Contains(t, pkgs, "mylib")
-	assert.Len(t, pkgs["mylib"], 1)
+	require.Len(t, pkgs["mylib"], 1)
 	assert.Equal(t, "helper", pkgs["mylib"][0].Name)
+	assert.Equal(t, "mylib", pkgs["mylib"][0].Package,
+		"package export should have Package field set")
+	assert.Equal(t, SymFunction, pkgs["mylib"][0].Kind)
 }

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -249,6 +249,15 @@ func TestScanWorkspaceFull_SkipsHiddenDirs(t *testing.T) {
 	assert.False(t, names["dep-fn"], "node_modules files should be skipped")
 }
 
+func TestShouldSkipDir(t *testing.T) {
+	assert.False(t, shouldSkipDir("."), "current directory should not be skipped")
+	assert.False(t, shouldSkipDir(".."), "parent directory should not be skipped")
+	assert.True(t, shouldSkipDir(".git"), "hidden directory should be skipped")
+	assert.True(t, shouldSkipDir(".vscode"), "hidden directory should be skipped")
+	assert.True(t, shouldSkipDir("node_modules"), "node_modules should be skipped")
+	assert.False(t, shouldSkipDir("src"), "normal directory should not be skipped")
+}
+
 func TestScanWorkspaceFull_CombinedResults(t *testing.T) {
 	dir := t.TempDir()
 

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -1,0 +1,171 @@
+# Editor Setup
+
+This guide covers setting up the ELPS LSP server in various editors and tools.
+
+For LSP features and capabilities, see `elps doc --lsp-guide` or [lsp-guide.md](lsp-guide.md).
+
+## Claude Code
+
+Claude Code supports LSP plugins that provide inline diagnostics when reading
+or editing files.
+
+### Prerequisites
+
+- `elps` binary on `$PATH` (or an embedder like `shirotester`)
+- Claude Code installed
+
+### 1. Create the plugin directory structure
+
+```
+.claude/plugins/elps-lsp/
+  .claude-plugin/
+    plugin.json        # Plugin manifest (required)
+  .lsp.json            # LSP server config
+```
+
+### 2. Plugin manifest
+
+Create `.claude/plugins/elps-lsp/.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "elps-lsp",
+  "description": "ELPS Lisp language server",
+  "version": "1.0.0",
+  "author": {
+    "name": "Luther Systems"
+  }
+}
+```
+
+### 3. LSP config
+
+Create `.claude/plugins/elps-lsp/.lsp.json`:
+
+```json
+{
+  "elps": {
+    "command": "elps",
+    "args": ["lsp"],
+    "extensionToLanguage": {
+      ".lisp": "lisp"
+    }
+  }
+}
+```
+
+For embedders that register Go builtins (e.g., substrate's `shirotester`):
+
+```json
+{
+  "elps": {
+    "command": "shirotester",
+    "args": ["lsp"],
+    "extensionToLanguage": {
+      ".lisp": "lisp"
+    }
+  }
+}
+```
+
+### 4. Create a local marketplace
+
+Create `.claude/plugins/.claude-plugin/marketplace.json`:
+
+```json
+{
+  "name": "my-plugins",
+  "owner": {
+    "name": "My Org"
+  },
+  "plugins": [
+    {
+      "name": "elps-lsp",
+      "source": "./elps-lsp",
+      "description": "ELPS Lisp language server"
+    }
+  ]
+}
+```
+
+### 5. Install the plugin
+
+```bash
+claude plugin marketplace add ./.claude/plugins
+claude plugin install elps-lsp@my-plugins
+```
+
+### 6. Restart Claude Code
+
+The LSP starts on demand when Claude reads or edits `.lisp` files. Diagnostics
+appear inline in tool results.
+
+## VS Code
+
+Use any generic LSP client extension (e.g., [vscode-languageclient](https://github.com/ArtifactDB/vscode-lsp-sample)).
+
+Add to `.vscode/settings.json`:
+
+```json
+{
+  "elps.server.command": "elps",
+  "elps.server.args": ["lsp", "--stdio"]
+}
+```
+
+Or configure a generic LSP client extension to run `elps lsp --stdio` for
+files matching `*.lisp`.
+
+## Neovim (nvim-lspconfig)
+
+```lua
+vim.api.nvim_create_autocmd('FileType', {
+  pattern = 'lisp',
+  callback = function()
+    vim.lsp.start({
+      name = 'elps',
+      cmd = { 'elps', 'lsp', '--stdio' },
+      root_dir = vim.fs.dirname(vim.fs.find({ '.git' }, { upward = true })[1]),
+    })
+  end,
+})
+```
+
+## Emacs (eglot)
+
+```elisp
+(add-to-list 'eglot-server-programs
+             '(lisp-mode . ("elps" "lsp" "--stdio")))
+```
+
+Then `M-x eglot` in a `.lisp` buffer.
+
+## Embedder Variant
+
+When ELPS is embedded in a Go application (e.g., `shirotester`), the embedder
+can expose an LSP command that boots the full runtime. This ensures
+Go-registered builtins are resolved correctly for hover, completion, and
+diagnostics.
+
+Replace `elps` with the embedder binary in any of the configurations above:
+
+```bash
+shirotester lsp --stdio
+```
+
+The embedder wires the LSP server with `lsp.WithEnv(env)` or
+`lsp.WithRegistry(reg)` to inject its packages.
+
+## Available Features
+
+| Feature            | Description                                        |
+|--------------------|----------------------------------------------------|
+| Diagnostics        | Parse errors and lint warnings as you type          |
+| Hover              | Function signatures, docstrings, source locations   |
+| Go to Definition   | Jump to defun/defmacro/set definition sites         |
+| Find References    | Find all uses of a symbol across the file           |
+| Document Symbols   | Outline of top-level definitions                    |
+| Completion         | Scope-aware symbol + package-qualified completion   |
+| Rename             | Rename a symbol at definition and all references    |
+| Formatting         | Source code formatting via `textDocument/formatting` |
+| Signature Help     | Parameter hints for function calls                  |

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -78,6 +78,12 @@ func (s *Server) packageCompletions(doc *Document, pkgName, partial string) []pr
 			detail := formatSignature(ext.Signature)
 			item.Detail = &detail
 		}
+		if ext.DocString != "" {
+			item.Documentation = &protocol.MarkupContent{
+				Kind:  protocol.MarkupKindMarkdown,
+				Value: ext.DocString,
+			}
+		}
 		items = append(items, item)
 	}
 	return items

--- a/lsp/document.go
+++ b/lsp/document.go
@@ -100,3 +100,14 @@ func (s *DocumentStore) Get(uri string) *Document {
 	defer s.mu.RUnlock()
 	return s.docs[uri]
 }
+
+// All returns a snapshot of all open documents.
+func (s *DocumentStore) All() []*Document {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	docs := make([]*Document, 0, len(s.docs))
+	for _, doc := range s.docs {
+		docs = append(docs, doc)
+	}
+	return docs
+}

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -1173,6 +1173,54 @@ func TestCompletionPackageQualifiedDocString(t *testing.T) {
 	assert.Equal(t, "Return the absolute value.", mc.Value)
 }
 
+func TestCompletionPackageQualifiedNoDocString(t *testing.T) {
+	s := testServer()
+	s.analysisCfg = &analysis.Config{
+		PackageExports: map[string][]analysis.ExternalSymbol{
+			"math": {
+				{Name: "abs", Kind: analysis.SymFunction, Package: "math"},
+			},
+		},
+	}
+
+	content := "(math:"
+	openDoc(s, "file:///test.lisp", content)
+
+	result, err := s.textDocumentCompletion(mockContext(), &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 0, Character: 6},
+		},
+	})
+	require.NoError(t, err)
+	items, ok := result.([]protocol.CompletionItem)
+	require.True(t, ok)
+	require.Len(t, items, 1)
+	assert.Equal(t, "math:abs", items[0].Label)
+	assert.Nil(t, items[0].Documentation,
+		"completion item without docstring should have nil documentation")
+}
+
+func TestHoverOnUnknownPackageQualifiedSymbol(t *testing.T) {
+	s := testServer()
+	// Package "nosuchpkg" doesn't exist in exports at all.
+	s.analysisCfg = &analysis.Config{
+		PackageExports: map[string][]analysis.ExternalSymbol{},
+	}
+
+	content := "(nosuchpkg:something 1)"
+	openDoc(s, "file:///test.lisp", content)
+
+	hover, err := s.textDocumentHover(mockContext(), &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 0, Character: 2},
+		},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, hover, "hover on unknown package should be nil")
+}
+
 func TestDeduplicateExports(t *testing.T) {
 	t.Run("no duplicates", func(t *testing.T) {
 		syms := []analysis.ExternalSymbol{
@@ -1180,24 +1228,31 @@ func TestDeduplicateExports(t *testing.T) {
 			{Name: "bar", Kind: analysis.SymFunction},
 		}
 		result := deduplicateExports(syms)
-		assert.Len(t, result, 2)
+		require.Len(t, result, 2)
+		names := make(map[string]bool)
+		for _, sym := range result {
+			names[sym.Name] = true
+		}
+		assert.True(t, names["foo"], "foo should survive deduplication")
+		assert.True(t, names["bar"], "bar should survive deduplication")
 	})
 
 	t.Run("duplicates removed", func(t *testing.T) {
 		syms := []analysis.ExternalSymbol{
 			{Name: "foo", Kind: analysis.SymFunction, DocString: "workspace"},
-			{Name: "bar", Kind: analysis.SymFunction},
+			{Name: "bar", Kind: analysis.SymFunction, DocString: "bar-doc"},
 			{Name: "foo", Kind: analysis.SymFunction, DocString: "registry"},
 		}
 		result := deduplicateExports(syms)
-		assert.Len(t, result, 2)
-		// Last entry (registry) should win.
+		require.Len(t, result, 2)
+		resultMap := make(map[string]analysis.ExternalSymbol)
 		for _, sym := range result {
-			if sym.Name == "foo" {
-				assert.Equal(t, "registry", sym.DocString,
-					"registry entry should take precedence over workspace")
-			}
+			resultMap[sym.Name] = sym
 		}
+		assert.Equal(t, "registry", resultMap["foo"].DocString,
+			"registry entry should take precedence over workspace")
+		assert.Equal(t, "bar-doc", resultMap["bar"].DocString,
+			"non-duplicate entry should be preserved")
 	})
 
 	t.Run("empty input", func(t *testing.T) {
@@ -1212,14 +1267,22 @@ func TestDocumentStoreAll(t *testing.T) {
 	store.Open("file:///b.lisp", 1, "(+ 3 4)")
 
 	all := store.All()
-	assert.Len(t, all, 2, "All() should return all open documents")
+	require.Len(t, all, 2, "All() should return all open documents")
 
-	uris := make(map[string]bool)
+	docsByURI := make(map[string]*Document)
 	for _, doc := range all {
-		uris[doc.URI] = true
+		docsByURI[doc.URI] = doc
 	}
-	assert.True(t, uris["file:///a.lisp"])
-	assert.True(t, uris["file:///b.lisp"])
+	require.Contains(t, docsByURI, "file:///a.lisp")
+	require.Contains(t, docsByURI, "file:///b.lisp")
+	assert.Equal(t, "(+ 1 2)", docsByURI["file:///a.lisp"].Content)
+	assert.Equal(t, "(+ 3 4)", docsByURI["file:///b.lisp"].Content)
+
+	// After closing one document, All() should reflect the change.
+	store.Close("file:///a.lisp")
+	all = store.All()
+	require.Len(t, all, 1, "All() should reflect closed documents")
+	assert.Equal(t, "file:///b.lisp", all[0].URI)
 }
 
 func TestReanalyzeOpenDocuments(t *testing.T) {
@@ -1240,8 +1303,19 @@ func TestReanalyzeOpenDocuments(t *testing.T) {
 
 	// First analysis: no workspace config yet, so use-package can't resolve.
 	s.analyzeAndPublish(doc)
-	initialCount := len(captured)
-	require.Greater(t, initialCount, 0, "initial analysis should publish diagnostics")
+	require.Len(t, captured, 1, "initial analysis should publish one diagnostic set")
+	initialDiags := captured[0].Diagnostics
+
+	// Without workspace config, assert-equal is unresolvable — expect diagnostics.
+	hasUndefinedSymbol := false
+	for _, d := range initialDiags {
+		if d.Message != "" {
+			hasUndefinedSymbol = true
+			break
+		}
+	}
+	require.True(t, hasUndefinedSymbol || len(initialDiags) > 0,
+		"initial analysis should produce diagnostics (unresolvable package)")
 
 	// Now simulate workspace index completing with testing package exports.
 	s.analysisCfg = &analysis.Config{
@@ -1254,8 +1328,13 @@ func TestReanalyzeOpenDocuments(t *testing.T) {
 
 	// Re-analyze should publish new diagnostics for all open docs.
 	s.reanalyzeOpenDocuments()
-	assert.Greater(t, len(captured), initialCount,
+	require.Greater(t, len(captured), 1,
 		"reanalyze should publish new diagnostics after workspace index completes")
+
+	// The re-analysis diagnostics should have fewer issues (false positives cleared).
+	reanalyzedDiags := captured[len(captured)-1].Diagnostics
+	assert.LessOrEqual(t, len(reanalyzedDiags), len(initialDiags),
+		"re-analysis with workspace config should produce fewer (or equal) diagnostics")
 }
 
 func TestDefinitionOnUndefinedSymbol(t *testing.T) {

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -1076,6 +1076,188 @@ func TestCompletionEmptyPrefix(t *testing.T) {
 	assert.Contains(t, labels, "aaa")
 }
 
+func TestHoverOnQualifiedSymbol(t *testing.T) {
+	s := testServer()
+	s.analysisCfg = &analysis.Config{
+		PackageExports: map[string][]analysis.ExternalSymbol{
+			"string": {
+				{
+					Name:      "join",
+					Kind:      analysis.SymFunction,
+					Package:   "string",
+					DocString: "Join a list of strings with a separator.",
+					Signature: &analysis.Signature{
+						Params: []lisp.ParamInfo{
+							{Name: "sep", Kind: lisp.ParamRequired},
+							{Name: "lst", Kind: lisp.ParamRequired},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	content := "(string:join \",\" '(\"a\" \"b\" \"c\"))"
+	openDoc(s, "file:///test.lisp", content)
+
+	hover, err := s.textDocumentHover(mockContext(), &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 0, Character: 2}, // on "string:join"
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, hover, "hover on qualified symbol should not be nil")
+	mc, ok := hover.Contents.(protocol.MarkupContent)
+	require.True(t, ok, "hover contents should be MarkupContent")
+	assert.Contains(t, mc.Value, "join")
+	assert.Contains(t, mc.Value, "function")
+	assert.Contains(t, mc.Value, "Join a list of strings with a separator.")
+}
+
+func TestHoverOnQualifiedSymbolUnknown(t *testing.T) {
+	s := testServer()
+	s.analysisCfg = &analysis.Config{
+		PackageExports: map[string][]analysis.ExternalSymbol{
+			"string": {
+				{Name: "join", Kind: analysis.SymFunction, Package: "string"},
+			},
+		},
+	}
+
+	content := "(string:nonexistent 1)"
+	openDoc(s, "file:///test.lisp", content)
+
+	hover, err := s.textDocumentHover(mockContext(), &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 0, Character: 2},
+		},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, hover, "hover on unknown qualified symbol should be nil")
+}
+
+func TestCompletionPackageQualifiedDocString(t *testing.T) {
+	s := testServer()
+	s.analysisCfg = &analysis.Config{
+		PackageExports: map[string][]analysis.ExternalSymbol{
+			"math": {
+				{
+					Name:      "abs",
+					Kind:      analysis.SymFunction,
+					Package:   "math",
+					DocString: "Return the absolute value.",
+				},
+			},
+		},
+	}
+
+	content := "(math:"
+	openDoc(s, "file:///test.lisp", content)
+
+	result, err := s.textDocumentCompletion(mockContext(), &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 0, Character: 6},
+		},
+	})
+	require.NoError(t, err)
+	items, ok := result.([]protocol.CompletionItem)
+	require.True(t, ok)
+	require.Len(t, items, 1)
+	assert.Equal(t, "math:abs", items[0].Label)
+	require.NotNil(t, items[0].Documentation, "completion item should have documentation")
+	mc, ok := items[0].Documentation.(*protocol.MarkupContent)
+	require.True(t, ok, "documentation should be MarkupContent")
+	assert.Equal(t, "Return the absolute value.", mc.Value)
+}
+
+func TestDeduplicateExports(t *testing.T) {
+	t.Run("no duplicates", func(t *testing.T) {
+		syms := []analysis.ExternalSymbol{
+			{Name: "foo", Kind: analysis.SymFunction},
+			{Name: "bar", Kind: analysis.SymFunction},
+		}
+		result := deduplicateExports(syms)
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("duplicates removed", func(t *testing.T) {
+		syms := []analysis.ExternalSymbol{
+			{Name: "foo", Kind: analysis.SymFunction, DocString: "workspace"},
+			{Name: "bar", Kind: analysis.SymFunction},
+			{Name: "foo", Kind: analysis.SymFunction, DocString: "registry"},
+		}
+		result := deduplicateExports(syms)
+		assert.Len(t, result, 2)
+		// Last entry (registry) should win.
+		for _, sym := range result {
+			if sym.Name == "foo" {
+				assert.Equal(t, "registry", sym.DocString,
+					"registry entry should take precedence over workspace")
+			}
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		result := deduplicateExports(nil)
+		assert.Empty(t, result)
+	})
+}
+
+func TestDocumentStoreAll(t *testing.T) {
+	store := NewDocumentStore()
+	store.Open("file:///a.lisp", 1, "(+ 1 2)")
+	store.Open("file:///b.lisp", 1, "(+ 3 4)")
+
+	all := store.All()
+	assert.Len(t, all, 2, "All() should return all open documents")
+
+	uris := make(map[string]bool)
+	for _, doc := range all {
+		uris[doc.URI] = true
+	}
+	assert.True(t, uris["file:///a.lisp"])
+	assert.True(t, uris["file:///b.lisp"])
+}
+
+func TestReanalyzeOpenDocuments(t *testing.T) {
+	s := testServer()
+	// Set up notification capturing.
+	var captured []*protocol.PublishDiagnosticsParams
+	s.notify = func(method string, params any) {
+		if method == protocol.ServerTextDocumentPublishDiagnostics {
+			captured = append(captured, params.(*protocol.PublishDiagnosticsParams))
+		}
+	}
+
+	// Open a document that uses a package (will have false positive until
+	// workspace index provides the package exports).
+	content := `(use-package 'testing)
+(assert-equal 1 1)`
+	doc := openDoc(s, "file:///test.lisp", content)
+
+	// First analysis: no workspace config yet, so use-package can't resolve.
+	s.analyzeAndPublish(doc)
+	initialCount := len(captured)
+	require.Greater(t, initialCount, 0, "initial analysis should publish diagnostics")
+
+	// Now simulate workspace index completing with testing package exports.
+	s.analysisCfg = &analysis.Config{
+		PackageExports: map[string][]analysis.ExternalSymbol{
+			"testing": {
+				{Name: "assert-equal", Kind: analysis.SymFunction, Package: "testing"},
+			},
+		},
+	}
+
+	// Re-analyze should publish new diagnostics for all open docs.
+	s.reanalyzeOpenDocuments()
+	assert.Greater(t, len(captured), initialCount,
+		"reanalyze should publish new diagnostics after workspace index completes")
+}
+
 func TestDefinitionOnUndefinedSymbol(t *testing.T) {
 	s := testServer()
 	content := "(nonexistent 1 2 3)"


### PR DESCRIPTION
## Summary

- **#162 Hover/completion for Go-registered builtins**: Added `DocString` field to `ExternalSymbol`, extracted docstrings from Go registry (`LVal.Docstring()`) and lisp source `(defun ... "docstring" ...)`. Added qualified symbol hover fallback (`pkg:name` lookup in PackageExports). Set `Documentation` on package-qualified completion items.
- **#163 Slow diagnostics**: Merged `ScanWorkspace` + `ScanWorkspacePackages` into single-pass `ScanWorkspaceFull` (halves filesystem walks). Skip hidden directories (`.git`, etc.) and `node_modules` during workspace scan.
- **#164 False positive undefined-symbol for use-package**: After `buildWorkspaceIndex()` completes, re-analyze all open documents via `reanalyzeOpenDocuments()`. Added `DocumentStore.All()` for iterating open docs.
- **#165 Duplicate completion items**: Added `deduplicateExports()` — removes duplicates by name, preferring registry entries over workspace entries.
- **#161 Editor setup docs**: Created `docs/editors.md` with setup guides for Claude Code (verified marketplace approach), VS Code, Neovim, and Emacs.

Fixes #162, fixes #163, fixes #164, fixes #165, closes #161

## Test plan
- [x] `make test` — all Go + lisp tests pass
- [x] `make static-checks` — golangci-lint clean (0 issues)
- [x] `go test ./analysis/...` — DocString extraction, workspace scan, hidden dir skipping
- [x] `go test ./lsp/...` — qualified hover, completion docs, dedup, reanalyze, DocumentStore.All

---
*Local tests passed. Security review completed. QA professor review pending.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>