### PR TITLE
fix: preserve macro-generated symbols during minify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 elps
 .claude/settings.local.json
+.claude/worktrees/
 .tmp/

--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -21,8 +21,23 @@ type Config struct {
 	// Used to resolve use-package imports from stdlib and workspace packages.
 	PackageExports map[string][]ExternalSymbol
 
+	// DefForms declares additional definition-form heads for embedding programs.
+	// Head is matched exactly against the form head symbol. FormalsIndex must
+	// point at the parameter list cell. If BindsName is true, NameIndex points
+	// at the defined symbol cell and the analyzer registers it using NameKind.
+	DefForms []DefFormSpec
+
 	// Filename is the source file being analyzed.
 	Filename string
+}
+
+// DefFormSpec describes a custom definition-like form.
+type DefFormSpec struct {
+	Head         string
+	FormalsIndex int
+	BindsName    bool
+	NameIndex    int
+	NameKind     SymbolKind
 }
 
 // ExternalSymbol represents a symbol defined in another file.

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -974,6 +974,34 @@ func TestAnalyze_CustomDefForm_EmptyFormals(t *testing.T) {
 	assert.Equal(t, SymFunction, sym.Kind)
 }
 
+func TestAnalyze_CustomDefForm_PrescanSupportsExportBeforeDefinition(t *testing.T) {
+	result := parseAndAnalyzeWithConfig(t, `
+(export 'handler)
+(endpoint handler (req) req)`, &Config{
+		DefForms: []DefFormSpec{
+			{Head: "endpoint", FormalsIndex: 2, BindsName: true, NameIndex: 1, NameKind: SymFunction},
+		},
+	})
+
+	sym := result.RootScope.LookupLocal("handler")
+	require.NotNil(t, sym)
+	assert.True(t, sym.Exported)
+}
+
+func TestAnalyze_CustomDefForm_PrescanSupportsForwardReference(t *testing.T) {
+	result := parseAndAnalyzeWithConfig(t, `
+(defun caller () (handler 1))
+(endpoint handler (req) req)`, &Config{
+		DefForms: []DefFormSpec{
+			{Head: "endpoint", FormalsIndex: 2, BindsName: true, NameIndex: 1, NameKind: SymFunction},
+		},
+	})
+
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "handler", u.Name)
+	}
+}
+
 func TestAnalyze_DefPrefix_DefaultInsideLabelsOptionalParam(t *testing.T) {
 	result := parseAndAnalyze(t, `
 (defun outer ()

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -134,7 +134,6 @@ func TestSignature_MinMaxArity(t *testing.T) {
 	}
 }
 
-
 // --- Builtins ---
 
 func TestPopulateBuiltins(t *testing.T) {
@@ -849,6 +848,31 @@ func TestAnalyze_DefPrefix_NoFormals(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
+func TestAnalyze_DefPrefix_DefaultCallFallsBackToNormalCall(t *testing.T) {
+	result := parseAndAnalyze(t, `(defun f (ctx) (default ctx (sorted-map)))`)
+
+	for _, sym := range result.Symbols {
+		assert.False(t,
+			(sym.Name == "ctx" && sym.Kind == SymFunction) ||
+				(sym.Name == "sorted-map" && sym.Kind == SymParameter),
+			"default call should not synthesize def-like symbols: %+v", sym)
+	}
+
+	var ctxRef *Reference
+	for _, ref := range result.References {
+		if ref.Node != nil && ref.Node.Str == "ctx" {
+			ctxRef = ref
+			break
+		}
+	}
+	require.NotNil(t, ctxRef, "ctx reference in default call should be resolved")
+	require.NotNil(t, ctxRef.Symbol)
+	assert.Equal(t, SymParameter, ctxRef.Symbol.Kind)
+	require.NotNil(t, ctxRef.Symbol.Source)
+	assert.Equal(t, 1, ctxRef.Symbol.Source.Line)
+	assert.Equal(t, 11, ctxRef.Symbol.Source.Col)
+}
+
 func TestAnalyze_DefPrefix_OptionalParams(t *testing.T) {
 	// Formals with &optional markers should be detected.
 	result := parseAndAnalyze(t, `(defmethod point :foo (self &optional extra) (list self extra))`)
@@ -904,6 +928,82 @@ func TestAnalyze_DefPrefix_NameNotRegisteredWhenFormalsLater(t *testing.T) {
 	for _, u := range result.Unresolved {
 		assert.NotEqual(t, "point", u.Name)
 	}
+}
+
+func TestAnalyze_CustomDefForm_NonDefPrefixBindsNameAndParams(t *testing.T) {
+	result := parseAndAnalyzeWithConfig(t, `(endpoint handler (req) (+ req 1))`, &Config{
+		DefForms: []DefFormSpec{
+			{Head: "endpoint", FormalsIndex: 2, BindsName: true, NameIndex: 1, NameKind: SymFunction},
+		},
+	})
+
+	sym := result.RootScope.LookupLocal("handler")
+	require.NotNil(t, sym)
+	assert.Equal(t, SymFunction, sym.Kind)
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "handler", u.Name)
+		assert.NotEqual(t, "req", u.Name)
+	}
+}
+
+func TestAnalyze_CustomDefForm_LaterFormalsWithoutBoundName(t *testing.T) {
+	result := parseAndAnalyzeWithConfig(t, `
+(set 'point 1)
+(register-method point :move (self) self)`, &Config{
+		DefForms: []DefFormSpec{
+			{Head: "register-method", FormalsIndex: 3},
+		},
+	})
+
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "point", u.Name)
+		assert.NotEqual(t, "self", u.Name)
+	}
+	assert.Nil(t, result.RootScope.LookupLocal(":move"))
+}
+
+func TestAnalyze_CustomDefForm_EmptyFormals(t *testing.T) {
+	result := parseAndAnalyzeWithConfig(t, `(endpoint healthcheck () (list 1))`, &Config{
+		DefForms: []DefFormSpec{
+			{Head: "endpoint", FormalsIndex: 2, BindsName: true, NameIndex: 1, NameKind: SymFunction},
+		},
+	})
+
+	sym := result.RootScope.LookupLocal("healthcheck")
+	require.NotNil(t, sym)
+	assert.Equal(t, SymFunction, sym.Kind)
+}
+
+func TestAnalyze_DefPrefix_DefaultInsideLabelsOptionalParam(t *testing.T) {
+	result := parseAndAnalyze(t, `
+(defun outer ()
+  (labels ([register (id name &optional ctx)
+            (let* ([body (default ctx (sorted-map))])
+              (assoc! body "id" id)
+              (assoc! body "name" name)
+              body)])
+    (register "a" "b")))`)
+
+	for _, sym := range result.Symbols {
+		assert.False(t,
+			(sym.Name == "ctx" && sym.Kind == SymFunction) ||
+				(sym.Name == "sorted-map" && sym.Kind == SymParameter),
+			"default call in labels should not synthesize def-like symbols: %+v", sym)
+	}
+
+	var ctxRef *Reference
+	for _, ref := range result.References {
+		if ref.Node != nil && ref.Node.Str == "ctx" && ref.Source != nil && ref.Source.Line == 4 {
+			ctxRef = ref
+			break
+		}
+	}
+	require.NotNil(t, ctxRef, "ctx reference in labels body should be resolved")
+	require.NotNil(t, ctxRef.Symbol)
+	assert.Equal(t, SymParameter, ctxRef.Symbol.Kind)
+	require.NotNil(t, ctxRef.Symbol.Source)
+	assert.Equal(t, 3, ctxRef.Symbol.Source.Line)
+	assert.Equal(t, 41, ctxRef.Symbol.Source.Col)
 }
 
 // --- Analyze: nested defun/defmacro ---

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -331,7 +331,7 @@ func (a *analyzer) analyzeExpr(node *lisp.LVal, scope *Scope) {
 		if strings.HasSuffix(head, ":deftype") && astutil.ArgCount(node) >= 1 &&
 			node.Cells[1].Type == lisp.LString {
 			a.analyzeStringDeftype(node, scope)
-		} else if strings.HasPrefix(head, "def") {
+		} else if _, ok := defLikeMatch(node, a.cfg); ok {
 			a.analyzeDefLike(node, scope)
 		} else {
 			a.analyzeCall(node, scope)
@@ -448,23 +448,8 @@ func (a *analyzer) analyzeStringDeftype(node *lisp.LVal, scope *Scope) {
 // are all symbols), creates a scope with those as parameters, and analyzes
 // the remaining children as body in that scope.
 func (a *analyzer) analyzeDefLike(node *lisp.LVal, scope *Scope) {
-	// Find the first child (after head) that looks like a formals list.
-	formalsIdx := -1
-	for i := 1; i < len(node.Cells); i++ {
-		if isFormalsLike(node.Cells[i]) {
-			formalsIdx = i
-			break
-		}
-	}
-	// Also check for empty formals () at the defun-like position (index 2).
-	// Empty () could be nil in a regular call, so only treat it as formals
-	// when preceded by a symbol name (defun-like pattern: def* name () body).
-	if formalsIdx < 0 && len(node.Cells) > 2 &&
-		node.Cells[1].Type == lisp.LSymbol && !node.Cells[1].Quoted &&
-		isEmptyFormals(node.Cells[2]) {
-		formalsIdx = 2
-	}
-	if formalsIdx < 0 {
+	match, ok := defLikeMatch(node, a.cfg)
+	if !ok {
 		// No formals detected — fall back to normal call analysis.
 		a.analyzeCall(node, scope)
 		return
@@ -478,13 +463,24 @@ func (a *analyzer) analyzeDefLike(node *lisp.LVal, scope *Scope) {
 	// defun). Register it in scope rather than resolving it as a reference.
 	// e.g. (defendpoint my-name (req) body...)
 	nameIdx := -1
-	if formalsIdx == 2 && node.Cells[1].Type == lisp.LSymbol && !node.Cells[1].Quoted {
-		nameIdx = 1
-		nameVal := node.Cells[1]
+	if match.bindsName &&
+		match.nameIdx > 0 &&
+		match.nameIdx < len(node.Cells) &&
+		node.Cells[match.nameIdx].Type == lisp.LSymbol &&
+		!node.Cells[match.nameIdx].Quoted {
+		nameIdx = match.nameIdx
+		nameVal := node.Cells[match.nameIdx]
 		if scope.LookupLocal(nameVal.Str) == nil {
+			kind := match.nameKind
+			if kind != SymVariable &&
+				kind != SymFunction &&
+				kind != SymMacro &&
+				kind != SymType {
+				kind = SymFunction
+			}
 			sym := &Symbol{
 				Name:   nameVal.Str,
-				Kind:   SymFunction,
+				Kind:   kind,
 				Source: nameVal.Source,
 				Node:   nameVal,
 			}
@@ -494,7 +490,7 @@ func (a *analyzer) analyzeDefLike(node *lisp.LVal, scope *Scope) {
 	}
 
 	// Analyze children before the formals in the outer scope (skip head and name).
-	for i := 1; i < formalsIdx; i++ {
+	for i := 1; i < match.formalsIdx; i++ {
 		if i == nameIdx {
 			continue
 		}
@@ -503,12 +499,120 @@ func (a *analyzer) analyzeDefLike(node *lisp.LVal, scope *Scope) {
 
 	// Create a function scope with the formals as parameters.
 	bodyScope := NewScope(ScopeFunction, scope, node)
-	a.addParams(node.Cells[formalsIdx], bodyScope)
+	a.addParams(node.Cells[match.formalsIdx], bodyScope)
 
 	// Analyze body (everything after formals) in the new scope.
-	for i := formalsIdx + 1; i < len(node.Cells); i++ {
+	for i := match.formalsIdx + 1; i < len(node.Cells); i++ {
 		a.analyzeExpr(node.Cells[i], bodyScope)
 	}
+}
+
+type defLikeSpec struct {
+	formalsIdx int
+	bindsName  bool
+	nameIdx    int
+	nameKind   SymbolKind
+}
+
+func defLikeMatch(node *lisp.LVal, cfg *Config) (defLikeSpec, bool) {
+	if match, ok := customDefLikeMatch(node, cfg); ok {
+		return match, true
+	}
+	if idx := heuristicDefLikeFormalsIndex(node); idx >= 0 {
+		return defLikeSpec{
+			formalsIdx: idx,
+			bindsName:  idx == 2,
+			nameIdx:    1,
+			nameKind:   SymFunction,
+		}, true
+	}
+	return defLikeSpec{}, false
+}
+
+func defLikeFormalsIndex(node *lisp.LVal) int {
+	match, ok := defLikeMatch(node, nil)
+	if !ok {
+		return -1
+	}
+	return match.formalsIdx
+}
+
+func customDefLikeMatch(node *lisp.LVal, cfg *Config) (defLikeSpec, bool) {
+	if node == nil || node.Type != lisp.LSExpr || node.Quoted || len(node.Cells) == 0 || cfg == nil {
+		return defLikeSpec{}, false
+	}
+	head := astutil.HeadSymbol(node)
+	for _, spec := range cfg.DefForms {
+		if spec.Head == "" || spec.Head != head {
+			continue
+		}
+		if !validDefFormSpec(node, spec) {
+			continue
+		}
+		nameKind := spec.NameKind
+		if spec.BindsName &&
+			nameKind != SymVariable &&
+			nameKind != SymFunction &&
+			nameKind != SymMacro &&
+			nameKind != SymType {
+			nameKind = SymFunction
+		}
+		return defLikeSpec{
+			formalsIdx: spec.FormalsIndex,
+			bindsName:  spec.BindsName,
+			nameIdx:    spec.NameIndex,
+			nameKind:   nameKind,
+		}, true
+	}
+	return defLikeSpec{}, false
+}
+
+func validDefFormSpec(node *lisp.LVal, spec DefFormSpec) bool {
+	if spec.FormalsIndex <= 0 || spec.FormalsIndex >= len(node.Cells)-1 {
+		return false
+	}
+	formals := node.Cells[spec.FormalsIndex]
+	if !isFormalsLike(formals) && !isEmptyFormals(formals) {
+		return false
+	}
+	if spec.BindsName {
+		if spec.NameIndex <= 0 || spec.NameIndex >= len(node.Cells) {
+			return false
+		}
+		if spec.NameIndex == spec.FormalsIndex {
+			return false
+		}
+		if node.Cells[spec.NameIndex].Type != lisp.LSymbol || node.Cells[spec.NameIndex].Quoted {
+			return false
+		}
+	}
+	return true
+}
+
+func heuristicDefLikeFormalsIndex(node *lisp.LVal) int {
+	if node == nil || node.Type != lisp.LSExpr || node.Quoted || len(node.Cells) < 4 {
+		return -1
+	}
+	head := astutil.HeadSymbol(node)
+	if !strings.HasPrefix(head, "def") {
+		return -1
+	}
+
+	// Find the first child (after head) that looks like a formals list.
+	for i := 1; i < len(node.Cells)-1; i++ {
+		if isFormalsLike(node.Cells[i]) {
+			return i
+		}
+	}
+	// Also check for empty formals () at the defun-like position (index 2).
+	// Empty () could be nil in a regular call, so only treat it as formals
+	// when preceded by a symbol name and followed by a body expression.
+	if len(node.Cells) > 3 &&
+		node.Cells[1].Type == lisp.LSymbol && !node.Cells[1].Quoted &&
+		isEmptyFormals(node.Cells[2]) {
+		return 2
+	}
+	return -1
 }
 
 // isFormalsLike returns true if the node looks like a parameter list:

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -529,14 +529,6 @@ func defLikeMatch(node *lisp.LVal, cfg *Config) (defLikeSpec, bool) {
 	return defLikeSpec{}, false
 }
 
-func defLikeFormalsIndex(node *lisp.LVal) int {
-	match, ok := defLikeMatch(node, nil)
-	if !ok {
-		return -1
-	}
-	return match.formalsIdx
-}
-
 func customDefLikeMatch(node *lisp.LVal, cfg *Config) (defLikeSpec, bool) {
 	if node == nil || node.Type != lisp.LSExpr || node.Quoted || len(node.Cells) == 0 || cfg == nil {
 		return defLikeSpec{}, false

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -40,6 +40,8 @@ func (a *analyzer) prescan(exprs []*lisp.LVal, scope *Scope) {
 			a.prescanUsePackage(expr, scope)
 		case "in-package":
 			a.prescanInPackage(expr, scope)
+		default:
+			a.prescanCustomDef(expr, scope)
 		}
 	}
 	// Phase 2: Apply exports (all definitions now exist in scope).
@@ -51,6 +53,34 @@ func (a *analyzer) prescan(exprs []*lisp.LVal, scope *Scope) {
 			a.prescanExport(expr, scope)
 		}
 	}
+}
+
+func (a *analyzer) prescanCustomDef(expr *lisp.LVal, scope *Scope) {
+	match, ok := customDefLikeMatch(expr, a.cfg)
+	if !ok || !match.bindsName || match.nameIdx <= 0 || match.nameIdx >= len(expr.Cells) {
+		return
+	}
+	nameVal := expr.Cells[match.nameIdx]
+	if nameVal.Type != lisp.LSymbol || scope.LookupLocal(nameVal.Str) != nil {
+		return
+	}
+	formalsVal := expr.Cells[match.formalsIdx]
+	if formalsVal.Type != lisp.LSExpr {
+		return
+	}
+	kind := match.nameKind
+	if kind != SymVariable && kind != SymFunction && kind != SymMacro && kind != SymType {
+		kind = SymFunction
+	}
+	sym := &Symbol{
+		Name:      nameVal.Str,
+		Kind:      kind,
+		Source:    nameVal.Source,
+		Node:      nameVal,
+		Signature: signatureFromFormals(formalsVal),
+	}
+	scope.Define(sym)
+	a.result.Symbols = append(a.result.Symbols, sym)
 }
 
 func (a *analyzer) prescanDefun(expr *lisp.LVal, scope *Scope, kind SymbolKind) {

--- a/lisp/x/debugger/engine_test.go
+++ b/lisp/x/debugger/engine_test.go
@@ -90,20 +90,6 @@ func waitForPauseStateChange(t *testing.T, e *Engine, previous *lisp.LVal) (*lis
 	return e.PausedState()
 }
 
-func waitForPausedPredicate(t *testing.T, e *Engine, predicate func(*lisp.LEnv, *lisp.LVal) bool, message string) (*lisp.LEnv, *lisp.LVal) {
-	t.Helper()
-
-	require.Eventually(t, func() bool {
-		if !e.IsPaused() {
-			return false
-		}
-		env, expr := e.PausedState()
-		return predicate(env, expr)
-	}, 2*time.Second, 10*time.Millisecond, message)
-
-	return e.PausedState()
-}
-
 func TestEngine_IsEnabled(t *testing.T) {
 	t.Parallel()
 	e := New()

--- a/lisp/x/debugger/engine_test.go
+++ b/lisp/x/debugger/engine_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type pauseSnapshot struct {
+	env          *lisp.LEnv
+	expr         *lisp.LVal
+	topFrameName string
+	stackDepth   int
+}
+
 // newTestEnv creates a minimal ELPS environment for testing.
 func newTestEnv(t *testing.T, dbg *Engine) *lisp.LEnv {
 	t.Helper()
@@ -27,6 +34,32 @@ func newTestEnv(t *testing.T, dbg *Engine) *lisp.LEnv {
 	rc = env.InPackage(lisp.String(lisp.DefaultUserPackage))
 	require.True(t, rc.IsNil(), "InPackage failed: %v", rc)
 	return env
+}
+
+func snapshotPause(evt Event) pauseSnapshot {
+	snapshot := pauseSnapshot{
+		env:  evt.Env,
+		expr: evt.Expr,
+	}
+	if evt.Env != nil {
+		snapshot.stackDepth = len(evt.Env.Runtime.Stack.Frames)
+		if snapshot.stackDepth > 0 {
+			snapshot.topFrameName = evt.Env.Runtime.Stack.Frames[snapshot.stackDepth-1].Name
+		}
+	}
+	return snapshot
+}
+
+func waitForStoppedEvent(t *testing.T, ch <-chan pauseSnapshot, message string) pauseSnapshot {
+	t.Helper()
+
+	select {
+	case snapshot := <-ch:
+		return snapshot
+	case <-time.After(2 * time.Second):
+		t.Fatal(message)
+		return pauseSnapshot{}
+	}
 }
 
 func waitForPauseStateChange(t *testing.T, e *Engine, previous *lisp.LVal) (*lisp.LEnv, *lisp.LVal) {
@@ -1590,7 +1623,12 @@ func TestEngine_SourceRefRegistry(t *testing.T) {
 
 func TestEngine_StepOutTailPosition(t *testing.T) {
 	t.Parallel()
-	e := New()
+	stoppedCh := make(chan pauseSnapshot, 8)
+	e := New(WithEventCallback(func(evt Event) {
+		if evt.Type == EventStopped {
+			stoppedCh <- snapshotPause(evt)
+		}
+	}))
 	e.Enable()
 	env := newTestEnv(t, e)
 
@@ -1614,28 +1652,26 @@ func TestEngine_StepOutTailPosition(t *testing.T) {
 	}()
 
 	// Wait for breakpoint inside inner.
-	require.Eventually(t, func() bool {
-		return e.IsPaused()
-	}, 2*time.Second, 10*time.Millisecond, "engine did not pause at breakpoint")
-
-	pausedEnv, expr := e.PausedState()
+	firstStop := waitForStoppedEvent(t, stoppedCh, "engine did not pause at breakpoint")
+	expr := firstStop.expr
 	require.NotNil(t, expr)
 	require.NotNil(t, expr.Source)
 	assert.Equal(t, 2, expr.Source.Line, "should pause on line 2")
-	innerDepth := len(pausedEnv.Runtime.Stack.Frames)
+	innerDepth := firstStop.stackDepth
 
 	// Clear breakpoints and step out.
 	e.Breakpoints().ClearFile("test")
 	e.StepOut()
 
 	// Should pause at the call site (NOT run to completion).
-	pausedEnv, expr = waitForPauseStateChange(t, e, expr)
+	secondStop := waitForStoppedEvent(t, stoppedCh, "step-out did not produce a stopped event")
+	expr = secondStop.expr
 	require.NotNil(t, expr)
 	require.NotNil(t, expr.Source, "paused expression should have source location")
 	assert.Equal(t, "test", expr.Source.File)
 	assert.NotEqual(t, 2, expr.Source.Line,
 		"should NOT still be on inner's body line after step-out")
-	outsideDepth := len(pausedEnv.Runtime.Stack.Frames)
+	outsideDepth := secondStop.stackDepth
 	assert.Less(t, outsideDepth, innerDepth,
 		"step-out should decrease stack depth (inner=%d, outside=%d)", innerDepth, outsideDepth)
 
@@ -1773,7 +1809,12 @@ func TestEngine_ScopeProviders(t *testing.T) {
 
 func TestEngine_StepInTarget(t *testing.T) {
 	t.Parallel()
-	e := New()
+	stoppedCh := make(chan pauseSnapshot, 8)
+	e := New(WithEventCallback(func(evt Event) {
+		if evt.Type == EventStopped {
+			stoppedCh <- snapshotPause(evt)
+		}
+	}))
 	e.Enable()
 	// Set breakpoint inside main's body (line 4: the call to f).
 	e.Breakpoints().Set("test", 4, "")
@@ -1791,10 +1832,8 @@ func TestEngine_StepInTarget(t *testing.T) {
 	}()
 
 	// Hit breakpoint on line 4 inside main.
-	require.Eventually(t, func() bool {
-		return e.IsPaused()
-	}, 2*time.Second, 10*time.Millisecond)
-	_, bpExpr := e.PausedState()
+	firstStop := waitForStoppedEvent(t, stoppedCh, "engine did not pause at breakpoint")
+	bpExpr := firstStop.expr
 	require.NotNil(t, bpExpr)
 	require.NotNil(t, bpExpr.Source)
 	assert.Equal(t, 4, bpExpr.Source.Line, "breakpoint should hit on line 4")
@@ -1807,7 +1846,8 @@ func TestEngine_StepInTarget(t *testing.T) {
 	e.StepOver()
 
 	// Should pause inside f's body (line 1).
-	_, stepExpr := waitForPauseStateChange(t, e, bpExpr)
+	secondStop := waitForStoppedEvent(t, stoppedCh, "targeted step-in did not stop")
+	stepExpr := secondStop.expr
 	require.NotNil(t, stepExpr)
 	require.NotNil(t, stepExpr.Source)
 	assert.Equal(t, 1, stepExpr.Source.Line,
@@ -1827,7 +1867,12 @@ func TestEngine_StepInTarget(t *testing.T) {
 func TestEngine_StepInTarget_SkipsNonTarget(t *testing.T) {
 	t.Parallel()
 
-	e := New()
+	stoppedCh := make(chan pauseSnapshot, 8)
+	e := New(WithEventCallback(func(evt Event) {
+		if evt.Type == EventStopped {
+			stoppedCh <- snapshotPause(evt)
+		}
+	}))
 	e.Enable()
 	// Set breakpoint on line 4 (inside main).
 	e.Breakpoints().Set("test", 4, "")
@@ -1845,9 +1890,7 @@ func TestEngine_StepInTarget_SkipsNonTarget(t *testing.T) {
 	}()
 
 	// Hit breakpoint on line 4.
-	require.Eventually(t, func() bool {
-		return e.IsPaused()
-	}, 2*time.Second, 10*time.Millisecond)
+	waitForStoppedEvent(t, stoppedCh, "engine did not pause at breakpoint")
 
 	// Clear breakpoint.
 	e.Breakpoints().Remove("test", 4)
@@ -1856,22 +1899,13 @@ func TestEngine_StepInTarget_SkipsNonTarget(t *testing.T) {
 	e.SetStepInTarget("user:f", 0)
 	e.StepOver()
 
-	pausedEnv, stepExpr := waitForPausedPredicate(t, e, func(env *lisp.LEnv, expr *lisp.LVal) bool {
-		if env == nil || expr == nil || expr.Source == nil {
-			return false
-		}
-		if len(env.Runtime.Stack.Frames) == 0 {
-			return false
-		}
-		topFrame := env.Runtime.Stack.Frames[len(env.Runtime.Stack.Frames)-1]
-		return topFrame.Name == "f" && expr.Source.Line == 1
-	}, "targeted step-in should pause in f")
+	stop := waitForStoppedEvent(t, stoppedCh, "targeted step-in should pause in f")
+	stepExpr := stop.expr
 	require.NotNil(t, stepExpr)
 	require.NotNil(t, stepExpr.Source)
 
 	// Verify we're in f, not g. Check the top frame on the stack.
-	topFrame := pausedEnv.Runtime.Stack.Frames[len(pausedEnv.Runtime.Stack.Frames)-1]
-	assert.Equal(t, "f", topFrame.Name,
+	assert.Equal(t, "f", stop.topFrameName,
 		"should be inside f's frame, not g's")
 	assert.Equal(t, 1, stepExpr.Source.Line,
 		"should pause on f's body line (line 1)")
@@ -1889,7 +1923,12 @@ func TestEngine_StepInTarget_SkipsNonTarget(t *testing.T) {
 
 func TestEngine_StepInTarget_SecondOccurrence(t *testing.T) {
 	t.Parallel()
-	e := New()
+	stoppedCh := make(chan pauseSnapshot, 8)
+	e := New(WithEventCallback(func(evt Event) {
+		if evt.Type == EventStopped {
+			stoppedCh <- snapshotPause(evt)
+		}
+	}))
 	e.Enable()
 	// Breakpoint inside main body (line 3).
 	e.Breakpoints().Set("test", 3, "")
@@ -1906,9 +1945,7 @@ func TestEngine_StepInTarget_SecondOccurrence(t *testing.T) {
 	}()
 
 	// Hit breakpoint on line 3.
-	require.Eventually(t, func() bool {
-		return e.IsPaused()
-	}, 2*time.Second, 10*time.Millisecond)
+	waitForStoppedEvent(t, stoppedCh, "engine did not pause at breakpoint")
 	e.Breakpoints().Remove("test", 3)
 
 	// Target second occurrence of f (count=1).
@@ -1916,22 +1953,11 @@ func TestEngine_StepInTarget_SecondOccurrence(t *testing.T) {
 	e.StepOver()
 
 	// Should pause inside f's body on the second call (f 20).
-	pausedEnv, stepExpr := waitForPausedPredicate(t, e, func(env *lisp.LEnv, expr *lisp.LVal) bool {
-		if env == nil || expr == nil || expr.Source == nil {
-			return false
-		}
-		if len(env.Runtime.Stack.Frames) == 0 {
-			return false
-		}
-		topFrame := env.Runtime.Stack.Frames[len(env.Runtime.Stack.Frames)-1]
-		if topFrame.Name != "f" || expr.Source.Line != 1 {
-			return false
-		}
-		xVal := e.EvalInContext(env, "x")
-		return xVal.Type == lisp.LInt && xVal.Int == 20
-	}, "targeted step-in should pause in second f invocation")
+	stop := waitForStoppedEvent(t, stoppedCh, "targeted step-in should pause in second f invocation")
+	pausedEnv, stepExpr := stop.env, stop.expr
 	require.NotNil(t, stepExpr)
 	require.NotNil(t, stepExpr.Source)
+	require.Equal(t, "f", stop.topFrameName, "should be inside f")
 	assert.Equal(t, 1, stepExpr.Source.Line,
 		"targeted step-in (2nd occurrence) should pause inside f's body")
 

--- a/minifier/minifier.go
+++ b/minifier/minifier.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/luthersystems/elps/analysis"
+	"github.com/luthersystems/elps/astutil"
 	"github.com/luthersystems/elps/formatter"
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/parser/rdparser"
@@ -28,10 +29,19 @@ type InputFile struct {
 
 // Config controls minification behavior.
 type Config struct {
-	Analysis      *analysis.Config
-	Exclusions    map[string]bool
-	RenameExports bool
-	Formatter     *formatter.Config
+	Analysis            *analysis.Config
+	Exclusions          map[string]bool
+	RenameExports       bool
+	PackageSurfaceForms []PackageSurfaceFormSpec
+	Formatter           *formatter.Config
+}
+
+// PackageSurfaceFormSpec declares a top-level form that creates a stable
+// package-visible binding that should be preserved by default.
+type PackageSurfaceFormSpec struct {
+	Head       string
+	NameIndex  int
+	QuotedName bool
 }
 
 // FileResult contains the minified output for one source unit.
@@ -77,6 +87,12 @@ type fileSymbols struct {
 	globals []analysis.ExternalSymbol
 }
 
+type preservationSet struct {
+	names      map[string]bool
+	symbols    map[*analysis.Symbol]bool
+	symbolKeys map[string]bool
+}
+
 // Minify rewrites one or more source units using a single deterministic
 // symbol-assignment session.
 func Minify(inputs []InputFile, cfg *Config) (*Result, error) {
@@ -107,7 +123,7 @@ func Minify(inputs []InputFile, cfg *Config) (*Result, error) {
 		files[i].analysis = analysis.Analyze(files[i].exprs, fileCfg)
 	}
 
-	protected := protectedMacroTemplateSymbols(files, cfg.Exclusions)
+	protected := buildPreservationSet(files, cfg)
 	assignments, assignmentKeys, symMap := buildAssignments(files, cfg, protected)
 	for i := range files {
 		applyAssignments(&files[i], assignments, assignmentKeys, cfg)
@@ -199,6 +215,7 @@ func mergeAnalysisConfig(base *analysis.Config, filename string, perFile map[str
 	if base != nil {
 		cfg.ExtraGlobals = append(cfg.ExtraGlobals, base.ExtraGlobals...)
 		cfg.PackageExports = copyPackageExports(base.PackageExports)
+		cfg.DefForms = append(cfg.DefForms, base.DefForms...)
 	}
 	if cfg.PackageExports == nil {
 		cfg.PackageExports = make(map[string][]analysis.ExternalSymbol)
@@ -360,7 +377,17 @@ func setName(arg *lisp.LVal) string {
 	return ""
 }
 
-func buildAssignments(files []parsedFile, cfg *Config, exclusions map[string]bool) (map[*analysis.Symbol]string, map[string]string, SymbolMap) {
+func setSymbolNode(arg *lisp.LVal) *lisp.LVal {
+	if arg.Type == lisp.LSymbol {
+		return arg
+	}
+	if arg.Type == lisp.LSExpr && arg.Quoted && len(arg.Cells) > 0 && arg.Cells[0].Type == lisp.LSymbol {
+		return arg.Cells[0]
+	}
+	return nil
+}
+
+func buildAssignments(files []parsedFile, cfg *Config, preserved *preservationSet) (map[*analysis.Symbol]string, map[string]string, SymbolMap) {
 	type symbolRecord struct {
 		sym *analysis.Symbol
 	}
@@ -368,7 +395,7 @@ func buildAssignments(files []parsedFile, cfg *Config, exclusions map[string]boo
 	var records []symbolRecord
 	for _, file := range files {
 		for _, sym := range file.analysis.Symbols {
-			if !renameable(sym, cfg, exclusions) {
+			if !renameable(sym, cfg, preserved) {
 				continue
 			}
 			records = append(records, symbolRecord{sym: sym})
@@ -429,7 +456,7 @@ func applyAssignments(file *parsedFile, assignments map[*analysis.Symbol]string,
 			newName, ok = assignmentKeys[symbolLookupKey(ref.Symbol)]
 		}
 		if ok && ref.Node != nil && ref.Node.Type == lisp.LSymbol {
-			ref.Node.Str = newName
+			rewriteReferenceNode(ref.Node, newName)
 		}
 	}
 
@@ -480,7 +507,7 @@ func rewriteExports(exprs []*lisp.LVal, scope *analysis.Scope, assignments map[*
 	}
 }
 
-func renameable(sym *analysis.Symbol, cfg *Config, exclusions map[string]bool) bool {
+func renameable(sym *analysis.Symbol, cfg *Config, preserved *preservationSet) bool {
 	if sym == nil || sym.Node == nil || sym.Node.Type != lisp.LSymbol {
 		return false
 	}
@@ -497,17 +524,33 @@ func renameable(sym *analysis.Symbol, cfg *Config, exclusions map[string]bool) b
 	if name == "" || strings.Contains(name, ":") || strings.HasPrefix(name, ":") || strings.HasPrefix(name, "%") {
 		return false
 	}
-	if exclusions != nil && exclusions[name] {
+	if sym.Scope != nil && sym.Scope.Kind == analysis.ScopeGlobal {
+		switch sym.Kind {
+		case analysis.SymMacro, analysis.SymVariable:
+			return false
+		}
+	}
+	if preserved != nil && preserved.names[name] {
+		return false
+	}
+	if preserved != nil && (preserved.symbols[sym] || preserved.symbolKeys[symbolLookupKey(sym)]) {
 		return false
 	}
 	return true
 }
 
-func protectedMacroTemplateSymbols(files []parsedFile, base map[string]bool) map[string]bool {
-	protected := make(map[string]bool, len(base))
-	for name := range base {
-		protected[name] = true
+func buildPreservationSet(files []parsedFile, cfg *Config) *preservationSet {
+	protected := &preservationSet{
+		names:      make(map[string]bool),
+		symbols:    make(map[*analysis.Symbol]bool),
+		symbolKeys: make(map[string]bool),
 	}
+	if cfg != nil {
+		for name := range cfg.Exclusions {
+			protected.names[name] = true
+		}
+	}
+	preservePackageSurfaceSymbols(files, cfg, protected)
 	for i := range files {
 		for _, expr := range files[i].exprs {
 			collectProtectedMacroTemplateSymbols(expr, files[i].analysis.RootScope, protected)
@@ -516,7 +559,101 @@ func protectedMacroTemplateSymbols(files []parsedFile, base map[string]bool) map
 	return protected
 }
 
-func collectProtectedMacroTemplateSymbols(expr *lisp.LVal, root *analysis.Scope, protected map[string]bool) {
+func preservePackageSurfaceSymbols(files []parsedFile, cfg *Config, protected *preservationSet) {
+	qualifiedRefs := make(map[string]bool)
+	for i := range files {
+		currentPkg := "user"
+		for _, expr := range files[i].exprs {
+			if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
+				continue
+			}
+			if expr.Cells[0].Type == lisp.LSymbol && expr.Cells[0].Str == "in-package" {
+				if pkg := packageName(expr.Cells[1:]); pkg != "" {
+					currentPkg = pkg
+				}
+			}
+			recordQualifiedReferences(expr, qualifiedRefs)
+			if expr.Cells[0].Type != lisp.LSymbol {
+				continue
+			}
+			switch expr.Cells[0].Str {
+			case "defmacro":
+				if len(expr.Cells) > 1 {
+					preserveNodeSymbol(files[i].analysis, expr.Cells[1], protected)
+				}
+			case "set":
+				if len(expr.Cells) > 1 {
+					preserveNodeSymbol(files[i].analysis, setSymbolNode(expr.Cells[1]), protected)
+				}
+			case "defun", "deftype":
+				if len(expr.Cells) > 1 && expr.Cells[1].Type == lisp.LSymbol {
+					if qualifiedRefs[currentPkg+"/"+expr.Cells[1].Str] {
+						preserveNodeSymbol(files[i].analysis, expr.Cells[1], protected)
+					}
+				}
+			}
+			if expr.Cells[0].Str == "set" && len(expr.Cells) > 1 {
+				if name := setName(expr.Cells[1]); name != "" && qualifiedRefs[currentPkg+"/"+name] {
+					preserveNodeSymbol(files[i].analysis, setSymbolNode(expr.Cells[1]), protected)
+				}
+			}
+			preserveConfiguredPackageSurfaceSymbol(files[i].analysis, expr, cfg, protected)
+		}
+	}
+}
+
+func preserveConfiguredPackageSurfaceSymbol(result *analysis.Result, expr *lisp.LVal, cfg *Config, protected *preservationSet) {
+	if result == nil || expr == nil || protected == nil || len(expr.Cells) == 0 {
+		return
+	}
+	head := astutil.HeadSymbol(expr)
+	for _, spec := range packageSurfaceForms(cfg) {
+		if spec.Head != head {
+			continue
+		}
+		node := packageSurfaceSymbolNode(expr, spec)
+		if node == nil {
+			continue
+		}
+		preserveNodeSymbol(result, node, protected)
+	}
+}
+
+func packageSurfaceForms(cfg *Config) []PackageSurfaceFormSpec {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.PackageSurfaceForms
+}
+
+func packageSurfaceSymbolNode(expr *lisp.LVal, spec PackageSurfaceFormSpec) *lisp.LVal {
+	if expr == nil || spec.NameIndex <= 0 || spec.NameIndex >= len(expr.Cells) {
+		return nil
+	}
+	arg := expr.Cells[spec.NameIndex]
+	if spec.QuotedName {
+		return setSymbolNode(arg)
+	}
+	if arg.Type == lisp.LSymbol && !arg.Quoted {
+		return arg
+	}
+	return nil
+}
+
+func preserveNodeSymbol(result *analysis.Result, node *lisp.LVal, protected *preservationSet) {
+	if result == nil || node == nil || node.Type != lisp.LSymbol || protected == nil {
+		return
+	}
+	for _, sym := range result.Symbols {
+		if sym != nil && sym.Node == node {
+			protected.symbols[sym] = true
+			protected.symbolKeys[symbolLookupKey(sym)] = true
+			return
+		}
+	}
+}
+
+func collectProtectedMacroTemplateSymbols(expr *lisp.LVal, root *analysis.Scope, protected *preservationSet) {
 	if expr == nil || root == nil || expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) < 4 {
 		return
 	}
@@ -532,7 +669,7 @@ func collectProtectedMacroTemplateSymbols(expr *lisp.LVal, root *analysis.Scope,
 	}
 }
 
-func walkMacroBodyForQuasiquote(node *lisp.LVal, scope *analysis.Scope, protected map[string]bool) {
+func walkMacroBodyForQuasiquote(node *lisp.LVal, scope *analysis.Scope, protected *preservationSet) {
 	if node == nil || node.Type != lisp.LSExpr {
 		return
 	}
@@ -547,13 +684,14 @@ func walkMacroBodyForQuasiquote(node *lisp.LVal, scope *analysis.Scope, protecte
 	}
 }
 
-func collectTemplateSymbols(node *lisp.LVal, scope *analysis.Scope, protected map[string]bool) {
+func collectTemplateSymbols(node *lisp.LVal, scope *analysis.Scope, protected *preservationSet) {
 	if node == nil {
 		return
 	}
 	if node.Type == lisp.LSymbol {
-		if preserveMacroTemplateSymbol(scope, node.Str) {
-			protected[node.Str] = true
+		if sym := preserveMacroTemplateSymbol(scope, node.Str); sym != nil {
+			protected.symbols[sym] = true
+			protected.symbolKeys[symbolLookupKey(sym)] = true
 		}
 		return
 	}
@@ -571,15 +709,63 @@ func collectTemplateSymbols(node *lisp.LVal, scope *analysis.Scope, protected ma
 	}
 }
 
-func preserveMacroTemplateSymbol(scope *analysis.Scope, name string) bool {
+func preserveMacroTemplateSymbol(scope *analysis.Scope, name string) *analysis.Symbol {
 	if name == "" ||
 		strings.Contains(name, ":") ||
 		strings.HasPrefix(name, ":") ||
 		strings.HasPrefix(name, "%") {
-		return false
+		return nil
 	}
 	sym := scope.Lookup(name)
-	return sym != nil && sym.Scope != nil && sym.Scope.Kind == analysis.ScopeGlobal
+	if sym != nil && sym.Scope != nil && sym.Scope.Kind == analysis.ScopeGlobal {
+		return sym
+	}
+	return nil
+}
+
+func recordQualifiedReferences(node *lisp.LVal, refs map[string]bool) {
+	if node == nil {
+		return
+	}
+	switch node.Type {
+	case lisp.LSymbol:
+		if pkg, name, ok := splitQualifiedSymbol(node.Str); ok {
+			refs[pkg+"/"+name] = true
+		}
+	case lisp.LSExpr:
+		if node.Quoted {
+			return
+		}
+		for _, child := range node.Cells {
+			recordQualifiedReferences(child, refs)
+		}
+	}
+}
+
+func rewriteReferenceNode(node *lisp.LVal, newName string) {
+	if node == nil || node.Type != lisp.LSymbol {
+		return
+	}
+	if pkg, _, ok := splitQualifiedSymbol(node.Str); ok {
+		node.Str = pkg + ":" + newName
+		return
+	}
+	node.Str = newName
+}
+
+func splitQualifiedSymbol(name string) (string, string, bool) {
+	if name == "" || strings.HasPrefix(name, ":") {
+		return "", "", false
+	}
+	for i := 1; i < len(name); i++ {
+		if name[i] == ':' {
+			if i+1 >= len(name) {
+				return "", "", false
+			}
+			return name[:i], name[i+1:], true
+		}
+	}
+	return "", "", false
 }
 
 func findScopeForNode(scope *analysis.Scope, node *lisp.LVal) *analysis.Scope {

--- a/minifier/minifier.go
+++ b/minifier/minifier.go
@@ -118,7 +118,7 @@ func Minify(inputs []InputFile, cfg *Config) (*Result, error) {
 		files = append(files, file)
 	}
 
-	perFile, pkgExports := scanInputSymbols(files)
+	perFile, pkgExports := scanInputSymbols(files, cfg)
 	for i := range files {
 		fileCfg := mergeAnalysisConfig(cfg.Analysis, files[i].path, perFile, pkgExports)
 		files[i].analysis = analysis.Analyze(files[i].exprs, fileCfg)
@@ -252,11 +252,11 @@ func copyPackageExports(in map[string][]analysis.ExternalSymbol) map[string][]an
 	return out
 }
 
-func scanInputSymbols(files []parsedFile) (map[string]fileSymbols, map[string][]analysis.ExternalSymbol) {
+func scanInputSymbols(files []parsedFile, cfg *Config) (map[string]fileSymbols, map[string][]analysis.ExternalSymbol) {
 	perFile := make(map[string]fileSymbols, len(files))
 	pkgExports := make(map[string][]analysis.ExternalSymbol)
 	for _, file := range files {
-		globals, exports, packages := scanProgramSymbols(file.exprs)
+		globals, exports, packages := scanProgramSymbols(file.exprs, cfg)
 		perFile[file.path] = fileSymbols{globals: globals, packages: packages}
 		for pkg, syms := range exports {
 			pkgExports[pkg] = append(pkgExports[pkg], syms...)
@@ -265,7 +265,7 @@ func scanInputSymbols(files []parsedFile) (map[string]fileSymbols, map[string][]
 	return perFile, pkgExports
 }
 
-func scanProgramSymbols(exprs []*lisp.LVal) ([]analysis.ExternalSymbol, map[string][]analysis.ExternalSymbol, map[string]bool) {
+func scanProgramSymbols(exprs []*lisp.LVal, cfg *Config) ([]analysis.ExternalSymbol, map[string][]analysis.ExternalSymbol, map[string]bool) {
 	defs := make(map[string]analysis.ExternalSymbol)
 	exported := make(map[string]map[string]bool)
 	currentPkg := "user"
@@ -308,6 +308,10 @@ func scanProgramSymbols(exprs []*lisp.LVal) ([]analysis.ExternalSymbol, map[stri
 			for _, name := range names {
 				exported[currentPkg][name] = true
 			}
+		default:
+			if sym := topLevelCustomDef(expr, currentPkg, cfg); sym != nil {
+				defs[currentPkg+"/"+sym.Name] = *sym
+			}
 		}
 	}
 
@@ -349,6 +353,35 @@ func topLevelSet(expr *lisp.LVal, pkg string) *analysis.ExternalSymbol {
 		Package: pkg,
 		Source:  expr.Cells[1].Source,
 	}
+}
+
+func topLevelCustomDef(expr *lisp.LVal, pkg string, cfg *Config) *analysis.ExternalSymbol {
+	if cfg == nil || cfg.Analysis == nil || len(expr.Cells) == 0 {
+		return nil
+	}
+	head := astutil.HeadSymbol(expr)
+	for _, spec := range cfg.Analysis.DefForms {
+		if spec.Head != head || !spec.BindsName || spec.NameIndex <= 0 || spec.NameIndex >= len(expr.Cells) {
+			continue
+		}
+		if expr.Cells[spec.NameIndex].Type != lisp.LSymbol {
+			continue
+		}
+		kind := spec.NameKind
+		if kind != analysis.SymVariable &&
+			kind != analysis.SymFunction &&
+			kind != analysis.SymMacro &&
+			kind != analysis.SymType {
+			kind = analysis.SymFunction
+		}
+		return &analysis.ExternalSymbol{
+			Name:    expr.Cells[spec.NameIndex].Str,
+			Kind:    kind,
+			Package: pkg,
+			Source:  expr.Cells[spec.NameIndex].Source,
+		}
+	}
+	return nil
 }
 
 func packageName(args []*lisp.LVal) string {
@@ -573,6 +606,9 @@ func buildPreservationSet(files []parsedFile, cfg *Config) *preservationSet {
 func preservePackageSurfaceSymbols(files []parsedFile, cfg *Config, protected *preservationSet) {
 	qualifiedRefs := make(map[string]bool)
 	for i := range files {
+		recordFileQualifiedReferences(files[i].exprs, qualifiedRefs)
+	}
+	for i := range files {
 		currentPkg := "user"
 		for _, expr := range files[i].exprs {
 			if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
@@ -583,7 +619,6 @@ func preservePackageSurfaceSymbols(files []parsedFile, cfg *Config, protected *p
 					currentPkg = pkg
 				}
 			}
-			recordQualifiedReferences(expr, qualifiedRefs)
 			if expr.Cells[0].Type != lisp.LSymbol {
 				continue
 			}
@@ -599,8 +634,12 @@ func preservePackageSurfaceSymbols(files []parsedFile, cfg *Config, protected *p
 			case "defun", "deftype":
 				if len(expr.Cells) > 1 && expr.Cells[1].Type == lisp.LSymbol {
 					if qualifiedRefs[currentPkg+"/"+expr.Cells[1].Str] {
-						preserveNodeSymbol(files[i].analysis, expr.Cells[1], protected)
+						preserveQualifiedDefinitionNode(files[i].analysis, expr.Cells[1], cfg, protected)
 					}
+				}
+			default:
+				if node := configuredTopLevelNameNode(expr, cfg); node != nil && qualifiedRefs[currentPkg+"/"+node.Str] {
+					preserveQualifiedDefinitionNode(files[i].analysis, node, cfg, protected)
 				}
 			}
 			if expr.Cells[0].Str == "set" && len(expr.Cells) > 1 {
@@ -610,6 +649,12 @@ func preservePackageSurfaceSymbols(files []parsedFile, cfg *Config, protected *p
 			}
 			preserveConfiguredPackageSurfaceSymbol(files[i].analysis, expr, cfg, protected)
 		}
+	}
+}
+
+func recordFileQualifiedReferences(exprs []*lisp.LVal, refs map[string]bool) {
+	for _, expr := range exprs {
+		recordQualifiedReferences(expr, refs)
 	}
 }
 
@@ -651,17 +696,52 @@ func packageSurfaceSymbolNode(expr *lisp.LVal, spec PackageSurfaceFormSpec) *lis
 	return nil
 }
 
+func configuredTopLevelNameNode(expr *lisp.LVal, cfg *Config) *lisp.LVal {
+	if expr == nil || len(expr.Cells) == 0 || cfg == nil || cfg.Analysis == nil {
+		return nil
+	}
+	head := astutil.HeadSymbol(expr)
+	for _, spec := range cfg.Analysis.DefForms {
+		if spec.Head != head || !spec.BindsName || spec.NameIndex <= 0 || spec.NameIndex >= len(expr.Cells) {
+			continue
+		}
+		node := expr.Cells[spec.NameIndex]
+		if node.Type == lisp.LSymbol && !node.Quoted {
+			return node
+		}
+	}
+	return nil
+}
+
 func preserveNodeSymbol(result *analysis.Result, node *lisp.LVal, protected *preservationSet) {
-	if result == nil || node == nil || node.Type != lisp.LSymbol || protected == nil {
+	if sym := nodeSymbol(result, node); sym != nil {
+		protected.symbols[sym] = true
+		protected.symbolKeys[symbolLookupKey(sym)] = true
+	}
+}
+
+func preserveQualifiedDefinitionNode(result *analysis.Result, node *lisp.LVal, cfg *Config, protected *preservationSet) {
+	sym := nodeSymbol(result, node)
+	if sym == nil {
 		return
+	}
+	if sym.Exported && cfg != nil && cfg.RenameExports {
+		return
+	}
+	protected.symbols[sym] = true
+	protected.symbolKeys[symbolLookupKey(sym)] = true
+}
+
+func nodeSymbol(result *analysis.Result, node *lisp.LVal) *analysis.Symbol {
+	if result == nil || node == nil || node.Type != lisp.LSymbol {
+		return nil
 	}
 	for _, sym := range result.Symbols {
 		if sym != nil && sym.Node == node {
-			protected.symbols[sym] = true
-			protected.symbolKeys[symbolLookupKey(sym)] = true
-			return
+			return sym
 		}
 	}
+	return nil
 }
 
 func collectProtectedMacroTemplateSymbols(expr *lisp.LVal, root *analysis.Scope, protected *preservationSet) {

--- a/minifier/minifier.go
+++ b/minifier/minifier.go
@@ -107,7 +107,8 @@ func Minify(inputs []InputFile, cfg *Config) (*Result, error) {
 		files[i].analysis = analysis.Analyze(files[i].exprs, fileCfg)
 	}
 
-	assignments, assignmentKeys, symMap := buildAssignments(files, cfg)
+	protected := protectedMacroTemplateNames(files, cfg.Exclusions)
+	assignments, assignmentKeys, symMap := buildAssignments(files, cfg, protected)
 	for i := range files {
 		applyAssignments(&files[i], assignments, assignmentKeys, cfg)
 	}
@@ -359,7 +360,7 @@ func setName(arg *lisp.LVal) string {
 	return ""
 }
 
-func buildAssignments(files []parsedFile, cfg *Config) (map[*analysis.Symbol]string, map[string]string, SymbolMap) {
+func buildAssignments(files []parsedFile, cfg *Config, exclusions map[string]bool) (map[*analysis.Symbol]string, map[string]string, SymbolMap) {
 	type symbolRecord struct {
 		sym *analysis.Symbol
 	}
@@ -367,7 +368,7 @@ func buildAssignments(files []parsedFile, cfg *Config) (map[*analysis.Symbol]str
 	var records []symbolRecord
 	for _, file := range files {
 		for _, sym := range file.analysis.Symbols {
-			if !renameable(sym, cfg) {
+			if !renameable(sym, cfg, exclusions) {
 				continue
 			}
 			records = append(records, symbolRecord{sym: sym})
@@ -479,7 +480,7 @@ func rewriteExports(exprs []*lisp.LVal, scope *analysis.Scope, assignments map[*
 	}
 }
 
-func renameable(sym *analysis.Symbol, cfg *Config) bool {
+func renameable(sym *analysis.Symbol, cfg *Config, exclusions map[string]bool) bool {
 	if sym == nil || sym.Node == nil || sym.Node.Type != lisp.LSymbol {
 		return false
 	}
@@ -496,10 +497,81 @@ func renameable(sym *analysis.Symbol, cfg *Config) bool {
 	if name == "" || strings.Contains(name, ":") || strings.HasPrefix(name, ":") || strings.HasPrefix(name, "%") {
 		return false
 	}
-	if cfg.Exclusions != nil && cfg.Exclusions[name] {
+	if exclusions != nil && exclusions[name] {
 		return false
 	}
 	return true
+}
+
+func protectedMacroTemplateNames(files []parsedFile, base map[string]bool) map[string]bool {
+	protected := make(map[string]bool, len(base))
+	for name := range base {
+		protected[name] = true
+	}
+	for _, file := range files {
+		for _, expr := range file.exprs {
+			collectProtectedMacroTemplateNames(expr, protected)
+		}
+	}
+	return protected
+}
+
+func collectProtectedMacroTemplateNames(expr *lisp.LVal, protected map[string]bool) {
+	if expr == nil || expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) < 4 {
+		return
+	}
+	if expr.Cells[0].Type != lisp.LSymbol || expr.Cells[0].Str != "defmacro" {
+		return
+	}
+	for _, body := range expr.Cells[3:] {
+		walkMacroBodyForQuasiquote(body, protected)
+	}
+}
+
+func walkMacroBodyForQuasiquote(node *lisp.LVal, protected map[string]bool) {
+	if node == nil || node.Type != lisp.LSExpr {
+		return
+	}
+	if !node.Quoted && len(node.Cells) > 0 && node.Cells[0].Type == lisp.LSymbol && node.Cells[0].Str == "quasiquote" {
+		if len(node.Cells) > 1 {
+			collectTemplateSymbols(node.Cells[1], protected)
+		}
+		return
+	}
+	for _, child := range node.Cells {
+		walkMacroBodyForQuasiquote(child, protected)
+	}
+}
+
+func collectTemplateSymbols(node *lisp.LVal, protected map[string]bool) {
+	if node == nil {
+		return
+	}
+	if node.Type == lisp.LSymbol {
+		if preserveMacroTemplateName(node.Str) {
+			protected[node.Str] = true
+		}
+		return
+	}
+	if node.Type != lisp.LSExpr {
+		return
+	}
+	if !node.Quoted && len(node.Cells) > 0 && node.Cells[0].Type == lisp.LSymbol {
+		switch node.Cells[0].Str {
+		case "unquote", "unquote-splicing":
+			return
+		}
+	}
+	for _, child := range node.Cells {
+		collectTemplateSymbols(child, protected)
+	}
+}
+
+func preserveMacroTemplateName(name string) bool {
+	return name != "" &&
+		!strings.Contains(name, ":") &&
+		!strings.HasPrefix(name, ":") &&
+		!strings.HasPrefix(name, "%")
 }
 
 func compareSymbols(a, b *analysis.Symbol) int {

--- a/minifier/minifier.go
+++ b/minifier/minifier.go
@@ -107,7 +107,7 @@ func Minify(inputs []InputFile, cfg *Config) (*Result, error) {
 		files[i].analysis = analysis.Analyze(files[i].exprs, fileCfg)
 	}
 
-	protected := protectedMacroTemplateNames(files, cfg.Exclusions)
+	protected := protectedMacroTemplateSymbols(files, cfg.Exclusions)
 	assignments, assignmentKeys, symMap := buildAssignments(files, cfg, protected)
 	for i := range files {
 		applyAssignments(&files[i], assignments, assignmentKeys, cfg)
@@ -503,52 +503,56 @@ func renameable(sym *analysis.Symbol, cfg *Config, exclusions map[string]bool) b
 	return true
 }
 
-func protectedMacroTemplateNames(files []parsedFile, base map[string]bool) map[string]bool {
+func protectedMacroTemplateSymbols(files []parsedFile, base map[string]bool) map[string]bool {
 	protected := make(map[string]bool, len(base))
 	for name := range base {
 		protected[name] = true
 	}
-	for _, file := range files {
-		for _, expr := range file.exprs {
-			collectProtectedMacroTemplateNames(expr, protected)
+	for i := range files {
+		for _, expr := range files[i].exprs {
+			collectProtectedMacroTemplateSymbols(expr, files[i].analysis.RootScope, protected)
 		}
 	}
 	return protected
 }
 
-func collectProtectedMacroTemplateNames(expr *lisp.LVal, protected map[string]bool) {
-	if expr == nil || expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) < 4 {
+func collectProtectedMacroTemplateSymbols(expr *lisp.LVal, root *analysis.Scope, protected map[string]bool) {
+	if expr == nil || root == nil || expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) < 4 {
 		return
 	}
 	if expr.Cells[0].Type != lisp.LSymbol || expr.Cells[0].Str != "defmacro" {
 		return
 	}
+	macroScope := findScopeForNode(root, expr)
+	if macroScope == nil {
+		return
+	}
 	for _, body := range expr.Cells[3:] {
-		walkMacroBodyForQuasiquote(body, protected)
+		walkMacroBodyForQuasiquote(body, macroScope, protected)
 	}
 }
 
-func walkMacroBodyForQuasiquote(node *lisp.LVal, protected map[string]bool) {
+func walkMacroBodyForQuasiquote(node *lisp.LVal, scope *analysis.Scope, protected map[string]bool) {
 	if node == nil || node.Type != lisp.LSExpr {
 		return
 	}
 	if !node.Quoted && len(node.Cells) > 0 && node.Cells[0].Type == lisp.LSymbol && node.Cells[0].Str == "quasiquote" {
 		if len(node.Cells) > 1 {
-			collectTemplateSymbols(node.Cells[1], protected)
+			collectTemplateSymbols(node.Cells[1], scope, protected)
 		}
 		return
 	}
 	for _, child := range node.Cells {
-		walkMacroBodyForQuasiquote(child, protected)
+		walkMacroBodyForQuasiquote(child, scope, protected)
 	}
 }
 
-func collectTemplateSymbols(node *lisp.LVal, protected map[string]bool) {
+func collectTemplateSymbols(node *lisp.LVal, scope *analysis.Scope, protected map[string]bool) {
 	if node == nil {
 		return
 	}
 	if node.Type == lisp.LSymbol {
-		if preserveMacroTemplateName(node.Str) {
+		if preserveMacroTemplateSymbol(scope, node.Str) {
 			protected[node.Str] = true
 		}
 		return
@@ -563,15 +567,34 @@ func collectTemplateSymbols(node *lisp.LVal, protected map[string]bool) {
 		}
 	}
 	for _, child := range node.Cells {
-		collectTemplateSymbols(child, protected)
+		collectTemplateSymbols(child, scope, protected)
 	}
 }
 
-func preserveMacroTemplateName(name string) bool {
-	return name != "" &&
-		!strings.Contains(name, ":") &&
-		!strings.HasPrefix(name, ":") &&
-		!strings.HasPrefix(name, "%")
+func preserveMacroTemplateSymbol(scope *analysis.Scope, name string) bool {
+	if name == "" ||
+		strings.Contains(name, ":") ||
+		strings.HasPrefix(name, ":") ||
+		strings.HasPrefix(name, "%") {
+		return false
+	}
+	sym := scope.Lookup(name)
+	return sym != nil && sym.Scope != nil && sym.Scope.Kind == analysis.ScopeGlobal
+}
+
+func findScopeForNode(scope *analysis.Scope, node *lisp.LVal) *analysis.Scope {
+	if scope == nil {
+		return nil
+	}
+	if scope.Node == node {
+		return scope
+	}
+	for _, child := range scope.Children {
+		if found := findScopeForNode(child, node); found != nil {
+			return found
+		}
+	}
+	return nil
 }
 
 func compareSymbols(a, b *analysis.Symbol) int {

--- a/minifier/minifier.go
+++ b/minifier/minifier.go
@@ -84,7 +84,8 @@ type parsedFile struct {
 }
 
 type fileSymbols struct {
-	globals []analysis.ExternalSymbol
+	globals  []analysis.ExternalSymbol
+	packages map[string]bool
 }
 
 type preservationSet struct {
@@ -223,11 +224,19 @@ func mergeAnalysisConfig(base *analysis.Config, filename string, perFile map[str
 	for pkg, exports := range pkgExports {
 		cfg.PackageExports[pkg] = append(cfg.PackageExports[pkg], exports...)
 	}
+	currentPackages := map[string]bool{"user": true}
+	if symbols, ok := perFile[filename]; ok && len(symbols.packages) > 0 {
+		currentPackages = symbols.packages
+	}
 	for path, symbols := range perFile {
 		if path == filename {
 			continue
 		}
-		cfg.ExtraGlobals = append(cfg.ExtraGlobals, symbols.globals...)
+		for _, sym := range symbols.globals {
+			if currentPackages[sym.Package] {
+				cfg.ExtraGlobals = append(cfg.ExtraGlobals, sym)
+			}
+		}
 	}
 	return cfg
 }
@@ -247,8 +256,8 @@ func scanInputSymbols(files []parsedFile) (map[string]fileSymbols, map[string][]
 	perFile := make(map[string]fileSymbols, len(files))
 	pkgExports := make(map[string][]analysis.ExternalSymbol)
 	for _, file := range files {
-		globals, exports := scanProgramSymbols(file.exprs)
-		perFile[file.path] = fileSymbols{globals: globals}
+		globals, exports, packages := scanProgramSymbols(file.exprs)
+		perFile[file.path] = fileSymbols{globals: globals, packages: packages}
 		for pkg, syms := range exports {
 			pkgExports[pkg] = append(pkgExports[pkg], syms...)
 		}
@@ -256,10 +265,11 @@ func scanInputSymbols(files []parsedFile) (map[string]fileSymbols, map[string][]
 	return perFile, pkgExports
 }
 
-func scanProgramSymbols(exprs []*lisp.LVal) ([]analysis.ExternalSymbol, map[string][]analysis.ExternalSymbol) {
+func scanProgramSymbols(exprs []*lisp.LVal) ([]analysis.ExternalSymbol, map[string][]analysis.ExternalSymbol, map[string]bool) {
 	defs := make(map[string]analysis.ExternalSymbol)
 	exported := make(map[string]map[string]bool)
 	currentPkg := "user"
+	packages := map[string]bool{"user": true}
 
 	for _, expr := range exprs {
 		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 || expr.Cells[0].Type != lisp.LSymbol {
@@ -269,6 +279,7 @@ func scanProgramSymbols(exprs []*lisp.LVal) ([]analysis.ExternalSymbol, map[stri
 		case "in-package":
 			if pkg := packageName(expr.Cells[1:]); pkg != "" {
 				currentPkg = pkg
+				packages[pkg] = true
 			}
 		case "defun":
 			if sym := topLevelDef(expr, analysis.SymFunction, currentPkg); sym != nil {
@@ -309,7 +320,7 @@ func scanProgramSymbols(exprs []*lisp.LVal) ([]analysis.ExternalSymbol, map[stri
 			pkgExports[pkg] = append(pkgExports[pkg], sym)
 		}
 	}
-	return globals, pkgExports
+	return globals, pkgExports, packages
 }
 
 func topLevelDef(expr *lisp.LVal, kind analysis.SymbolKind, pkg string) *analysis.ExternalSymbol {

--- a/minifier/minifier_test.go
+++ b/minifier/minifier_test.go
@@ -462,6 +462,92 @@ func TestMinifySource_RenameExportsRewritesQualifiedReferences(t *testing.T) {
 	assert.Equal(t, 42, evalResult.Int)
 }
 
+func TestMinify_ImportedExportedSymbolBeatsUnrelatedPrivateHelper(t *testing.T) {
+	inputs := []InputFile{
+		{
+			Path: "utils.lisp",
+			Source: []byte(`(in-package 'utils)
+(export 'string-starts-with?)
+(defun string-starts-with? (corpus prefix)
+  true)
+`),
+		},
+		{
+			Path: "appctrl.lisp",
+			Source: []byte(`(in-package 'appctrl)
+(defun string-starts-with? (corpus prefix)
+  false)
+`),
+		},
+		{
+			Path: "validations.lisp",
+			Source: []byte(`(in-package 'validations)
+(use-package 'utils)
+(defun validate (value)
+  (string-starts-with? value "+44"))
+
+(validate "demo")
+`),
+		},
+	}
+
+	result, err := Minify(inputs, &Config{})
+	require.NoError(t, err)
+	require.Len(t, result.Files, 3)
+
+	var privateHelperMinified string
+	for _, entry := range result.SymbolMap.Entries {
+		if entry.Original == "string-starts-with?" {
+			privateHelperMinified = entry.Minified
+		}
+	}
+	require.NotEmpty(t, privateHelperMinified, "private helper should still be minified")
+	assert.Contains(t, string(result.Files[2].Output), "(string-starts-with? x")
+	assert.NotContains(t, string(result.Files[2].Output), "("+privateHelperMinified+" x")
+
+	evalResult := evalMinifiedProgram(t, []InputFile{
+		{Path: result.Files[0].Path, Source: result.Files[0].Output},
+		{Path: result.Files[1].Path, Source: result.Files[1].Output},
+		{Path: result.Files[2].Path, Source: result.Files[2].Output},
+	})
+	require.Equal(t, lisp.LSymbol, evalResult.Type)
+	assert.Equal(t, "true", evalResult.Str)
+}
+
+func TestMinify_SamePackagePrivateCrossFileReferenceStillRewrites(t *testing.T) {
+	inputs := []InputFile{
+		{
+			Path: "helpers.lisp",
+			Source: []byte(`(in-package 'shared)
+(defun helper (value)
+  value)
+`),
+		},
+		{
+			Path: "consumer.lisp",
+			Source: []byte(`(in-package 'shared)
+(defun outer (value)
+  (helper value))
+`),
+		},
+	}
+
+	result, err := Minify(inputs, &Config{})
+	require.NoError(t, err)
+	require.Len(t, result.Files, 2)
+
+	var helperMinified string
+	for _, entry := range result.SymbolMap.Entries {
+		if entry.Original == "helper" {
+			helperMinified = entry.Minified
+			break
+		}
+	}
+	require.NotEmpty(t, helperMinified)
+	assert.Contains(t, string(result.Files[0].Output), "(defun "+helperMinified+" ")
+	assert.Contains(t, string(result.Files[1].Output), "("+helperMinified+" x")
+}
+
 func TestMinify_MultiFileMacroTemplateReferencesRemainExecutable(t *testing.T) {
 	inputs := []InputFile{
 		{

--- a/minifier/minifier_test.go
+++ b/minifier/minifier_test.go
@@ -462,6 +462,42 @@ func TestMinifySource_RenameExportsRewritesQualifiedReferences(t *testing.T) {
 	assert.Equal(t, 42, evalResult.Int)
 }
 
+func TestMinify_PrivateQualifiedReferencePreservedRegardlessOfFileOrder(t *testing.T) {
+	inputs := []InputFile{
+		{
+			Path: "router.lisp",
+			Source: []byte(`(in-package 'router)
+(defun helper (value)
+  value)
+`),
+		},
+		{
+			Path: "batch.lisp",
+			Source: []byte(`(in-package 'batch)
+(defun run ()
+  (router:helper 42))
+
+(run)
+`),
+		},
+	}
+
+	result, err := Minify(inputs, &Config{})
+	require.NoError(t, err)
+	require.Len(t, result.Files, 2)
+
+	assert.Contains(t, string(result.Files[0].Output), "(defun helper ")
+	assert.Contains(t, string(result.Files[1].Output), "(router:helper 42)")
+	assert.NotContains(t, result.SymbolMap.OriginalToMinified, "helper")
+
+	evalResult := evalMinifiedProgram(t, []InputFile{
+		{Path: result.Files[0].Path, Source: result.Files[0].Output},
+		{Path: result.Files[1].Path, Source: result.Files[1].Output},
+	})
+	require.Equal(t, lisp.LInt, evalResult.Type)
+	assert.Equal(t, 42, evalResult.Int)
+}
+
 func TestMinify_ImportedExportedSymbolBeatsUnrelatedPrivateHelper(t *testing.T) {
 	inputs := []InputFile{
 		{
@@ -546,6 +582,42 @@ func TestMinify_SamePackagePrivateCrossFileReferenceStillRewrites(t *testing.T) 
 	require.NotEmpty(t, helperMinified)
 	assert.Contains(t, string(result.Files[0].Output), "(defun "+helperMinified+" ")
 	assert.Contains(t, string(result.Files[1].Output), "("+helperMinified+" x")
+}
+
+func TestMinify_CustomDefForm_MultiFileReferencesRewriteAndExportsPreserve(t *testing.T) {
+	inputs := []InputFile{
+		{
+			Path: "api.lisp",
+			Source: []byte(`(in-package 'svc)
+(export 'handler)
+(endpoint handler (req)
+  req)
+`),
+		},
+		{
+			Path: "app.lisp",
+			Source: []byte(`(in-package 'svc)
+(endpoint caller ()
+  (handler 42))
+
+(caller)
+`),
+		},
+	}
+
+	result, err := Minify(inputs, &Config{
+		Analysis: &analysis.Config{
+			DefForms: []analysis.DefFormSpec{
+				{Head: "endpoint", FormalsIndex: 2, BindsName: true, NameIndex: 1, NameKind: analysis.SymFunction},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Files, 2)
+
+	assert.Contains(t, string(result.Files[0].Output), "(export 'handler)")
+	assert.Contains(t, string(result.Files[0].Output), "(endpoint handler (x1) x1)")
+	assert.Contains(t, string(result.Files[1].Output), "(endpoint x2 () (handler 42))")
 }
 
 func TestMinify_MultiFileMacroTemplateReferencesRemainExecutable(t *testing.T) {

--- a/minifier/minifier_test.go
+++ b/minifier/minifier_test.go
@@ -259,10 +259,207 @@ func TestMinifySource_MacroTemplateBindersDoNotBlockUnrelatedRenames(t *testing.
 	require.NoError(t, err)
 
 	assert.Contains(t, string(out), "(let ((x 1)) x)")
-	assert.Equal(t, "(defmacro x1 () (quasiquote (let ((x 1)) x)))\n(defun x2 (x3) (+ x3 1))\n", string(out))
-	assert.Equal(t, "m", symMap.MinifiedToOriginal["x1"])
-	assert.Equal(t, "f", symMap.MinifiedToOriginal["x2"])
-	assert.Equal(t, "x", symMap.MinifiedToOriginal["x3"])
+	assert.Equal(t, "(defmacro m () (quasiquote (let ((x 1)) x)))\n(defun x1 (x2) (+ x2 1))\n", string(out))
+	assert.Equal(t, "f", symMap.MinifiedToOriginal["x1"])
+	assert.Equal(t, "x", symMap.MinifiedToOriginal["x2"])
+	assert.NotContains(t, symMap.OriginalToMinified, "m")
+}
+
+func TestMinifySource_DefaultCallDoesNotProduceInconsistentOptionalRename(t *testing.T) {
+	src := []byte(`(defun outer ()
+  (labels ([register (id name &optional ctx)
+            (let* ([body (default ctx (sorted-map))])
+              (assoc! body "id" id)
+              (assoc! body "name" name)
+              body)])
+    (register "a" "b")))
+`)
+
+	out, symMap, err := MinifySource(src, "default-optional.lisp", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "(defun x1 () (labels ([x2 (x3 x4 &optional x5) (let* ([x6 (default x5 (sorted-map))]) (assoc! x6 \"id\" x3) (assoc! x6 \"name\" x4) x6)]) (x2 \"a\" \"b\")))\n", string(out))
+	assert.Equal(t, "ctx", symMap.MinifiedToOriginal["x5"])
+	result := evalMinifiedProgram(t, []InputFile{{Path: "default-optional.lisp", Source: out}})
+	require.NotNil(t, result)
+	assert.NotEqual(t, lisp.LError, result.Type)
+}
+
+func TestMinifySource_DefaultCallOutsideLabelsFallsBackToNormalCall(t *testing.T) {
+	src := []byte(`(defun fallback (ctx)
+  (default ctx (sorted-map)))
+`)
+
+	out, symMap, err := MinifySource(src, "default-call.lisp", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "(defun x1 (x2) (default x2 (sorted-map)))\n", string(out))
+	assert.Equal(t, "fallback", symMap.MinifiedToOriginal["x1"])
+	assert.Equal(t, "ctx", symMap.MinifiedToOriginal["x2"])
+}
+
+func TestMinifySource_WithCustomDefFormConfig(t *testing.T) {
+	src := []byte(`(endpoint handler (req)
+  (+ req 1))
+`)
+
+	out, symMap, err := MinifySource(src, "custom-def-form.lisp", &Config{
+		Analysis: &analysis.Config{
+			DefForms: []analysis.DefFormSpec{
+				{Head: "endpoint", FormalsIndex: 2, BindsName: true, NameIndex: 1, NameKind: analysis.SymFunction},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "(endpoint x1 (x2) (+ x2 1))\n", string(out))
+	assert.Equal(t, "handler", symMap.MinifiedToOriginal["x1"])
+	assert.Equal(t, "req", symMap.MinifiedToOriginal["x2"])
+}
+
+func TestMinifySource_WithCustomPackageSurfaceFormPreservesCustomDefName(t *testing.T) {
+	src := []byte(`(endpoint handler (req)
+  (+ req 1))
+`)
+
+	out, symMap, err := MinifySource(src, "custom-surface-form.lisp", &Config{
+		Analysis: &analysis.Config{
+			DefForms: []analysis.DefFormSpec{
+				{Head: "endpoint", FormalsIndex: 2, BindsName: true, NameIndex: 1, NameKind: analysis.SymFunction},
+			},
+		},
+		PackageSurfaceForms: []PackageSurfaceFormSpec{
+			{Head: "endpoint", NameIndex: 1},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "(endpoint handler (x1) (+ x1 1))\n", string(out))
+	assert.Equal(t, "req", symMap.MinifiedToOriginal["x1"])
+	assert.NotContains(t, symMap.OriginalToMinified, "handler")
+}
+
+func TestMinifySource_WithCustomQuotedPackageSurfaceFormPreservesName(t *testing.T) {
+	src := []byte(`(define-surface 'handler (lambda (value) value))
+
+(defun use-value (value)
+  (+ value 1))
+`)
+
+	out, symMap, err := MinifySource(src, "custom-quoted-surface-form.lisp", &Config{
+		PackageSurfaceForms: []PackageSurfaceFormSpec{
+			{Head: "define-surface", NameIndex: 1, QuotedName: true},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "(define-surface 'handler (lambda (x1) x1))\n(defun x2 (x3) (+ x3 1))\n", string(out))
+	assert.Equal(t, "value", symMap.MinifiedToOriginal["x1"])
+	assert.Equal(t, "use-value", symMap.MinifiedToOriginal["x2"])
+	assert.Equal(t, "value", symMap.MinifiedToOriginal["x3"])
+	assert.NotContains(t, symMap.OriginalToMinified, "handler")
+}
+
+func TestMinifySource_TopLevelSetNamesPreservedByDefault(t *testing.T) {
+	src := []byte(`(set 'counter 0)
+
+(defun use-counter (value)
+  (+ counter value))
+`)
+
+	out, symMap, err := MinifySource(src, "set-preserve.lisp", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "(set 'counter 0)\n(defun x1 (x2) (+ counter x2))\n", string(out))
+	assert.Equal(t, "use-counter", symMap.MinifiedToOriginal["x1"])
+	assert.Equal(t, "value", symMap.MinifiedToOriginal["x2"])
+	assert.NotContains(t, symMap.OriginalToMinified, "counter")
+}
+
+func TestMinifySource_QualifiedInternalSetReferencePreservedSafely(t *testing.T) {
+	inputs := []InputFile{
+		{
+			Path: "router.lisp",
+			Source: []byte(`(in-package 'router)
+(set 'add-init-pre-hook (lambda (callback) callback))
+`),
+		},
+		{
+			Path: "batch.lisp",
+			Source: []byte(`(in-package 'batch)
+(use-package 'router)
+(defun handler ()
+  (router:add-init-pre-hook (lambda () true)))
+
+(handler)
+`),
+		},
+	}
+
+	result, err := Minify(inputs, &Config{})
+	require.NoError(t, err)
+	require.Len(t, result.Files, 2)
+
+	assert.Contains(t, string(result.Files[0].Output), "(set 'add-init-pre-hook (lambda (")
+	assert.Contains(t, string(result.Files[0].Output), ") ")
+	assert.Contains(t, string(result.Files[1].Output), "(router:add-init-pre-hook (lambda () true))")
+	assert.Contains(t, string(result.Files[1].Output), "(defun x")
+	assert.NotContains(t, result.SymbolMap.OriginalToMinified, "add-init-pre-hook")
+
+	evalResult := evalMinifiedProgram(t, []InputFile{
+		{Path: result.Files[0].Path, Source: result.Files[0].Output},
+		{Path: result.Files[1].Path, Source: result.Files[1].Output},
+	})
+	require.NotNil(t, evalResult)
+	assert.NotEqual(t, lisp.LError, evalResult.Type)
+}
+
+func TestMinifySource_RenameExportsRewritesQualifiedReferences(t *testing.T) {
+	inputs := []InputFile{
+		{
+			Path: "router.lisp",
+			Source: []byte(`(in-package 'router)
+(export 'helper)
+(defun helper (value) value)
+`),
+		},
+		{
+			Path: "batch.lisp",
+			Source: []byte(`(in-package 'batch)
+(defun handler ()
+  (router:helper 42))
+
+(handler)
+`),
+		},
+	}
+
+	result, err := Minify(inputs, &Config{RenameExports: true})
+	require.NoError(t, err)
+	require.Len(t, result.Files, 2)
+
+	assert.Contains(t, string(result.Files[0].Output), "(export 'x")
+	assert.Contains(t, string(result.Files[0].Output), "(defun x")
+	assert.Contains(t, string(result.Files[1].Output), "(router:x")
+
+	var helperMinified string
+	for _, entry := range result.SymbolMap.Entries {
+		if entry.Original == "helper" {
+			helperMinified = entry.Minified
+			break
+		}
+	}
+	require.NotEmpty(t, helperMinified)
+	assert.Contains(t, string(result.Files[0].Output), "(export '"+helperMinified+")")
+	assert.Contains(t, string(result.Files[0].Output), "(defun "+helperMinified+" (")
+	assert.Contains(t, string(result.Files[1].Output), "(router:"+helperMinified+" 42)")
+
+	evalResult := evalMinifiedProgram(t, []InputFile{
+		{Path: result.Files[0].Path, Source: result.Files[0].Output},
+		{Path: result.Files[1].Path, Source: result.Files[1].Output},
+	})
+	require.Equal(t, lisp.LInt, evalResult.Type)
+	assert.Equal(t, 42, evalResult.Int)
 }
 
 func TestMinify_MultiFileMacroTemplateReferencesRemainExecutable(t *testing.T) {

--- a/minifier/minifier_test.go
+++ b/minifier/minifier_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/luthersystems/elps/analysis"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,19 +143,6 @@ func TestMinifySource_StripsCommentsByDefault(t *testing.T) {
 	assert.Equal(t, "(defun x1 (x2) (let ((x3 (+ x2 1))) x3))\n", string(out))
 }
 
-func TestMinifySource_QuasiquoteOnlyRenamesUnquotedCode(t *testing.T) {
-	src := []byte(`(set 'x 1)
-(quasiquote (list x (unquote x) (unquote-splicing [x])))
-`)
-
-	out, symMap, err := MinifySource(src, "qq.lisp", nil)
-	require.NoError(t, err)
-
-	assert.Equal(t, "(set 'x1 1)\n(quasiquote (list x (unquote x1) (unquote-splicing [x])))\n", string(out))
-	require.Len(t, symMap.Entries, 1)
-	assert.Equal(t, "x", symMap.MinifiedToOriginal["x1"])
-}
-
 func TestMinifySource_WithWorkspacePreservesImportedSymbols(t *testing.T) {
 	dir := t.TempDir()
 	libPath := filepath.Join(dir, "lib.lisp")
@@ -176,6 +165,121 @@ func TestMinifySource_WithWorkspacePreservesImportedSymbols(t *testing.T) {
 	require.Len(t, symMap.Entries, 2)
 	assert.Equal(t, "outer", symMap.MinifiedToOriginal["x1"])
 	assert.Equal(t, "value", symMap.MinifiedToOriginal["x2"])
+}
+
+func TestMinifySource_PreservesMacroTemplateHelperReferences(t *testing.T) {
+	src := []byte(`(defun helper (value)
+  (+ value 1))
+
+(defmacro wrap (expr)
+  (quasiquote
+    (helper (unquote expr))))
+
+(defun outer (value)
+  (wrap value))
+
+(outer 41)
+`)
+
+	out, symMap, err := MinifySource(src, "macro-helper.lisp", nil)
+	require.NoError(t, err)
+
+	result := evalMinifiedProgram(t, []InputFile{{Path: "macro-helper.lisp", Source: out}})
+	require.Equal(t, lisp.LInt, result.Type)
+	assert.Equal(t, 42, result.Int)
+
+	assert.Contains(t, string(out), "(defun helper")
+	assert.Contains(t, string(out), "(helper (unquote x")
+	assert.NotContains(t, symMap.MinifiedToOriginal, "helper")
+	assert.Contains(t, symMap.OriginalToMinified, "outer")
+}
+
+func TestMinifySource_PreservesMacroTemplateQuotedSetSymbols(t *testing.T) {
+	src := []byte(`(set 'counter 0)
+
+(defmacro bump-counter ()
+  (quasiquote
+    (set 'counter (+ counter 1))))
+
+(defun run ()
+  (bump-counter)
+  counter)
+
+(run)
+`)
+
+	out, symMap, err := MinifySource(src, "macro-set.lisp", nil)
+	require.NoError(t, err)
+
+	result := evalMinifiedProgram(t, []InputFile{{Path: "macro-set.lisp", Source: out}})
+	require.Equal(t, lisp.LInt, result.Type)
+	assert.Equal(t, 1, result.Int)
+
+	assert.Contains(t, string(out), "(set 'counter")
+	assert.NotContains(t, symMap.MinifiedToOriginal, "counter")
+}
+
+func TestMinifySource_PreservesMacroGeneratedLocalRecursion(t *testing.T) {
+	src := []byte(`(defmacro sum-down (n)
+  (quasiquote
+    (labels ([loop (x acc)
+              (if (<= x 0)
+                acc
+                (loop (- x 1) (+ acc x)))])
+      (loop (unquote n) 0))))
+
+(defun run (value)
+  (sum-down value))
+
+(run 4)
+`)
+
+	out, symMap, err := MinifySource(src, "macro-labels.lisp", nil)
+	require.NoError(t, err)
+
+	result := evalMinifiedProgram(t, []InputFile{{Path: "macro-labels.lisp", Source: out}})
+	require.Equal(t, lisp.LInt, result.Type)
+	assert.Equal(t, 10, result.Int)
+
+	assert.Contains(t, string(out), "[loop (x acc)")
+	assert.NotContains(t, symMap.MinifiedToOriginal, "loop")
+}
+
+func TestMinify_MultiFileMacroTemplateReferencesRemainExecutable(t *testing.T) {
+	inputs := []InputFile{
+		{
+			Path: "lib.lisp",
+			Source: []byte(`(defun helper (value)
+  (+ value 1))
+
+(defmacro wrap (expr)
+  (quasiquote
+    (helper (unquote expr))))
+`),
+		},
+		{
+			Path: "main.lisp",
+			Source: []byte(`(defun outer (value)
+  (wrap value))
+
+(outer 41)
+`),
+		},
+	}
+
+	result, err := Minify(inputs, &Config{})
+	require.NoError(t, err)
+	require.Len(t, result.Files, 2)
+
+	evalResult := evalMinifiedProgram(t, []InputFile{
+		{Path: result.Files[0].Path, Source: result.Files[0].Output},
+		{Path: result.Files[1].Path, Source: result.Files[1].Output},
+	})
+	require.Equal(t, lisp.LInt, evalResult.Type)
+	assert.Equal(t, 42, evalResult.Int)
+
+	assert.Contains(t, string(result.Files[0].Output), "(defun helper")
+	assert.NotContains(t, result.SymbolMap.MinifiedToOriginal, "helper")
 }
 
 func TestReadExcludeFile(t *testing.T) {
@@ -203,4 +307,26 @@ func TestSymbolMapJSON(t *testing.T) {
 	assert.Equal(t, symMap.Entries, parsed.Entries)
 	assert.Equal(t, symMap.MinifiedToOriginal, parsed.MinifiedToOriginal)
 	assert.Equal(t, symMap.OriginalToMinified, parsed.OriginalToMinified)
+}
+
+func evalMinifiedProgram(t *testing.T, files []InputFile) *lisp.LVal {
+	t.Helper()
+
+	env := lisp.NewEnv(nil)
+	lerr := lisp.InitializeUserEnv(env)
+	require.Truef(t, lerr.IsNil(), "InitializeUserEnv failed: %v", lerr)
+	env.Runtime.Reader = parser.NewReader()
+	lerr = env.InPackage(lisp.String(lisp.DefaultUserPackage))
+	require.Truef(t, lerr.IsNil(), "InPackage failed: %v", lerr)
+
+	var result *lisp.LVal
+	for _, file := range files {
+		program := env.LoadString(file.Path, string(file.Source))
+		require.NotNil(t, program)
+		result = env.Eval(program)
+		require.NotNil(t, result)
+		require.NotEqualf(t, lisp.LError, result.Type, "program %s failed: %v", file.Path, result)
+	}
+
+	return result
 }

--- a/minifier/minifier_test.go
+++ b/minifier/minifier_test.go
@@ -245,6 +245,26 @@ func TestMinifySource_PreservesMacroGeneratedLocalRecursion(t *testing.T) {
 	assert.NotContains(t, symMap.MinifiedToOriginal, "loop")
 }
 
+func TestMinifySource_MacroTemplateBindersDoNotBlockUnrelatedRenames(t *testing.T) {
+	src := []byte(`(defmacro m ()
+  (quasiquote
+    (let ((x 1))
+      x)))
+
+(defun f (x)
+  (+ x 1))
+`)
+
+	out, symMap, err := MinifySource(src, "macro-binder.lisp", nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "(let ((x 1)) x)")
+	assert.Equal(t, "(defmacro x1 () (quasiquote (let ((x 1)) x)))\n(defun x2 (x3) (+ x3 1))\n", string(out))
+	assert.Equal(t, "m", symMap.MinifiedToOriginal["x1"])
+	assert.Equal(t, "f", symMap.MinifiedToOriginal["x2"])
+	assert.Equal(t, "x", symMap.MinifiedToOriginal["x3"])
+}
+
 func TestMinify_MultiFileMacroTemplateReferencesRemainExecutable(t *testing.T) {
 	inputs := []InputFile{
 		{


### PR DESCRIPTION
## Summary
- preserve names that appear in defmacro quasiquote template output so minified generated code keeps valid runtime bindings
- add runtime-backed minifier regressions for helper calls, quoted set symbols, local recursion, and multi-file macro usage
- closes #215

## Test plan
- [x] go test ./minifier ./formatter ./cmd
- [x] go test ./...

---
Local tests passed. Security review completed. QA review completed.