### PR TITLE
Add SARIF and Mermaid output formatters for perf analysis

### DIFF
--- a/analysis/perf/format_mermaid.go
+++ b/analysis/perf/format_mermaid.go
@@ -1,0 +1,171 @@
+// Copyright © 2024 The ELPS authors
+
+package perf
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// FormatMermaid writes a Mermaid flowchart of the call graph from result.
+// Nodes are labeled with function name, score, and scaling order.
+// Edges show loop context annotations and cycle edges are styled distinctly.
+func FormatMermaid(w io.Writer, result *Result) error {
+	if result == nil || result.Graph == nil {
+		fmt.Fprintln(w, "flowchart TD") //nolint:errcheck
+		return nil
+	}
+
+	graph := result.Graph
+	solved := buildSolvedIndex(result.Solved)
+	cycleEdges := buildCycleEdgeSet(result.Issues)
+	expensiveFuncs := buildExpensiveSet(result.Issues)
+
+	// Collect all node names from edges for stable ordering.
+	nodeSet := make(map[string]bool)
+	for _, edge := range graph.Edges {
+		nodeSet[edge.Caller] = true
+		nodeSet[edge.Callee] = true
+	}
+	// Also include functions from the graph that may have no edges.
+	for name := range graph.Functions {
+		nodeSet[name] = true
+	}
+
+	nodes := make([]string, 0, len(nodeSet))
+	for name := range nodeSet {
+		nodes = append(nodes, name)
+	}
+	sort.Strings(nodes)
+
+	// Assign stable IDs to nodes (Mermaid IDs can't contain special chars).
+	nodeID := make(map[string]string, len(nodes))
+	for i, name := range nodes {
+		nodeID[name] = fmt.Sprintf("n%d", i)
+	}
+
+	ew := &errWriter{w: w}
+	ew.printf("flowchart TD\n")
+
+	// Emit node definitions.
+	for _, name := range nodes {
+		id := nodeID[name]
+		label := buildNodeLabel(name, solved[name], expensiveFuncs[name])
+		if expensiveFuncs[name] {
+			// Hexagon shape for expensive functions.
+			ew.printf("    %s{{%q}}\n", id, label)
+		} else {
+			ew.printf("    %s[%q]\n", id, label)
+		}
+	}
+
+	// Emit edges.
+	for _, edge := range graph.Edges {
+		fromID := nodeID[edge.Caller]
+		toID := nodeID[edge.Callee]
+		edgeKey := edge.Caller + " -> " + edge.Callee
+		if cycleEdges[edgeKey] {
+			// Dashed edge for cycle.
+			if edge.Context.InLoop {
+				ew.printf("    %s -.->|%q| %s\n", fromID, fmt.Sprintf("loop depth=%d", edge.Context.LoopDepth), toID)
+			} else {
+				ew.printf("    %s -.-> %s\n", fromID, toID)
+			}
+		} else if edge.Context.InLoop {
+			ew.printf("    %s -->|%q| %s\n", fromID, fmt.Sprintf("loop depth=%d", edge.Context.LoopDepth), toID)
+		} else {
+			ew.printf("    %s --> %s\n", fromID, toID)
+		}
+	}
+
+	// Emit styles for expensive functions.
+	for _, name := range nodes {
+		if expensiveFuncs[name] {
+			ew.printf("    style %s fill:#f96\n", nodeID[name])
+		}
+	}
+
+	return ew.err
+}
+
+func buildNodeLabel(name string, sf *SolvedFunction, expensive bool) string {
+	var parts []string
+	parts = append(parts, name)
+	if sf != nil {
+		parts = append(parts, fmt.Sprintf("score=%d %s", sf.TotalScore, scalingString(sf.ScalingOrder)))
+	}
+	if expensive {
+		parts = append(parts, "⚠️ expensive")
+	}
+	return strings.Join(parts, "\n")
+}
+
+func scalingString(order int) string {
+	switch order {
+	case 0:
+		return "O(1)"
+	case 1:
+		return "O(N)"
+	case 2:
+		return "O(N²)"
+	case 3:
+		return "O(N³)"
+	default:
+		return fmt.Sprintf("O(N^%d)", order)
+	}
+}
+
+func buildSolvedIndex(solved []*SolvedFunction) map[string]*SolvedFunction {
+	m := make(map[string]*SolvedFunction, len(solved))
+	for _, sf := range solved {
+		m[sf.Name] = sf
+	}
+	return m
+}
+
+func buildCycleEdgeSet(issues []Issue) map[string]bool {
+	set := make(map[string]bool)
+	for _, issue := range issues {
+		if issue.Rule != PERF004 {
+			continue
+		}
+		// Cycle members are listed in Details; create edges between consecutive members.
+		for i := 0; i < len(issue.Details)-1; i++ {
+			set[issue.Details[i]+" -> "+issue.Details[i+1]] = true
+		}
+		// Close the cycle.
+		if len(issue.Details) > 1 {
+			set[issue.Details[len(issue.Details)-1]+" -> "+issue.Details[0]] = true
+		}
+	}
+	return set
+}
+
+func buildExpensiveSet(issues []Issue) map[string]bool {
+	set := make(map[string]bool)
+	for _, issue := range issues {
+		if issue.Rule != PERF003 {
+			continue
+		}
+		// The trace's last entry is typically the expensive callee.
+		if len(issue.Trace) > 0 {
+			set[issue.Trace[len(issue.Trace)-1].Function] = true
+		}
+	}
+	return set
+}
+
+// errWriter wraps an io.Writer and captures the first error.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (ew *errWriter) printf(format string, args ...any) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = fmt.Fprintf(ew.w, format, args...)
+}

--- a/analysis/perf/format_mermaid_test.go
+++ b/analysis/perf/format_mermaid_test.go
@@ -1,0 +1,162 @@
+// Copyright © 2024 The ELPS authors
+
+package perf
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatMermaid_BasicGraph(t *testing.T) {
+	result := &Result{
+		Graph: &CallGraph{
+			Functions: map[string]*FunctionSummary{
+				"main":     {Name: "main"},
+				"process":  {Name: "process"},
+				"save":     {Name: "save"},
+			},
+			Edges: []CallEdge{
+				{Caller: "main", Callee: "process"},
+				{Caller: "process", Callee: "save"},
+			},
+		},
+		Solved: []*SolvedFunction{
+			{Name: "main", TotalScore: 100, ScalingOrder: 0},
+			{Name: "process", TotalScore: 50, ScalingOrder: 1},
+			{Name: "save", TotalScore: 10, ScalingOrder: 0},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := FormatMermaid(&buf, result)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "flowchart TD")
+	assert.Contains(t, output, "main")
+	assert.Contains(t, output, "process")
+	assert.Contains(t, output, "save")
+	assert.Contains(t, output, "-->")
+	assert.Contains(t, output, "score=100")
+	assert.Contains(t, output, "O(N)")
+}
+
+func TestFormatMermaid_LoopAnnotations(t *testing.T) {
+	result := &Result{
+		Graph: &CallGraph{
+			Functions: map[string]*FunctionSummary{
+				"outer": {Name: "outer"},
+				"inner": {Name: "inner"},
+			},
+			Edges: []CallEdge{
+				{
+					Caller:  "outer",
+					Callee:  "inner",
+					Context: CallContext{LoopDepth: 2, InLoop: true},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := FormatMermaid(&buf, result)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "loop depth=2")
+}
+
+func TestFormatMermaid_CycleHighlight(t *testing.T) {
+	result := &Result{
+		Graph: &CallGraph{
+			Functions: map[string]*FunctionSummary{
+				"ping": {Name: "ping"},
+				"pong": {Name: "pong"},
+			},
+			Edges: []CallEdge{
+				{Caller: "ping", Callee: "pong"},
+				{Caller: "pong", Callee: "ping"},
+			},
+		},
+		Issues: []Issue{
+			{
+				Rule:     PERF004,
+				Severity: SeverityWarning,
+				Message:  "recursive cycle: ping -> pong",
+				Function: "ping",
+				Details:  []string{"ping", "pong"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := FormatMermaid(&buf, result)
+	require.NoError(t, err)
+
+	output := buf.String()
+	// Cycle edges should use dashed arrow syntax.
+	assert.Contains(t, output, "-.->")
+}
+
+func TestFormatMermaid_ExpensiveNodes(t *testing.T) {
+	result := &Result{
+		Graph: &CallGraph{
+			Functions: map[string]*FunctionSummary{
+				"caller": {Name: "caller"},
+				"db-put": {Name: "db-put"},
+			},
+			Edges: []CallEdge{
+				{Caller: "caller", Callee: "db-put", Context: CallContext{InLoop: true, LoopDepth: 1}, IsExpensive: true},
+			},
+		},
+		Issues: []Issue{
+			{
+				Rule:     PERF003,
+				Severity: SeverityWarning,
+				Message:  `expensive call "db-put" inside loop (depth 1)`,
+				Function: "caller",
+				Source:   &token.Location{File: "test.lisp", Line: 5, Col: 3},
+				File:     "test.lisp",
+				Trace: []TraceEntry{
+					{Function: "caller", Note: "calls db-put in loop"},
+					{Function: "db-put", Note: "expensive"},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := FormatMermaid(&buf, result)
+	require.NoError(t, err)
+
+	output := buf.String()
+	// Expensive nodes get hexagon shape and fill style.
+	assert.Contains(t, output, "expensive")
+	assert.Contains(t, output, "fill:#f96")
+}
+
+func TestFormatMermaid_EmptyGraph(t *testing.T) {
+	// nil result
+	var buf bytes.Buffer
+	err := FormatMermaid(&buf, nil)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "flowchart TD")
+
+	// empty result
+	buf.Reset()
+	err = FormatMermaid(&buf, &Result{})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "flowchart TD")
+
+	// result with empty graph
+	buf.Reset()
+	err = FormatMermaid(&buf, &Result{Graph: &CallGraph{
+		Functions: map[string]*FunctionSummary{},
+	}})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "flowchart TD")
+}

--- a/analysis/perf/format_mermaid_test.go
+++ b/analysis/perf/format_mermaid_test.go
@@ -4,6 +4,8 @@ package perf
 
 import (
 	"bytes"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/luthersystems/elps/parser/token"
@@ -12,12 +14,13 @@ import (
 )
 
 func TestFormatMermaid_BasicGraph(t *testing.T) {
+	t.Parallel()
 	result := &Result{
 		Graph: &CallGraph{
 			Functions: map[string]*FunctionSummary{
-				"main":     {Name: "main"},
-				"process":  {Name: "process"},
-				"save":     {Name: "save"},
+				"main":    {Name: "main"},
+				"process": {Name: "process"},
+				"save":    {Name: "save"},
 			},
 			Edges: []CallEdge{
 				{Caller: "main", Callee: "process"},
@@ -35,17 +38,26 @@ func TestFormatMermaid_BasicGraph(t *testing.T) {
 	err := FormatMermaid(&buf, result)
 	require.NoError(t, err)
 
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+
+	// First line must be the flowchart header.
+	require.True(t, len(lines) > 0)
+	assert.Equal(t, "flowchart TD", lines[0])
+
 	output := buf.String()
-	assert.Contains(t, output, "flowchart TD")
-	assert.Contains(t, output, "main")
-	assert.Contains(t, output, "process")
-	assert.Contains(t, output, "save")
-	assert.Contains(t, output, "-->")
-	assert.Contains(t, output, "score=100")
-	assert.Contains(t, output, "O(N)")
+
+	// Verify node labels are tied to correct scores and scaling.
+	assert.Contains(t, output, `"main\nscore=100 O(1)"`)
+	assert.Contains(t, output, `"process\nscore=50 O(N)"`)
+	assert.Contains(t, output, `"save\nscore=10 O(1)"`)
+
+	// Verify both edges exist (node IDs are stable sorted: main=n0, process=n1, save=n2).
+	assert.Contains(t, output, "n0 --> n1")
+	assert.Contains(t, output, "n1 --> n2")
 }
 
 func TestFormatMermaid_LoopAnnotations(t *testing.T) {
+	t.Parallel()
 	result := &Result{
 		Graph: &CallGraph{
 			Functions: map[string]*FunctionSummary{
@@ -67,19 +79,24 @@ func TestFormatMermaid_LoopAnnotations(t *testing.T) {
 	require.NoError(t, err)
 
 	output := buf.String()
-	assert.Contains(t, output, "loop depth=2")
+	// Verify full Mermaid edge annotation syntax with pipe delimiters.
+	assert.Contains(t, output, `-->|"loop depth=2"|`)
 }
 
 func TestFormatMermaid_CycleHighlight(t *testing.T) {
+	t.Parallel()
+	// Mixed graph: ping<->pong cycle + ping->helper non-cycle edge.
 	result := &Result{
 		Graph: &CallGraph{
 			Functions: map[string]*FunctionSummary{
-				"ping": {Name: "ping"},
-				"pong": {Name: "pong"},
+				"helper": {Name: "helper"},
+				"ping":   {Name: "ping"},
+				"pong":   {Name: "pong"},
 			},
 			Edges: []CallEdge{
 				{Caller: "ping", Callee: "pong"},
 				{Caller: "pong", Callee: "ping"},
+				{Caller: "ping", Callee: "helper"},
 			},
 		},
 		Issues: []Issue{
@@ -98,11 +115,49 @@ func TestFormatMermaid_CycleHighlight(t *testing.T) {
 	require.NoError(t, err)
 
 	output := buf.String()
-	// Cycle edges should use dashed arrow syntax.
+
+	// Cycle edges should use dashed arrows.
 	assert.Contains(t, output, "-.->")
+
+	// Non-cycle edge (ping->helper) should use solid arrow.
+	// Sorted: helper=n0, ping=n1, pong=n2
+	assert.Contains(t, output, "n1 --> n0") // ping -> helper (solid)
+	assert.Contains(t, output, "n1 -.-> n2") // ping -> pong (dashed cycle)
+	assert.Contains(t, output, "n2 -.-> n1") // pong -> ping (dashed cycle)
+}
+
+func TestFormatMermaid_CycleWithLoopAnnotation(t *testing.T) {
+	t.Parallel()
+	result := &Result{
+		Graph: &CallGraph{
+			Functions: map[string]*FunctionSummary{
+				"a": {Name: "a"},
+				"b": {Name: "b"},
+			},
+			Edges: []CallEdge{
+				{Caller: "a", Callee: "b", Context: CallContext{InLoop: true, LoopDepth: 1}},
+				{Caller: "b", Callee: "a"},
+			},
+		},
+		Issues: []Issue{
+			{
+				Rule:    PERF004,
+				Details: []string{"a", "b"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := FormatMermaid(&buf, result)
+	require.NoError(t, err)
+
+	output := buf.String()
+	// Cycle edge in loop should get dashed arrow WITH annotation.
+	assert.Contains(t, output, `-.->|"loop depth=1"|`)
 }
 
 func TestFormatMermaid_ExpensiveNodes(t *testing.T) {
+	t.Parallel()
 	result := &Result{
 		Graph: &CallGraph{
 			Functions: map[string]*FunctionSummary{
@@ -134,29 +189,81 @@ func TestFormatMermaid_ExpensiveNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	output := buf.String()
-	// Expensive nodes get hexagon shape and fill style.
+	// Expensive nodes use hexagon shape syntax {{}}.
+	assert.Contains(t, output, "{{")
+	// Regular nodes use bracket syntax [].
+	assert.Contains(t, output, `["caller"`)
+	// Expensive node label includes warning.
 	assert.Contains(t, output, "expensive")
+	// Style directive applied.
 	assert.Contains(t, output, "fill:#f96")
 }
 
 func TestFormatMermaid_EmptyGraph(t *testing.T) {
-	// nil result
-	var buf bytes.Buffer
-	err := FormatMermaid(&buf, nil)
-	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "flowchart TD")
+	t.Parallel()
+	cases := []struct {
+		name   string
+		result *Result
+	}{
+		{"nil result", nil},
+		{"empty result", &Result{}},
+		{"empty graph", &Result{Graph: &CallGraph{Functions: map[string]*FunctionSummary{}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := FormatMermaid(&buf, tc.result)
+			require.NoError(t, err)
+			output := strings.TrimSpace(buf.String())
+			// Output should be exactly the header with no nodes or edges.
+			assert.Equal(t, "flowchart TD", output)
+		})
+	}
+}
 
-	// empty result
-	buf.Reset()
-	err = FormatMermaid(&buf, &Result{})
-	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "flowchart TD")
+func TestScalingString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		order int
+		want  string
+	}{
+		{0, "O(1)"},
+		{1, "O(N)"},
+		{2, "O(N²)"},
+		{3, "O(N³)"},
+		{4, "O(N^4)"},
+		{10, "O(N^10)"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, scalingString(tt.order))
+	}
+}
 
-	// result with empty graph
-	buf.Reset()
-	err = FormatMermaid(&buf, &Result{Graph: &CallGraph{
-		Functions: map[string]*FunctionSummary{},
-	}})
-	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "flowchart TD")
+func TestFormatMermaid_WriterError(t *testing.T) {
+	t.Parallel()
+	errBoom := errors.New("boom")
+	fw := &failWriter{failAfter: 5, err: errBoom}
+	result := &Result{
+		Graph: &CallGraph{
+			Functions: map[string]*FunctionSummary{"a": {Name: "a"}},
+			Edges:     []CallEdge{{Caller: "a", Callee: "a"}},
+		},
+	}
+	err := FormatMermaid(fw, result)
+	assert.ErrorIs(t, err, errBoom)
+}
+
+// failWriter returns an error after failAfter bytes have been written.
+type failWriter struct {
+	written   int
+	failAfter int
+	err       error
+}
+
+func (fw *failWriter) Write(p []byte) (int, error) {
+	if fw.written+len(p) > fw.failAfter {
+		return 0, fw.err
+	}
+	fw.written += len(p)
+	return len(p), nil
 }

--- a/analysis/perf/format_sarif.go
+++ b/analysis/perf/format_sarif.go
@@ -1,0 +1,229 @@
+// Copyright © 2024 The ELPS authors
+
+package perf
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// FormatSARIF writes issues in SARIF v2.1.0 JSON format.
+// The toolName and toolVersion parameters identify the analysis tool in the
+// SARIF output (e.g., "elps-perf", "0.1.0").
+func FormatSARIF(w io.Writer, issues []Issue, toolName, toolVersion string) error {
+	rules := buildRuleDescriptors()
+	ruleIndex := make(map[RuleID]int, len(rules))
+	for i, r := range rules {
+		ruleIndex[RuleID(r.ID)] = i
+	}
+
+	var results []sarifResult
+	for _, issue := range issues {
+		r := sarifResult{
+			RuleID:    string(issue.Rule),
+			RuleIndex: ruleIndex[issue.Rule],
+			Level:     severityToSARIFLevel(issue.Severity),
+			Message:   sarifMessage{Text: issue.Message},
+			PartialFingerprints: map[string]string{
+				"primaryLocationLineHash": issue.Fingerprint,
+			},
+		}
+
+		if issue.Source != nil || issue.File != "" {
+			loc := buildSARIFLocation(issue.File, issue.Source, nil)
+			r.Locations = []sarifLocation{loc}
+		}
+
+		if len(issue.Trace) > 0 {
+			var tfLocs []sarifThreadFlowLocation
+			for _, entry := range issue.Trace {
+				file := ""
+				if entry.Source != nil {
+					file = entry.Source.File
+				}
+				msg := entry.Note
+				tfl := sarifThreadFlowLocation{
+					Location: buildSARIFLocation(file, entry.Source, &msg),
+				}
+				tfLocs = append(tfLocs, tfl)
+			}
+			r.CodeFlows = []sarifCodeFlow{
+				{
+					ThreadFlows: []sarifThreadFlow{
+						{Locations: tfLocs},
+					},
+				},
+			}
+		}
+
+		results = append(results, r)
+	}
+
+	log := sarifLog{
+		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+		Version: "2.1.0",
+		Runs: []sarifRun{
+			{
+				Tool: sarifTool{
+					Driver: sarifDriver{
+						Name:    toolName,
+						Version: toolVersion,
+						Rules:   rules,
+					},
+				},
+				Results: results,
+			},
+		},
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(log)
+}
+
+func severityToSARIFLevel(s Severity) string {
+	switch s {
+	case SeverityError:
+		return "error"
+	case SeverityWarning:
+		return "warning"
+	case SeverityInfo:
+		return "note"
+	default:
+		return "none"
+	}
+}
+
+func buildSARIFLocation(file string, src *token.Location, message *string) sarifLocation {
+	loc := sarifLocation{
+		PhysicalLocation: sarifPhysicalLocation{
+			ArtifactLocation: sarifArtifactLocation{URI: file},
+		},
+	}
+	if src != nil && src.Line > 0 {
+		loc.PhysicalLocation.Region = &sarifRegion{
+			StartLine:   src.Line,
+			StartColumn: src.Col,
+		}
+	}
+	if message != nil {
+		loc.Message = &sarifMessage{Text: *message}
+	}
+	return loc
+}
+
+func buildRuleDescriptors() []sarifRule {
+	return []sarifRule{
+		{
+			ID:               string(PERF001),
+			Name:             "HotPath",
+			ShortDescription: sarifMessage{Text: "Cumulative cost score exceeds threshold"},
+			DefaultConfig:    sarifRuleConfig{Level: "warning"},
+		},
+		{
+			ID:               string(PERF002),
+			Name:             "ScalingRisk",
+			ShortDescription: sarifMessage{Text: "O(N^k) complexity at or above threshold"},
+			DefaultConfig:    sarifRuleConfig{Level: "warning"},
+		},
+		{
+			ID:               string(PERF003),
+			Name:             "ExpensiveInLoop",
+			ShortDescription: sarifMessage{Text: "Known-expensive function called inside a loop"},
+			DefaultConfig:    sarifRuleConfig{Level: "warning"},
+		},
+		{
+			ID:               string(PERF004),
+			Name:             "RecursiveCycle",
+			ShortDescription: sarifMessage{Text: "Mutual or self-recursion detected"},
+			DefaultConfig:    sarifRuleConfig{Level: "warning"},
+		},
+		{
+			ID:               string(UNKNOWN001),
+			Name:             "DynamicDispatch",
+			ShortDescription: sarifMessage{Text: "Callee cannot be statically resolved"},
+			DefaultConfig:    sarifRuleConfig{Level: "note"},
+		},
+	}
+}
+
+// SARIF v2.1.0 JSON types — hand-rolled to avoid external dependencies.
+
+type sarifLog struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name    string      `json:"name"`
+	Version string      `json:"version"`
+	Rules   []sarifRule `json:"rules"`
+}
+
+type sarifRule struct {
+	ID               string          `json:"id"`
+	Name             string          `json:"name"`
+	ShortDescription sarifMessage    `json:"shortDescription"`
+	DefaultConfig    sarifRuleConfig `json:"defaultConfiguration"`
+}
+
+type sarifRuleConfig struct {
+	Level string `json:"level"`
+}
+
+type sarifMessage struct {
+	Text string `json:"text"`
+}
+
+type sarifResult struct {
+	RuleID              string            `json:"ruleId"`
+	RuleIndex           int               `json:"ruleIndex"`
+	Level               string            `json:"level"`
+	Message             sarifMessage      `json:"message"`
+	Locations           []sarifLocation   `json:"locations,omitempty"`
+	PartialFingerprints map[string]string `json:"partialFingerprints"`
+	CodeFlows           []sarifCodeFlow   `json:"codeFlows,omitempty"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+	Message          *sarifMessage         `json:"message,omitempty"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+	Region           *sarifRegion          `json:"region,omitempty"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type sarifRegion struct {
+	StartLine   int `json:"startLine"`
+	StartColumn int `json:"startColumn,omitempty"`
+}
+
+type sarifCodeFlow struct {
+	ThreadFlows []sarifThreadFlow `json:"threadFlows"`
+}
+
+type sarifThreadFlow struct {
+	Locations []sarifThreadFlowLocation `json:"locations"`
+}
+
+type sarifThreadFlowLocation struct {
+	Location sarifLocation `json:"location"`
+}

--- a/analysis/perf/format_sarif_test.go
+++ b/analysis/perf/format_sarif_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestFormatSARIF_ValidSchema(t *testing.T) {
+	t.Parallel()
 	issues := []Issue{
 		{
 			Rule:        PERF001,
@@ -39,6 +40,7 @@ func TestFormatSARIF_ValidSchema(t *testing.T) {
 }
 
 func TestFormatSARIF_CodeFlows(t *testing.T) {
+	t.Parallel()
 	issues := []Issue{
 		{
 			Rule:        PERF001,
@@ -73,11 +75,16 @@ func TestFormatSARIF_CodeFlows(t *testing.T) {
 	assert.Equal(t, "app.lisp", locs[0].Location.PhysicalLocation.ArtifactLocation.URI)
 	assert.Equal(t, 10, locs[0].Location.PhysicalLocation.Region.StartLine)
 	assert.Equal(t, "entry point", locs[0].Location.Message.Text)
+	// Verify middle trace entry is correct too.
+	assert.Equal(t, "app.lisp", locs[1].Location.PhysicalLocation.ArtifactLocation.URI)
+	assert.Equal(t, 20, locs[1].Location.PhysicalLocation.Region.StartLine)
+	assert.Equal(t, "calls save-item in loop (depth 1)", locs[1].Location.Message.Text)
 	assert.Equal(t, "db.lisp", locs[2].Location.PhysicalLocation.ArtifactLocation.URI)
 	assert.Equal(t, "expensive call", locs[2].Location.Message.Text)
 }
 
 func TestFormatSARIF_Fingerprints(t *testing.T) {
+	t.Parallel()
 	issues := []Issue{
 		{
 			Rule:        PERF003,
@@ -98,9 +105,15 @@ func TestFormatSARIF_Fingerprints(t *testing.T) {
 
 	result := log.Runs[0].Results[0]
 	assert.Equal(t, "deadbeef12345678", result.PartialFingerprints["primaryLocationLineHash"])
+
+	// Source is nil but File is set — location URI should be populated, region nil.
+	require.Len(t, result.Locations, 1)
+	assert.Equal(t, "test.lisp", result.Locations[0].PhysicalLocation.ArtifactLocation.URI)
+	assert.Nil(t, result.Locations[0].PhysicalLocation.Region)
 }
 
 func TestFormatSARIF_AllRules(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	err := FormatSARIF(&buf, nil, "elps-perf", "0.1.0")
 	require.NoError(t, err)
@@ -118,13 +131,18 @@ func TestFormatSARIF_AllRules(t *testing.T) {
 	assert.Equal(t, []string{"PERF001", "PERF002", "PERF003", "PERF004", "UNKNOWN001"}, ruleIDs)
 	assert.Equal(t, "HotPath", rules[0].Name)
 	assert.Equal(t, "DynamicDispatch", rules[4].Name)
+
+	// Nil issues should produce an empty results array.
+	assert.Empty(t, log.Runs[0].Results)
 }
 
 func TestFormatSARIF_SeverityMapping(t *testing.T) {
+	t.Parallel()
 	issues := []Issue{
 		{Rule: PERF001, Severity: SeverityError, Message: "err", Function: "f1", File: "a.lisp", Fingerprint: "a"},
 		{Rule: PERF002, Severity: SeverityWarning, Message: "warn", Function: "f2", File: "b.lisp", Fingerprint: "b"},
 		{Rule: UNKNOWN001, Severity: SeverityInfo, Message: "info", Function: "f3", File: "c.lisp", Fingerprint: "c"},
+		{Rule: PERF003, Severity: Severity(99), Message: "unknown", Function: "f4", File: "d.lisp", Fingerprint: "d"},
 	}
 
 	var buf bytes.Buffer
@@ -133,8 +151,15 @@ func TestFormatSARIF_SeverityMapping(t *testing.T) {
 
 	var log sarifLog
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &log))
-	require.Len(t, log.Runs[0].Results, 3)
+	require.Len(t, log.Runs[0].Results, 4)
 	assert.Equal(t, "error", log.Runs[0].Results[0].Level)
 	assert.Equal(t, "warning", log.Runs[0].Results[1].Level)
 	assert.Equal(t, "note", log.Runs[0].Results[2].Level)
+	assert.Equal(t, "none", log.Runs[0].Results[3].Level)
+
+	// Verify ruleIndex maps to correct rule in the rules array.
+	assert.Equal(t, 0, log.Runs[0].Results[0].RuleIndex) // PERF001 -> index 0
+	assert.Equal(t, 1, log.Runs[0].Results[1].RuleIndex) // PERF002 -> index 1
+	assert.Equal(t, 4, log.Runs[0].Results[2].RuleIndex) // UNKNOWN001 -> index 4
+	assert.Equal(t, 2, log.Runs[0].Results[3].RuleIndex) // PERF003 -> index 2
 }

--- a/analysis/perf/format_sarif_test.go
+++ b/analysis/perf/format_sarif_test.go
@@ -1,0 +1,140 @@
+// Copyright © 2024 The ELPS authors
+
+package perf
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatSARIF_ValidSchema(t *testing.T) {
+	issues := []Issue{
+		{
+			Rule:        PERF001,
+			Severity:    SeverityWarning,
+			Message:     "hot path: score 5000 exceeds threshold 1000",
+			Function:    "process-batch",
+			Source:      &token.Location{File: "app.lisp", Line: 10, Col: 1},
+			File:        "app.lisp",
+			Fingerprint: "abc123",
+		},
+	}
+
+	var buf bytes.Buffer
+	err := FormatSARIF(&buf, issues, "elps-perf", "0.1.0")
+	require.NoError(t, err)
+
+	var log sarifLog
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &log))
+	assert.Equal(t, "2.1.0", log.Version)
+	assert.Equal(t, "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json", log.Schema)
+	require.Len(t, log.Runs, 1)
+	assert.Equal(t, "elps-perf", log.Runs[0].Tool.Driver.Name)
+	assert.Equal(t, "0.1.0", log.Runs[0].Tool.Driver.Version)
+}
+
+func TestFormatSARIF_CodeFlows(t *testing.T) {
+	issues := []Issue{
+		{
+			Rule:        PERF001,
+			Severity:    SeverityWarning,
+			Message:     "hot path",
+			Function:    "process-batch",
+			Source:      &token.Location{File: "app.lisp", Line: 10, Col: 1},
+			File:        "app.lisp",
+			Fingerprint: "abc123",
+			Trace: []TraceEntry{
+				{Function: "process-batch", Source: &token.Location{File: "app.lisp", Line: 10, Col: 1}, Note: "entry point"},
+				{Function: "save-item", Source: &token.Location{File: "app.lisp", Line: 20, Col: 5}, Note: "calls save-item in loop (depth 1)"},
+				{Function: "db-put", Source: &token.Location{File: "db.lisp", Line: 3, Col: 1}, Note: "expensive call"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := FormatSARIF(&buf, issues, "elps-perf", "0.1.0")
+	require.NoError(t, err)
+
+	var log sarifLog
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &log))
+	require.Len(t, log.Runs[0].Results, 1)
+
+	result := log.Runs[0].Results[0]
+	require.Len(t, result.CodeFlows, 1)
+	require.Len(t, result.CodeFlows[0].ThreadFlows, 1)
+
+	locs := result.CodeFlows[0].ThreadFlows[0].Locations
+	require.Len(t, locs, 3)
+	assert.Equal(t, "app.lisp", locs[0].Location.PhysicalLocation.ArtifactLocation.URI)
+	assert.Equal(t, 10, locs[0].Location.PhysicalLocation.Region.StartLine)
+	assert.Equal(t, "entry point", locs[0].Location.Message.Text)
+	assert.Equal(t, "db.lisp", locs[2].Location.PhysicalLocation.ArtifactLocation.URI)
+	assert.Equal(t, "expensive call", locs[2].Location.Message.Text)
+}
+
+func TestFormatSARIF_Fingerprints(t *testing.T) {
+	issues := []Issue{
+		{
+			Rule:        PERF003,
+			Severity:    SeverityWarning,
+			Message:     "expensive in loop",
+			Function:    "do-stuff",
+			File:        "test.lisp",
+			Fingerprint: "deadbeef12345678",
+		},
+	}
+
+	var buf bytes.Buffer
+	err := FormatSARIF(&buf, issues, "elps-perf", "0.1.0")
+	require.NoError(t, err)
+
+	var log sarifLog
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &log))
+
+	result := log.Runs[0].Results[0]
+	assert.Equal(t, "deadbeef12345678", result.PartialFingerprints["primaryLocationLineHash"])
+}
+
+func TestFormatSARIF_AllRules(t *testing.T) {
+	var buf bytes.Buffer
+	err := FormatSARIF(&buf, nil, "elps-perf", "0.1.0")
+	require.NoError(t, err)
+
+	var log sarifLog
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &log))
+
+	rules := log.Runs[0].Tool.Driver.Rules
+	require.Len(t, rules, 5)
+
+	ruleIDs := make([]string, len(rules))
+	for i, r := range rules {
+		ruleIDs[i] = r.ID
+	}
+	assert.Equal(t, []string{"PERF001", "PERF002", "PERF003", "PERF004", "UNKNOWN001"}, ruleIDs)
+	assert.Equal(t, "HotPath", rules[0].Name)
+	assert.Equal(t, "DynamicDispatch", rules[4].Name)
+}
+
+func TestFormatSARIF_SeverityMapping(t *testing.T) {
+	issues := []Issue{
+		{Rule: PERF001, Severity: SeverityError, Message: "err", Function: "f1", File: "a.lisp", Fingerprint: "a"},
+		{Rule: PERF002, Severity: SeverityWarning, Message: "warn", Function: "f2", File: "b.lisp", Fingerprint: "b"},
+		{Rule: UNKNOWN001, Severity: SeverityInfo, Message: "info", Function: "f3", File: "c.lisp", Fingerprint: "c"},
+	}
+
+	var buf bytes.Buffer
+	err := FormatSARIF(&buf, issues, "elps-perf", "0.1.0")
+	require.NoError(t, err)
+
+	var log sarifLog
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &log))
+	require.Len(t, log.Runs[0].Results, 3)
+	assert.Equal(t, "error", log.Runs[0].Results[0].Level)
+	assert.Equal(t, "warning", log.Runs[0].Results[1].Level)
+	assert.Equal(t, "note", log.Runs[0].Results[2].Level)
+}


### PR DESCRIPTION
## Summary

- Add `FormatSARIF()` — writes perf analysis issues in SARIF v2.1.0 JSON format, enabling GitHub Code Scanning integration via `codeql-action/upload-sarif`
- Add `FormatMermaid()` — generates Mermaid flowchart visualization of the call graph with score/scaling annotations, loop edge labels, cycle highlighting (dashed edges), and expensive function styling
- Hand-rolled SARIF JSON structs (~150 lines, no external deps) with all 5 rules (PERF001-PERF004, UNKNOWN001), code flows from traces, and partial fingerprints

Closes #205

## Test plan

- [x] `TestFormatSARIF_ValidSchema` — valid JSON with correct `$schema`/`version`
- [x] `TestFormatSARIF_CodeFlows` — traces map to `codeFlows.threadFlows`
- [x] `TestFormatSARIF_Fingerprints` — `partialFingerprints` populated
- [x] `TestFormatSARIF_AllRules` — all 5 rules in `tool.driver.rules[]`
- [x] `TestFormatSARIF_SeverityMapping` — Error/Warning/Info → error/warning/note
- [x] `TestFormatMermaid_BasicGraph` — simple call chain renders valid Mermaid
- [x] `TestFormatMermaid_LoopAnnotations` — loop edges annotated with depth
- [x] `TestFormatMermaid_CycleHighlight` — cycle edges use dashed arrows
- [x] `TestFormatMermaid_ExpensiveNodes` — expensive nodes get hexagon shape + fill style
- [x] `TestFormatMermaid_EmptyGraph` — no crash on nil/empty input
- [x] `make test` — full test suite passes
- [x] `make static-checks` — golangci-lint clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>