### PR TITLE
feat: add workspace/symbol support for global search

### DIFF
--- a/lsp/server.go
+++ b/lsp/server.go
@@ -105,6 +105,8 @@ func New(opts ...Option) *Server {
 		TextDocumentPrepareCallHierarchy: s.textDocumentPrepareCallHierarchy,
 		CallHierarchyIncomingCalls:       s.callHierarchyIncomingCalls,
 		CallHierarchyOutgoingCalls:       s.callHierarchyOutgoingCalls,
+
+		WorkspaceSymbol: s.workspaceSymbol,
 	}
 
 	s.glspSrv = glspserver.NewServer(&s.handler, serverName, false)

--- a/lsp/workspace_symbols.go
+++ b/lsp/workspace_symbols.go
@@ -1,0 +1,136 @@
+// Copyright © 2024 The ELPS authors
+
+package lsp
+
+import (
+	"strings"
+
+	"github.com/luthersystems/elps/analysis"
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// workspaceSymbol handles the workspace/symbol request.
+// It returns all top-level definitions across the workspace that match the
+// query string. An empty query returns all symbols.
+func (s *Server) workspaceSymbol(_ *glsp.Context, params *protocol.WorkspaceSymbolParams) ([]protocol.SymbolInformation, error) {
+	s.ensureWorkspaceIndex()
+
+	s.analysisCfgMu.RLock()
+	cfg := s.analysisCfg
+	s.analysisCfgMu.RUnlock()
+
+	if cfg == nil {
+		return nil, nil
+	}
+
+	query := strings.ToLower(params.Query)
+	var results []protocol.SymbolInformation
+
+	// Collect symbols from workspace globals (top-level defs across files).
+	for _, sym := range cfg.ExtraGlobals {
+		if !matchesQuery(sym.Name, query) {
+			continue
+		}
+		si, ok := externalSymbolToInfo(sym, "")
+		if !ok {
+			continue
+		}
+		results = append(results, si)
+	}
+
+	// Collect symbols from package exports.
+	for pkg, syms := range cfg.PackageExports {
+		for _, sym := range syms {
+			if !matchesQuery(sym.Name, query) && !matchesQuery(pkg+":"+sym.Name, query) {
+				continue
+			}
+			si, ok := externalSymbolToInfo(sym, pkg)
+			if !ok {
+				continue
+			}
+			results = append(results, si)
+		}
+	}
+
+	// Also include symbols from open documents (definitions the user is
+	// actively editing that may not yet be in the workspace index).
+	seen := make(map[string]bool)
+	for _, r := range results {
+		seen[r.Name+"|"+r.Location.URI] = true
+	}
+	for _, doc := range s.docs.All() {
+		s.ensureAnalysis(doc)
+		if doc.analysis == nil {
+			continue
+		}
+		docPath := uriToPath(doc.URI)
+		for _, sym := range doc.analysis.Symbols {
+			if sym.External {
+				continue
+			}
+			if sym.Source == nil || sym.Source.Line == 0 {
+				continue
+			}
+			if sym.Source.File != "" && sym.Source.File != docPath {
+				continue
+			}
+			// Only top-level definitions.
+			if sym.Scope != nil && sym.Scope.Kind != analysis.ScopeGlobal {
+				continue
+			}
+			if !matchesQuery(sym.Name, query) {
+				continue
+			}
+			key := sym.Name + "|" + doc.URI
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			r := elpsToLSPRange(sym.Source, len(sym.Name))
+			results = append(results, protocol.SymbolInformation{
+				Name: sym.Name,
+				Kind: mapSymbolKind(sym.Kind),
+				Location: protocol.Location{
+					URI:   doc.URI,
+					Range: r,
+				},
+			})
+		}
+	}
+
+	return results, nil
+}
+
+// externalSymbolToInfo converts an analysis.ExternalSymbol to a
+// protocol.SymbolInformation. Returns false if the symbol has no usable
+// source location.
+func externalSymbolToInfo(sym analysis.ExternalSymbol, pkg string) (protocol.SymbolInformation, bool) {
+	if sym.Source == nil || sym.Source.Line == 0 {
+		return protocol.SymbolInformation{}, false
+	}
+	r := elpsToLSPRange(sym.Source, len(sym.Name))
+	uri := pathToURI(sym.Source.File)
+
+	name := sym.Name
+	var containerName *string
+	if pkg != "" {
+		containerName = &pkg
+	}
+
+	return protocol.SymbolInformation{
+		Name:          name,
+		Kind:          mapSymbolKind(sym.Kind),
+		Location:      protocol.Location{URI: uri, Range: r},
+		ContainerName: containerName,
+	}, true
+}
+
+// matchesQuery performs case-insensitive substring matching. An empty query
+// matches everything (per LSP spec: empty string requests all symbols).
+func matchesQuery(name, lowerQuery string) bool {
+	if lowerQuery == "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(name), lowerQuery)
+}

--- a/lsp/workspace_symbols_test.go
+++ b/lsp/workspace_symbols_test.go
@@ -1,0 +1,174 @@
+// Copyright © 2024 The ELPS authors
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/analysis"
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+func TestWorkspaceSymbol(t *testing.T) {
+	s := testServer()
+
+	// Set up a workspace config with some external symbols.
+	cfg := &analysis.Config{
+		ExtraGlobals: []analysis.ExternalSymbol{
+			{
+				Name:    "my-handler",
+				Kind:    analysis.SymFunction,
+				Package: "user",
+				Source:  &token.Location{File: "/workspace/handlers.lisp", Line: 5, Col: 1},
+			},
+			{
+				Name:    "process-request",
+				Kind:    analysis.SymFunction,
+				Package: "user",
+				Source:  &token.Location{File: "/workspace/handlers.lisp", Line: 15, Col: 1},
+			},
+			{
+				Name:    "max-retries",
+				Kind:    analysis.SymVariable,
+				Package: "user",
+				Source:  &token.Location{File: "/workspace/config.lisp", Line: 3, Col: 1},
+			},
+		},
+		PackageExports: map[string][]analysis.ExternalSymbol{
+			"router": {
+				{
+					Name:    "defendpoint",
+					Kind:    analysis.SymMacro,
+					Package: "router",
+					Source:  &token.Location{File: "/workspace/router.lisp", Line: 10, Col: 1},
+				},
+			},
+		},
+	}
+	setTestAnalysisCfg(s, cfg)
+
+	t.Run("empty query returns all symbols", func(t *testing.T) {
+		result, err := s.workspaceSymbol(mockContext(), &protocol.WorkspaceSymbolParams{
+			Query: "",
+		})
+		require.NoError(t, err)
+		// Should have globals + package exports.
+		assert.GreaterOrEqual(t, len(result), 4)
+		names := symbolNames(result)
+		assert.Contains(t, names, "my-handler")
+		assert.Contains(t, names, "process-request")
+		assert.Contains(t, names, "max-retries")
+		assert.Contains(t, names, "defendpoint")
+	})
+
+	t.Run("query filters by substring", func(t *testing.T) {
+		result, err := s.workspaceSymbol(mockContext(), &protocol.WorkspaceSymbolParams{
+			Query: "handler",
+		})
+		require.NoError(t, err)
+		names := symbolNames(result)
+		assert.Contains(t, names, "my-handler")
+		assert.NotContains(t, names, "max-retries")
+		assert.NotContains(t, names, "defendpoint")
+	})
+
+	t.Run("query is case-insensitive", func(t *testing.T) {
+		result, err := s.workspaceSymbol(mockContext(), &protocol.WorkspaceSymbolParams{
+			Query: "HANDLER",
+		})
+		require.NoError(t, err)
+		names := symbolNames(result)
+		assert.Contains(t, names, "my-handler")
+	})
+
+	t.Run("query matches package-qualified names", func(t *testing.T) {
+		result, err := s.workspaceSymbol(mockContext(), &protocol.WorkspaceSymbolParams{
+			Query: "router:def",
+		})
+		require.NoError(t, err)
+		names := symbolNames(result)
+		assert.Contains(t, names, "defendpoint")
+	})
+
+	t.Run("package exports have container name", func(t *testing.T) {
+		result, err := s.workspaceSymbol(mockContext(), &protocol.WorkspaceSymbolParams{
+			Query: "defendpoint",
+		})
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.NotNil(t, result[0].ContainerName)
+		assert.Equal(t, "router", *result[0].ContainerName)
+	})
+
+	t.Run("symbol kind is mapped correctly", func(t *testing.T) {
+		result, err := s.workspaceSymbol(mockContext(), &protocol.WorkspaceSymbolParams{
+			Query: "max-retries",
+		})
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, protocol.SymbolKindVariable, result[0].Kind)
+	})
+
+	t.Run("no results for non-matching query", func(t *testing.T) {
+		result, err := s.workspaceSymbol(mockContext(), &protocol.WorkspaceSymbolParams{
+			Query: "zzz-nonexistent",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("symbols without source are excluded", func(t *testing.T) {
+		cfg2 := &analysis.Config{
+			ExtraGlobals: []analysis.ExternalSymbol{
+				{Name: "no-source", Kind: analysis.SymFunction},
+				{Name: "has-source", Kind: analysis.SymFunction, Source: &token.Location{File: "/f.lisp", Line: 1, Col: 1}},
+			},
+		}
+		setTestAnalysisCfg(s, cfg2)
+
+		result, err := s.workspaceSymbol(mockContext(), &protocol.WorkspaceSymbolParams{
+			Query: "",
+		})
+		require.NoError(t, err)
+		names := symbolNames(result)
+		assert.Contains(t, names, "has-source")
+		assert.NotContains(t, names, "no-source")
+	})
+
+	t.Run("includes open document symbols", func(t *testing.T) {
+		cfg3 := &analysis.Config{
+			ExtraGlobals: []analysis.ExternalSymbol{},
+		}
+		setTestAnalysisCfg(s, cfg3)
+
+		openDoc(s, "file:///workspace/active.lisp",
+			`(defun active-fn (x) x)`)
+
+		result, err := s.workspaceSymbol(mockContext(), &protocol.WorkspaceSymbolParams{
+			Query: "active-fn",
+		})
+		require.NoError(t, err)
+		names := symbolNames(result)
+		assert.Contains(t, names, "active-fn")
+	})
+}
+
+func TestMatchesQuery(t *testing.T) {
+	assert.True(t, matchesQuery("defun", ""))
+	assert.True(t, matchesQuery("my-handler", "handler"))
+	assert.True(t, matchesQuery("MY-HANDLER", "handler"))
+	// matchesQuery expects lowerQuery to already be lowered (caller does this).
+	assert.False(t, matchesQuery("my-handler", "HANDLER"), "upper query not pre-lowered → no match")
+	assert.False(t, matchesQuery("my-handler", "zzz"))
+}
+
+func symbolNames(syms []protocol.SymbolInformation) []string {
+	names := make([]string, len(syms))
+	for i, s := range syms {
+		names[i] = s.Name
+	}
+	return names
+}


### PR DESCRIPTION
## Summary
- Implement `workspace/symbol` LSP handler for Cmd+T / Ctrl+T global symbol search
- Queries the workspace index (`analysisCfg`) and open documents with case-insensitive substring matching
- Returns `SymbolInformation` with proper symbol kinds and package-qualified container names

Closes #183

## Test plan
- [x] Unit tests: 10 tests covering empty query, matching, package-qualified symbols, open document symbols, no-match
- [x] `go test ./lsp/...` passes
- [x] `make test` passes
- [x] `make static-checks` passes (0 issues)

---
*Local tests passed. Security review completed.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>