### PR TITLE
fix(lsp): resolve null hover/completion for package-qualified symbols

### DIFF
--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -50,6 +50,8 @@ func splitPackageQualified(prefix string) (pkg, partial string, ok bool) {
 
 // packageCompletions returns completion items from a package's exports.
 func (s *Server) packageCompletions(doc *Document, pkgName, partial string) []protocol.CompletionItem {
+	s.ensureWorkspaceIndex()
+
 	s.analysisCfgMu.RLock()
 	cfg := s.analysisCfg
 	s.analysisCfgMu.RUnlock()

--- a/lsp/hover.go
+++ b/lsp/hover.go
@@ -57,6 +57,8 @@ func (s *Server) qualifiedSymbolHover(word string) string {
 		return ""
 	}
 
+	s.ensureWorkspaceIndex()
+
 	s.analysisCfgMu.RLock()
 	cfg := s.analysisCfg
 	s.analysisCfgMu.RUnlock()


### PR DESCRIPTION
## Summary

Fixes five related LSP issues where hover, completion, and formatting returned `null` for package-qualified symbols (e.g., `cc:log`, `statedb:get`, `string:join`):

- **`buildWorkspaceIndex()` early return** (#169, #170, #171): When `rootPath` was empty, the entire function returned early — including the registry extraction step. This meant Go-registered package exports (cc, statedb, crypto, etc.) were never populated in the analysis config.

- **No fallback for failed `initialized` notification** (#173): The glsp library fails to unmarshal `InitializedParams` when clients send null/omitted params. Since `buildWorkspaceIndex()` was only triggered from the `initialized` handler, a parse error there meant the workspace index was never built. Added `ensureWorkspaceIndex()` (sync.Once) that lazily builds the index on first demand from `ensureAnalysis()`, `qualifiedSymbolHover()`, and `packageCompletions()`.

- **Deadlock prevention**: Separated `reanalyzeOpenDocuments()` from `buildWorkspaceIndex()` to prevent a deadlock cycle: `ensureAnalysis` → doc.mu.Lock → `ensureWorkspaceIndex` → `buildWorkspaceIndex` → `reanalyzeOpenDocuments` → doc.mu.Lock. Now `reanalyzeOpenDocuments()` is only called from the `initialized` handler goroutine.

- **Formatting** (#172): Was already working correctly — confirmed with existing and new tests. The root cause was likely the same `initialized` failure blocking downstream features.

## Test plan

- [x] New unit tests reproduce all 5 issues (confirmed failing before fix)
- [x] `TestHoverOnStdlibQualifiedSymbol` — hover on `string:join` returns content
- [x] `TestHoverOnStdlibQualifiedSymbol_NoWorkspaceIndex` — hover works even without prior `initialized`
- [x] `TestCompletionForPackageQualifiedPrefix` — `string:` prefix returns package exports
- [x] `TestCompletionForPackageQualifiedPrefix_NoWorkspaceIndex` — completion works without prior `initialized`
- [x] `TestHoverOnUsePackageImportedSymbol` — hover on use-package imported symbol
- [x] `TestFormattingReturnsEdits` — formatting returns edits for badly-formatted code
- [x] `TestWorkspaceIndexWithEmptyRootPath` — registry extraction works with empty rootPath
- [x] All existing tests pass (`make test`)
- [x] Static checks clean (`make static-checks` — 0 issues)

Closes #169, closes #170, closes #171, closes #172, closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)