### PR TITLE
feat: add folding range support for code folding

### DIFF
--- a/lsp/folding.go
+++ b/lsp/folding.go
@@ -1,0 +1,104 @@
+// Copyright © 2024 The ELPS authors
+
+package lsp
+
+import (
+	"strings"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// textDocumentFoldingRange handles the textDocument/foldingRange request.
+// It returns folding ranges for multi-line s-expressions and consecutive
+// comment blocks.
+func (s *Server) textDocumentFoldingRange(_ *glsp.Context, params *protocol.FoldingRangeParams) ([]protocol.FoldingRange, error) {
+	doc := s.docs.Get(params.TextDocument.URI)
+	if doc == nil {
+		return nil, nil
+	}
+
+	doc.mu.Lock()
+	ast := doc.ast
+	content := doc.Content
+	doc.mu.Unlock()
+
+	var ranges []protocol.FoldingRange
+
+	// Fold multi-line s-expressions from the AST.
+	for _, expr := range ast {
+		collectFoldingRanges(expr, &ranges)
+	}
+
+	// Fold consecutive comment blocks from source text.
+	ranges = append(ranges, commentFoldingRanges(content)...)
+
+	return ranges, nil
+}
+
+// collectFoldingRanges recursively walks the AST and emits a folding range
+// for each s-expression that spans more than one line.
+func collectFoldingRanges(v *lisp.LVal, ranges *[]protocol.FoldingRange) {
+	if v == nil || v.Source == nil {
+		return
+	}
+
+	// Only fold list expressions (s-expressions).
+	if v.Type == lisp.LSExpr && v.Source.Line > 0 && v.Source.EndLine > 0 {
+		startLine := v.Source.Line - 1 // convert to 0-based
+		endLine := v.Source.EndLine - 1
+		if endLine > startLine {
+			kind := string(protocol.FoldingRangeKindRegion)
+			*ranges = append(*ranges, protocol.FoldingRange{
+				StartLine: protocol.UInteger(startLine),
+				EndLine:   protocol.UInteger(endLine),
+				Kind:      &kind,
+			})
+		}
+	}
+
+	// Recurse into children.
+	for _, child := range v.Cells {
+		collectFoldingRanges(child, ranges)
+	}
+}
+
+// commentFoldingRanges detects consecutive lines starting with ";" and
+// produces a folding range for each block of 2+ lines.
+func commentFoldingRanges(content string) []protocol.FoldingRange {
+	lines := strings.Split(content, "\n")
+	var ranges []protocol.FoldingRange
+
+	blockStart := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		isComment := strings.HasPrefix(trimmed, ";")
+		if isComment {
+			if blockStart < 0 {
+				blockStart = i
+			}
+		} else {
+			if blockStart >= 0 && i-1 > blockStart {
+				kind := string(protocol.FoldingRangeKindComment)
+				ranges = append(ranges, protocol.FoldingRange{
+					StartLine: protocol.UInteger(blockStart),
+					EndLine:   protocol.UInteger(i - 1),
+					Kind:      &kind,
+				})
+			}
+			blockStart = -1
+		}
+	}
+	// Handle comment block at end of file.
+	if blockStart >= 0 && len(lines)-1 > blockStart {
+		kind := string(protocol.FoldingRangeKindComment)
+		ranges = append(ranges, protocol.FoldingRange{
+			StartLine: protocol.UInteger(blockStart),
+			EndLine:   protocol.UInteger(len(lines) - 1),
+			Kind:      &kind,
+		})
+	}
+
+	return ranges
+}

--- a/lsp/folding.go
+++ b/lsp/folding.go
@@ -51,8 +51,8 @@ func collectFoldingRanges(v *lisp.LVal, ranges *[]protocol.FoldingRange) {
 		if endLine > startLine {
 			kind := string(protocol.FoldingRangeKindRegion)
 			*ranges = append(*ranges, protocol.FoldingRange{
-				StartLine: protocol.UInteger(startLine),
-				EndLine:   protocol.UInteger(endLine),
+				StartLine: safeUint(startLine),
+				EndLine:   safeUint(endLine),
 				Kind:      &kind,
 			})
 		}
@@ -82,8 +82,8 @@ func commentFoldingRanges(content string) []protocol.FoldingRange {
 			if blockStart >= 0 && i-1 > blockStart {
 				kind := string(protocol.FoldingRangeKindComment)
 				ranges = append(ranges, protocol.FoldingRange{
-					StartLine: protocol.UInteger(blockStart),
-					EndLine:   protocol.UInteger(i - 1),
+					StartLine: safeUint(blockStart),
+					EndLine:   safeUint(i - 1),
 					Kind:      &kind,
 				})
 			}
@@ -94,8 +94,8 @@ func commentFoldingRanges(content string) []protocol.FoldingRange {
 	if blockStart >= 0 && len(lines)-1 > blockStart {
 		kind := string(protocol.FoldingRangeKindComment)
 		ranges = append(ranges, protocol.FoldingRange{
-			StartLine: protocol.UInteger(blockStart),
-			EndLine:   protocol.UInteger(len(lines) - 1),
+			StartLine: safeUint(blockStart),
+			EndLine:   safeUint(len(lines) - 1),
 			Kind:      &kind,
 		})
 	}

--- a/lsp/folding_test.go
+++ b/lsp/folding_test.go
@@ -1,0 +1,120 @@
+// Copyright © 2024 The ELPS authors
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+func TestFoldingRange(t *testing.T) {
+	s := testServer()
+
+	t.Run("single-line form is not folded", func(t *testing.T) {
+		doc := openDoc(s, "file:///test/single.lisp", `(defun foo () 42)`)
+		result, err := s.textDocumentFoldingRange(mockContext(), &protocol.FoldingRangeParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: doc.URI},
+		})
+		require.NoError(t, err)
+		// Filter to region folds only (exclude comment folds).
+		regions := filterFoldKind(result, protocol.FoldingRangeKindRegion)
+		assert.Empty(t, regions)
+	})
+
+	t.Run("multi-line defun is folded", func(t *testing.T) {
+		doc := openDoc(s, "file:///test/multi.lisp", "(defun foo (x)\n  (+ x 1))")
+		result, err := s.textDocumentFoldingRange(mockContext(), &protocol.FoldingRangeParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: doc.URI},
+		})
+		require.NoError(t, err)
+		regions := filterFoldKind(result, protocol.FoldingRangeKindRegion)
+		require.NotEmpty(t, regions)
+		// The outer defun spans lines 0-1 (0-based).
+		assert.Equal(t, protocol.UInteger(0), regions[0].StartLine)
+		assert.Equal(t, protocol.UInteger(1), regions[0].EndLine)
+	})
+
+	t.Run("nested multi-line forms produce separate ranges", func(t *testing.T) {
+		src := "(defun outer ()\n  (let ((x 1))\n    (+ x\n       2)))"
+		doc := openDoc(s, "file:///test/nested.lisp", src)
+		result, err := s.textDocumentFoldingRange(mockContext(), &protocol.FoldingRangeParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: doc.URI},
+		})
+		require.NoError(t, err)
+		regions := filterFoldKind(result, protocol.FoldingRangeKindRegion)
+		// Should have at least 2: outer defun and inner let.
+		assert.GreaterOrEqual(t, len(regions), 2)
+	})
+
+	t.Run("consecutive comments produce a comment fold", func(t *testing.T) {
+		src := "; line 1\n; line 2\n; line 3\n(defun foo () 42)"
+		doc := openDoc(s, "file:///test/comments.lisp", src)
+		result, err := s.textDocumentFoldingRange(mockContext(), &protocol.FoldingRangeParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: doc.URI},
+		})
+		require.NoError(t, err)
+		comments := filterFoldKind(result, protocol.FoldingRangeKindComment)
+		require.Len(t, comments, 1)
+		assert.Equal(t, protocol.UInteger(0), comments[0].StartLine)
+		assert.Equal(t, protocol.UInteger(2), comments[0].EndLine)
+	})
+
+	t.Run("single comment line is not folded", func(t *testing.T) {
+		src := "; just one comment\n(defun foo () 42)"
+		doc := openDoc(s, "file:///test/onecomment.lisp", src)
+		result, err := s.textDocumentFoldingRange(mockContext(), &protocol.FoldingRangeParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: doc.URI},
+		})
+		require.NoError(t, err)
+		comments := filterFoldKind(result, protocol.FoldingRangeKindComment)
+		assert.Empty(t, comments)
+	})
+
+	t.Run("nil doc returns nil", func(t *testing.T) {
+		result, err := s.textDocumentFoldingRange(mockContext(), &protocol.FoldingRangeParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///missing.lisp"},
+		})
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestCommentFoldingRanges(t *testing.T) {
+	t.Run("consecutive block", func(t *testing.T) {
+		ranges := commentFoldingRanges("; a\n; b\n; c\n(code)")
+		require.Len(t, ranges, 1)
+		assert.Equal(t, protocol.UInteger(0), ranges[0].StartLine)
+		assert.Equal(t, protocol.UInteger(2), ranges[0].EndLine)
+	})
+
+	t.Run("two separate blocks", func(t *testing.T) {
+		ranges := commentFoldingRanges("; a\n; b\n\n; c\n; d")
+		require.Len(t, ranges, 2)
+	})
+
+	t.Run("no comments", func(t *testing.T) {
+		ranges := commentFoldingRanges("(defun foo () 42)")
+		assert.Empty(t, ranges)
+	})
+
+	t.Run("comments at end of file", func(t *testing.T) {
+		ranges := commentFoldingRanges("(code)\n; a\n; b")
+		require.Len(t, ranges, 1)
+		assert.Equal(t, protocol.UInteger(1), ranges[0].StartLine)
+		assert.Equal(t, protocol.UInteger(2), ranges[0].EndLine)
+	})
+}
+
+// filterFoldKind returns only folding ranges with the given kind.
+func filterFoldKind(ranges []protocol.FoldingRange, kind protocol.FoldingRangeKind) []protocol.FoldingRange {
+	var result []protocol.FoldingRange
+	for _, r := range ranges {
+		if r.Kind != nil && *r.Kind == string(kind) {
+			result = append(result, r)
+		}
+	}
+	return result
+}

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -100,6 +100,7 @@ func New(opts ...Option) *Server {
 		TextDocumentFormatting:     s.textDocumentFormatting,
 		TextDocumentSignatureHelp:  s.textDocumentSignatureHelp,
 		TextDocumentCodeAction:     s.textDocumentCodeAction,
+		TextDocumentFoldingRange:   s.textDocumentFoldingRange,
 	}
 
 	s.glspSrv = glspserver.NewServer(&s.handler, serverName, false)


### PR DESCRIPTION
## Summary
- Implement `textDocument/foldingRange` LSP handler for code folding in editors
- Walk AST to emit fold ranges for multi-line s-expressions (region kind)
- Scan source text for consecutive comment line blocks (comment kind)

Closes #185

## Test plan
- [x] Unit tests: 10 tests covering nested forms, comment blocks, single-line forms, empty documents
- [x] `go test ./lsp/...` passes
- [x] `make test` passes
- [x] `make static-checks` passes (0 issues)

---
*Local tests passed. Security review completed.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>