### PR TITLE
feat: add AmplificationCausesScaling for N+1 detection

### DIFF
--- a/analysis/perf/config.go
+++ b/analysis/perf/config.go
@@ -54,6 +54,12 @@ type Config struct {
 	// override this (e.g., "substrate-analyze-disable").
 	SuppressionPrefix string `yaml:"suppression_prefix"`
 
+	// AmplificationCausesScaling enables N+1 detection mode. When true,
+	// calling an expensive function inside a loop adds +1 to the caller's
+	// scaling order beyond the loop depth contribution. This surfaces the
+	// classic N+1 query pattern more aggressively.
+	AmplificationCausesScaling bool `yaml:"amplification_causes_scaling"`
+
 	// Rules filters which rules to run. When empty, all rules run.
 	// Valid values: "PERF001", "PERF002", "PERF003", "PERF004", "UNKNOWN001".
 	Rules []string `yaml:"rules"`

--- a/analysis/perf/solver.go
+++ b/analysis/perf/solver.go
@@ -67,6 +67,17 @@ func Solve(graph *CallGraph, cfg *Config) ([]*SolvedFunction, []Issue) {
 		for _, edge := range fn.Calls {
 			callee := solved[edge.Callee]
 			if callee == nil {
+				// External callee (not in graph). Treat as O(1) leaf
+				// but still propagate loop depth and amplification.
+				if edge.Context.InLoop {
+					calleeOrder := edge.Context.LoopDepth
+					if cfg.AmplificationCausesScaling && edge.IsExpensive {
+						calleeOrder++
+					}
+					if calleeOrder > sf.ScalingOrder {
+						sf.ScalingOrder = calleeOrder
+					}
+				}
 				continue
 			}
 			// Propagate cost with loop amplification
@@ -78,6 +89,9 @@ func Solve(graph *CallGraph, cfg *Config) ([]*SolvedFunction, []Issue) {
 
 			// Propagate scaling order
 			calleeOrder := callee.ScalingOrder + edge.Context.LoopDepth
+			if cfg.AmplificationCausesScaling && edge.IsExpensive && edge.Context.InLoop {
+				calleeOrder++
+			}
 			if calleeOrder > sf.ScalingOrder {
 				sf.ScalingOrder = calleeOrder
 			}

--- a/analysis/perf/solver_test.go
+++ b/analysis/perf/solver_test.go
@@ -273,3 +273,81 @@ func TestSolve_UNKNOWN001_FuncallApply(t *testing.T) {
 	}
 	assert.Len(t, unknown, 2, "expected UNKNOWN001 for funcall and apply")
 }
+
+func TestSolve_AmplificationCausesScaling_Disabled(t *testing.T) {
+	// db-put is expensive, called inside a loop (depth 1).
+	// Without amplification: scaling = 0 (db-put leaf) + 1 (loop) = 1.
+	src := `
+(defun process (items)
+  (map 'list (lambda (item) (db-put item)) items))
+`
+	exprs := parseSource(t, src)
+	cfg := DefaultConfig()
+	cfg.AmplificationCausesScaling = false
+	summaries := ScanFile(exprs, "test.lisp", cfg)
+	graph := BuildGraph(summaries)
+	solved, _ := Solve(graph, cfg)
+
+	var processSolved *SolvedFunction
+	for _, sf := range solved {
+		if sf.Name == "process" {
+			processSolved = sf
+			break
+		}
+	}
+	require.NotNil(t, processSolved)
+	assert.Equal(t, 1, processSolved.ScalingOrder,
+		"without amplification, scaling should be 1 (loop depth only)")
+}
+
+func TestSolve_AmplificationCausesScaling_Enabled(t *testing.T) {
+	// db-put is expensive, called inside a loop (depth 1).
+	// With amplification: scaling = 0 (db-put leaf) + 1 (loop) + 1 (amplification) = 2.
+	src := `
+(defun process (items)
+  (map 'list (lambda (item) (db-put item)) items))
+`
+	exprs := parseSource(t, src)
+	cfg := DefaultConfig()
+	cfg.AmplificationCausesScaling = true
+	summaries := ScanFile(exprs, "test.lisp", cfg)
+	graph := BuildGraph(summaries)
+	solved, _ := Solve(graph, cfg)
+
+	var processSolved *SolvedFunction
+	for _, sf := range solved {
+		if sf.Name == "process" {
+			processSolved = sf
+			break
+		}
+	}
+	require.NotNil(t, processSolved)
+	assert.Equal(t, 2, processSolved.ScalingOrder,
+		"with amplification, scaling should be 2 (loop depth + expensive amplification)")
+}
+
+func TestSolve_AmplificationCausesScaling_NonExpensiveUnaffected(t *testing.T) {
+	// concat is NOT expensive, called inside a loop.
+	// With amplification enabled: scaling should still be 1 (no amplification for non-expensive).
+	src := `
+(defun process (items)
+  (map 'list (lambda (item) (concat 'string item "x")) items))
+`
+	exprs := parseSource(t, src)
+	cfg := DefaultConfig()
+	cfg.AmplificationCausesScaling = true
+	summaries := ScanFile(exprs, "test.lisp", cfg)
+	graph := BuildGraph(summaries)
+	solved, _ := Solve(graph, cfg)
+
+	var processSolved *SolvedFunction
+	for _, sf := range solved {
+		if sf.Name == "process" {
+			processSolved = sf
+			break
+		}
+	}
+	require.NotNil(t, processSolved)
+	assert.Equal(t, 1, processSolved.ScalingOrder,
+		"non-expensive calls should not get amplification bonus")
+}

--- a/analysis/perf/solver_test.go
+++ b/analysis/perf/solver_test.go
@@ -274,9 +274,22 @@ func TestSolve_UNKNOWN001_FuncallApply(t *testing.T) {
 	assert.Len(t, unknown, 2, "expected UNKNOWN001 for funcall and apply")
 }
 
+// findSolved returns the SolvedFunction with the given name, or fails the test.
+func findSolved(t *testing.T, solved []*SolvedFunction, name string) *SolvedFunction {
+	t.Helper()
+	for _, sf := range solved {
+		if sf.Name == name {
+			return sf
+		}
+	}
+	t.Fatalf("solved function %q not found", name)
+	return nil
+}
+
 func TestSolve_AmplificationCausesScaling_Disabled(t *testing.T) {
-	// db-put is expensive, called inside a loop (depth 1).
+	// db-put is expensive (external), called inside a loop (depth 1).
 	// Without amplification: scaling = 0 (db-put leaf) + 1 (loop) = 1.
+	// This is a control test paired with _Enabled below.
 	src := `
 (defun process (items)
   (map 'list (lambda (item) (db-put item)) items))
@@ -286,23 +299,24 @@ func TestSolve_AmplificationCausesScaling_Disabled(t *testing.T) {
 	cfg.AmplificationCausesScaling = false
 	summaries := ScanFile(exprs, "test.lisp", cfg)
 	graph := BuildGraph(summaries)
-	solved, _ := Solve(graph, cfg)
+	solved, issues := Solve(graph, cfg)
 
-	var processSolved *SolvedFunction
-	for _, sf := range solved {
-		if sf.Name == "process" {
-			processSolved = sf
-			break
+	sf := findSolved(t, solved, "process")
+	assert.Equal(t, 1, sf.ScalingOrder,
+		"without amplification, scaling should be 1 (loop depth only)")
+
+	// ScalingOrder=1 < MaxAcceptableOrder=2, so no PERF002
+	for _, issue := range issues {
+		if issue.Rule == PERF002 && issue.Function == "process" {
+			t.Error("PERF002 should not fire for process without amplification (scaling=1)")
 		}
 	}
-	require.NotNil(t, processSolved)
-	assert.Equal(t, 1, processSolved.ScalingOrder,
-		"without amplification, scaling should be 1 (loop depth only)")
 }
 
 func TestSolve_AmplificationCausesScaling_Enabled(t *testing.T) {
-	// db-put is expensive, called inside a loop (depth 1).
+	// db-put is expensive (external), called inside a loop (depth 1).
 	// With amplification: scaling = 0 (db-put leaf) + 1 (loop) + 1 (amplification) = 2.
+	// ScalingOrder=2 >= MaxAcceptableOrder=2 → PERF002 warning.
 	src := `
 (defun process (items)
   (map 'list (lambda (item) (db-put item)) items))
@@ -312,18 +326,21 @@ func TestSolve_AmplificationCausesScaling_Enabled(t *testing.T) {
 	cfg.AmplificationCausesScaling = true
 	summaries := ScanFile(exprs, "test.lisp", cfg)
 	graph := BuildGraph(summaries)
-	solved, _ := Solve(graph, cfg)
+	solved, issues := Solve(graph, cfg)
 
-	var processSolved *SolvedFunction
-	for _, sf := range solved {
-		if sf.Name == "process" {
-			processSolved = sf
-			break
+	sf := findSolved(t, solved, "process")
+	assert.Equal(t, 2, sf.ScalingOrder,
+		"with amplification, scaling should be 2 (loop depth + expensive amplification)")
+
+	// ScalingOrder=2 >= MaxAcceptableOrder=2 → PERF002 warning
+	var perf002 []Issue
+	for _, issue := range issues {
+		if issue.Rule == PERF002 && issue.Function == "process" {
+			perf002 = append(perf002, issue)
 		}
 	}
-	require.NotNil(t, processSolved)
-	assert.Equal(t, 2, processSolved.ScalingOrder,
-		"with amplification, scaling should be 2 (loop depth + expensive amplification)")
+	require.NotEmpty(t, perf002, "PERF002 should fire for process with amplification (scaling=2)")
+	assert.Equal(t, SeverityWarning, perf002[0].Severity)
 }
 
 func TestSolve_AmplificationCausesScaling_NonExpensiveUnaffected(t *testing.T) {
@@ -340,14 +357,65 @@ func TestSolve_AmplificationCausesScaling_NonExpensiveUnaffected(t *testing.T) {
 	graph := BuildGraph(summaries)
 	solved, _ := Solve(graph, cfg)
 
-	var processSolved *SolvedFunction
-	for _, sf := range solved {
-		if sf.Name == "process" {
-			processSolved = sf
-			break
+	sf := findSolved(t, solved, "process")
+	assert.Equal(t, 1, sf.ScalingOrder,
+		"non-expensive calls should not get amplification bonus")
+}
+
+func TestSolve_AmplificationCausesScaling_InGraphCallee(t *testing.T) {
+	// db-helper matches "db-*" expensive pattern and IS in the call graph.
+	// This exercises the in-graph amplification path (solver.go Path B).
+	// With amplification: scaling = 0 (db-helper leaf) + 1 (loop) + 1 (amp) = 2.
+	src := `
+(defun db-helper () (concat 'string "x"))
+(defun process (items)
+  (map 'list (lambda (item) (db-helper)) items))
+`
+	exprs := parseSource(t, src)
+	cfg := DefaultConfig()
+	cfg.AmplificationCausesScaling = true
+	summaries := ScanFile(exprs, "test.lisp", cfg)
+	graph := BuildGraph(summaries)
+	solved, _ := Solve(graph, cfg)
+
+	sf := findSolved(t, solved, "process")
+	assert.Equal(t, 2, sf.ScalingOrder,
+		"in-graph expensive callee in loop should get amplification bonus")
+
+	// Verify db-helper itself is unaffected (not called in a loop from its own perspective)
+	dbHelper := findSolved(t, solved, "db-helper")
+	assert.Equal(t, 0, dbHelper.ScalingOrder,
+		"db-helper itself should have scaling order 0 (leaf)")
+}
+
+func TestSolve_AmplificationCausesScaling_NestedLoops(t *testing.T) {
+	// db-put is expensive (external), called inside nested loops (depth 2).
+	// With amplification: scaling = 0 + 2 (loops) + 1 (amp) = 3.
+	// ScalingOrder=3 >= ScalingErrorThreshold=3 → PERF002 error.
+	// This is the key scenario: amplification pushes from warning to error.
+	src := `
+(defun process (matrix)
+  (map 'list (lambda (row)
+    (map 'list (lambda (item) (db-put item)) row)) matrix))
+`
+	exprs := parseSource(t, src)
+	cfg := DefaultConfig()
+	cfg.AmplificationCausesScaling = true
+	summaries := ScanFile(exprs, "test.lisp", cfg)
+	graph := BuildGraph(summaries)
+	solved, issues := Solve(graph, cfg)
+
+	sf := findSolved(t, solved, "process")
+	assert.Equal(t, 3, sf.ScalingOrder,
+		"nested loops + amplification: scaling should be 3")
+
+	// ScalingOrder=3 >= ScalingErrorThreshold=3 → PERF002 error
+	var perf002Errors []Issue
+	for _, issue := range issues {
+		if issue.Rule == PERF002 && issue.Function == "process" && issue.Severity == SeverityError {
+			perf002Errors = append(perf002Errors, issue)
 		}
 	}
-	require.NotNil(t, processSolved)
-	assert.Equal(t, 1, processSolved.ScalingOrder,
-		"non-expensive calls should not get amplification bonus")
+	require.NotEmpty(t, perf002Errors,
+		"amplification in nested loops should push PERF002 to error severity")
 }


### PR DESCRIPTION
## Summary

- Adds `amplification_causes_scaling` config option to the perf analyzer (`analysis/perf`)
- When enabled, calling an expensive function inside a loop adds +1 to the caller's scaling order, surfacing N+1 query patterns more aggressively via PERF002
- External callees (builtins not in the call graph) also participate in scaling propagation when in a loop
- Default is `false` (opt-in) — no change to existing behavior

## Test plan

- [x] Test with `amplification_causes_scaling: false` — scaling order unchanged (loop depth only)
- [x] Test with `amplification_causes_scaling: true` — expensive call in loop gets +1 scaling
- [x] Test that non-expensive calls in loops are unaffected by the flag
- [x] All existing tests pass (no regressions)
- [x] `make test && make static-checks` pass

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)