### PR TITLE
feat: add scope-aware ELPS minifier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,3 +134,12 @@ Prescriptive workflows live in `.claude/skills/`. **Before starting a task, read
 | `release/SKILL.md` | Create a tagged GitHub release with auto-generated notes from merged PRs |
 
 Multiple skills can chain: e.g., a GitHub issue triggers `pickup-issue`, which uses `implement` for the code change, `verify` before committing, and `pr` to ship.
+
+## GitHub Tooling
+
+Use `gh` for GitHub-hosted resources in this repository's workflows:
+- issues: `gh issue view`, `gh issue list`, `gh issue comment`
+- pull requests: `gh pr view`, `gh pr checks`, `gh pr create`
+- repo metadata and API queries: `gh repo view`, `gh api`
+
+Do not use generic web-scraping/search tooling for normal GitHub issue or PR retrieval when the GitHub CLI can provide the data directly.

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -79,6 +79,7 @@ func (a *analyzer) prescanDefun(expr *lisp.LVal, scope *Scope, kind SymbolKind) 
 		Name:      nameVal.Str,
 		Kind:      kind,
 		Source:    nameVal.Source,
+		Node:      nameVal,
 		Signature: signatureFromFormals(formalsVal),
 		DocString: docStr,
 	}
@@ -102,6 +103,7 @@ func (a *analyzer) prescanSet(expr *lisp.LVal, scope *Scope) {
 		Name:   name,
 		Kind:   SymVariable,
 		Source: expr.Cells[1].Source,
+		Node:   extractSetSymbolNode(expr.Cells[1]),
 	}
 	scope.Define(sym)
 	a.result.Symbols = append(a.result.Symbols, sym)
@@ -123,6 +125,7 @@ func (a *analyzer) prescanDeftype(expr *lisp.LVal, scope *Scope) {
 		Name:   nameVal.Str,
 		Kind:   SymType,
 		Source: nameVal.Source,
+		Node:   nameVal,
 	}
 	scope.Define(sym)
 	a.result.Symbols = append(a.result.Symbols, sym)
@@ -245,6 +248,16 @@ func extractSetSymbolName(arg *lisp.LVal) string {
 	return ""
 }
 
+func extractSetSymbolNode(arg *lisp.LVal) *lisp.LVal {
+	if arg.Type == lisp.LSymbol {
+		return arg
+	}
+	if arg.Type == lisp.LSExpr && arg.Quoted && len(arg.Cells) > 0 && arg.Cells[0].Type == lisp.LSymbol {
+		return arg.Cells[0]
+	}
+	return nil
+}
+
 // analyzeExpr recursively walks an expression, building scopes and
 // tracking symbol references.
 func (a *analyzer) analyzeExpr(node *lisp.LVal, scope *Scope) {
@@ -340,6 +353,7 @@ func (a *analyzer) analyzeDefun(node *lisp.LVal, scope *Scope, kind SymbolKind) 
 			Name:   nameVal.Str,
 			Kind:   kind,
 			Source: nameVal.Source,
+			Node:   nameVal,
 		}
 		if formalsForSig.Type == lisp.LSExpr {
 			sym.Signature = signatureFromFormals(formalsForSig)
@@ -387,6 +401,7 @@ func (a *analyzer) analyzeDeftype(node *lisp.LVal, scope *Scope) {
 			Name:   nameVal.Str,
 			Kind:   SymType,
 			Source: nameVal.Source,
+			Node:   nameVal,
 		}
 		scope.Define(sym)
 		a.result.Symbols = append(a.result.Symbols, sym)
@@ -417,6 +432,7 @@ func (a *analyzer) analyzeStringDeftype(node *lisp.LVal, scope *Scope) {
 		Name:   nameVal.Str,
 		Kind:   SymVariable,
 		Source: nameVal.Source,
+		Node:   nameVal,
 	}
 	scope.Define(sym)
 	a.result.Symbols = append(a.result.Symbols, sym)
@@ -470,6 +486,7 @@ func (a *analyzer) analyzeDefLike(node *lisp.LVal, scope *Scope) {
 				Name:   nameVal.Str,
 				Kind:   SymFunction,
 				Source: nameVal.Source,
+				Node:   nameVal,
 			}
 			scope.Define(sym)
 			a.result.Symbols = append(a.result.Symbols, sym)
@@ -569,6 +586,7 @@ func (a *analyzer) analyzeLet(node *lisp.LVal, scope *Scope, sequential bool) {
 				Name:   nameVal.Str,
 				Kind:   SymVariable,
 				Source: nameVal.Source,
+				Node:   nameVal,
 			}
 			letScope.Define(sym)
 			a.result.Symbols = append(a.result.Symbols, sym)
@@ -607,6 +625,7 @@ func (a *analyzer) analyzeFlet(node *lisp.LVal, scope *Scope, labels bool) {
 				Name:      nameVal.Str,
 				Kind:      SymFunction,
 				Source:    nameVal.Source,
+				Node:      nameVal,
 				Signature: signatureFromFormals(formalsVal),
 			}
 			fletScope.Define(sym)
@@ -641,6 +660,7 @@ func (a *analyzer) analyzeFlet(node *lisp.LVal, scope *Scope, labels bool) {
 				Name:      nameVal.Str,
 				Kind:      SymFunction,
 				Source:    nameVal.Source,
+				Node:      nameVal,
 				Signature: signatureFromFormals(formalsVal),
 			}
 			fletScope.Define(sym)
@@ -681,6 +701,7 @@ func (a *analyzer) analyzeDotimes(node *lisp.LVal, scope *Scope) {
 			Name:   varVal.Str,
 			Kind:   SymVariable,
 			Source: varVal.Source,
+			Node:   varVal,
 		}
 		dotimesScope.Define(sym)
 		a.result.Symbols = append(a.result.Symbols, sym)
@@ -736,6 +757,7 @@ func (a *analyzer) analyzeTestLet(node *lisp.LVal, scope *Scope, sequential bool
 				Name:   nameVal.Str,
 				Kind:   SymVariable,
 				Source: nameVal.Source,
+				Node:   nameVal,
 			}
 			letScope.Define(sym)
 			a.result.Symbols = append(a.result.Symbols, sym)
@@ -766,6 +788,7 @@ func (a *analyzer) analyzeSet(node *lisp.LVal, scope *Scope) {
 			Name:   name,
 			Kind:   SymVariable,
 			Source: node.Cells[1].Source,
+			Node:   extractSetSymbolNode(node.Cells[1]),
 		}
 		scope.Define(sym)
 		a.result.Symbols = append(a.result.Symbols, sym)
@@ -926,6 +949,7 @@ func (a *analyzer) addParams(formalsVal *lisp.LVal, scope *Scope) {
 		for _, cell := range formalsVal.Cells {
 			if cell.Type == lisp.LSymbol && cell.Str == p.Name {
 				sym.Source = cell.Source
+				sym.Node = cell
 				break
 			}
 		}

--- a/analysis/symbol.go
+++ b/analysis/symbol.go
@@ -46,6 +46,7 @@ type Symbol struct {
 	Name       string
 	Kind       SymbolKind
 	Source     *token.Location // nil for builtins
+	Node       *lisp.LVal
 	Scope      *Scope
 	Signature  *Signature // non-nil for callables
 	DocString  string

--- a/cmd/minify.go
+++ b/cmd/minify.go
@@ -1,0 +1,175 @@
+// Copyright © 2026 The ELPS authors
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/luthersystems/elps/formatter"
+	"github.com/luthersystems/elps/lint"
+	"github.com/luthersystems/elps/minifier"
+	"github.com/spf13/cobra"
+)
+
+var (
+	minifyWrite         bool
+	minifyMapPath       string
+	minifyExcludeFiles  []string
+	minifyExcludes      []string
+	minifyWorkspace     string
+	minifyRenameExports bool
+)
+
+var minifyCmd = &cobra.Command{
+	Use:   "minify [flags] [files...]",
+	Short: "Minify ELPS source files with a symbol map",
+	Long: `Minify ELPS source files using deterministic, scope-aware symbol renaming.
+
+With no files, reads from stdin and writes the minified source to stdout.
+With one file, prints minified output to stdout unless -w is given.
+With multiple files, use -w to rewrite files in place.
+
+The command can also emit a machine-readable JSON symbol map for downstream
+tooling via --map. Minified output uses the formatter's compact mode, which
+removes redundant whitespace and strips comments.`,
+	Run: func(_ *cobra.Command, args []string) {
+		if err := runMinify(args, os.Stdin, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "elps minify: %v\n", err)
+			os.Exit(2)
+		}
+	},
+}
+
+func buildMinifyConfig() (*minifier.Config, error) {
+	exclusions := make(map[string]bool, len(minifyExcludes))
+	for _, name := range minifyExcludes {
+		exclusions[name] = true
+	}
+	for _, path := range minifyExcludeFiles {
+		names, err := minifier.ReadExcludeFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading exclude file %s: %w", path, err)
+		}
+		for _, name := range names {
+			exclusions[name] = true
+		}
+	}
+
+	cfg := &minifier.Config{
+		Exclusions:    exclusions,
+		RenameExports: minifyRenameExports,
+		Formatter:     formatter.DefaultConfig(),
+	}
+	cfg.Formatter.Compact = true
+	cfg.Formatter.StripComments = true
+
+	if minifyWorkspace != "" {
+		acfg, err := lint.BuildAnalysisConfig(&lint.LintConfig{Workspace: minifyWorkspace})
+		if err != nil {
+			return nil, err
+		}
+		cfg.Analysis = acfg
+	}
+
+	return cfg, nil
+}
+
+func runMinify(args []string, stdin io.Reader, stdout io.Writer) error {
+	if len(args) > 1 && !minifyWrite {
+		return fmt.Errorf("multiple files require --write")
+	}
+
+	cfg, err := buildMinifyConfig()
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return minifyStdin(cfg, stdin, stdout)
+	}
+
+	expanded, err := expandArgs(args, nil)
+	if err != nil {
+		return err
+	}
+	if len(expanded) == 0 {
+		return fmt.Errorf("no .lisp files found")
+	}
+
+	inputs := make([]minifier.InputFile, 0, len(expanded))
+	for _, path := range expanded {
+		src, readErr := os.ReadFile(path) //nolint:gosec // CLI tool reads user-specified files
+		if readErr != nil {
+			return fmt.Errorf("%s: %w", path, readErr)
+		}
+		inputs = append(inputs, minifier.InputFile{Path: path, Source: src})
+	}
+
+	result, err := minifier.Minify(inputs, cfg)
+	if err != nil {
+		return err
+	}
+
+	if minifyWrite {
+		for _, file := range result.Files {
+			info, statErr := os.Stat(file.Path)
+			if statErr != nil {
+				return fmt.Errorf("%s: %w", file.Path, statErr)
+			}
+			if writeErr := os.WriteFile(file.Path, file.Output, info.Mode().Perm()); writeErr != nil {
+				return fmt.Errorf("%s: %w", file.Path, writeErr)
+			}
+		}
+	} else {
+		if _, err := stdout.Write(result.Files[0].Output); err != nil {
+			return err
+		}
+	}
+
+	return writeMapIfNeeded(result.SymbolMap)
+}
+
+func minifyStdin(cfg *minifier.Config, stdin io.Reader, stdout io.Writer) error {
+	src, err := io.ReadAll(stdin)
+	if err != nil {
+		return err
+	}
+	out, symMap, err := minifier.MinifySource(src, "<stdin>", cfg)
+	if err != nil {
+		return err
+	}
+	if _, err := stdout.Write(out); err != nil {
+		return err
+	}
+	return writeMapIfNeeded(symMap)
+}
+
+func writeMapIfNeeded(symMap minifier.SymbolMap) error {
+	if minifyMapPath == "" {
+		return nil
+	}
+	data, err := symMap.JSON()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(minifyMapPath, data, 0o600)
+}
+
+func init() {
+	rootCmd.AddCommand(minifyCmd)
+
+	minifyCmd.Flags().BoolVarP(&minifyWrite, "write", "w", false,
+		"Write result back to source files.")
+	minifyCmd.Flags().StringVar(&minifyMapPath, "map", "",
+		"Write the JSON symbol map to the given path.")
+	minifyCmd.Flags().StringArrayVar(&minifyExcludes, "exclude", nil,
+		"Symbol name to exclude from renaming (may be repeated).")
+	minifyCmd.Flags().StringArrayVar(&minifyExcludeFiles, "exclude-file", nil,
+		"File containing symbols to exclude from renaming (may be repeated).")
+	minifyCmd.Flags().StringVar(&minifyWorkspace, "workspace", "",
+		"Workspace root for cross-file semantic resolution.")
+	minifyCmd.Flags().BoolVar(&minifyRenameExports, "rename-exports", false,
+		"Rename exported top-level symbols and rewrite matching export forms.")
+}

--- a/cmd/minify_test.go
+++ b/cmd/minify_test.go
@@ -33,7 +33,7 @@ func TestRunMinify_StdoutSingleFile(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "(defun x1 (x2) x2)\n", out.String())
-	src, err := os.ReadFile(path)
+	src, err := os.ReadFile(path) //nolint:gosec // test reads temp file created in this test
 	require.NoError(t, err)
 	assert.Equal(t, "(defun outer (value) value)\n", string(src))
 }
@@ -52,11 +52,11 @@ func TestRunMinify_WriteAndMap(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, out.String())
 
-	src, err := os.ReadFile(path)
+	src, err := os.ReadFile(path) //nolint:gosec // test reads temp file created in this test
 	require.NoError(t, err)
 	assert.Equal(t, "(defun x1 (x2) x2)\n", string(src))
 
-	mapBytes, err := os.ReadFile(mapPath)
+	mapBytes, err := os.ReadFile(mapPath) //nolint:gosec // test reads temp file created in this test
 	require.NoError(t, err)
 	var symMap minifier.SymbolMap
 	require.NoError(t, json.Unmarshal(mapBytes, &symMap))

--- a/cmd/minify_test.go
+++ b/cmd/minify_test.go
@@ -1,0 +1,103 @@
+// Copyright © 2026 The ELPS authors
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luthersystems/elps/minifier"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMinifyCommand_DefaultFlags(t *testing.T) {
+	assert.Equal(t, "minify [flags] [files...]", minifyCmd.Use)
+
+	for _, name := range []string{"write", "map", "exclude", "exclude-file", "workspace", "rename-exports"} {
+		assert.NotNil(t, minifyCmd.Flags().Lookup(name), "missing flag: %s", name)
+	}
+}
+
+func TestRunMinify_StdoutSingleFile(t *testing.T) {
+	resetMinifyFlags()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demo.lisp")
+	require.NoError(t, os.WriteFile(path, []byte("(defun outer (value) value)\n"), 0o600))
+
+	var out bytes.Buffer
+	err := runMinify([]string{path}, bytes.NewBuffer(nil), &out)
+	require.NoError(t, err)
+
+	assert.Equal(t, "(defun x1 (x2) x2)\n", out.String())
+	src, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "(defun outer (value) value)\n", string(src))
+}
+
+func TestRunMinify_WriteAndMap(t *testing.T) {
+	resetMinifyFlags()
+	minifyWrite = true
+	dir := t.TempDir()
+	path := filepath.Join(dir, "demo.lisp")
+	mapPath := filepath.Join(dir, "map.json")
+	minifyMapPath = mapPath
+	require.NoError(t, os.WriteFile(path, []byte("(defun outer (value) value)\n"), 0o600))
+
+	var out bytes.Buffer
+	err := runMinify([]string{path}, bytes.NewBuffer(nil), &out)
+	require.NoError(t, err)
+	assert.Empty(t, out.String())
+
+	src, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "(defun x1 (x2) x2)\n", string(src))
+
+	mapBytes, err := os.ReadFile(mapPath)
+	require.NoError(t, err)
+	var symMap minifier.SymbolMap
+	require.NoError(t, json.Unmarshal(mapBytes, &symMap))
+	assert.Equal(t, "outer", symMap.MinifiedToOriginal["x1"])
+	assert.Equal(t, "value", symMap.MinifiedToOriginal["x2"])
+}
+
+func TestRunMinify_Stdin(t *testing.T) {
+	resetMinifyFlags()
+
+	var out bytes.Buffer
+	err := runMinify(nil, bytes.NewBufferString("(defun outer (value) value)\n"), &out)
+	require.NoError(t, err)
+	assert.Equal(t, "(defun x1 (x2) x2)\n", out.String())
+}
+
+func TestRunMinify_MultipleFilesRequireWrite(t *testing.T) {
+	resetMinifyFlags()
+	err := runMinify([]string{"a.lisp", "b.lisp"}, bytes.NewBuffer(nil), &bytes.Buffer{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple files require --write")
+}
+
+func TestRunMinify_RenameExports(t *testing.T) {
+	resetMinifyFlags()
+	minifyRenameExports = true
+	dir := t.TempDir()
+	path := filepath.Join(dir, "exports.lisp")
+	require.NoError(t, os.WriteFile(path, []byte("(export 'public)\n(defun public (arg) arg)\n"), 0o600))
+
+	var out bytes.Buffer
+	err := runMinify([]string{path}, bytes.NewBuffer(nil), &out)
+	require.NoError(t, err)
+	assert.Equal(t, "(export 'x1)\n(defun x1 (x2) x2)\n", out.String())
+}
+
+func resetMinifyFlags() {
+	minifyWrite = false
+	minifyMapPath = ""
+	minifyExcludeFiles = nil
+	minifyExcludes = nil
+	minifyWorkspace = ""
+	minifyRenameExports = false
+}

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -34,7 +34,7 @@ func Format(source []byte, cfg *Config) ([]byte, error) {
 
 	pr := newPrinter(cfg)
 	if cfg.Compact {
-		pr.writeTopLevelCompact(exprs)
+		pr.writeTopLevelCompact(exprs, trailingComments)
 	} else {
 		pr.writeTopLevel(exprs, trailingComments)
 	}
@@ -67,7 +67,7 @@ func FormatFile(source []byte, filename string, cfg *Config) ([]byte, error) {
 
 	pr := newPrinter(cfg)
 	if cfg.Compact {
-		pr.writeTopLevelCompact(exprs)
+		pr.writeTopLevelCompact(exprs, trailingComments)
 	} else {
 		pr.writeTopLevel(exprs, trailingComments)
 	}
@@ -90,7 +90,7 @@ func FormatProgram(exprs []*lisp.LVal, trailingComments []*token.Token, cfg *Con
 
 	pr := newPrinter(cfg)
 	if cfg.Compact {
-		pr.writeTopLevelCompact(exprs)
+		pr.writeTopLevelCompact(exprs, trailingComments)
 	} else {
 		pr.writeTopLevel(exprs, trailingComments)
 	}

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"strings"
 
+	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/parser/rdparser"
 	"github.com/luthersystems/elps/parser/token"
 )
@@ -32,7 +33,11 @@ func Format(source []byte, cfg *Config) ([]byte, error) {
 	trailingComments := p.PendingComments()
 
 	pr := newPrinter(cfg)
-	pr.writeTopLevel(exprs, trailingComments)
+	if cfg.Compact {
+		pr.writeTopLevelCompact(exprs)
+	} else {
+		pr.writeTopLevel(exprs, trailingComments)
+	}
 
 	result := pr.buf.String()
 
@@ -61,7 +66,11 @@ func FormatFile(source []byte, filename string, cfg *Config) ([]byte, error) {
 	trailingComments := p.PendingComments()
 
 	pr := newPrinter(cfg)
-	pr.writeTopLevel(exprs, trailingComments)
+	if cfg.Compact {
+		pr.writeTopLevelCompact(exprs)
+	} else {
+		pr.writeTopLevel(exprs, trailingComments)
+	}
 
 	result := pr.buf.String()
 
@@ -70,4 +79,25 @@ func FormatFile(source []byte, filename string, cfg *Config) ([]byte, error) {
 	}
 
 	return []byte(result), nil
+}
+
+// FormatProgram formats an already-parsed ELPS program plus any trailing
+// comments collected after the last expression.
+func FormatProgram(exprs []*lisp.LVal, trailingComments []*token.Token, cfg *Config) []byte {
+	if cfg == nil {
+		cfg = DefaultConfig()
+	}
+
+	pr := newPrinter(cfg)
+	if cfg.Compact {
+		pr.writeTopLevelCompact(exprs)
+	} else {
+		pr.writeTopLevel(exprs, trailingComments)
+	}
+
+	result := pr.buf.String()
+	if len(result) > 0 {
+		result = strings.TrimRight(result, "\n") + "\n"
+	}
+	return []byte(result)
 }

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -255,6 +255,18 @@ func TestCompactMode(t *testing.T) {
 			expected: "''value\n",
 			config:   cfg,
 		},
+		{
+			name:     "compact preserves comments when strip-comments is false",
+			input:    ";; header\n(foo bar) ; tail\n",
+			expected: ";; header\n(foo bar) ; tail\n",
+			config: &Config{
+				Compact:       true,
+				StripComments: false,
+				IndentSize:    2,
+				MaxBlankLines: 1,
+				Rules:         DefaultRules(),
+			},
+		},
 	}
 	runFormatTests(t, tests)
 	for _, tt := range tests {

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -92,8 +92,8 @@ func TestIndentDefaultAlign(t *testing.T) {
 				"     baz)\n",
 		},
 		{
-			name:  "extra spaces preserved for column alignment",
-			input: "(foo   bar   baz)",
+			name:     "extra spaces preserved for column alignment",
+			input:    "(foo   bar   baz)",
 			expected: "(foo   bar   baz)\n",
 		},
 	})
@@ -102,18 +102,18 @@ func TestIndentDefaultAlign(t *testing.T) {
 func TestIndentDefun(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "defun body indent",
+			name:  "defun body indent",
 			input: "(defun square (x)\n(* x x))",
 			expected: "(defun square (x)\n" +
 				"  (* x x))\n",
 		},
 		{
-			name: "defun single line stays single",
-			input: "(defun id (x) x)",
+			name:     "defun single line stays single",
+			input:    "(defun id (x) x)",
 			expected: "(defun id (x) x)\n",
 		},
 		{
-			name: "defmacro body indent",
+			name:  "defmacro body indent",
 			input: "(defmacro my-macro (x)\n(list x))",
 			expected: "(defmacro my-macro (x)\n" +
 				"  (list x))\n",
@@ -124,7 +124,7 @@ func TestIndentDefun(t *testing.T) {
 func TestIndentLambda(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "lambda body indent",
+			name:  "lambda body indent",
 			input: "(lambda (x)\n(+ x 1))",
 			expected: "(lambda (x)\n" +
 				"  (+ x 1))\n",
@@ -135,13 +135,13 @@ func TestIndentLambda(t *testing.T) {
 func TestIndentLet(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "let body indent",
+			name:  "let body indent",
 			input: "(let ((x 1))\n(+ x 2))",
 			expected: "(let ((x 1))\n" +
 				"  (+ x 2))\n",
 		},
 		{
-			name: "let with brackets",
+			name:  "let with brackets",
 			input: "(let ([x 1] [y 2])\n(+ x y))",
 			expected: "(let ([x 1] [y 2])\n" +
 				"  (+ x y))\n",
@@ -152,7 +152,7 @@ func TestIndentLet(t *testing.T) {
 func TestIndentIf(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "if then else",
+			name:  "if then else",
 			input: "(if (> x 0)\ntrue\nfalse)",
 			expected: "(if (> x 0)\n" +
 				"  true\n" +
@@ -164,7 +164,7 @@ func TestIndentIf(t *testing.T) {
 func TestIndentProgn(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "progn body",
+			name:  "progn body",
 			input: "(progn\n(foo)\n(bar))",
 			expected: "(progn\n" +
 				"  (foo)\n" +
@@ -176,14 +176,14 @@ func TestIndentProgn(t *testing.T) {
 func TestIndentCond(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "cond args on next line use body indent",
+			name:  "cond args on next line use body indent",
 			input: "(cond\n((= x 1) \"one\")\n(:else \"other\"))",
 			expected: "(cond\n" +
 				"  ((= x 1) \"one\")\n" +
 				"  (:else \"other\"))\n",
 		},
 		{
-			name: "cond first-arg on same line uses alignment",
+			name:  "cond first-arg on same line uses alignment",
 			input: "(cond ((= x 1) \"one\")\n((= x 2) \"two\"))",
 			expected: "(cond ((= x 1) \"one\")\n" +
 				"      ((= x 2) \"two\"))\n",
@@ -222,16 +222,58 @@ func TestIndentOrAnd(t *testing.T) {
 	})
 }
 
+func TestCompactMode(t *testing.T) {
+	cfg := &Config{
+		Compact:       true,
+		StripComments: true,
+		IndentSize:    2,
+		MaxBlankLines: 1,
+		Rules:         DefaultRules(),
+	}
+	tests := []formatTest{
+		{
+			name:     "compact removes comments and redundant whitespace",
+			input:    ";; top\n(defun demo (value)\n\n  ; inline lead\n  (let ((value (+ value 1))) ; trailing\n    (debug-print 'value)\n    value))\n",
+			expected: "(defun demo (value) (let ((value (+ value 1))) (debug-print 'value) value))\n",
+			config:   cfg,
+		},
+		{
+			name:     "compact keeps top-level forms on separate lines",
+			input:    "(set x 1)\n\n(set y 2)\n",
+			expected: "(set x 1)\n(set y 2)\n",
+			config:   cfg,
+		},
+		{
+			name:     "compact preserves quoted bracket lists",
+			input:    "(quasiquote (let ([(unquote patt) 42]) [patt]))\n",
+			expected: "(quasiquote (let ([(unquote patt) 42]) [patt]))\n",
+			config:   cfg,
+		},
+		{
+			name:     "compact preserves multiple quote levels",
+			input:    "''value\n",
+			expected: "''value\n",
+			config:   cfg,
+		},
+	}
+	runFormatTests(t, tests)
+	for _, tt := range tests {
+		got, err := Format([]byte(tt.input), cfg)
+		require.NoError(t, err)
+		roundTripEqual(t, tt.input, string(got))
+	}
+}
+
 func TestIndentTest(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "test special",
+			name:  "test special",
 			input: "(test \"my test\"\n(assert= 1 1))",
 			expected: "(test \"my test\"\n" +
 				"  (assert= 1 1))\n",
 		},
 		{
-			name: "test-let special 2 header args",
+			name:  "test-let special 2 header args",
 			input: "(test-let \"my test\" ((x 1))\n(assert= 1 x))",
 			expected: "(test-let \"my test\" ((x 1))\n" +
 				"  (assert= 1 x))\n",
@@ -242,14 +284,14 @@ func TestIndentTest(t *testing.T) {
 func TestIndentThreading(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "thread-first aligns with first arg",
+			name:  "thread-first aligns with first arg",
 			input: "(thread-first val\n(foo)\n(bar))",
 			expected: "(thread-first val\n" +
 				"              (foo)\n" +
 				"              (bar))\n",
 		},
 		{
-			name: "thread-first wraps to body indent",
+			name:  "thread-first wraps to body indent",
 			input: "(thread-first\nval\n(foo)\n(bar))",
 			expected: "(thread-first\n" +
 				"  val\n" +
@@ -262,7 +304,7 @@ func TestIndentThreading(t *testing.T) {
 func TestIndentDo(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "do special",
+			name:  "do special",
 			input: "(do ((i 0 (+ i 1)))\n(body))",
 			expected: "(do ((i 0 (+ i 1)))\n" +
 				"  (body))\n",
@@ -273,7 +315,7 @@ func TestIndentDo(t *testing.T) {
 func TestIndentIgnoreErrors(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "ignore-errors body",
+			name:  "ignore-errors body",
 			input: "(ignore-errors\n(risky-op))",
 			expected: "(ignore-errors\n" +
 				"  (risky-op))\n",
@@ -286,8 +328,8 @@ func TestIndentIgnoreErrors(t *testing.T) {
 func TestCommentLeadingTopLevel(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "comment before top-level form",
-			input: "; hello\n(foo)",
+			name:     "comment before top-level form",
+			input:    "; hello\n(foo)",
 			expected: "; hello\n(foo)\n",
 		},
 	})
@@ -296,8 +338,8 @@ func TestCommentLeadingTopLevel(t *testing.T) {
 func TestCommentBetweenForms(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "comment between two forms",
-			input: "(foo)\n\n; separator\n(bar)",
+			name:     "comment between two forms",
+			input:    "(foo)\n\n; separator\n(bar)",
 			expected: "(foo)\n\n; separator\n(bar)\n",
 		},
 	})
@@ -306,7 +348,7 @@ func TestCommentBetweenForms(t *testing.T) {
 func TestCommentInsideSExpr(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "comment inside s-expr",
+			name:  "comment inside s-expr",
 			input: "(defun foo (x)\n  ; compute\n  (+ x 1))",
 			expected: "(defun foo (x)\n" +
 				"  ; compute\n" +
@@ -318,7 +360,7 @@ func TestCommentInsideSExpr(t *testing.T) {
 func TestCommentInsideList(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "comment inside brackets",
+			name:  "comment inside brackets",
 			input: "[a\n; comment\nb]",
 			expected: "[a\n" +
 				" ; comment\n" +
@@ -330,8 +372,8 @@ func TestCommentInsideList(t *testing.T) {
 func TestCommentMultipleConsecutive(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "multiple consecutive comments",
-			input: "; line 1\n; line 2\n(foo)",
+			name:     "multiple consecutive comments",
+			input:    "; line 1\n; line 2\n(foo)",
 			expected: "; line 1\n; line 2\n(foo)\n",
 		},
 	})
@@ -362,17 +404,17 @@ func TestCommentAttachedVsDetached(t *testing.T) {
 			expected: ";; hello\n(world)\n",
 		},
 		{
-			name: "section header detached then attached comment",
-			input: ";; section header\n\n;; attached comment\n(defun foo () 1)\n",
+			name:     "section header detached then attached comment",
+			input:    ";; section header\n\n;; attached comment\n(defun foo () 1)\n",
 			expected: ";; section header\n\n;; attached comment\n(defun foo () 1)\n",
 		},
 		{
-			name: "two comment blocks separated by blank line",
-			input: ";; block 1\n;; block 1 cont\n\n;; block 2\n(foo)\n",
+			name:     "two comment blocks separated by blank line",
+			input:    ";; block 1\n;; block 1 cont\n\n;; block 2\n(foo)\n",
 			expected: ";; block 1\n;; block 1 cont\n\n;; block 2\n(foo)\n",
 		},
 		{
-			name: "detached comments inside function body",
+			name:  "detached comments inside function body",
 			input: "(defun setup ()\n  ;; section one\n\n  (init)\n\n  ;; section two\n\n  (run))",
 			expected: "(defun setup ()\n" +
 				"  ;; section one\n\n" +
@@ -460,7 +502,7 @@ func TestBracketEmpty(t *testing.T) {
 func TestDataListIndent(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "let* binding pairs align inside bracket",
+			name:  "let* binding pairs align inside bracket",
 			input: "(let* ([x 1]\n[y 2]\n[z 3])\n(+ x y z))",
 			expected: "(let* ([x 1]\n" +
 				"       [y 2]\n" +
@@ -468,13 +510,13 @@ func TestDataListIndent(t *testing.T) {
 				"  (+ x y z))\n",
 		},
 		{
-			name: "cond with first-arg on same line aligns",
+			name:  "cond with first-arg on same line aligns",
 			input: "(cond ((= x 1) \"one\")\n((= x 2) \"two\"))",
 			expected: "(cond ((= x 1) \"one\")\n" +
 				"      ((= x 2) \"two\"))\n",
 		},
 		{
-			name: "nested data list in let",
+			name:  "nested data list in let",
 			input: "(let (([a 1] [b 2]))\n(+ a b))",
 			expected: "(let (([a 1] [b 2]))\n" +
 				"  (+ a b))\n",
@@ -653,8 +695,8 @@ func TestWhitespaceSpacingPreservation(t *testing.T) {
 				"  \"longer-key\" '(\"c\" \"d\"))\n",
 		},
 		{
-			name: "column-aligned data table preserved",
-			input: "(vector role \"permission/name\"   \"uuid-here\"  true  false)",
+			name:     "column-aligned data table preserved",
+			input:    "(vector role \"permission/name\"   \"uuid-here\"  true  false)",
 			expected: "(vector role \"permission/name\"   \"uuid-here\"  true  false)\n",
 		},
 		{
@@ -688,8 +730,8 @@ func TestListFirstChildOnNewLine(t *testing.T) {
 				"   [b \"2\"]])\n",
 		},
 		{
-			name: "empty list with bracket style preserved",
-			input: "(foo\n  [])",
+			name:     "empty list with bracket style preserved",
+			input:    "(foo\n  [])",
 			expected: "(foo\n  [])\n",
 		},
 	})
@@ -715,8 +757,8 @@ func TestDataListHeadOnNewLine(t *testing.T) {
 				" )\n",
 		},
 		{
-			name: "data list head on same line stays on same line",
-			input: "([a 1]\n [b 2])",
+			name:     "data list head on same line stays on same line",
+			input:    "([a 1]\n [b 2])",
 			expected: "([a 1]\n [b 2])\n",
 		},
 	})
@@ -725,18 +767,18 @@ func TestDataListHeadOnNewLine(t *testing.T) {
 func TestClosingBracketOnNewLine(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "closing paren on its own line preserved",
-			input: "(foo\n  bar\n  baz\n  )",
+			name:     "closing paren on its own line preserved",
+			input:    "(foo\n  bar\n  baz\n  )",
 			expected: "(foo\n  bar\n  baz\n  )\n",
 		},
 		{
-			name: "closing bracket on its own line preserved",
-			input: "[a\n b\n c\n ]",
+			name:     "closing bracket on its own line preserved",
+			input:    "[a\n b\n c\n ]",
 			expected: "[a\n b\n c\n ]\n",
 		},
 		{
-			name: "closing paren on same line stays on same line",
-			input: "(foo\n  bar\n  baz)",
+			name:     "closing paren on same line stays on same line",
+			input:    "(foo\n  bar\n  baz)",
 			expected: "(foo\n  bar\n  baz)\n",
 		},
 	})
@@ -765,8 +807,8 @@ func TestWhitespaceBeforeClose(t *testing.T) {
 func TestWhitespaceTrailing(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "trailing whitespace removed",
-			input: "(foo)   \n",
+			name:     "trailing whitespace removed",
+			input:    "(foo)   \n",
 			expected: "(foo)\n",
 		},
 	})
@@ -777,8 +819,8 @@ func TestWhitespaceTrailing(t *testing.T) {
 func TestBlankLineSinglePreserved(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name:  "single blank line preserved",
-			input: "(foo)\n\n(bar)\n",
+			name:     "single blank line preserved",
+			input:    "(foo)\n\n(bar)\n",
 			expected: "(foo)\n\n(bar)\n",
 		},
 	})
@@ -787,8 +829,8 @@ func TestBlankLineSinglePreserved(t *testing.T) {
 func TestBlankLineMultipleCollapsed(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name:  "multiple blank lines collapsed",
-			input: "(foo)\n\n\n\n(bar)\n",
+			name:     "multiple blank lines collapsed",
+			input:    "(foo)\n\n\n\n(bar)\n",
 			expected: "(foo)\n\n(bar)\n",
 		},
 	})
@@ -819,14 +861,14 @@ func TestTrailingNewline(t *testing.T) {
 func TestBlankLinesInsideBody(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "blank line between forms in defun body",
+			name:  "blank line between forms in defun body",
 			input: "(defun foo ()\n(bar)\n\n(baz))",
 			expected: "(defun foo ()\n" +
 				"  (bar)\n\n" +
 				"  (baz))\n",
 		},
 		{
-			name: "blank line between forms in progn",
+			name:  "blank line between forms in progn",
 			input: "(progn\n(a)\n\n(b))",
 			expected: "(progn\n" +
 				"  (a)\n\n" +
@@ -840,20 +882,20 @@ func TestBlankLinesInsideBody(t *testing.T) {
 func TestIndentSpecialNewlineFallback(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "unless condition on same line keeps special",
+			name:  "unless condition on same line keeps special",
 			input: "(unless (> x 0)\n(do-something))",
 			expected: "(unless (> x 0)\n" +
 				"  (do-something))\n",
 		},
 		{
-			name: "unless condition on next line uses body indent",
+			name:  "unless condition on next line uses body indent",
 			input: "(unless\n(> x 0)\n(do-something))",
 			expected: "(unless\n" +
 				"  (> x 0)\n" +
 				"  (do-something))\n",
 		},
 		{
-			name: "if condition on next line uses body indent",
+			name:  "if condition on next line uses body indent",
 			input: "(if\ncondition\nthen\nelse)",
 			expected: "(if\n" +
 				"  condition\n" +
@@ -878,7 +920,7 @@ func TestNestedDeep(t *testing.T) {
 func TestNestedMixedRules(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "defun with let inside",
+			name:  "defun with let inside",
 			input: "(defun foo (x)\n(let ((y 1))\n(+ x y)))",
 			expected: "(defun foo (x)\n" +
 				"  (let ((y 1))\n" +
@@ -970,7 +1012,7 @@ func TestConfigCustomIndentSize(t *testing.T) {
 	cfg.IndentSize = 4
 	runFormatTests(t, []formatTest{
 		{
-			name: "4-space indent",
+			name:  "4-space indent",
 			input: "(defun foo (x)\n(+ x 1))",
 			expected: "(defun foo (x)\n" +
 				"    (+ x 1))\n",
@@ -984,7 +1026,7 @@ func TestConfigCustomRule(t *testing.T) {
 	cfg.Rules["my-form"] = &IndentRule{Style: IndentSpecial, HeaderArgs: 1}
 	runFormatTests(t, []formatTest{
 		{
-			name: "custom rule",
+			name:  "custom rule",
 			input: "(my-form header\nbody)",
 			expected: "(my-form header\n" +
 				"  body)\n",
@@ -1039,7 +1081,7 @@ func TestHashbang(t *testing.T) {
 func TestIndentDeftype(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "deftype body indent",
+			name:  "deftype body indent",
 			input: "(deftype my-type (x)\n(validate x))",
 			expected: "(deftype my-type (x)\n" +
 				"  (validate x))\n",
@@ -1052,7 +1094,7 @@ func TestIndentDeftype(t *testing.T) {
 func TestIndentFlet(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "flet body indent",
+			name:  "flet body indent",
 			input: "(flet ((helper (x) (+ x 1)))\n(helper 5))",
 			expected: "(flet ((helper (x) (+ x 1)))\n" +
 				"  (helper 5))\n",
@@ -1065,7 +1107,7 @@ func TestIndentFlet(t *testing.T) {
 func TestIndentHandlerBind(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "handler-bind body indent",
+			name:  "handler-bind body indent",
 			input: "(handler-bind ((error (lambda (c) (handle c))))\n(risky-op))",
 			expected: "(handler-bind ((error (lambda (c) (handle c))))\n" +
 				"  (risky-op))\n",
@@ -1078,7 +1120,7 @@ func TestIndentHandlerBind(t *testing.T) {
 func TestIndentDotimes(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "dotimes body indent",
+			name:  "dotimes body indent",
 			input: "(dotimes (i 10)\n(print i))",
 			expected: "(dotimes (i 10)\n" +
 				"  (print i))\n",
@@ -1091,7 +1133,7 @@ func TestIndentDotimes(t *testing.T) {
 func TestIndentWhen(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "when body indent",
+			name:  "when body indent",
 			input: "(when (> x 0)\n(do-something))",
 			expected: "(when (> x 0)\n" +
 				"  (do-something))\n",
@@ -1102,7 +1144,7 @@ func TestIndentWhen(t *testing.T) {
 func TestIndentUnless(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "unless body indent",
+			name:  "unless body indent",
 			input: "(unless (> x 0)\n(do-something))",
 			expected: "(unless (> x 0)\n" +
 				"  (do-something))\n",
@@ -1145,7 +1187,7 @@ func TestPatternCondWithClauses(t *testing.T) {
 func TestPatternSortedMapWrapped(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "sorted-map with args on next line uses body indent",
+			name:  "sorted-map with args on next line uses body indent",
 			input: "(set 'lookup (sorted-map\n\"key1\" 1\n\"key2\" 2\n\"key3\" 3))",
 			expected: "(set 'lookup (sorted-map\n" +
 				"               \"key1\" 1\n" +
@@ -1158,7 +1200,7 @@ func TestPatternSortedMapWrapped(t *testing.T) {
 func TestPatternHandlerBind(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "handler-bind with handler on same line",
+			name:  "handler-bind with handler on same line",
 			input: "(handler-bind ([err (lambda (c) (handle c))])\n(risky-op)\n(more-ops))",
 			expected: "(handler-bind ([err (lambda (c) (handle c))])\n" +
 				"  (risky-op)\n" +
@@ -1194,7 +1236,7 @@ func TestPatternNestedLetLambda(t *testing.T) {
 func TestPatternThreadFirst(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "thread-first with multiple transformations",
+			name:  "thread-first with multiple transformations",
 			input: "(thread-first message\n(to-bytes)\n(compress)\n(encode)\n(to-string))",
 			expected: "(thread-first message\n" +
 				"              (to-bytes)\n" +
@@ -1208,7 +1250,7 @@ func TestPatternThreadFirst(t *testing.T) {
 func TestPatternBlankLinesInBody(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "blank lines between body forms in defun",
+			name:  "blank lines between body forms in defun",
 			input: "(defun setup ()\n(init-db)\n\n(init-cache)\n\n(start-server))",
 			expected: "(defun setup ()\n" +
 				"  (init-db)\n\n" +
@@ -1221,12 +1263,12 @@ func TestPatternBlankLinesInBody(t *testing.T) {
 func TestPatternBlankLineAfterComment(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "blank line between comment and form preserved at top level",
-			input: "; storage key format\n; prefix:id\n\n(set 'storage-prefix \"data\")",
+			name:     "blank line between comment and form preserved at top level",
+			input:    "; storage key format\n; prefix:id\n\n(set 'storage-prefix \"data\")",
 			expected: "; storage key format\n; prefix:id\n\n(set 'storage-prefix \"data\")\n",
 		},
 		{
-			name: "blank line after comment inside body",
+			name:  "blank line after comment inside body",
 			input: "(defun foo ()\n; setup\n\n(init)\n(run))",
 			expected: "(defun foo ()\n" +
 				"  ; setup\n\n" +
@@ -1239,14 +1281,14 @@ func TestPatternBlankLineAfterComment(t *testing.T) {
 func TestPatternAndOrAlignment(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "and with conditions on same line aligns",
+			name:  "and with conditions on same line aligns",
 			input: "(and (not passed)\n(not optional)\n(key? lookup id))",
 			expected: "(and (not passed)\n" +
 				"     (not optional)\n" +
 				"     (key? lookup id))\n",
 		},
 		{
-			name: "or with conditions on same line aligns",
+			name:  "or with conditions on same line aligns",
 			input: "(or (empty? status)\n(equal? status \"DISABLED\"))",
 			expected: "(or (empty? status)\n" +
 				"    (equal? status \"DISABLED\"))\n",
@@ -1257,20 +1299,20 @@ func TestPatternAndOrAlignment(t *testing.T) {
 func TestPatternFirstArgWrapped(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "long function name with first arg wrapped uses body indent",
+			name:  "long function name with first arg wrapped uses body indent",
 			input: "(assert-error\n'lisp:assert\nexamples)",
 			expected: "(assert-error\n" +
 				"  'lisp:assert\n" +
 				"  examples)\n",
 		},
 		{
-			name: "long function name with first arg on same line aligns",
+			name:  "long function name with first arg on same line aligns",
 			input: "(assert-error 'lisp:assert\nexamples)",
 			expected: "(assert-error 'lisp:assert\n" +
 				"              examples)\n",
 		},
 		{
-			name: "user can avoid rightward drift by wrapping first arg",
+			name:  "user can avoid rightward drift by wrapping first arg",
 			input: "(some-very-long-function-name\nfirst-arg\nsecond-arg\nthird-arg)",
 			expected: "(some-very-long-function-name\n" +
 				"  first-arg\n" +
@@ -1296,8 +1338,8 @@ func TestPatternDefunWithDocstring(t *testing.T) {
 				"      (report-errors errors))))\n",
 		},
 		{
-			name: "defun docstring on same line stays",
-			input: "(defun id (x) \"Returns its argument unchanged.\" x)",
+			name:     "defun docstring on same line stays",
+			input:    "(defun id (x) \"Returns its argument unchanged.\" x)",
 			expected: "(defun id (x) \"Returns its argument unchanged.\" x)\n",
 		},
 	})
@@ -1306,13 +1348,13 @@ func TestPatternDefunWithDocstring(t *testing.T) {
 func TestPatternUnlessWrapped(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "unless with long condition on same line",
+			name:  "unless with long condition on same line",
 			input: "(unless (nil? owner-id)\n(validate-owner owner-id))",
 			expected: "(unless (nil? owner-id)\n" +
 				"  (validate-owner owner-id))\n",
 		},
 		{
-			name: "unless with condition wrapped to next line",
+			name:  "unless with condition wrapped to next line",
 			input: "(unless\n(and (empty? required-by) (empty? required-from))\n(validate-requirement))",
 			expected: "(unless\n" +
 				"  (and (empty? required-by) (empty? required-from))\n" +
@@ -1325,13 +1367,13 @@ func TestPatternUnlessWrapped(t *testing.T) {
 func TestInlineTrailingComment(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name:  "trailing comment on binding",
-			input: "(let* ([aud (first items)] ; grab first\n       [x 1])\n  body)",
+			name:     "trailing comment on binding",
+			input:    "(let* ([aud (first items)] ; grab first\n       [x 1])\n  body)",
 			expected: "(let* ([aud (first items)] ; grab first\n       [x 1])\n  body)\n",
 		},
 		{
-			name:  "trailing comment on last child",
-			input: "(foo bar ; comment\n  baz)",
+			name:     "trailing comment on last child",
+			input:    "(foo bar ; comment\n  baz)",
 			expected: "(foo bar ; comment\n     baz)\n",
 		},
 		{
@@ -1350,18 +1392,18 @@ func TestInlineTrailingComment(t *testing.T) {
 func TestInnerTrailingComment(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "comment before closing bracket",
-			input: "(let* ([x 1]\n       [y 2]\n       ; end bindings\n       )\n  body)",
+			name:     "comment before closing bracket",
+			input:    "(let* ([x 1]\n       [y 2]\n       ; end bindings\n       )\n  body)",
 			expected: "(let* ([x 1]\n       [y 2]\n       ; end bindings\n       )\n  body)\n",
 		},
 		{
-			name: "comment before closing bracket in list",
-			input: "[a\n b\n ; last item\n ]",
+			name:     "comment before closing bracket in list",
+			input:    "[a\n b\n ; last item\n ]",
 			expected: "[a\n b\n ; last item\n ]\n",
 		},
 		{
-			name: "multiple inner trailing comments",
-			input: "(progn\n  (do-a)\n  ; note 1\n  ; note 2\n  )",
+			name:     "multiple inner trailing comments",
+			input:    "(progn\n  (do-a)\n  ; note 1\n  ; note 2\n  )",
 			expected: "(progn\n  (do-a)\n  ; note 1\n  ; note 2\n  )\n",
 		},
 	})
@@ -1370,18 +1412,18 @@ func TestInnerTrailingComment(t *testing.T) {
 func TestDefPrefixHeuristic(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name:  "def-app-route like defun",
-			input: "(def-app-route \"create_thing\" (obj)\n  (let* ([id (mk-uuid)])\n    (create! id)))",
+			name:     "def-app-route like defun",
+			input:    "(def-app-route \"create_thing\" (obj)\n  (let* ([id (mk-uuid)])\n    (create! id)))",
 			expected: "(def-app-route \"create_thing\" (obj)\n  (let* ([id (mk-uuid)])\n    (create! id)))\n",
 		},
 		{
-			name:  "def-case-verification with 2 header args",
-			input: "(def-case-verification config bindings\n  body)",
+			name:     "def-case-verification with 2 header args",
+			input:    "(def-case-verification config bindings\n  body)",
 			expected: "(def-case-verification config bindings\n  body)\n",
 		},
 		{
-			name:  "defmacro header arg wraps to new line",
-			input: "(defmacro assert-error\n  (err msg &rest expr)\n  (progn body))",
+			name:     "defmacro header arg wraps to new line",
+			input:    "(defmacro assert-error\n  (err msg &rest expr)\n  (progn body))",
 			expected: "(defmacro assert-error\n  (err msg &rest expr)\n  (progn body))\n",
 		},
 	})
@@ -1390,13 +1432,13 @@ func TestDefPrefixHeuristic(t *testing.T) {
 func TestIndentSpecialHeaderArgWrap(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name:  "unless condition on new line",
-			input: "(unless\n  cond\n  body1\n  body2)",
+			name:     "unless condition on new line",
+			input:    "(unless\n  cond\n  body1\n  body2)",
 			expected: "(unless\n  cond\n  body1\n  body2)\n",
 		},
 		{
-			name:  "if condition on new line",
-			input: "(if\n  cond\n  then\n  else)",
+			name:     "if condition on new line",
+			input:    "(if\n  cond\n  then\n  else)",
 			expected: "(if\n  cond\n  then\n  else)\n",
 		},
 	})
@@ -1737,8 +1779,8 @@ func TestAtomFallbackNoMeta(t *testing.T) {
 func TestInnerTrailingCommentBlankLine(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
-			name: "inner trailing comments separated by blank line",
-			input: "(progn\n  (do-a)\n  ; note 1\n\n  ; note 2\n  )",
+			name:     "inner trailing comments separated by blank line",
+			input:    "(progn\n  (do-a)\n  ; note 1\n\n  ; note 2\n  )",
 			expected: "(progn\n  (do-a)\n  ; note 1\n\n  ; note 2\n  )\n",
 		},
 	})

--- a/formatter/printer.go
+++ b/formatter/printer.go
@@ -156,12 +156,24 @@ func (p *printer) writeInnerTrailingComments(v *lisp.LVal, indent int) {
 	}
 }
 
-func (p *printer) writeTopLevelCompact(exprs []*lisp.LVal) {
-	for i, expr := range exprs {
-		if i > 0 {
-			p.newline()
-		}
+func (p *printer) writeTopLevelCompact(exprs []*lisp.LVal, trailingComments []*token.Token) {
+	for _, expr := range exprs {
+		p.writeLeadingComments(expr, 0)
+		p.writeBlankLinesAfterComments(expr)
 		p.writeCompactExpr(expr)
+		p.writeTrailingComment(expr)
+		p.newline()
+		p.first = false
+	}
+
+	if p.cfg.StripComments {
+		return
+	}
+	for _, c := range trailingComments {
+		p.writeIndent(0)
+		p.writeString(c.Text)
+		p.newline()
+		p.first = false
 	}
 }
 

--- a/formatter/printer.go
+++ b/formatter/printer.go
@@ -45,6 +45,9 @@ func (p *printer) writeTopLevel(exprs []*lisp.LVal, trailingComments []*token.To
 	}
 
 	// Trailing comments
+	if p.cfg.StripComments {
+		return
+	}
 	for _, c := range trailingComments {
 		if !p.first {
 			blankLines := 0
@@ -67,6 +70,9 @@ func (p *printer) writeTopLevel(exprs []*lisp.LVal, trailingComments []*token.To
 
 // writeLeadingComments writes comments that precede a node.
 func (p *printer) writeLeadingComments(v *lisp.LVal, indent int) {
+	if p.cfg.StripComments {
+		return
+	}
 	if v.Meta == nil || len(v.Meta.LeadingComments) == 0 {
 		return
 	}
@@ -90,6 +96,9 @@ func (p *printer) writeLeadingComments(v *lisp.LVal, indent int) {
 // writeBlankLinesAfterComments emits blank lines between the last leading
 // comment and the expression, if any were present in the source.
 func (p *printer) writeBlankLinesAfterComments(v *lisp.LVal) {
+	if p.cfg.StripComments {
+		return
+	}
 	if v.Meta == nil {
 		return
 	}
@@ -106,6 +115,9 @@ func (p *printer) writeBlankLinesAfterComments(v *lisp.LVal) {
 // as the expression, after the expression. Preserves original spacing for
 // column-aligned comments.
 func (p *printer) writeTrailingComment(v *lisp.LVal) {
+	if p.cfg.StripComments {
+		return
+	}
 	if v.Meta != nil && v.Meta.TrailingComment != nil {
 		spaces := 1
 		if v.Meta.TrailingComment.PrecedingSpaces > 1 {
@@ -122,6 +134,9 @@ func (p *printer) writeTrailingComment(v *lisp.LVal) {
 // writeInnerTrailingComments writes comments that appeared between the last
 // child and the closing bracket of an s-expression or list.
 func (p *printer) writeInnerTrailingComments(v *lisp.LVal, indent int) {
+	if p.cfg.StripComments {
+		return
+	}
 	if v.Meta == nil || len(v.Meta.InnerTrailingComments) == 0 {
 		return
 	}
@@ -141,8 +156,21 @@ func (p *printer) writeInnerTrailingComments(v *lisp.LVal, indent int) {
 	}
 }
 
+func (p *printer) writeTopLevelCompact(exprs []*lisp.LVal) {
+	for i, expr := range exprs {
+		if i > 0 {
+			p.newline()
+		}
+		p.writeCompactExpr(expr)
+	}
+}
+
 // writeExpr dispatches to the appropriate printer for a node type.
 func (p *printer) writeExpr(v *lisp.LVal, indent int) {
+	if p.cfg.Compact {
+		p.writeCompactExpr(v)
+		return
+	}
 	// Handle quoting prefix for non-LQuote types
 	if v.Quoted && v.Type != lisp.LQuote && v.Type != lisp.LSExpr {
 		p.writeString("'")
@@ -174,6 +202,42 @@ func (p *printer) writeExpr(v *lisp.LVal, indent int) {
 	default:
 		p.writeString(v.String())
 	}
+}
+
+func (p *printer) writeCompactExpr(v *lisp.LVal) {
+	if v.Quoted && v.Type != lisp.LQuote && v.Type != lisp.LSExpr {
+		p.writeString("'")
+	}
+	switch v.Type {
+	case lisp.LInt, lisp.LFloat:
+		p.writeAtom(v)
+	case lisp.LString:
+		p.writeStringLiteral(v)
+	case lisp.LSymbol:
+		p.writeString(v.Str)
+	case lisp.LSExpr:
+		p.writeCompactList(v)
+	case lisp.LQuote:
+		p.writeString("'")
+		p.writeCompactExpr(v.Cells[0])
+	default:
+		p.writeString(v.String())
+	}
+}
+
+func (p *printer) writeCompactList(v *lisp.LVal) {
+	bracket := bracketOpen(v)
+	if v.Quoted && (v.Meta == nil || v.Meta.BracketType != '[') {
+		p.writeString("'")
+	}
+	p.writeString(string(bracket))
+	for i, child := range v.Cells {
+		if i > 0 {
+			p.writeString(" ")
+		}
+		p.writeCompactExpr(child)
+	}
+	p.writeString(string(bracketClose(bracket)))
 }
 
 // writeAtom writes an integer or float, using original text if available.

--- a/formatter/rules.go
+++ b/formatter/rules.go
@@ -26,6 +26,8 @@ type IndentRule struct {
 type Config struct {
 	IndentSize    int                    // spaces per indent level (default: 2)
 	MaxBlankLines int                    // max consecutive blank lines (default: 1)
+	Compact       bool                   // emit compact output with minimal whitespace
+	StripComments bool                   // omit comments from output
 	Rules         map[string]*IndentRule // form name -> rule
 }
 

--- a/minifier/minifier.go
+++ b/minifier/minifier.go
@@ -146,7 +146,9 @@ func ReadExcludeFile(path string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	var out []string
 	scanner := bufio.NewScanner(f)

--- a/minifier/minifier.go
+++ b/minifier/minifier.go
@@ -1,0 +1,363 @@
+// Copyright © 2026 The ELPS authors
+
+// Package minifier provides deterministic, scope-aware identifier minification
+// for ELPS source files and parsed programs.
+package minifier
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/elps/analysis"
+	"github.com/luthersystems/elps/formatter"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/rdparser"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// InputFile is a source unit to minify.
+type InputFile struct {
+	Path   string
+	Source []byte
+}
+
+// Config controls minification behavior.
+type Config struct {
+	Analysis      *analysis.Config
+	Exclusions    map[string]bool
+	RenameExports bool
+	Formatter     *formatter.Config
+}
+
+// FileResult contains the minified output for one source unit.
+type FileResult struct {
+	Path    string
+	Source  []byte
+	Output  []byte
+	Program []*lisp.LVal
+}
+
+// SymbolMapEntry records one deterministic symbol assignment.
+type SymbolMapEntry struct {
+	Minified string `json:"minified"`
+	Original string `json:"original"`
+	Kind     string `json:"kind"`
+	File     string `json:"file,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	Col      int    `json:"col,omitempty"`
+}
+
+// SymbolMap is the machine-readable symbol mapping emitted by a minify run.
+type SymbolMap struct {
+	Entries            []SymbolMapEntry    `json:"entries"`
+	MinifiedToOriginal map[string]string   `json:"minified_to_original"`
+	OriginalToMinified map[string][]string `json:"original_to_minified,omitempty"`
+}
+
+// Result contains the outputs of a minify run.
+type Result struct {
+	Files     []FileResult
+	SymbolMap SymbolMap
+}
+
+type parsedFile struct {
+	path             string
+	source           []byte
+	exprs            []*lisp.LVal
+	trailingComments []*token.Token
+	analysis         *analysis.Result
+}
+
+// Minify rewrites one or more source units using a single deterministic
+// symbol-assignment session.
+func Minify(inputs []InputFile, cfg *Config) (*Result, error) {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+	if cfg.Formatter == nil {
+		cfg.Formatter = formatter.DefaultConfig()
+		cfg.Formatter.Compact = true
+		cfg.Formatter.StripComments = true
+	}
+	if len(inputs) == 0 {
+		return &Result{}, nil
+	}
+
+	files := make([]parsedFile, 0, len(inputs))
+	for _, input := range inputs {
+		file, err := parseFile(input)
+		if err != nil {
+			return nil, err
+		}
+		if cfg.Analysis != nil {
+			fileCfg := *cfg.Analysis
+			fileCfg.Filename = input.Path
+			file.analysis = analysis.Analyze(file.exprs, &fileCfg)
+		} else {
+			file.analysis = analysis.Analyze(file.exprs, &analysis.Config{Filename: input.Path})
+		}
+		files = append(files, file)
+	}
+
+	assignments, symMap := buildAssignments(files, cfg)
+	for i := range files {
+		applyAssignments(&files[i], assignments, cfg)
+	}
+
+	result := &Result{
+		Files:     make([]FileResult, 0, len(files)),
+		SymbolMap: symMap,
+	}
+	for _, file := range files {
+		result.Files = append(result.Files, FileResult{
+			Path:    file.path,
+			Source:  file.source,
+			Output:  formatter.FormatProgram(file.exprs, file.trailingComments, cfg.Formatter),
+			Program: file.exprs,
+		})
+	}
+	return result, nil
+}
+
+// MinifySource is a convenience wrapper for a single source unit.
+func MinifySource(source []byte, filename string, cfg *Config) ([]byte, SymbolMap, error) {
+	result, err := Minify([]InputFile{{Path: filename, Source: source}}, cfg)
+	if err != nil {
+		return nil, SymbolMap{}, err
+	}
+	if len(result.Files) == 0 {
+		return nil, result.SymbolMap, nil
+	}
+	return result.Files[0].Output, result.SymbolMap, nil
+}
+
+// ReadExcludeFile loads one symbol per line, ignoring blank lines and comment
+// lines that start with ';'.
+func ReadExcludeFile(path string) ([]string, error) {
+	f, err := os.Open(path) //nolint:gosec // CLI helper reads a user-specified file
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var out []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, ";") {
+			continue
+		}
+		out = append(out, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// JSON returns the symbol map encoded as indented JSON.
+func (m SymbolMap) JSON() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(m); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func parseFile(input InputFile) (parsedFile, error) {
+	s := token.NewScanner(input.Path, bytes.NewReader(input.Source))
+	p := rdparser.NewFormatting(s)
+
+	exprs, err := p.ParseProgram()
+	if err != nil {
+		return parsedFile{}, fmt.Errorf("%s: %w", input.Path, err)
+	}
+
+	return parsedFile{
+		path:             input.Path,
+		source:           input.Source,
+		exprs:            exprs,
+		trailingComments: p.PendingComments(),
+	}, nil
+}
+
+func buildAssignments(files []parsedFile, cfg *Config) (map[*analysis.Symbol]string, SymbolMap) {
+	type symbolRecord struct {
+		sym *analysis.Symbol
+	}
+
+	var records []symbolRecord
+	for _, file := range files {
+		for _, sym := range file.analysis.Symbols {
+			if !renameable(sym, cfg) {
+				continue
+			}
+			records = append(records, symbolRecord{sym: sym})
+		}
+	}
+
+	sort.Slice(records, func(i, j int) bool {
+		return compareSymbols(records[i].sym, records[j].sym) < 0
+	})
+
+	assignments := make(map[*analysis.Symbol]string, len(records))
+	entries := make([]SymbolMapEntry, 0, len(records))
+	minToOrig := make(map[string]string, len(records))
+	origToMin := make(map[string][]string)
+
+	for i, record := range records {
+		newName := fmt.Sprintf("x%d", i+1)
+		assignments[record.sym] = newName
+
+		entry := SymbolMapEntry{
+			Minified: newName,
+			Original: record.sym.Name,
+			Kind:     record.sym.Kind.String(),
+		}
+		if record.sym.Source != nil {
+			entry.File = record.sym.Source.File
+			entry.Line = record.sym.Source.Line
+			entry.Col = record.sym.Source.Col
+		}
+		entries = append(entries, entry)
+		minToOrig[newName] = record.sym.Name
+		origToMin[record.sym.Name] = append(origToMin[record.sym.Name], newName)
+	}
+
+	for name := range origToMin {
+		sort.Strings(origToMin[name])
+	}
+
+	return assignments, SymbolMap{
+		Entries:            entries,
+		MinifiedToOriginal: minToOrig,
+		OriginalToMinified: origToMin,
+	}
+}
+
+func applyAssignments(file *parsedFile, assignments map[*analysis.Symbol]string, cfg *Config) {
+	for sym, newName := range assignments {
+		if sym.Node != nil && sym.Node.Type == lisp.LSymbol {
+			sym.Node.Str = newName
+		}
+	}
+
+	for _, ref := range file.analysis.References {
+		if newName, ok := assignments[ref.Symbol]; ok && ref.Node != nil && ref.Node.Type == lisp.LSymbol {
+			ref.Node.Str = newName
+		}
+	}
+
+	if cfg.RenameExports {
+		rewriteExports(file.exprs, file.analysis.RootScope, assignments)
+	}
+}
+
+func rewriteExports(exprs []*lisp.LVal, scope *analysis.Scope, assignments map[*analysis.Symbol]string) {
+	for _, expr := range exprs {
+		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
+			continue
+		}
+		if expr.Cells[0].Type != lisp.LSymbol || expr.Cells[0].Str != "export" {
+			continue
+		}
+		for _, arg := range expr.Cells[1:] {
+			switch {
+			case arg.Type == lisp.LSymbol:
+				if sym := scope.LookupLocal(arg.Str); sym != nil {
+					if newName, ok := assignments[sym]; ok {
+						arg.Str = newName
+					}
+				}
+			case arg.Type == lisp.LSExpr && arg.Quoted && len(arg.Cells) > 0 && arg.Cells[0].Type == lisp.LSymbol:
+				if sym := scope.LookupLocal(arg.Cells[0].Str); sym != nil {
+					if newName, ok := assignments[sym]; ok {
+						arg.Cells[0].Str = newName
+					}
+				}
+			}
+		}
+	}
+}
+
+func renameable(sym *analysis.Symbol, cfg *Config) bool {
+	if sym == nil || sym.Node == nil || sym.Node.Type != lisp.LSymbol {
+		return false
+	}
+	if sym.External {
+		return false
+	}
+	if sym.Kind == analysis.SymBuiltin || sym.Kind == analysis.SymSpecialOp {
+		return false
+	}
+	if sym.Exported && !cfg.RenameExports {
+		return false
+	}
+	name := sym.Name
+	if name == "" || strings.Contains(name, ":") || strings.HasPrefix(name, ":") || strings.HasPrefix(name, "%") {
+		return false
+	}
+	if cfg.Exclusions != nil && cfg.Exclusions[name] {
+		return false
+	}
+	return true
+}
+
+func compareSymbols(a, b *analysis.Symbol) int {
+	if a == nil || b == nil {
+		switch {
+		case a == nil && b == nil:
+			return 0
+		case a == nil:
+			return -1
+		default:
+			return 1
+		}
+	}
+
+	if diff := compareLocations(a.Source, b.Source); diff != 0 {
+		return diff
+	}
+	if a.Name != b.Name {
+		return strings.Compare(a.Name, b.Name)
+	}
+	if a.Kind != b.Kind {
+		return strings.Compare(a.Kind.String(), b.Kind.String())
+	}
+	return 0
+}
+
+func compareLocations(a, b *token.Location) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	}
+
+	if a.File != b.File {
+		return strings.Compare(a.File, b.File)
+	}
+	if a.Line != b.Line {
+		if a.Line < b.Line {
+			return -1
+		}
+		return 1
+	}
+	if a.Col != b.Col {
+		if a.Col < b.Col {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}

--- a/minifier/minifier.go
+++ b/minifier/minifier.go
@@ -73,6 +73,10 @@ type parsedFile struct {
 	analysis         *analysis.Result
 }
 
+type fileSymbols struct {
+	globals []analysis.ExternalSymbol
+}
+
 // Minify rewrites one or more source units using a single deterministic
 // symbol-assignment session.
 func Minify(inputs []InputFile, cfg *Config) (*Result, error) {
@@ -94,19 +98,18 @@ func Minify(inputs []InputFile, cfg *Config) (*Result, error) {
 		if err != nil {
 			return nil, err
 		}
-		if cfg.Analysis != nil {
-			fileCfg := *cfg.Analysis
-			fileCfg.Filename = input.Path
-			file.analysis = analysis.Analyze(file.exprs, &fileCfg)
-		} else {
-			file.analysis = analysis.Analyze(file.exprs, &analysis.Config{Filename: input.Path})
-		}
 		files = append(files, file)
 	}
 
-	assignments, symMap := buildAssignments(files, cfg)
+	perFile, pkgExports := scanInputSymbols(files)
 	for i := range files {
-		applyAssignments(&files[i], assignments, cfg)
+		fileCfg := mergeAnalysisConfig(cfg.Analysis, files[i].path, perFile, pkgExports)
+		files[i].analysis = analysis.Analyze(files[i].exprs, fileCfg)
+	}
+
+	assignments, assignmentKeys, symMap := buildAssignments(files, cfg)
+	for i := range files {
+		applyAssignments(&files[i], assignments, assignmentKeys, cfg)
 	}
 
 	result := &Result{
@@ -188,7 +191,173 @@ func parseFile(input InputFile) (parsedFile, error) {
 	}, nil
 }
 
-func buildAssignments(files []parsedFile, cfg *Config) (map[*analysis.Symbol]string, SymbolMap) {
+func mergeAnalysisConfig(base *analysis.Config, filename string, perFile map[string]fileSymbols, pkgExports map[string][]analysis.ExternalSymbol) *analysis.Config {
+	cfg := &analysis.Config{Filename: filename}
+	if base != nil {
+		cfg.ExtraGlobals = append(cfg.ExtraGlobals, base.ExtraGlobals...)
+		cfg.PackageExports = copyPackageExports(base.PackageExports)
+	}
+	if cfg.PackageExports == nil {
+		cfg.PackageExports = make(map[string][]analysis.ExternalSymbol)
+	}
+	for pkg, exports := range pkgExports {
+		cfg.PackageExports[pkg] = append(cfg.PackageExports[pkg], exports...)
+	}
+	for path, symbols := range perFile {
+		if path == filename {
+			continue
+		}
+		cfg.ExtraGlobals = append(cfg.ExtraGlobals, symbols.globals...)
+	}
+	return cfg
+}
+
+func copyPackageExports(in map[string][]analysis.ExternalSymbol) map[string][]analysis.ExternalSymbol {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string][]analysis.ExternalSymbol, len(in))
+	for pkg, symbols := range in {
+		out[pkg] = append([]analysis.ExternalSymbol(nil), symbols...)
+	}
+	return out
+}
+
+func scanInputSymbols(files []parsedFile) (map[string]fileSymbols, map[string][]analysis.ExternalSymbol) {
+	perFile := make(map[string]fileSymbols, len(files))
+	pkgExports := make(map[string][]analysis.ExternalSymbol)
+	for _, file := range files {
+		globals, exports := scanProgramSymbols(file.exprs)
+		perFile[file.path] = fileSymbols{globals: globals}
+		for pkg, syms := range exports {
+			pkgExports[pkg] = append(pkgExports[pkg], syms...)
+		}
+	}
+	return perFile, pkgExports
+}
+
+func scanProgramSymbols(exprs []*lisp.LVal) ([]analysis.ExternalSymbol, map[string][]analysis.ExternalSymbol) {
+	defs := make(map[string]analysis.ExternalSymbol)
+	exported := make(map[string]map[string]bool)
+	currentPkg := "user"
+
+	for _, expr := range exprs {
+		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 || expr.Cells[0].Type != lisp.LSymbol {
+			continue
+		}
+		switch expr.Cells[0].Str {
+		case "in-package":
+			if pkg := packageName(expr.Cells[1:]); pkg != "" {
+				currentPkg = pkg
+			}
+		case "defun":
+			if sym := topLevelDef(expr, analysis.SymFunction, currentPkg); sym != nil {
+				defs[currentPkg+"/"+sym.Name] = *sym
+			}
+		case "defmacro":
+			if sym := topLevelDef(expr, analysis.SymMacro, currentPkg); sym != nil {
+				defs[currentPkg+"/"+sym.Name] = *sym
+			}
+		case "deftype":
+			if sym := topLevelDef(expr, analysis.SymType, currentPkg); sym != nil {
+				defs[currentPkg+"/"+sym.Name] = *sym
+			}
+		case "set":
+			if sym := topLevelSet(expr, currentPkg); sym != nil {
+				defs[currentPkg+"/"+sym.Name] = *sym
+			}
+		case "export":
+			names := exportNames(expr.Cells[1:])
+			if len(names) == 0 {
+				continue
+			}
+			if exported[currentPkg] == nil {
+				exported[currentPkg] = make(map[string]bool)
+			}
+			for _, name := range names {
+				exported[currentPkg][name] = true
+			}
+		}
+	}
+
+	globals := make([]analysis.ExternalSymbol, 0, len(defs))
+	pkgExports := make(map[string][]analysis.ExternalSymbol)
+	for key, sym := range defs {
+		globals = append(globals, sym)
+		pkg, name, _ := strings.Cut(key, "/")
+		if exported[pkg][name] {
+			pkgExports[pkg] = append(pkgExports[pkg], sym)
+		}
+	}
+	return globals, pkgExports
+}
+
+func topLevelDef(expr *lisp.LVal, kind analysis.SymbolKind, pkg string) *analysis.ExternalSymbol {
+	if len(expr.Cells) < 2 || expr.Cells[1].Type != lisp.LSymbol {
+		return nil
+	}
+	return &analysis.ExternalSymbol{
+		Name:    expr.Cells[1].Str,
+		Kind:    kind,
+		Package: pkg,
+		Source:  expr.Cells[1].Source,
+	}
+}
+
+func topLevelSet(expr *lisp.LVal, pkg string) *analysis.ExternalSymbol {
+	if len(expr.Cells) < 2 {
+		return nil
+	}
+	name := setName(expr.Cells[1])
+	if name == "" {
+		return nil
+	}
+	return &analysis.ExternalSymbol{
+		Name:    name,
+		Kind:    analysis.SymVariable,
+		Package: pkg,
+		Source:  expr.Cells[1].Source,
+	}
+}
+
+func packageName(args []*lisp.LVal) string {
+	if len(args) == 0 {
+		return ""
+	}
+	arg := args[0]
+	if arg.Type == lisp.LString || arg.Type == lisp.LSymbol {
+		return arg.Str
+	}
+	if arg.Type == lisp.LSExpr && arg.Quoted && len(arg.Cells) > 0 && arg.Cells[0].Type == lisp.LSymbol {
+		return arg.Cells[0].Str
+	}
+	return ""
+}
+
+func exportNames(args []*lisp.LVal) []string {
+	out := make([]string, 0, len(args))
+	for _, arg := range args {
+		switch {
+		case arg.Type == lisp.LSymbol:
+			out = append(out, arg.Str)
+		case arg.Type == lisp.LSExpr && arg.Quoted && len(arg.Cells) > 0 && arg.Cells[0].Type == lisp.LSymbol:
+			out = append(out, arg.Cells[0].Str)
+		}
+	}
+	return out
+}
+
+func setName(arg *lisp.LVal) string {
+	if arg.Type == lisp.LSymbol {
+		return arg.Str
+	}
+	if arg.Type == lisp.LSExpr && arg.Quoted && len(arg.Cells) > 0 && arg.Cells[0].Type == lisp.LSymbol {
+		return arg.Cells[0].Str
+	}
+	return ""
+}
+
+func buildAssignments(files []parsedFile, cfg *Config) (map[*analysis.Symbol]string, map[string]string, SymbolMap) {
 	type symbolRecord struct {
 		sym *analysis.Symbol
 	}
@@ -208,6 +377,7 @@ func buildAssignments(files []parsedFile, cfg *Config) (map[*analysis.Symbol]str
 	})
 
 	assignments := make(map[*analysis.Symbol]string, len(records))
+	assignmentKeys := make(map[string]string, len(records))
 	entries := make([]SymbolMapEntry, 0, len(records))
 	minToOrig := make(map[string]string, len(records))
 	origToMin := make(map[string][]string)
@@ -215,6 +385,7 @@ func buildAssignments(files []parsedFile, cfg *Config) (map[*analysis.Symbol]str
 	for i, record := range records {
 		newName := fmt.Sprintf("x%d", i+1)
 		assignments[record.sym] = newName
+		assignmentKeys[symbolLookupKey(record.sym)] = newName
 
 		entry := SymbolMapEntry{
 			Minified: newName,
@@ -235,14 +406,14 @@ func buildAssignments(files []parsedFile, cfg *Config) (map[*analysis.Symbol]str
 		sort.Strings(origToMin[name])
 	}
 
-	return assignments, SymbolMap{
+	return assignments, assignmentKeys, SymbolMap{
 		Entries:            entries,
 		MinifiedToOriginal: minToOrig,
 		OriginalToMinified: origToMin,
 	}
 }
 
-func applyAssignments(file *parsedFile, assignments map[*analysis.Symbol]string, cfg *Config) {
+func applyAssignments(file *parsedFile, assignments map[*analysis.Symbol]string, assignmentKeys map[string]string, cfg *Config) {
 	for sym, newName := range assignments {
 		if sym.Node != nil && sym.Node.Type == lisp.LSymbol {
 			sym.Node.Str = newName
@@ -250,7 +421,11 @@ func applyAssignments(file *parsedFile, assignments map[*analysis.Symbol]string,
 	}
 
 	for _, ref := range file.analysis.References {
-		if newName, ok := assignments[ref.Symbol]; ok && ref.Node != nil && ref.Node.Type == lisp.LSymbol {
+		newName, ok := assignments[ref.Symbol]
+		if !ok {
+			newName, ok = assignmentKeys[symbolLookupKey(ref.Symbol)]
+		}
+		if ok && ref.Node != nil && ref.Node.Type == lisp.LSymbol {
 			ref.Node.Str = newName
 		}
 	}
@@ -258,6 +433,21 @@ func applyAssignments(file *parsedFile, assignments map[*analysis.Symbol]string,
 	if cfg.RenameExports {
 		rewriteExports(file.exprs, file.analysis.RootScope, assignments)
 	}
+}
+
+func symbolLookupKey(sym *analysis.Symbol) string {
+	if sym == nil {
+		return ""
+	}
+	file := ""
+	line := 0
+	col := 0
+	if sym.Source != nil {
+		file = sym.Source.File
+		line = sym.Source.Line
+		col = sym.Source.Col
+	}
+	return fmt.Sprintf("%s|%s|%s|%d|%d", sym.Name, sym.Kind.String(), file, line, col)
 }
 
 func rewriteExports(exprs []*lisp.LVal, scope *analysis.Scope, assignments map[*analysis.Symbol]string) {

--- a/minifier/minifier_test.go
+++ b/minifier/minifier_test.go
@@ -105,6 +105,28 @@ func TestMinify_ExclusionsAndMultiFileSession(t *testing.T) {
 	assert.Equal(t, "second", result.SymbolMap.MinifiedToOriginal["x3"])
 }
 
+func TestMinify_MultiFileRewritesCrossFileReferences(t *testing.T) {
+	inputs := []InputFile{
+		{
+			Path:   "a.lisp",
+			Source: []byte("(defun helper () 42)\n"),
+		},
+		{
+			Path:   "b.lisp",
+			Source: []byte("(defun outer () (helper))\n"),
+		},
+	}
+
+	result, err := Minify(inputs, &Config{})
+	require.NoError(t, err)
+	require.Len(t, result.Files, 2)
+
+	assert.Equal(t, "(defun x1 () 42)\n", string(result.Files[0].Output))
+	assert.Equal(t, "(defun x2 () (x1))\n", string(result.Files[1].Output))
+	assert.Equal(t, "helper", result.SymbolMap.MinifiedToOriginal["x1"])
+	assert.Equal(t, "outer", result.SymbolMap.MinifiedToOriginal["x2"])
+}
+
 func TestMinifySource_StripsCommentsByDefault(t *testing.T) {
 	src := []byte(`;; comment
 (defun demo (value)

--- a/minifier/minifier_test.go
+++ b/minifier/minifier_test.go
@@ -1,0 +1,184 @@
+// Copyright © 2026 The ELPS authors
+
+package minifier
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luthersystems/elps/analysis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMinifySource_DeterministicAndScopeAware(t *testing.T) {
+	src := []byte(`(defun outer (value)
+  (let ((value value))
+    value))
+`)
+
+	out1, map1, err := MinifySource(src, "test.lisp", nil)
+	require.NoError(t, err)
+
+	out2, map2, err := MinifySource(src, "test.lisp", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(out1), string(out2))
+	assert.Equal(t, map1.Entries, map2.Entries)
+	assert.Equal(t, "(defun x1 (x2) (let ((x3 x2)) x3))\n", string(out1))
+	require.Len(t, map1.Entries, 3)
+	assert.Equal(t, "outer", map1.MinifiedToOriginal["x1"])
+	assert.Equal(t, "value", map1.MinifiedToOriginal["x2"])
+	assert.Equal(t, "value", map1.MinifiedToOriginal["x3"])
+}
+
+func TestMinifySource_PreservesQuotedDataAndQualifiedSymbols(t *testing.T) {
+	src := []byte(`(defun demo (value)
+  '(value pkg:qualified :kw)
+  pkg:qualified
+  value)
+`)
+
+	out, symMap, err := MinifySource(src, "quoted.lisp", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "(defun x1 (x2) '(value pkg:qualified :kw) pkg:qualified x2)\n", string(out))
+	assert.Len(t, symMap.Entries, 2)
+}
+
+func TestMinifySource_ExportedSymbolsPreservedByDefault(t *testing.T) {
+	src := []byte(`(export 'public)
+(defun public (arg)
+  arg)
+`)
+
+	out, symMap, err := MinifySource(src, "exports.lisp", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "(export 'public)\n(defun public (x1) x1)\n", string(out))
+	assert.Len(t, symMap.Entries, 1)
+	assert.Equal(t, "arg", symMap.MinifiedToOriginal["x1"])
+}
+
+func TestMinifySource_RenameExportsOptionRewritesExportForms(t *testing.T) {
+	src := []byte(`(export 'public)
+(defun public (arg)
+  arg)
+`)
+
+	out, symMap, err := MinifySource(src, "exports.lisp", &Config{RenameExports: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, "(export 'x1)\n(defun x1 (x2) x2)\n", string(out))
+	assert.Len(t, symMap.Entries, 2)
+	assert.Equal(t, "public", symMap.MinifiedToOriginal["x1"])
+}
+
+func TestMinify_ExclusionsAndMultiFileSession(t *testing.T) {
+	inputs := []InputFile{
+		{
+			Path: "a.lisp",
+			Source: []byte(`(defun keep-name (first)
+  first)
+`),
+		},
+		{
+			Path: "b.lisp",
+			Source: []byte(`(defun helper (second)
+  second)
+`),
+		},
+	}
+
+	result, err := Minify(inputs, &Config{
+		Exclusions: map[string]bool{"keep-name": true},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Files, 2)
+
+	assert.Equal(t, "(defun keep-name (x1) x1)\n", string(result.Files[0].Output))
+	assert.Equal(t, "(defun x2 (x3) x3)\n", string(result.Files[1].Output))
+	assert.Equal(t, "first", result.SymbolMap.MinifiedToOriginal["x1"])
+	assert.Equal(t, "helper", result.SymbolMap.MinifiedToOriginal["x2"])
+	assert.Equal(t, "second", result.SymbolMap.MinifiedToOriginal["x3"])
+}
+
+func TestMinifySource_StripsCommentsByDefault(t *testing.T) {
+	src := []byte(`;; comment
+(defun demo (value)
+  ; lead
+  (let ((value (+ value 1))) ; trailing
+    value))
+`)
+
+	out, _, err := MinifySource(src, "comments.lisp", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "(defun x1 (x2) (let ((x3 (+ x2 1))) x3))\n", string(out))
+}
+
+func TestMinifySource_QuasiquoteOnlyRenamesUnquotedCode(t *testing.T) {
+	src := []byte(`(set 'x 1)
+(quasiquote (list x (unquote x) (unquote-splicing [x])))
+`)
+
+	out, symMap, err := MinifySource(src, "qq.lisp", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "(set 'x1 1)\n(quasiquote (list x (unquote x1) (unquote-splicing [x])))\n", string(out))
+	require.Len(t, symMap.Entries, 1)
+	assert.Equal(t, "x", symMap.MinifiedToOriginal["x1"])
+}
+
+func TestMinifySource_WithWorkspacePreservesImportedSymbols(t *testing.T) {
+	dir := t.TempDir()
+	libPath := filepath.Join(dir, "lib.lisp")
+	mainPath := filepath.Join(dir, "main.lisp")
+	require.NoError(t, os.WriteFile(libPath, []byte("(in-package 'lib)\n(export 'helper)\n(defun helper (value) value)\n"), 0o600))
+	require.NoError(t, os.WriteFile(mainPath, []byte("(use-package 'lib)\n(defun outer (value) (helper value))\n"), 0o600))
+
+	wsGlobals, wsPkgs, err := analysis.ScanWorkspaceFull(dir)
+	require.NoError(t, err)
+
+	out, symMap, err := MinifySource([]byte("(use-package 'lib)\n(defun outer (value) (helper value))\n"), mainPath, &Config{
+		Analysis: &analysis.Config{
+			ExtraGlobals:   wsGlobals,
+			PackageExports: wsPkgs,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "(use-package 'lib)\n(defun x1 (x2) (helper x2))\n", string(out))
+	require.Len(t, symMap.Entries, 2)
+	assert.Equal(t, "outer", symMap.MinifiedToOriginal["x1"])
+	assert.Equal(t, "value", symMap.MinifiedToOriginal["x2"])
+}
+
+func TestReadExcludeFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "symbols.spec")
+	require.NoError(t, os.WriteFile(path, []byte("; comment\nkeep\n\nstay\n"), 0o600))
+
+	names, err := ReadExcludeFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"keep", "stay"}, names)
+}
+
+func TestSymbolMapJSON(t *testing.T) {
+	symMap := SymbolMap{
+		Entries:            []SymbolMapEntry{{Minified: "x1", Original: "foo", Kind: "function"}},
+		MinifiedToOriginal: map[string]string{"x1": "foo"},
+		OriginalToMinified: map[string][]string{"foo": []string{"x1"}},
+	}
+
+	data, err := symMap.JSON()
+	require.NoError(t, err)
+
+	var parsed SymbolMap
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Equal(t, symMap.Entries, parsed.Entries)
+	assert.Equal(t, symMap.MinifiedToOriginal, parsed.MinifiedToOriginal)
+	assert.Equal(t, symMap.OriginalToMinified, parsed.OriginalToMinified)
+}


### PR DESCRIPTION
## Summary
- add a reusable scope-aware ELPS minifier library with deterministic symbol-map JSON output
- add `elps minify` and compact formatter output for comment-stripping/minified source emission
- extend analysis metadata and add coverage for CLI behavior, compact formatting, quasiquote handling, and workspace-aware minification

Closes #207.

## Test plan
- [x] `go test ./cmd ./minifier ./formatter`
- [x] `go test ./...`
- [x] Manual: `go run . minify` on sample ELPS source and confirm original/minified programs behave the same

---
*Local tests passed. Security review completed. QA professor review completed.*
