### PR TITLE
feat: support rule-specific analyze suppression

### DIFF
--- a/analysis/perf/local.go
+++ b/analysis/perf/local.go
@@ -50,11 +50,11 @@ func ScanFile(exprs []*lisp.LVal, filename string, cfg *Config) []*FunctionSumma
 		src := astutil.SourceOf(sexpr)
 
 		summary := &FunctionSummary{
-			Name:       funcName,
-			Source:     src.Source,
-			File:       filename,
-			Suppressed: isSuppressed(sexpr, cfg.SuppressionPrefix),
+			Name:   funcName,
+			Source: src.Source,
+			File:   filename,
 		}
+		applySuppression(summary, parseSuppression(sexpr, cfg.SuppressionPrefix))
 
 		// Walk the function body (skip name and formals)
 		bodyStart := 3 // Cells[0]=head, Cells[1]=name, Cells[2]=formals
@@ -100,7 +100,7 @@ func scanExpr(expr *lisp.LVal, caller string, loopDepth int, ctx *scanContext, s
 			summary.Calls = append(summary.Calls, CallEdge{
 				Caller:  caller,
 				Callee:  "<dynamic>",
-				Source:   astutil.SourceOf(expr).Source,
+				Source:  astutil.SourceOf(expr).Source,
 				Context: CallContext{LoopDepth: loopDepth, InLoop: loopDepth > 0},
 			})
 		}
@@ -144,7 +144,7 @@ func scanExpr(expr *lisp.LVal, caller string, loopDepth int, ctx *scanContext, s
 		summary.Calls = append(summary.Calls, CallEdge{
 			Caller:  caller,
 			Callee:  "<dynamic>",
-			Source:   callSource(expr),
+			Source:  callSource(expr),
 			Context: CallContext{LoopDepth: loopDepth, InLoop: loopDepth > 0},
 		})
 		// Scan arguments (skip head + function arg)
@@ -174,7 +174,7 @@ func scanExpr(expr *lisp.LVal, caller string, loopDepth int, ctx *scanContext, s
 		summary.Calls = append(summary.Calls, CallEdge{
 			Caller:      caller,
 			Callee:      head,
-			Source:       callSource(expr),
+			Source:      callSource(expr),
 			Context:     CallContext{LoopDepth: loopDepth, InLoop: loopDepth > 0},
 			IsExpensive: expensive,
 		})

--- a/analysis/perf/local_test.go
+++ b/analysis/perf/local_test.go
@@ -31,7 +31,8 @@ func TestScanFile_SimpleFunction(t *testing.T) {
 	require.Len(t, summaries, 1)
 	assert.Equal(t, "greet", summaries[0].Name)
 	assert.Equal(t, "test.lisp", summaries[0].File)
-	assert.False(t, summaries[0].Suppressed)
+	assert.False(t, summaries[0].SuppressAll)
+	assert.Empty(t, summaries[0].SuppressedRules)
 }
 
 func TestScanFile_ExpensiveCall(t *testing.T) {

--- a/analysis/perf/model.go
+++ b/analysis/perf/model.go
@@ -87,8 +87,10 @@ type FunctionSummary struct {
 	MaxLoopDepth int
 	// Calls are the outgoing call edges from this function.
 	Calls []CallEdge
-	// Suppressed is true if the function has an elps-analyze-disable comment.
-	Suppressed bool
+	// SuppressAll is true if the function has a bare elps-analyze-disable comment.
+	SuppressAll bool
+	// SuppressedRules contains rule IDs suppressed for this function.
+	SuppressedRules map[RuleID]bool
 }
 
 // CallGraph holds the complete call graph for a set of source files.

--- a/analysis/perf/solver.go
+++ b/analysis/perf/solver.go
@@ -215,7 +215,7 @@ func Solve(graph *CallGraph, cfg *Config) ([]*SolvedFunction, []Issue) {
 					Trace:    trace,
 				}
 				issue.Fingerprint = fingerprint(issue)
-				issues = appendIssueUnlessSuppressed(issues, fn, issue)
+				issues = appendCycleIssueUnlessSuppressed(issues, graph, sorted, issue)
 			}
 		}
 
@@ -265,6 +265,15 @@ func Solve(graph *CallGraph, cfg *Config) ([]*SolvedFunction, []Issue) {
 func appendIssueUnlessSuppressed(issues []Issue, fn *FunctionSummary, issue Issue) []Issue {
 	if suppressesRule(fn, issue.Rule) {
 		return issues
+	}
+	return append(issues, issue)
+}
+
+func appendCycleIssueUnlessSuppressed(issues []Issue, graph *CallGraph, cycle []string, issue Issue) []Issue {
+	for _, member := range cycle {
+		if suppressesRule(graph.Functions[member], issue.Rule) {
+			return issues
+		}
 	}
 	return append(issues, issue)
 }

--- a/analysis/perf/solver.go
+++ b/analysis/perf/solver.go
@@ -112,7 +112,7 @@ func Solve(graph *CallGraph, cfg *Config) ([]*SolvedFunction, []Issue) {
 	for _, name := range order {
 		sf := solved[name]
 		fn := graph.Functions[name]
-		if sf == nil || fn == nil || fn.Suppressed {
+		if sf == nil || fn == nil {
 			continue
 		}
 
@@ -128,7 +128,7 @@ func Solve(graph *CallGraph, cfg *Config) ([]*SolvedFunction, []Issue) {
 				Trace:    buildHotPathTrace(name, graph, solved, cfg),
 			}
 			issue.Fingerprint = fingerprint(issue)
-			issues = append(issues, issue)
+			issues = appendIssueUnlessSuppressed(issues, fn, issue)
 		}
 
 		// PERF002: Scaling risk
@@ -144,7 +144,7 @@ func Solve(graph *CallGraph, cfg *Config) ([]*SolvedFunction, []Issue) {
 					Trace:    buildScalingTrace(name, graph, solved),
 				}
 				issue.Fingerprint = fingerprint(issue)
-				issues = append(issues, issue)
+				issues = appendIssueUnlessSuppressed(issues, fn, issue)
 			} else if sf.ScalingOrder >= cfg.MaxAcceptableOrder {
 				issue := Issue{
 					Rule:     PERF002,
@@ -156,7 +156,7 @@ func Solve(graph *CallGraph, cfg *Config) ([]*SolvedFunction, []Issue) {
 					Trace:    buildScalingTrace(name, graph, solved),
 				}
 				issue.Fingerprint = fingerprint(issue)
-				issues = append(issues, issue)
+				issues = appendIssueUnlessSuppressed(issues, fn, issue)
 			}
 		}
 
@@ -181,7 +181,7 @@ func Solve(graph *CallGraph, cfg *Config) ([]*SolvedFunction, []Issue) {
 						},
 					}
 					issue.Fingerprint = fingerprint(issue)
-					issues = append(issues, issue)
+					issues = appendIssueUnlessSuppressed(issues, fn, issue)
 				}
 			}
 		}
@@ -215,7 +215,7 @@ func Solve(graph *CallGraph, cfg *Config) ([]*SolvedFunction, []Issue) {
 					Trace:    trace,
 				}
 				issue.Fingerprint = fingerprint(issue)
-				issues = append(issues, issue)
+				issues = appendIssueUnlessSuppressed(issues, fn, issue)
 			}
 		}
 
@@ -232,7 +232,7 @@ func Solve(graph *CallGraph, cfg *Config) ([]*SolvedFunction, []Issue) {
 						File:     fn.File,
 					}
 					issue.Fingerprint = fingerprint(issue)
-					issues = append(issues, issue)
+					issues = appendIssueUnlessSuppressed(issues, fn, issue)
 				}
 			}
 		}
@@ -260,6 +260,13 @@ func Solve(graph *CallGraph, cfg *Config) ([]*SolvedFunction, []Issue) {
 		}
 	}
 	return solvedList, issues
+}
+
+func appendIssueUnlessSuppressed(issues []Issue, fn *FunctionSummary, issue Issue) []Issue {
+	if suppressesRule(fn, issue.Rule) {
+		return issues
+	}
+	return append(issues, issue)
 }
 
 // fingerprint generates a stable sha256-based identifier for an issue.

--- a/analysis/perf/solver_test.go
+++ b/analysis/perf/solver_test.go
@@ -113,6 +113,71 @@ func TestSolve_Suppressed(t *testing.T) {
 	}
 }
 
+func TestSolve_RuleSpecificSuppression(t *testing.T) {
+	src := `
+;; elps-analyze-disable:PERF004
+(defun recursive-expensive (items)
+  (map 'list (lambda (item) (db-put item)) items)
+  (recursive-expensive items))
+`
+	exprs := parseSource(t, src)
+	cfg := DefaultConfig()
+	cfg.MaxScore = 10
+	summaries := ScanFile(exprs, "test.lisp", cfg)
+	graph := BuildGraph(summaries)
+	_, issues := Solve(graph, cfg)
+
+	var perf001, perf003, perf004 int
+	for _, issue := range issues {
+		if issue.Function != "recursive-expensive" {
+			continue
+		}
+		switch issue.Rule {
+		case PERF001:
+			perf001++
+		case PERF003:
+			perf003++
+		case PERF004:
+			perf004++
+		}
+	}
+
+	assert.Greater(t, perf001, 0, "rule-specific suppression should not hide PERF001")
+	assert.Greater(t, perf003, 0, "rule-specific suppression should not hide PERF003")
+	assert.Zero(t, perf004, "PERF004 should be suppressed for this function")
+}
+
+func TestSolve_MultiRuleSuppression(t *testing.T) {
+	src := `
+;; elps-analyze-disable:PERF001,PERF004
+(defun recursive-expensive (items)
+  (map 'list (lambda (item) (db-put item)) items)
+  (recursive-expensive items))
+`
+	exprs := parseSource(t, src)
+	cfg := DefaultConfig()
+	cfg.MaxScore = 10
+	summaries := ScanFile(exprs, "test.lisp", cfg)
+	graph := BuildGraph(summaries)
+	_, issues := Solve(graph, cfg)
+
+	for _, issue := range issues {
+		if issue.Function != "recursive-expensive" {
+			continue
+		}
+		assert.NotEqual(t, PERF001, issue.Rule)
+		assert.NotEqual(t, PERF004, issue.Rule)
+	}
+
+	var perf003 int
+	for _, issue := range issues {
+		if issue.Function == "recursive-expensive" && issue.Rule == PERF003 {
+			perf003++
+		}
+	}
+	assert.Greater(t, perf003, 0, "multi-rule suppression should still allow other findings")
+}
+
 func TestSolve_ScalingPropagation(t *testing.T) {
 	src := `
 (defun inner () (concat 'string "x"))

--- a/analysis/perf/solver_test.go
+++ b/analysis/perf/solver_test.go
@@ -178,6 +178,23 @@ func TestSolve_MultiRuleSuppression(t *testing.T) {
 	assert.Greater(t, perf003, 0, "multi-rule suppression should still allow other findings")
 }
 
+func TestSolve_PERF004SuppressionOnAnyCycleMember(t *testing.T) {
+	src := `
+(defun alpha (n) (if (= n 0) true (beta (- n 1))))
+;; elps-analyze-disable:PERF004
+(defun beta (n) (if (= n 0) true (alpha (- n 1))))
+`
+	exprs := parseSource(t, src)
+	cfg := DefaultConfig()
+	summaries := ScanFile(exprs, "test.lisp", cfg)
+	graph := BuildGraph(summaries)
+	_, issues := Solve(graph, cfg)
+
+	for _, issue := range issues {
+		assert.NotEqual(t, PERF004, issue.Rule, "PERF004 should be suppressed when any cycle member suppresses it")
+	}
+}
+
 func TestSolve_ScalingPropagation(t *testing.T) {
 	src := `
 (defun inner () (concat 'string "x"))

--- a/analysis/perf/suppress.go
+++ b/analysis/perf/suppress.go
@@ -8,19 +8,15 @@ import (
 	"github.com/luthersystems/elps/lisp"
 )
 
-// isSuppressed checks whether a function definition has a suppression
-// comment in its leading comments. The default directive is:
-//
-//	;; elps-analyze-disable
-//
-// The prefix can be customized via Config.SuppressionPrefix so that
-// embedders can use their own convention (e.g., "substrate-analyze-disable").
-//
-// When present on a defun/defmacro, the function is excluded from
-// performance analysis entirely.
-func isSuppressed(node *lisp.LVal, prefix string) bool {
+type suppression struct {
+	all   bool
+	rules map[RuleID]bool
+}
+
+func parseSuppression(node *lisp.LVal, prefix string) suppression {
+	var out suppression
 	if node == nil || node.Meta == nil {
-		return false
+		return out
 	}
 	if prefix == "" {
 		prefix = "elps-analyze-disable"
@@ -33,8 +29,52 @@ func isSuppressed(node *lisp.LVal, prefix string) bool {
 		text = strings.TrimLeft(text, ";")
 		text = strings.TrimSpace(text)
 		if text == prefix {
-			return true
+			out.all = true
+			out.rules = nil
+			return out
+		}
+		ruleText, ok := strings.CutPrefix(text, prefix+":")
+		if !ok {
+			continue
+		}
+		if out.rules == nil {
+			out.rules = make(map[RuleID]bool)
+		}
+		for _, part := range strings.Split(ruleText, ",") {
+			rule := parseSuppressedRule(part)
+			if rule == "" {
+				continue
+			}
+			out.rules[rule] = true
 		}
 	}
-	return false
+	return out
+}
+
+func parseSuppressedRule(part string) RuleID {
+	rule := RuleID(strings.TrimSpace(part))
+	switch rule {
+	case PERF001, PERF002, PERF003, PERF004, UNKNOWN001:
+		return rule
+	default:
+		return ""
+	}
+}
+
+func applySuppression(summary *FunctionSummary, s suppression) {
+	if summary == nil {
+		return
+	}
+	summary.SuppressAll = s.all
+	summary.SuppressedRules = s.rules
+}
+
+func suppressesRule(summary *FunctionSummary, rule RuleID) bool {
+	if summary == nil {
+		return false
+	}
+	if summary.SuppressAll {
+		return true
+	}
+	return summary.SuppressedRules[rule]
 }

--- a/analysis/perf/suppress_test.go
+++ b/analysis/perf/suppress_test.go
@@ -36,6 +36,34 @@ func TestSuppressed(t *testing.T) {
 	require.NotNil(t, noisy)
 	require.NotNil(t, normal)
 
-	assert.True(t, noisy.Suppressed)
-	assert.False(t, normal.Suppressed)
+	assert.True(t, noisy.SuppressAll)
+	assert.Empty(t, noisy.SuppressedRules)
+	assert.False(t, normal.SuppressAll)
+	assert.Empty(t, normal.SuppressedRules)
+}
+
+func TestSuppressed_SpecificRules(t *testing.T) {
+	src := `
+;; elps-analyze-disable: PERF002, PERF004
+(defun noisy (items)
+  (map 'list (lambda (item) (db-put item)) items))
+
+;; elps-analyze-disable: PERF999, PERF003
+(defmacro noisy-macro (items)
+  (map 'list (lambda (item) (db-put item)) items))
+`
+	exprs := parseSource(t, src)
+	cfg := DefaultConfig()
+	summaries := ScanFile(exprs, "test.lisp", cfg)
+
+	require.Len(t, summaries, 2)
+
+	assert.False(t, summaries[0].SuppressAll)
+	assert.True(t, summaries[0].SuppressedRules[PERF002])
+	assert.True(t, summaries[0].SuppressedRules[PERF004])
+	assert.False(t, summaries[0].SuppressedRules[PERF003])
+
+	assert.False(t, summaries[1].SuppressAll)
+	assert.True(t, summaries[1].SuppressedRules[PERF003])
+	assert.False(t, summaries[1].SuppressedRules[PERF004])
 }

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -97,6 +97,8 @@ directory upward). Override with --config.
 
 To suppress analysis for a specific function, add a leading comment:
   ;; elps-analyze-disable
+  ;; elps-analyze-disable:PERF004
+  ;; elps-analyze-disable:PERF002,PERF004
   (defun my-function () ...)
 
 Exit codes:


### PR DESCRIPTION
## Summary
- implement #212 by adding rule-specific perf suppression comments for `elps analyze` while keeping bare `elps-analyze-disable` as full-function suppression
- store suppression metadata per function and filter matching rule IDs during issue emission, including `PERF004` cycle suppression when any member of a recursive cycle opts out
- document the new comment forms and add parser/solver regressions for bare, single-rule, multi-rule, and mutual-recursion cycle suppression

## Test plan
- [x] `go test ./analysis/perf ./cmd`
- [x] `go test ./...`

## Follow-up Fixes
- honor `PERF004` suppression on any member of a mutual-recursion cycle instead of only the alphabetically reported member
- add a regression covering suppression on the non-reporting member of a recursive cycle

Closes #212.