### PR TITLE
fix: resolve LSP issues #177, #178, #179

### DIFF
--- a/lsp/e2e_test.go
+++ b/lsp/e2e_test.go
@@ -737,6 +737,65 @@ func TestE2E_Formatting(t *testing.T) {
 	send(t, conn, jsonRPCNotification("exit", nil))
 }
 
+// TestE2E_InitializedNotRequired verifies that the server works correctly
+// even when the client never sends the "initialized" notification (#179).
+// The workspace index should be built lazily on first demand.
+func TestE2E_InitializedNotRequired(t *testing.T) {
+	conn, cleanup := e2eServer(t)
+	defer cleanup()
+
+	reader := bufio.NewReader(conn)
+	testURI := "file:///tmp/e2e-noinit/test.lisp"
+
+	// Step 1: Initialize (but deliberately skip "initialized" notification).
+	send(t, conn, jsonRPCRequest(1, "initialize", map[string]any{
+		"capabilities": map[string]any{},
+		"rootUri":      "file:///tmp/e2e-noinit",
+	}))
+	readResponse(t, reader, 1)
+	// NOTE: No "initialized" notification sent here.
+
+	// Step 2: Open a document.
+	send(t, conn, jsonRPCNotification("textDocument/didOpen", map[string]any{
+		"textDocument": map[string]any{
+			"uri":        testURI,
+			"languageId": "elps",
+			"version":    1,
+			"text":       "(defun add (a b)\n  \"Add two numbers.\"\n  (+ a b))\n\n(add 1 2)",
+		},
+	}))
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Step 3: Hover should work without initialized notification.
+	send(t, conn, jsonRPCRequest(2, "textDocument/hover", map[string]any{
+		"textDocument": map[string]any{"uri": testURI},
+		"position":     map[string]any{"line": 0, "character": 7},
+	}))
+
+	hoverResp, _ := readResponse(t, reader, 2)
+	require.NotNil(t, hoverResp["result"], "hover should work without initialized notification (#179)")
+	hoverResult := hoverResp["result"].(map[string]any)
+	hoverContents := hoverResult["contents"].(map[string]any)
+	hoverValue := hoverContents["value"].(string)
+	assert.Contains(t, hoverValue, "add", "hover should mention function name")
+	assert.Contains(t, hoverValue, "function", "hover should show kind")
+
+	// Step 4: Completion should also work.
+	send(t, conn, jsonRPCRequest(3, "textDocument/completion", map[string]any{
+		"textDocument": map[string]any{"uri": testURI},
+		"position":     map[string]any{"line": 4, "character": 2},
+	}))
+
+	compResp, _ := readResponse(t, reader, 3)
+	require.NotNil(t, compResp["result"], "completion should work without initialized notification (#179)")
+
+	// Cleanup.
+	send(t, conn, jsonRPCRequest(99, "shutdown", nil))
+	readResponse(t, reader, 99)
+	send(t, conn, jsonRPCNotification("exit", nil))
+}
+
 func TestE2E_RenameBuiltinRejected(t *testing.T) {
 	conn, cleanup := e2eServer(t)
 	defer cleanup()

--- a/lsp/e2e_test.go
+++ b/lsp/e2e_test.go
@@ -789,6 +789,13 @@ func TestE2E_InitializedNotRequired(t *testing.T) {
 
 	compResp, _ := readResponse(t, reader, 3)
 	require.NotNil(t, compResp["result"], "completion should work without initialized notification (#179)")
+	compItems := compResp["result"].([]any)
+	var compLabels []string
+	for _, item := range compItems {
+		ci := item.(map[string]any)
+		compLabels = append(compLabels, ci["label"].(string))
+	}
+	assert.Contains(t, compLabels, "add", "completion should include user-defined 'add'")
 
 	// Cleanup.
 	send(t, conn, jsonRPCRequest(99, "shutdown", nil))

--- a/lsp/signature.go
+++ b/lsp/signature.go
@@ -13,7 +13,14 @@ import (
 
 // textDocumentSignatureHelp handles textDocument/signatureHelp requests.
 // It finds the enclosing function call at the cursor position, looks up
-// its signature, and returns parameter hints.
+// its signature, and returns parameter hints. Three strategies are tried
+// in order:
+//  1. AST-based: walk the parsed AST for the innermost call containing
+//     the cursor (works for complete, well-formed code).
+//  2. Text-based: scan raw text for parentheses (fallback for incomplete
+//     code where the parser didn't include the unclosed expression).
+//  3. Qualified lookup: if the name contains ":", look up the symbol in
+//     the workspace package exports rather than the analysis scope.
 func (s *Server) textDocumentSignatureHelp(_ *glsp.Context, params *protocol.SignatureHelpParams) (*protocol.SignatureHelp, error) {
 	doc := s.docs.Get(params.TextDocument.URI)
 	if doc == nil {
@@ -24,29 +31,217 @@ func (s *Server) textDocumentSignatureHelp(_ *glsp.Context, params *protocol.Sig
 	doc.mu.Lock()
 	ast := doc.ast
 	docAnalysis := doc.analysis
+	content := doc.Content
 	doc.mu.Unlock()
 
-	if len(ast) == 0 || docAnalysis == nil {
-		return nil, nil
+	line := int(params.Position.Line)
+	col := int(params.Position.Character)
+
+	// Strategy 1: AST-based lookup.
+	var name string
+	var argIdx int
+	if len(ast) > 0 {
+		elpsLine := line + 1
+		elpsCol := col + 1
+		name, argIdx = enclosingCall(ast, elpsLine, elpsCol)
 	}
 
-	// Convert LSP 0-based to ELPS 1-based.
-	elpsLine := int(params.Position.Line) + 1
-	elpsCol := int(params.Position.Character) + 1
+	// Strategy 2: text-based fallback for incomplete code.
+	if name == "" {
+		name, argIdx = enclosingCallText(content, line, col)
+	}
 
-	// Find the enclosing function call.
-	name, argIdx := enclosingCall(ast, elpsLine, elpsCol)
 	if name == "" {
 		return nil, nil
 	}
 
-	// Look up the symbol in the analysis result.
-	sym := lookupCallable(docAnalysis, name)
-	if sym == nil || sym.Signature == nil {
-		return nil, nil
+	// Strategy 3a: scope-based lookup.
+	if docAnalysis != nil {
+		sym := lookupCallable(docAnalysis, name)
+		if sym != nil && sym.Signature != nil {
+			return buildSignatureHelp(sym, argIdx), nil
+		}
 	}
 
-	return buildSignatureHelp(sym, argIdx), nil
+	// Strategy 3b: qualified symbol lookup in package exports.
+	if ext := s.lookupQualifiedCallable(name); ext != nil {
+		sym := &analysis.Symbol{
+			Name:      ext.Name,
+			Kind:      ext.Kind,
+			Source:    ext.Source,
+			Signature: ext.Signature,
+			DocString: ext.DocString,
+			External:  true,
+		}
+		return buildSignatureHelp(sym, argIdx), nil
+	}
+
+	return nil, nil
+}
+
+// lookupQualifiedCallable looks up a qualified symbol (e.g. "string:join")
+// in the workspace package exports and returns it if it has a signature.
+func (s *Server) lookupQualifiedCallable(name string) *analysis.ExternalSymbol {
+	pkgName, symName, ok := splitPackageQualified(name)
+	if !ok || symName == "" {
+		return nil
+	}
+
+	s.ensureWorkspaceIndex()
+
+	s.analysisCfgMu.RLock()
+	cfg := s.analysisCfg
+	s.analysisCfgMu.RUnlock()
+
+	if cfg == nil || cfg.PackageExports == nil {
+		return nil
+	}
+
+	exports, ok := cfg.PackageExports[pkgName]
+	if !ok {
+		return nil
+	}
+
+	for i := range exports {
+		if exports[i].Name == symName && exports[i].Signature != nil {
+			return &exports[i]
+		}
+	}
+	return nil
+}
+
+// enclosingCallText is a text-based fallback for finding the enclosing
+// function call when the AST doesn't contain the cursor position (e.g.,
+// because the user is typing an incomplete expression with an unclosed
+// paren). It scans backwards from the cursor position counting parentheses
+// to find the innermost unclosed '(' and extracts the function name.
+func enclosingCallText(content string, line, col int) (string, int) {
+	lines := strings.Split(content, "\n")
+	if line < 0 || line >= len(lines) {
+		return "", 0
+	}
+
+	// Build the text up to the cursor position.
+	var sb strings.Builder
+	for i := 0; i < line; i++ {
+		sb.WriteString(lines[i])
+		sb.WriteByte('\n')
+	}
+	ln := lines[line]
+	if col > len(ln) {
+		col = len(ln)
+	}
+	sb.WriteString(ln[:col])
+	text := sb.String()
+
+	// Scan backwards to find the innermost unclosed '('.
+	depth := 0
+	inString := false
+	openIdx := -1
+	argCount := 0
+
+	for i := len(text) - 1; i >= 0; i-- {
+		ch := text[i]
+
+		// Handle string literals (simplified: just track unescaped quotes).
+		if ch == '"' && (i == 0 || text[i-1] != '\\') {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+
+		if ch == ')' {
+			depth++
+		} else if ch == '(' {
+			if depth > 0 {
+				depth--
+			} else {
+				// Found the innermost unclosed '('.
+				openIdx = i
+				break
+			}
+		}
+	}
+
+	if openIdx < 0 {
+		return "", 0
+	}
+
+	// Extract the function name after the '('.
+	rest := text[openIdx+1:]
+	name := extractLeadingSymbol(rest)
+	if name == "" {
+		return "", 0
+	}
+
+	// Count arguments: number of top-level whitespace-separated tokens
+	// after the function name in the text between openIdx and cursor.
+	afterName := rest[len(name):]
+	argCount = countTopLevelArgs(afterName)
+
+	return name, argCount
+}
+
+// extractLeadingSymbol extracts the first symbol-like token from text.
+func extractLeadingSymbol(text string) string {
+	// Skip leading whitespace.
+	i := 0
+	for i < len(text) && (text[i] == ' ' || text[i] == '\t' || text[i] == '\n' || text[i] == '\r') {
+		i++
+	}
+	start := i
+	for i < len(text) && isSymbolChar(text[i]) {
+		i++
+	}
+	return text[start:i]
+}
+
+// countTopLevelArgs counts the number of top-level arguments in the text
+// after a function name. It handles strings and nested parens.
+func countTopLevelArgs(text string) int {
+	count := 0
+	depth := 0
+	inString := false
+	inArg := false
+
+	for i := 0; i < len(text); i++ {
+		ch := text[i]
+
+		if ch == '"' && (i == 0 || text[i-1] != '\\') {
+			inString = !inString
+			if !inArg && depth == 0 {
+				inArg = true
+				count++
+			}
+			continue
+		}
+		if inString {
+			continue
+		}
+
+		switch ch {
+		case '(':
+			if !inArg && depth == 0 {
+				inArg = true
+				count++
+			}
+			depth++
+		case ')':
+			depth--
+		case ' ', '\t', '\n', '\r':
+			if depth == 0 {
+				inArg = false
+			}
+		default:
+			if !inArg && depth == 0 {
+				inArg = true
+				count++
+			}
+		}
+	}
+	return count
 }
 
 // enclosingCall walks the AST to find the innermost s-expression


### PR DESCRIPTION
## Summary

- **#179**: Remove `Initialized` handler from the protocol handler. The glsp library crashes when parsing an empty `initialized` notification. The workspace index is now built lazily on first demand via `ensureWorkspaceIndex()`, which also invalidates cached analysis for all open documents so they get re-analyzed with the workspace config.
- **#177**: Add comprehensive hover tests proving qualified symbol hover works at all column positions for stdlib symbols across multiple packages (string, math, regexp, json). The root cause was the #179 initialization error disrupting workspace index timing.
- **#178**: Add text-based fallback (`enclosingCallText`) for signature help on incomplete code where the parser doesn't include unclosed expressions in the AST. Also add qualified symbol lookup via package exports for `string:join` etc. The handler now chains three strategies: AST-based → text-based → qualified lookup.

Closes #177
Closes #178
Closes #179

## Test plan

- [x] `TestE2E_InitializedNotRequired` — server works without initialized notification
- [x] `TestEnsureWorkspaceIndexInvalidatesAnalysis` — workspace build invalidates cached analysis
- [x] `TestHoverOnQualifiedSymbolAllPositions` — hover at every column on qualified symbols
- [x] `TestHoverOnShortQualifiedSymbol` — hover on short names like `math:abs` with boundary tests
- [x] `TestHoverOnMultipleStdlibPackages` — hover across math, regexp, json packages
- [x] `TestSignatureHelpIncompleteCall` — sig help with unclosed paren
- [x] `TestSignatureHelpIncompleteSecondArg` — active param tracking for incomplete calls
- [x] `TestSignatureHelpQualifiedSymbol` — sig help for qualified symbols with parameter assertions
- [x] `TestEnclosingCallText` — unit tests for text-based paren scanning (8 cases)
- [x] `make test` — all Go tests and lisp example files pass
- [x] `make static-checks` — golangci-lint clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)