### PR TITLE
feat: add --json flag to elps doc for machine-readable output

### DIFF
--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -33,6 +34,7 @@ func DocCommand(opts ...Option) *cobra.Command {
 		guide        bool
 		debugGuide   bool
 		lspGuide     bool
+		jsonOutput   bool
 	)
 
 	// makeEnv returns an LEnv suitable for documentation queries. When
@@ -95,6 +97,11 @@ Use --debug-guide to print the debugging guide:
 Use --lsp-guide to print the Language Server Protocol guide:
   elps doc --lsp-guide
 
+Use --json for machine-readable output (for LSP, MCP, editor extensions):
+  elps doc --json -l                   All packages with symbols as JSON
+  elps doc --json -p math              Single package as JSON
+  elps doc --json map                  Single symbol as JSON
+
 Common packages to explore:
   lisp      Core language (140+ builtins: map, filter, reduce, car, cdr, ...)
   math      Trigonometry, logarithms, constants (pi, inf)
@@ -115,6 +122,13 @@ Common packages to explore:
 			}
 			if missing {
 				if err := docCheckMissing(makeEnv); err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+				return
+			}
+			if jsonOutput {
+				if err := docJSON(makeEnv, sourceFile, pkgFlag, listPackages, args); err != nil {
 					fmt.Fprintln(os.Stderr, err)
 					os.Exit(1)
 				}
@@ -157,8 +171,52 @@ Common packages to explore:
 		"Print the debugging guide.")
 	cmd.Flags().BoolVar(&lspGuide, "lsp-guide", false,
 		"Print the Language Server Protocol guide.")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false,
+		"Output as JSON.")
 
 	return cmd
+}
+
+func docJSON(makeEnv func() (*lisp.LEnv, error), sourceFile string, pkgFlag, listPackages bool, args []string) error {
+	env, err := makeEnv()
+	if err != nil {
+		return err
+	}
+	if sourceFile != "" {
+		res := env.LoadFile(sourceFile)
+		if res.Type == lisp.LError {
+			_, _ = (*lisp.ErrorVal)(res).WriteTrace(os.Stderr)
+			os.Exit(1)
+		}
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+
+	// --json -l or --json with no args: all packages
+	if listPackages || (len(args) == 0 && !pkgFlag) {
+		return enc.Encode(libhelp.QueryPackages(env))
+	}
+
+	if len(args) != 1 {
+		return fmt.Errorf("--json requires exactly one argument (or use -l for all packages)")
+	}
+	query := args[0]
+
+	// --json -p <pkg>: single package
+	if pkgFlag {
+		pd, err := libhelp.QueryPackage(env, query)
+		if err != nil {
+			return err
+		}
+		return enc.Encode(pd)
+	}
+
+	// --json <symbol>: single symbol
+	sd, err := libhelp.QuerySymbol(env, query)
+	if err != nil {
+		return err
+	}
+	return enc.Encode(sd)
 }
 
 func docListPkgs(makeEnv func() (*lisp.LEnv, error), sourceFile string) error {

--- a/lisp/lisplib/libhelp/libhelp.go
+++ b/lisp/lisplib/libhelp/libhelp.go
@@ -199,7 +199,7 @@ func symbolDocFromLVal(name string, v *lisp.LVal, symbolDoc string) *SymbolDoc {
 // key argument lists based on the &optional, &rest, and &key sentinels.
 func parseFormals(formals *lisp.LVal) *FormalsDoc {
 	if formals == nil || formals.Len() == 0 {
-		return &FormalsDoc{}
+		return &FormalsDoc{Required: []string{}}
 	}
 
 	fd := &FormalsDoc{}

--- a/lisp/lisplib/libhelp/libhelp.go
+++ b/lisp/lisplib/libhelp/libhelp.go
@@ -17,6 +17,252 @@ import (
 // DefaultPackageName is the package name used by LoadPackage.
 const DefaultPackageName = "help"
 
+// SymbolDoc describes a documented symbol for JSON output.
+type SymbolDoc struct {
+	Name    string      `json:"name"`
+	Kind    string      `json:"kind"`             // "function", "macro", "operator", "variable"
+	Doc     string      `json:"doc,omitempty"`
+	Formals *FormalsDoc `json:"formals,omitempty"` // nil for non-functions
+}
+
+// FormalsDoc describes a function's parameter list.
+type FormalsDoc struct {
+	Required []string `json:"required"`
+	Optional []string `json:"optional,omitempty"`
+	Rest     string   `json:"rest,omitempty"`
+	Keys     []string `json:"keys,omitempty"`
+}
+
+// PackageDoc describes a package for JSON output.
+type PackageDoc struct {
+	Name    string      `json:"name"`
+	Doc     string      `json:"doc,omitempty"`
+	Symbols []SymbolDoc `json:"symbols"`
+}
+
+// QueryPackages returns structured documentation for all packages in
+// the environment, suitable for JSON serialization.
+func QueryPackages(env *lisp.LEnv) []PackageDoc {
+	// Collect core builtins into the "lisp" package.
+	lispSyms := queryCoreSymbols()
+
+	names := make([]string, 0, len(env.Runtime.Registry.Packages))
+	for name := range env.Runtime.Registry.Packages {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var pkgs []PackageDoc
+	for _, name := range names {
+		pkg := env.Runtime.Registry.Packages[name]
+		pd := PackageDoc{
+			Name: pkg.Name,
+			Doc:  cleanDocRaw(pkg.Doc),
+		}
+		if name == "lisp" {
+			pd.Symbols = lispSyms
+		} else {
+			pd.Symbols = queryPackageSymbols(pkg)
+		}
+		pkgs = append(pkgs, pd)
+	}
+	return pkgs
+}
+
+// QueryPackage returns structured documentation for a single package.
+func QueryPackage(env *lisp.LEnv, name string) (*PackageDoc, error) {
+	pkg := env.Runtime.Registry.Packages[name]
+	if pkg == nil {
+		return nil, fmt.Errorf("no package: %q", name)
+	}
+	pd := &PackageDoc{
+		Name: pkg.Name,
+		Doc:  cleanDocRaw(pkg.Doc),
+	}
+	if name == "lisp" {
+		pd.Symbols = queryCoreSymbols()
+	} else {
+		pd.Symbols = queryPackageSymbols(pkg)
+	}
+	return pd, nil
+}
+
+// QuerySymbol returns structured documentation for a single symbol,
+// resolved in the context of env. Supports qualified names (pkg:sym).
+func QuerySymbol(env *lisp.LEnv, sym string) (*SymbolDoc, error) {
+	// Check if it's a qualified name.
+	if i := strings.Index(sym, ":"); i >= 0 {
+		pkgName := sym[:i]
+		symName := sym[i+1:]
+		pkg := env.Runtime.Registry.Packages[pkgName]
+		if pkg == nil {
+			return nil, fmt.Errorf("no package: %q", pkgName)
+		}
+		if pkgName == "lisp" {
+			// Core builtins — search DefaultBuiltins/Ops/Macros first.
+			if sd := queryCoreSymbol(symName); sd != nil {
+				return sd, nil
+			}
+		}
+		v := pkg.Get(lisp.Symbol(symName))
+		if v.Type == lisp.LError {
+			return nil, fmt.Errorf("symbol not found: %s", sym)
+		}
+		return symbolDocFromLVal(symName, v, pkg.SymbolDocs[symName]), nil
+	}
+
+	// Unqualified: check core builtins first, then env.Get.
+	if sd := queryCoreSymbol(sym); sd != nil {
+		return sd, nil
+	}
+
+	v := env.Get(lisp.Symbol(sym))
+	if err := lisp.GoError(v); err != nil {
+		return nil, err
+	}
+	return symbolDocFromLVal(sym, v, LookupSymbolDoc(env, sym)), nil
+}
+
+// queryCoreSymbols builds SymbolDoc entries for DefaultBuiltins,
+// DefaultSpecialOps, and DefaultMacros.
+func queryCoreSymbols() []SymbolDoc {
+	var syms []SymbolDoc
+	for _, b := range lisp.DefaultBuiltins() {
+		syms = append(syms, symbolDocFromDef(b, "function"))
+	}
+	for _, op := range lisp.DefaultSpecialOps() {
+		syms = append(syms, symbolDocFromDef(op, "operator"))
+	}
+	for _, m := range lisp.DefaultMacros() {
+		syms = append(syms, symbolDocFromDef(m, "macro"))
+	}
+	sort.Slice(syms, func(i, j int) bool { return syms[i].Name < syms[j].Name })
+	return syms
+}
+
+// queryCoreSymbol looks up a single symbol among the core builtins/ops/macros.
+func queryCoreSymbol(name string) *SymbolDoc {
+	for _, b := range lisp.DefaultBuiltins() {
+		if b.Name() == name {
+			sd := symbolDocFromDef(b, "function")
+			return &sd
+		}
+	}
+	for _, op := range lisp.DefaultSpecialOps() {
+		if op.Name() == name {
+			sd := symbolDocFromDef(op, "operator")
+			return &sd
+		}
+	}
+	for _, m := range lisp.DefaultMacros() {
+		if m.Name() == name {
+			sd := symbolDocFromDef(m, "macro")
+			return &sd
+		}
+	}
+	return nil
+}
+
+// symbolDocFromDef creates a SymbolDoc from an LBuiltinDef.
+func symbolDocFromDef(defn lisp.LBuiltinDef, kind string) SymbolDoc {
+	sd := SymbolDoc{
+		Name:    defn.Name(),
+		Kind:    kind,
+		Doc:     cleanDocRaw(docstring(defn)),
+		Formals: parseFormals(defn.Formals()),
+	}
+	return sd
+}
+
+// symbolDocFromLVal creates a SymbolDoc from a resolved LVal.
+func symbolDocFromLVal(name string, v *lisp.LVal, symbolDoc string) *SymbolDoc {
+	if v.Type == lisp.LFun {
+		doc := cleanDocRaw(v.Docstring())
+		if doc == "" {
+			doc = cleanDocRaw(symbolDoc)
+		}
+		return &SymbolDoc{
+			Name:    name,
+			Kind:    v.FunType.String(),
+			Doc:     doc,
+			Formals: parseFormals(v.Cells[0]),
+		}
+	}
+	return &SymbolDoc{
+		Name: name,
+		Kind: "variable",
+		Doc:  cleanDocRaw(symbolDoc),
+	}
+}
+
+// parseFormals splits a formals LVal into required, optional, rest, and
+// key argument lists based on the &optional, &rest, and &key sentinels.
+func parseFormals(formals *lisp.LVal) *FormalsDoc {
+	if formals == nil || formals.Len() == 0 {
+		return &FormalsDoc{}
+	}
+
+	fd := &FormalsDoc{}
+	mode := "required"
+	for _, cell := range formals.Cells {
+		sym := cell.Str
+		switch sym {
+		case lisp.OptArgSymbol:
+			mode = "optional"
+			continue
+		case lisp.VarArgSymbol:
+			mode = "rest"
+			continue
+		case lisp.KeyArgSymbol:
+			mode = "key"
+			continue
+		}
+		switch mode {
+		case "required":
+			fd.Required = append(fd.Required, sym)
+		case "optional":
+			fd.Optional = append(fd.Optional, sym)
+		case "rest":
+			fd.Rest = sym
+			mode = "done" // only one rest arg
+		case "key":
+			fd.Keys = append(fd.Keys, sym)
+		}
+	}
+	if fd.Required == nil {
+		fd.Required = []string{}
+	}
+	return fd
+}
+
+// queryPackageSymbols builds SymbolDoc entries for a non-lisp package's
+// exported symbols.
+func queryPackageSymbols(pkg *lisp.Package) []SymbolDoc {
+	var syms []SymbolDoc
+	for _, exsym := range pkg.Externals {
+		v := pkg.Get(lisp.Symbol(exsym))
+		if v.Type == lisp.LError {
+			continue
+		}
+		syms = append(syms, *symbolDocFromLVal(exsym, v, pkg.SymbolDocs[exsym]))
+	}
+	return syms
+}
+
+// cleanDocRaw dedents a docstring without word-wrapping.
+// JSON consumers get clean text they can format themselves.
+func cleanDocRaw(doc string) string {
+	if doc == "" {
+		return ""
+	}
+	if doc[0] == '\n' {
+		doc = doc[1:]
+	}
+	doc = dedentDoc(doc)
+	doc = strings.TrimSpace(doc)
+	return doc
+}
+
 // MissingDoc describes a symbol with no documentation.
 type MissingDoc struct {
 	// Kind is the type of the symbol: "builtin", "special-op", "macro",

--- a/lisp/lisplib/libhelp/libhelp_test.go
+++ b/lisp/lisplib/libhelp/libhelp_test.go
@@ -505,22 +505,18 @@ func TestQueryPackages(t *testing.T) {
 
 	require.NotEmpty(t, pkgs, "QueryPackages should return at least one package")
 
-	// Every package should have a name.
+	// Verify expected core packages are all present.
+	names := make(map[string]bool, len(pkgs))
 	for _, pkg := range pkgs {
 		assert.NotEmpty(t, pkg.Name, "package name should not be empty")
+		names[pkg.Name] = true
+	}
+	for _, expected := range []string{"lisp", "math", "string", "json", "help", "user"} {
+		assert.True(t, names[expected], "expected package %q not found", expected)
 	}
 
-	// Check a known package exists.
-	var foundMath bool
-	for _, pkg := range pkgs {
-		if pkg.Name == "math" {
-			foundMath = true
-			assert.NotEmpty(t, pkg.Symbols, "math package should have symbols")
-			assert.NotEmpty(t, pkg.Doc, "math package should have a doc string")
-			break
-		}
-	}
-	assert.True(t, foundMath, "should find math package")
+	// Verify no duplicates.
+	assert.Equal(t, len(names), len(pkgs), "QueryPackages should not return duplicate packages")
 }
 
 func TestQueryPackage(t *testing.T) {
@@ -581,7 +577,7 @@ func TestQuerySymbol(t *testing.T) {
 	assert.Equal(t, "function", sd.Kind)
 	assert.NotEmpty(t, sd.Doc)
 	require.NotNil(t, sd.Formals)
-	assert.NotEmpty(t, sd.Formals.Required)
+	assert.Equal(t, []string{"type-specifier", "fn", "seq"}, sd.Formals.Required)
 }
 
 func TestQuerySymbolQualified(t *testing.T) {
@@ -627,6 +623,15 @@ func TestQuerySymbol_NotFound(t *testing.T) {
 
 	_, err := libhelp.QuerySymbol(env, "nonexistent-sym-xyz")
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-sym-xyz")
+}
+
+func TestQuerySymbol_QualifiedNotFound(t *testing.T) {
+	env := newTestEnv(t)
+
+	_, err := libhelp.QuerySymbol(env, "math:nonexistent-sym")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "math:nonexistent-sym")
 }
 
 func TestParseFormals_Optional(t *testing.T) {
@@ -658,7 +663,20 @@ func TestParseFormals_Rest(t *testing.T) {
 	sd, err := libhelp.QuerySymbol(env, "+")
 	require.NoError(t, err)
 	require.NotNil(t, sd.Formals)
-	assert.NotEmpty(t, sd.Formals.Rest, "+ should have a rest arg")
+	assert.Equal(t, "x", sd.Formals.Rest, "+ should have rest arg 'x'")
+}
+
+func TestParseFormals_ZeroArity(t *testing.T) {
+	env := newTestEnv(t)
+
+	// help:help-packages has no arguments.
+	sd, err := libhelp.QuerySymbol(env, "help:help-packages")
+	require.NoError(t, err)
+	require.NotNil(t, sd.Formals)
+	assert.Equal(t, []string{}, sd.Formals.Required)
+	assert.Empty(t, sd.Formals.Optional)
+	assert.Empty(t, sd.Formals.Rest)
+	assert.Empty(t, sd.Formals.Keys)
 }
 
 func TestQueryPackages_JSONSerializable(t *testing.T) {
@@ -669,11 +687,20 @@ func TestQueryPackages_JSONSerializable(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, json.Valid(data), "QueryPackages output should be valid JSON")
 
-	// Round-trip: deserialize back
+	// Round-trip: deserialize back and verify structural equality.
 	var decoded []libhelp.PackageDoc
 	err = json.Unmarshal(data, &decoded)
 	require.NoError(t, err)
-	assert.Equal(t, len(pkgs), len(decoded))
+	require.Equal(t, len(pkgs), len(decoded))
+
+	// Spot-check: math package fields survive the round trip.
+	for i, pkg := range decoded {
+		if pkg.Name == "math" {
+			assert.Equal(t, pkgs[i].Doc, pkg.Doc, "math doc should survive round-trip")
+			assert.Equal(t, len(pkgs[i].Symbols), len(pkg.Symbols), "math symbol count should survive round-trip")
+			break
+		}
+	}
 }
 
 func TestQuerySymbol_DocNotWordWrapped(t *testing.T) {
@@ -682,10 +709,23 @@ func TestQuerySymbol_DocNotWordWrapped(t *testing.T) {
 	// Get a symbol known to have a long docstring.
 	sd, err := libhelp.QuerySymbol(env, "map")
 	require.NoError(t, err)
+	require.NotEmpty(t, sd.Doc, "map should have a docstring")
 
 	// The doc should NOT contain the 2-space indent that cleanDocstring adds.
-	if sd.Doc != "" {
-		assert.False(t, strings.HasPrefix(sd.Doc, "  "),
-			"JSON doc should not have leading indent")
-	}
+	assert.False(t, strings.HasPrefix(sd.Doc, "  "),
+		"JSON doc should not have leading indent")
+	// The doc should not have leading/trailing whitespace (cleanDocRaw trims).
+	assert.Equal(t, strings.TrimSpace(sd.Doc), sd.Doc,
+		"JSON doc should be trimmed")
+}
+
+func TestQuerySymbol_Variable(t *testing.T) {
+	env := newTestEnv(t)
+
+	sd, err := libhelp.QuerySymbol(env, "math:pi")
+	require.NoError(t, err)
+	assert.Equal(t, "pi", sd.Name)
+	assert.Equal(t, "variable", sd.Kind)
+	assert.NotEmpty(t, sd.Doc)
+	assert.Nil(t, sd.Formals, "variables should not have formals")
 }

--- a/lisp/lisplib/libhelp/libhelp_test.go
+++ b/lisp/lisplib/libhelp/libhelp_test.go
@@ -4,6 +4,7 @@ package libhelp_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -494,4 +495,197 @@ func TestRenderFun_SymbolDocsFallback(t *testing.T) {
 	require.NoError(t, err)
 	output := buf.String()
 	assert.Contains(t, output, "Documented via set.")
+}
+
+// --- JSON query tests ---
+
+func TestQueryPackages(t *testing.T) {
+	env := newTestEnv(t)
+	pkgs := libhelp.QueryPackages(env)
+
+	require.NotEmpty(t, pkgs, "QueryPackages should return at least one package")
+
+	// Every package should have a name.
+	for _, pkg := range pkgs {
+		assert.NotEmpty(t, pkg.Name, "package name should not be empty")
+	}
+
+	// Check a known package exists.
+	var foundMath bool
+	for _, pkg := range pkgs {
+		if pkg.Name == "math" {
+			foundMath = true
+			assert.NotEmpty(t, pkg.Symbols, "math package should have symbols")
+			assert.NotEmpty(t, pkg.Doc, "math package should have a doc string")
+			break
+		}
+	}
+	assert.True(t, foundMath, "should find math package")
+}
+
+func TestQueryPackage(t *testing.T) {
+	env := newTestEnv(t)
+
+	pd, err := libhelp.QueryPackage(env, "math")
+	require.NoError(t, err)
+	assert.Equal(t, "math", pd.Name)
+	assert.NotEmpty(t, pd.Doc)
+	assert.NotEmpty(t, pd.Symbols)
+
+	// "sin" should be a function with required=["radians"]
+	var foundSin bool
+	for _, sym := range pd.Symbols {
+		if sym.Name == "sin" {
+			foundSin = true
+			assert.Equal(t, "function", sym.Kind)
+			require.NotNil(t, sym.Formals)
+			assert.Contains(t, sym.Formals.Required, "radians")
+			break
+		}
+	}
+	assert.True(t, foundSin, "math package should contain sin")
+}
+
+func TestQueryPackage_CoreBuiltins(t *testing.T) {
+	env := newTestEnv(t)
+
+	pd, err := libhelp.QueryPackage(env, "lisp")
+	require.NoError(t, err)
+	assert.Equal(t, "lisp", pd.Name)
+	assert.NotEmpty(t, pd.Symbols)
+
+	// Should include builtins, operators, and macros.
+	kindCounts := map[string]int{}
+	for _, sym := range pd.Symbols {
+		kindCounts[sym.Kind]++
+	}
+	assert.Greater(t, kindCounts["function"], 0, "lisp package should have functions")
+	assert.Greater(t, kindCounts["operator"], 0, "lisp package should have operators")
+	assert.Greater(t, kindCounts["macro"], 0, "lisp package should have macros")
+}
+
+func TestQueryPackageNotFound(t *testing.T) {
+	env := newTestEnv(t)
+
+	_, err := libhelp.QueryPackage(env, "nonexistent-pkg")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-pkg")
+}
+
+func TestQuerySymbol(t *testing.T) {
+	env := newTestEnv(t)
+
+	sd, err := libhelp.QuerySymbol(env, "map")
+	require.NoError(t, err)
+	assert.Equal(t, "map", sd.Name)
+	assert.Equal(t, "function", sd.Kind)
+	assert.NotEmpty(t, sd.Doc)
+	require.NotNil(t, sd.Formals)
+	assert.NotEmpty(t, sd.Formals.Required)
+}
+
+func TestQuerySymbolQualified(t *testing.T) {
+	env := newTestEnv(t)
+
+	sd, err := libhelp.QuerySymbol(env, "math:sin")
+	require.NoError(t, err)
+	assert.Equal(t, "sin", sd.Name)
+	assert.Equal(t, "function", sd.Kind)
+	require.NotNil(t, sd.Formals)
+	assert.Contains(t, sd.Formals.Required, "radians")
+}
+
+func TestQuerySymbolQualified_Core(t *testing.T) {
+	env := newTestEnv(t)
+
+	sd, err := libhelp.QuerySymbol(env, "lisp:map")
+	require.NoError(t, err)
+	assert.Equal(t, "map", sd.Name)
+	assert.Equal(t, "function", sd.Kind)
+}
+
+func TestQuerySymbol_Operator(t *testing.T) {
+	env := newTestEnv(t)
+
+	sd, err := libhelp.QuerySymbol(env, "lambda")
+	require.NoError(t, err)
+	assert.Equal(t, "lambda", sd.Name)
+	assert.Equal(t, "operator", sd.Kind)
+}
+
+func TestQuerySymbol_Macro(t *testing.T) {
+	env := newTestEnv(t)
+
+	sd, err := libhelp.QuerySymbol(env, "defun")
+	require.NoError(t, err)
+	assert.Equal(t, "defun", sd.Name)
+	assert.Equal(t, "macro", sd.Kind)
+}
+
+func TestQuerySymbol_NotFound(t *testing.T) {
+	env := newTestEnv(t)
+
+	_, err := libhelp.QuerySymbol(env, "nonexistent-sym-xyz")
+	assert.Error(t, err)
+}
+
+func TestParseFormals_Optional(t *testing.T) {
+	env := newTestEnv(t)
+
+	// math:atan has &optional.
+	sd, err := libhelp.QuerySymbol(env, "math:atan")
+	require.NoError(t, err)
+	require.NotNil(t, sd.Formals)
+	assert.Contains(t, sd.Formals.Required, "radians")
+	assert.Contains(t, sd.Formals.Optional, "quotient")
+}
+
+func TestParseFormals_Key(t *testing.T) {
+	env := newTestEnv(t)
+
+	// json:dump-string has &key.
+	sd, err := libhelp.QuerySymbol(env, "json:dump-string")
+	require.NoError(t, err)
+	require.NotNil(t, sd.Formals)
+	assert.Contains(t, sd.Formals.Required, "object")
+	assert.Contains(t, sd.Formals.Keys, "string-numbers")
+}
+
+func TestParseFormals_Rest(t *testing.T) {
+	env := newTestEnv(t)
+
+	// "+" has &rest args.
+	sd, err := libhelp.QuerySymbol(env, "+")
+	require.NoError(t, err)
+	require.NotNil(t, sd.Formals)
+	assert.NotEmpty(t, sd.Formals.Rest, "+ should have a rest arg")
+}
+
+func TestQueryPackages_JSONSerializable(t *testing.T) {
+	env := newTestEnv(t)
+	pkgs := libhelp.QueryPackages(env)
+
+	data, err := json.Marshal(pkgs)
+	require.NoError(t, err)
+	assert.True(t, json.Valid(data), "QueryPackages output should be valid JSON")
+
+	// Round-trip: deserialize back
+	var decoded []libhelp.PackageDoc
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, len(pkgs), len(decoded))
+}
+
+func TestQuerySymbol_DocNotWordWrapped(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Get a symbol known to have a long docstring.
+	sd, err := libhelp.QuerySymbol(env, "map")
+	require.NoError(t, err)
+
+	// The doc should NOT contain the 2-space indent that cleanDocstring adds.
+	if sd.Doc != "" {
+		assert.False(t, strings.HasPrefix(sd.Doc, "  "),
+			"JSON doc should not have leading indent")
+	}
 }


### PR DESCRIPTION
## Summary

- Add `--json` flag to `elps doc` command for structured JSON output of packages, symbols, formals, and docstrings
- New exported types (`SymbolDoc`, `FormalsDoc`, `PackageDoc`) and query functions (`QueryPackages`, `QueryPackage`, `QuerySymbol`) in `libhelp` package for programmatic access
- Formals parser correctly splits `&optional`, `&rest`, `&key` argument groups

**PR 1 of 2** for #198 (builtin registry with virtual file navigation). This PR provides the data extraction layer; PR 2 will wire it into the LSP virtual file scheme.

## Usage

```bash
elps doc --json -l              # All packages with symbols
elps doc --json -p math         # Single package detail
elps doc --json map             # Single symbol detail
elps doc --json                 # Same as --json -l
```

## Test plan

- [x] 14 new unit tests covering QueryPackages, QueryPackage, QuerySymbol, formals parsing (optional/key/rest), JSON serialization round-trip, qualified symbol lookup, core builtin/operator/macro resolution, not-found errors, and doc formatting
- [x] `make test` passes (Go tests + example lisp files)
- [x] `make static-checks` passes (golangci-lint with gosec, 0 issues)
- [x] Manual spot-checks: `--json -l`, `--json -p math`, `--json map` produce valid JSON with correct content

Closes #198

---
*Local tests passed. Security review completed. QA professor review pending.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>