### PR TITLE
feat: cross-file references, call hierarchy, and rename

### DIFF
--- a/lsp/call_hierarchy.go
+++ b/lsp/call_hierarchy.go
@@ -213,7 +213,13 @@ func (s *Server) callHierarchyOutgoingCalls(_ *glsp.Context, params *protocol.Ca
 
 	var result []protocol.CallHierarchyOutgoingCall
 	for _, c := range callees {
-		item := symbolToCallHierarchyItem(c.sym, data.URI)
+		// Determine the URI for the callee. If the symbol is defined in
+		// another file (External with a Source.File), resolve its URI.
+		calleeURI := data.URI
+		if c.sym.External && c.sym.Source != nil && c.sym.Source.File != "" {
+			calleeURI = s.resolveURI(data.URI, c.sym.Source.File)
+		}
+		item := symbolToCallHierarchyItem(c.sym, calleeURI)
 		result = append(result, protocol.CallHierarchyOutgoingCall{
 			To:         item,
 			FromRanges: c.ranges,

--- a/lsp/call_hierarchy_test.go
+++ b/lsp/call_hierarchy_test.go
@@ -346,6 +346,8 @@ func TestCrossFileOutgoingCalls_MultipleCalls(t *testing.T) {
 	calleeNames := make(map[string]string) // name -> URI
 	for _, call := range result {
 		calleeNames[call.To.Name] = call.To.URI
+		// Each outgoing call should have at least one call site range.
+		require.NotEmpty(t, call.FromRanges, "callee %s should have at least one call site range", call.To.Name)
 	}
 	assert.Contains(t, calleeNames, "ext-fn-1", "should have outgoing call to ext-fn-1")
 	assert.Contains(t, calleeNames, "ext-fn-2", "should have outgoing call to ext-fn-2")

--- a/lsp/call_hierarchy_test.go
+++ b/lsp/call_hierarchy_test.go
@@ -160,19 +160,15 @@ func TestCrossFileIncomingCalls(t *testing.T) {
 		Item: items[0],
 	})
 	require.NoError(t, err)
-	require.NotEmpty(t, result, "should have incoming calls from cross-file")
+	require.Len(t, result, 1, "should have exactly 1 incoming call from cross-file")
 
-	// Find the cross-file caller.
-	var found bool
-	for _, call := range result {
-		if call.From.Name == "remote-caller" {
-			found = true
-			assert.Contains(t, call.From.URI, "b.lisp", "caller should be from b.lisp")
-			assert.NotEmpty(t, call.FromRanges)
-			break
-		}
-	}
-	assert.True(t, found, "should find remote-caller from b.lisp in incoming calls")
+	call := result[0]
+	assert.Equal(t, "remote-caller", call.From.Name, "caller should be remote-caller")
+	assert.Equal(t, "file:///workspace/b.lisp", call.From.URI, "caller should be from b.lisp")
+	require.Len(t, call.FromRanges, 1, "should have exactly 1 call site range")
+	// Injected at Line:1, Col:25 → LSP 0-based: line 0, char 24.
+	assert.Equal(t, protocol.UInteger(0), call.FromRanges[0].Start.Line, "call site should be on line 0")
+	assert.Equal(t, protocol.UInteger(24), call.FromRanges[0].Start.Character, "call site should start at char 24")
 }
 
 func TestDecodeCallHierarchyData(t *testing.T) {

--- a/lsp/call_hierarchy_test.go
+++ b/lsp/call_hierarchy_test.go
@@ -295,6 +295,8 @@ func TestCrossFileIncomingCalls_MultipleCallers(t *testing.T) {
 	callerNames := make(map[string]string) // name -> URI
 	for _, call := range result {
 		callerNames[call.From.Name] = call.From.URI
+		// Each caller should have at least one call site range.
+		require.NotEmpty(t, call.FromRanges, "caller %s should have at least one call site range", call.From.Name)
 	}
 	assert.Contains(t, callerNames, "caller-b", "should have incoming call from caller-b")
 	assert.Contains(t, callerNames, "caller-c", "should have incoming call from caller-c")

--- a/lsp/diagnostics.go
+++ b/lsp/diagnostics.go
@@ -78,6 +78,13 @@ func (s *Server) textDocumentDidSave(ctx *glsp.Context, params *protocol.DidSave
 	if doc != nil {
 		s.analyzeAndPublish(doc)
 	}
+
+	// Incrementally update the workspace reference index for the saved file.
+	go func() {
+		defer func() { _ = recover() }() // don't crash on update panic
+		s.updateFileRefs(params.TextDocument.URI)
+	}()
+
 	return nil
 }
 

--- a/lsp/position.go
+++ b/lsp/position.go
@@ -152,54 +152,9 @@ func isSymbolChar(c byte) bool {
 }
 
 // scopeAtPosition returns the innermost scope that contains the given
-// 1-based ELPS line and column. It walks the scope tree depth-first.
+// 1-based ELPS line and column. Delegates to analysis.ScopeAtPosition.
 func scopeAtPosition(root *analysis.Scope, line, col int) *analysis.Scope {
-	if root == nil {
-		return nil
-	}
-	best := root
-	for _, child := range root.Children {
-		if s := scopeContaining(child, line, col); s != nil {
-			best = s
-		}
-	}
-	return best
-}
-
-// scopeContaining checks if a scope's node contains the position and
-// recursively checks children for the most specific match.
-func scopeContaining(scope *analysis.Scope, line, col int) *analysis.Scope {
-	if scope.Node == nil || scope.Node.Source == nil {
-		return nil
-	}
-	loc := scope.Node.Source
-	if loc.Line == 0 {
-		return nil
-	}
-	// A scope contains the position if its source range spans the line.
-	// For scopes without EndLine, we accept any position after the start.
-	startLine := loc.Line
-	endLine := loc.EndLine
-	if endLine == 0 {
-		endLine = startLine + 1000 // heuristic: scope extends far
-	}
-	if line < startLine || line > endLine {
-		return nil
-	}
-	if line == startLine && col < loc.Col {
-		return nil
-	}
-	if line == endLine && loc.EndCol > 0 && col >= loc.EndCol {
-		return nil
-	}
-	// This scope contains the position; check children for a tighter match.
-	best := scope
-	for _, child := range scope.Children {
-		if s := scopeContaining(child, line, col); s != nil {
-			best = s
-		}
-	}
-	return best
+	return analysis.ScopeAtPosition(root, line, col)
 }
 
 // collectVisibleSymbols walks the scope chain outward from scope, collecting


### PR DESCRIPTION
## Summary

- Build a workspace reference index (`SymbolKey` → `FileReference[]`) that maps symbol identity keys to reference locations across all workspace `.lisp` files
- Update `textDocument/references`, `callHierarchy/incomingCalls`, and `textDocument/rename` to span the entire workspace (not just the current document)
- Add incremental index updates on `textDocument/didSave` and relax `prepareRename` to allow workspace-defined external symbols
- Comprehensive cross-file test suite covering hover, completion, signature help, definition, references, rename, and call hierarchy

## Implementation

### Analysis package (`analysis/workspace.go`)
- `SymbolKey` and `FileReference` types for cross-file symbol tracking
- `AnalyzeFile()` — parse + full `Analyze()` on a single file
- `ExtractFileRefs()` — extract global-scope references (skips builtins/params/locals)
- `ScanWorkspaceRefs()` — walk workspace, analyze each file, collect `FileReference`s
- `FindEnclosingFunction()` and `ScopeAtPosition()` — moved from LSP to analysis for reuse

### LSP server (`lsp/server.go`)
- `workspaceRefs` / `workspaceRefsMu` on `Server` for the shared index
- `buildWorkspaceIndex()` now calls `ScanWorkspaceRefs()` after existing definition scan
- `getWorkspaceRefs()` filters out current-file refs to avoid double-counting
- `updateFileRefs()` incrementally updates index on save

### LSP handlers
- `references.go` — appends cross-file locations after single-file loop
- `call_hierarchy.go` — adds `uri` field to `callerInfo`, constructs synthetic `Symbol` for cross-file callers
- `rename.go` — appends cross-file edits; relaxes `External` check for workspace-defined symbols
- `diagnostics.go` — triggers `updateFileRefs` goroutine on `didSave`
- `position.go` — delegates `scopeAtPosition` to `analysis.ScopeAtPosition`

## Test plan

### Core cross-file features
- [x] `TestScanWorkspaceRefs_CrossFile` — two files, A defines/exports `helper`, B calls it; verifies index contains cross-file reference with correct enclosing function
- [x] `TestExtractFileRefs_SkipsBuiltinsAndLocals` — verifies builtins (`+`), parameters (`x`), and locals (`local-var`) are excluded
- [x] `TestFindEnclosingFunction` — verifies enclosing function detection at various positions
- [x] `TestSymbolKey_String` — verifies key format
- [x] `TestCrossFileReferences` — injected workspace refs appear in `textDocument/references` results from both files
- [x] `TestCrossFileReferences_NoDuplicates` — current-file refs not double-counted
- [x] `TestCrossFileRename` — `WorkspaceEdit` contains edits in both files
- [x] `TestCrossFileIncomingCalls` — incoming calls include cross-file caller with correct URI
- [x] `TestCrossFileOutgoingCalls` — outgoing calls resolve to external file URI

### Cross-file hover (3 tests)
- [x] `TestCrossFileHover` — hover on unqualified external symbol shows kind, docstring, signature
- [x] `TestCrossFileHover_Definition` — hover on local definition still works when externals exist
- [x] `TestCrossFileHover_NoExtraGlobals` — hover on unresolved symbol gracefully returns nil

### Cross-file completion (3 tests)
- [x] `TestCrossFileCompletion` — external symbols appear filtered by prefix
- [x] `TestCrossFileCompletion_NoPrefix` — all externals appear with empty prefix
- [x] `TestCrossFileCompletion_LocalShadowsExternal` — local definition coexists with external

### Cross-file signature help (3 tests)
- [x] `TestCrossFileSignatureHelp` — signature with required + optional params from external
- [x] `TestCrossFileSignatureHelp_Incomplete` — text-based fallback finds external function in incomplete call
- [x] `TestCrossFileSignatureHelp_NoSignature` — non-callable external returns nil

### Cross-file definition & edge cases (4 tests)
- [x] `TestCrossFileDefinition` — go-to-definition jumps to external file with correct 0-based position
- [x] `TestCrossFileReferences_ExternalCursor` — find-references from a call site (not definition) spans 3 files
- [x] `TestCrossFileRename_ExternalCursor` — rename from a call site produces edits across 3 files
- [x] `TestCrossFileIncomingCalls_MultipleCallers` — 2 callers from different files
- [x] `TestCrossFileOutgoingCalls_MultipleCalls` — 2 external callees in different files
- [x] `TestCrossFileOutgoingCalls_MixedLocalAndExternal` — mixed local + external outgoing calls

### CI
- [x] `make test` — all existing tests pass (no regressions)
- [x] `make static-checks` — golangci-lint clean, 0 issues

---
*Local tests passed. Security review completed. QA professor review completed.*

Closes #193

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>