### PR TITLE
feat: add release and release-notes Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,71 @@ tree-sitter-test:
 .PHONY: static-checks
 static-checks:
 	golangci-lint run ./...
+
+# --- Release targets ---
+
+LATEST_TAG := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "none")
+
+.PHONY: release-notes
+release-notes:
+	@echo "=== Release Notes Preview ==="
+	@echo ""
+	@echo "Latest tag: $(LATEST_TAG)"
+	@echo ""
+	@branch=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ "$$branch" != "main" ]; then \
+		echo "WARNING: not on main branch (currently on $$branch)"; \
+		echo ""; \
+	fi
+	@echo "--- CI status on main ---"
+	@gh run list --branch main --limit 5 --json status,conclusion,name,headSha --template \
+		'{{range .}}{{.name}}	{{.status}}	{{.conclusion}}	{{.headSha | printf "%.7s"}}{{"\n"}}{{end}}'
+	@echo ""
+	@echo "--- Commits since $(LATEST_TAG) ---"
+	@if [ "$(LATEST_TAG)" = "none" ]; then \
+		git log --oneline; \
+	else \
+		git log --oneline $(LATEST_TAG)..HEAD; \
+	fi
+	@echo ""
+	@echo "--- Merged PRs since $(LATEST_TAG) ---"
+	@if [ "$(LATEST_TAG)" = "none" ]; then \
+		gh pr list --state merged --limit 50 --json number,title,mergedAt --template \
+			'{{range .}}#{{.number}} {{.title}} ({{.mergedAt | timeago}}){{"\n"}}{{end}}'; \
+	else \
+		gh pr list --state merged --search "merged:>=$$(git log -1 --format=%aI $(LATEST_TAG))" --limit 50 --json number,title,mergedAt --template \
+			'{{range .}}#{{.number}} {{.title}} ({{.mergedAt | timeago}}){{"\n"}}{{end}}'; \
+	fi
+
+.PHONY: release
+release:
+ifndef VERSION
+	$(error VERSION is required. Usage: make release VERSION=v1.29.0)
+endif
+	@branch=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ "$$branch" != "main" ]; then \
+		echo "Error: must be on main branch (currently on $$branch)"; \
+		exit 1; \
+	fi
+	@echo "Checking CI status on main..."
+	@if ! gh run list --branch main --limit 1 --json conclusion --jq '.[0].conclusion' | grep -q "success"; then \
+		echo "Error: latest CI run on main did not succeed"; \
+		gh run list --branch main --limit 3; \
+		exit 1; \
+	fi
+	@echo ""
+	@echo "Latest tag: $(LATEST_TAG)"
+	@echo "Creating release $(VERSION)..."
+	@echo ""
+	@if [ "$(LATEST_TAG)" = "none" ]; then \
+		echo "--- Commits included ---"; \
+		git log --oneline; \
+	else \
+		echo "--- Commits since $(LATEST_TAG) ---"; \
+		git log --oneline $(LATEST_TAG)..HEAD; \
+	fi
+	@echo ""
+	gh release create $(VERSION) --target main --generate-notes --title "$(VERSION)"
+	@echo ""
+	@echo "Release $(VERSION) created successfully."
+	@echo "View at: $$(gh release view $(VERSION) --json url --jq '.url')"


### PR DESCRIPTION
## Summary
- Adds `make release-notes` for a dry-run preview of what would go into a release (latest tag, CI status, commits, merged PRs)
- Adds `make release VERSION=vX.Y.Z` to cut a GitHub release with safety guards (main branch, CI green, VERSION required)
- Uses `gh release create --generate-notes` for auto-generated release notes from merged PRs

## Test plan
- [ ] `make release-notes` shows correct latest tag, CI status, and PR list
- [ ] `make release` without VERSION errors with usage message
- [ ] `make release VERSION=v0.0.0-test` on a non-main branch errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)