### PR TITLE
feat: add built-in /help command to DAP debug server

### DIFF
--- a/lisp/x/debugger/engine_test.go
+++ b/lisp/x/debugger/engine_test.go
@@ -1970,6 +1970,75 @@ func TestEngine_Commands(t *testing.T) {
 		assert.Equal(t, []string{"alpha", "middle", "zebra"}, names)
 	})
 
+	t.Run("RegisterCommandWithDescription", func(t *testing.T) {
+		t.Parallel()
+		e := New()
+		e.RegisterCommand("reload", func(args string) (string, bool, error) {
+			return "reloaded", false, nil
+		}, "Reload all modules")
+
+		h := e.Command("reload")
+		require.NotNil(t, h)
+		resp, _, _ := h("")
+		assert.Equal(t, "reloaded", resp)
+
+		assert.Equal(t, "Reload all modules", e.CommandDescription("reload"))
+	})
+
+	t.Run("RegisterCommandWithoutDescription", func(t *testing.T) {
+		t.Parallel()
+		e := New()
+		e.RegisterCommand("ping", func(args string) (string, bool, error) {
+			return "pong", false, nil
+		})
+
+		assert.Equal(t, "", e.CommandDescription("ping"))
+	})
+
+	t.Run("CommandDescriptions", func(t *testing.T) {
+		t.Parallel()
+		e := New()
+		e.RegisterCommand("reload", func(args string) (string, bool, error) {
+			return "", false, nil
+		}, "Reload all modules")
+		e.RegisterCommand("reset", func(args string) (string, bool, error) {
+			return "", false, nil
+		}, "Reset state")
+
+		descs := e.CommandDescriptions()
+		assert.Equal(t, map[string]string{
+			"reload": "Reload all modules",
+			"reset":  "Reset state",
+		}, descs)
+	})
+
+	t.Run("WithCommandsEmptyDescriptions", func(t *testing.T) {
+		t.Parallel()
+		e := New(WithCommands(map[string]CommandHandler{
+			"ping": func(args string) (string, bool, error) {
+				return "pong", false, nil
+			},
+		}))
+
+		// WithCommands commands have empty descriptions.
+		assert.Equal(t, "", e.CommandDescription("ping"))
+
+		descs := e.CommandDescriptions()
+		assert.Equal(t, map[string]string{"ping": ""}, descs)
+	})
+
+	t.Run("CommandDescriptionUnknown", func(t *testing.T) {
+		t.Parallel()
+		e := New()
+		assert.Equal(t, "", e.CommandDescription("nonexistent"))
+	})
+
+	t.Run("CommandDescriptionsEmpty", func(t *testing.T) {
+		t.Parallel()
+		e := New()
+		assert.Nil(t, e.CommandDescriptions())
+	})
+
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
 		e := New()


### PR DESCRIPTION
Closes #167

## Summary
- Add description metadata to engine commands via `commandEntry` struct and extend `RegisterCommand` with optional description parameter (backward compatible)
- Add built-in `/help` command to DAP handler that lists all available slash commands (built-in + custom) with aligned descriptions
- Include `/help` in completions and propagate custom command descriptions to completion items

## Test plan
- [x] `go test ./lisp/x/debugger/...` — all engine + DAP handler tests pass
- [x] `make test` — full test suite passes
- [x] `make static-checks` — no lint issues
- [x] Engine tests: `RegisterCommandWithDescription`, `RegisterCommandWithoutDescription`, `CommandDescriptions`, `WithCommandsEmptyDescriptions`, `CommandDescriptionUnknown`, `CommandDescriptionsEmpty`
- [x] DAP tests: `TestDAPServer_HelpCommand`, `TestDAPServer_HelpCommand_WithDescriptions`, `TestDAPServer_HelpCommand_Completions`
- [x] Existing custom command and completion tests still pass

---
*Local tests passed. Security review completed.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>