### PR TITLE
feat: add code actions for quick fixes

### DIFF
--- a/lsp/code_actions.go
+++ b/lsp/code_actions.go
@@ -1,0 +1,236 @@
+// Copyright © 2024 The ELPS authors
+
+package lsp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/luthersystems/elps/analysis"
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// textDocumentCodeAction handles the textDocument/codeAction request.
+// It returns quick-fix actions for diagnostics in the requested range.
+func (s *Server) textDocumentCodeAction(_ *glsp.Context, params *protocol.CodeActionParams) (any, error) {
+	doc := s.docs.Get(params.TextDocument.URI)
+	if doc == nil {
+		return nil, nil
+	}
+
+	// If the client only wants specific kinds, check we support them.
+	if len(params.Context.Only) > 0 {
+		if !slicesContains(params.Context.Only, protocol.CodeActionKindQuickFix) {
+			return nil, nil
+		}
+	}
+
+	s.ensureAnalysis(doc)
+
+	doc.mu.Lock()
+	content := doc.Content
+	docAnalysis := doc.analysis
+	doc.mu.Unlock()
+
+	s.analysisCfgMu.RLock()
+	cfg := s.analysisCfg
+	s.analysisCfgMu.RUnlock()
+
+	var actions []protocol.CodeAction
+
+	for _, diag := range params.Context.Diagnostics {
+		// Only handle diagnostics from our lint source.
+		if diag.Source == nil {
+			continue
+		}
+
+		switch *diag.Source {
+		case "elps-lint":
+			analyzerName := ""
+			if diag.Code != nil {
+				analyzerName = fmt.Sprintf("%v", diag.Code.Value)
+			}
+
+			switch analyzerName {
+			case "undefined-symbol":
+				actions = append(actions,
+					fixUndefinedSymbol(params.TextDocument.URI, diag, content, cfg)...)
+			case "unused-variable", "unused-function":
+				// Offer nolint suppression for unused warnings.
+				actions = append(actions,
+					suppressLintAction(params.TextDocument.URI, diag, analyzerName, content))
+			default:
+				// All lint diagnostics can be suppressed with nolint.
+				if analyzerName != "" {
+					actions = append(actions,
+						suppressLintAction(params.TextDocument.URI, diag, analyzerName, content))
+				}
+			}
+		case "elps":
+			// Parse errors — no quick fixes available.
+		}
+	}
+
+	// Also offer "add use-package" for unresolved refs from analysis
+	// that overlap with the requested range.
+	actions = append(actions,
+		unresolvedRefActions(params.TextDocument.URI, params.Range, docAnalysis, content, cfg)...)
+
+	if len(actions) == 0 {
+		return nil, nil
+	}
+	return actions, nil
+}
+
+// fixUndefinedSymbol creates code actions to add use-package for an undefined symbol.
+func fixUndefinedSymbol(uri string, diag protocol.Diagnostic, content string, cfg *analysis.Config) []protocol.CodeAction {
+	if cfg == nil {
+		return nil
+	}
+	// Extract the symbol name from the diagnostic message.
+	// Messages look like: "undefined symbol: foo"
+	symName := extractSymbolFromMessage(diag.Message)
+	if symName == "" {
+		return nil
+	}
+
+	return usePackageActions(uri, diag.Range, symName, content, cfg, &diag)
+}
+
+// unresolvedRefActions creates code actions for unresolved references that
+// overlap with the requested range.
+func unresolvedRefActions(uri string, rng protocol.Range, res *analysis.Result, content string, cfg *analysis.Config) []protocol.CodeAction {
+	if res == nil || cfg == nil {
+		return nil
+	}
+	var actions []protocol.CodeAction
+	for _, ref := range res.Unresolved {
+		if ref.Source == nil || ref.Source.Line == 0 {
+			continue
+		}
+		refLine := safeUint(ref.Source.Line - 1)
+		if refLine < rng.Start.Line || refLine > rng.End.Line {
+			continue
+		}
+		actions = append(actions,
+			usePackageActions(uri, elpsToLSPRange(ref.Source, len(ref.Name)), ref.Name, content, cfg, nil)...)
+	}
+	return actions
+}
+
+// usePackageActions searches all package exports for a symbol name and returns
+// code actions that insert (use-package 'pkg) at the top of the file.
+func usePackageActions(uri string, _ protocol.Range, symName, content string, cfg *analysis.Config, diag *protocol.Diagnostic) []protocol.CodeAction {
+	var actions []protocol.CodeAction
+	for pkg, exports := range cfg.PackageExports {
+		for _, sym := range exports {
+			if sym.Name == symName {
+				title := fmt.Sprintf("Add (use-package '%s)", pkg)
+				insertText := fmt.Sprintf("(use-package '%s)\n", pkg)
+				insertPos := usePackageInsertPosition(content)
+				kind := protocol.CodeActionKindQuickFix
+				action := protocol.CodeAction{
+					Title: title,
+					Kind:  &kind,
+					Edit: &protocol.WorkspaceEdit{
+						Changes: map[string][]protocol.TextEdit{
+							uri: {
+								{
+									Range:   protocol.Range{Start: insertPos, End: insertPos},
+									NewText: insertText,
+								},
+							},
+						},
+					},
+				}
+				if diag != nil {
+					action.Diagnostics = []protocol.Diagnostic{*diag}
+				}
+				actions = append(actions, action)
+				break // one action per package
+			}
+		}
+	}
+	return actions
+}
+
+// suppressLintAction creates a code action that adds a ; nolint:analyzer-name
+// comment to the end of the diagnostic line.
+func suppressLintAction(uri string, diag protocol.Diagnostic, analyzer, content string) protocol.CodeAction {
+	line := int(diag.Range.Start.Line)
+	lines := strings.Split(content, "\n")
+	lineEnd := 0
+	if line >= 0 && line < len(lines) {
+		lineEnd = len(lines[line])
+	}
+
+	kind := protocol.CodeActionKindQuickFix
+	insertPos := protocol.Position{Line: diag.Range.Start.Line, Character: safeUint(lineEnd)}
+	return protocol.CodeAction{
+		Title:       fmt.Sprintf("Suppress with ; nolint:%s", analyzer),
+		Kind:        &kind,
+		Diagnostics: []protocol.Diagnostic{diag},
+		Edit: &protocol.WorkspaceEdit{
+			Changes: map[string][]protocol.TextEdit{
+				uri: {
+					{
+						Range:   protocol.Range{Start: insertPos, End: insertPos},
+						NewText: " ; nolint:" + analyzer,
+					},
+				},
+			},
+		},
+	}
+}
+
+// usePackageInsertPosition finds the best position to insert a use-package form.
+// It inserts after the last existing use-package or in-package at the top of
+// the file, or at the very beginning if none exist.
+func usePackageInsertPosition(content string) protocol.Position {
+	lines := strings.Split(content, "\n")
+	lastPkgLine := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "(in-package ") ||
+			strings.HasPrefix(trimmed, "(use-package ") {
+			lastPkgLine = i
+		}
+	}
+	if lastPkgLine >= 0 {
+		// Insert after the last package-related form.
+		return protocol.Position{
+			Line:      safeUint(lastPkgLine + 1),
+			Character: 0,
+		}
+	}
+	// Insert at the very beginning.
+	return protocol.Position{Line: 0, Character: 0}
+}
+
+// extractSymbolFromMessage extracts the symbol name from a lint message.
+// Expected formats: "undefined symbol: foo", "undefined symbol: foo (did you mean ...)"
+// extractSymbolFromMessage extracts the symbol name from a lint message.
+// Expected formats: "undefined symbol: foo", "undefined symbol: foo (did you mean ...)"
+func extractSymbolFromMessage(msg string) string {
+	const prefix = "undefined symbol: "
+	_, after, found := strings.Cut(msg, prefix)
+	if !found {
+		return ""
+	}
+	// Trim any parenthetical suffix.
+	if rest, _, ok := strings.Cut(after, " ("); ok {
+		return strings.TrimSpace(rest)
+	}
+	return strings.TrimSpace(after)
+}
+
+// slicesContains checks if a string slice contains a value.
+func slicesContains(ss []string, v string) bool {
+	for _, s := range ss {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}

--- a/lsp/code_actions_test.go
+++ b/lsp/code_actions_test.go
@@ -1,0 +1,190 @@
+// Copyright © 2024 The ELPS authors
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/analysis"
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+func TestCodeActionSuppressLint(t *testing.T) {
+	s := testServer()
+	setTestAnalysisCfg(s, &analysis.Config{})
+
+	src := "(set x 1)\n(set x 2)"
+	doc := openDoc(s, "file:///test/suppress.lisp", src)
+
+	// Simulate a lint diagnostic on line 1 (0-based) for "set-usage".
+	sev := protocol.DiagnosticSeverityWarning
+	diag := protocol.Diagnostic{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 1, Character: 1},
+			End:   protocol.Position{Line: 1, Character: 4},
+		},
+		Severity: &sev,
+		Source:   strPtr("elps-lint"),
+		Code:     &protocol.IntegerOrString{Value: "set-usage"},
+		Message:  "set reassigns symbol x; use set! to mutate",
+	}
+
+	result, err := s.textDocumentCodeAction(mockContext(), &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: doc.URI},
+		Range:        diag.Range,
+		Context: protocol.CodeActionContext{
+			Diagnostics: []protocol.Diagnostic{diag},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	actions, ok := result.([]protocol.CodeAction)
+	require.True(t, ok)
+	require.NotEmpty(t, actions)
+
+	// Should have a suppress action.
+	var found bool
+	for _, a := range actions {
+		if a.Title == "Suppress with ; nolint:set-usage" {
+			found = true
+			require.NotNil(t, a.Edit)
+			edits := a.Edit.Changes[doc.URI]
+			require.Len(t, edits, 1)
+			assert.Contains(t, edits[0].NewText, "; nolint:set-usage")
+			break
+		}
+	}
+	assert.True(t, found, "expected a suppress action for set-usage")
+}
+
+func TestCodeActionFixUndefinedSymbol(t *testing.T) {
+	s := testServer()
+
+	// Configure workspace with a package that exports "join".
+	cfg := &analysis.Config{
+		PackageExports: map[string][]analysis.ExternalSymbol{
+			"string": {
+				{
+					Name:    "join",
+					Kind:    analysis.SymFunction,
+					Package: "string",
+					Source:  &token.Location{File: "/lib/string.lisp", Line: 1, Col: 1},
+				},
+			},
+		},
+	}
+	setTestAnalysisCfg(s, cfg)
+
+	src := "(join items \",\")"
+	doc := openDoc(s, "file:///test/undef.lisp", src)
+
+	sev := protocol.DiagnosticSeverityError
+	diag := protocol.Diagnostic{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 1},
+			End:   protocol.Position{Line: 0, Character: 5},
+		},
+		Severity: &sev,
+		Source:   strPtr("elps-lint"),
+		Code:     &protocol.IntegerOrString{Value: "undefined-symbol"},
+		Message:  "undefined symbol: join",
+	}
+
+	result, err := s.textDocumentCodeAction(mockContext(), &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: doc.URI},
+		Range:        diag.Range,
+		Context: protocol.CodeActionContext{
+			Diagnostics: []protocol.Diagnostic{diag},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	actions, ok := result.([]protocol.CodeAction)
+	require.True(t, ok)
+
+	// Should have an "add use-package" action.
+	var found bool
+	for _, a := range actions {
+		if a.Title == "Add (use-package 'string)" {
+			found = true
+			require.NotNil(t, a.Edit)
+			edits := a.Edit.Changes[doc.URI]
+			require.NotEmpty(t, edits)
+			assert.Contains(t, edits[0].NewText, "(use-package 'string)")
+			break
+		}
+	}
+	assert.True(t, found, "expected an add use-package action for string")
+}
+
+func TestCodeActionNoDiagnostics(t *testing.T) {
+	s := testServer()
+	setTestAnalysisCfg(s, &analysis.Config{})
+
+	doc := openDoc(s, "file:///test/clean.lisp", "(defun foo () 42)")
+	result, err := s.textDocumentCodeAction(mockContext(), &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: doc.URI},
+		Range:        protocol.Range{},
+		Context:      protocol.CodeActionContext{Diagnostics: []protocol.Diagnostic{}},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestCodeActionOnlyFilter(t *testing.T) {
+	s := testServer()
+	setTestAnalysisCfg(s, &analysis.Config{})
+
+	doc := openDoc(s, "file:///test/filter.lisp", "(set x 1)")
+
+	// Request only refactor actions — quickfix should be excluded.
+	result, err := s.textDocumentCodeAction(mockContext(), &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: doc.URI},
+		Range:        protocol.Range{},
+		Context: protocol.CodeActionContext{
+			Diagnostics: []protocol.Diagnostic{},
+			Only:        []protocol.CodeActionKind{protocol.CodeActionKindRefactor},
+		},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestExtractSymbolFromMessage(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want string
+	}{
+		{"undefined symbol: foo", "foo"},
+		{"undefined symbol: bar (did you mean baz?)", "bar"},
+		{"some other error", ""},
+		{"undefined symbol: my-func", "my-func"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractSymbolFromMessage(tt.msg))
+		})
+	}
+}
+
+func TestUsePackageInsertPosition(t *testing.T) {
+	t.Run("after in-package", func(t *testing.T) {
+		pos := usePackageInsertPosition("(in-package 'myapp)\n\n(defun foo () 42)")
+		assert.Equal(t, protocol.UInteger(1), pos.Line)
+	})
+
+	t.Run("after last use-package", func(t *testing.T) {
+		pos := usePackageInsertPosition("(in-package 'myapp)\n(use-package 'string)\n\n(defun foo () 42)")
+		assert.Equal(t, protocol.UInteger(2), pos.Line)
+	})
+
+	t.Run("at beginning when no package forms", func(t *testing.T) {
+		pos := usePackageInsertPosition("(defun foo () 42)")
+		assert.Equal(t, protocol.UInteger(0), pos.Line)
+	})
+}

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -99,6 +99,7 @@ func New(opts ...Option) *Server {
 		TextDocumentPrepareRename:  s.textDocumentPrepareRename,
 		TextDocumentFormatting:     s.textDocumentFormatting,
 		TextDocumentSignatureHelp:  s.textDocumentSignatureHelp,
+		TextDocumentCodeAction:     s.textDocumentCodeAction,
 	}
 
 	s.glspSrv = glspserver.NewServer(&s.handler, serverName, false)


### PR DESCRIPTION
## Summary
- Implement `textDocument/codeAction` LSP handler for quick-fix code actions
- Three action types: add `use-package` for undefined symbols, suppress lint with `; nolint:` comment, general lint suppression
- Smart insertion positions use-package forms after existing in-package/use-package declarations

Closes #181

## Test plan
- [x] Unit tests: 6 tests covering fix-undefined-symbol, suppress-lint, insert-position logic, symbol extraction from diagnostics
- [x] `go test ./lsp/...` passes
- [x] `make test` passes
- [x] `make static-checks` passes (0 issues)

---
*Local tests passed. Security review completed.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>