### PR TITLE
feat(lint): add duplicate-definition analyzer

### DIFF
--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -159,7 +159,7 @@ var AnalyzerLetBindings = &Analyzer{
 					continue
 				}
 				// Accept (unquote sym) as a valid binding name — it expands to a symbol at macro-expansion time.
-			if binding.Cells[0].Type != lisp.LSymbol && HeadSymbol(binding.Cells[0]) != "unquote" {
+				if binding.Cells[0].Type != lisp.LSymbol && HeadSymbol(binding.Cells[0]) != "unquote" {
 					pass.Reportf(bindingSource(binding, src),
 						"%s binding %d: first element must be a symbol, got %s", head, i+1, binding.Cells[0].Type)
 					continue
@@ -895,9 +895,9 @@ var AnalyzerUndefinedSymbol = &Analyzer{
 
 // AnalyzerDuplicateDefinition warns when the same symbol is defined more than
 // once at the top level (e.g. two defun with the same name). Only flags
-// defun/defmacro/deftype duplicates — repeated set is already covered by
-// set-usage. Cross-file duplicates are detected when an External symbol
-// matches a local definition. Requires semantic analysis.
+// defun/defmacro duplicates — repeated set is already covered by set-usage.
+// Cross-file duplicates are detected when an External symbol matches a local
+// definition. Requires semantic analysis.
 var AnalyzerDuplicateDefinition = &Analyzer{
 	Name:     "duplicate-definition",
 	Severity: SeverityWarning,
@@ -910,7 +910,7 @@ var AnalyzerDuplicateDefinition = &Analyzer{
 
 		// definitionKinds are the symbol kinds we check for duplicates.
 		isDefKind := func(k analysis.SymbolKind) bool {
-			return k == analysis.SymFunction || k == analysis.SymMacro || k == analysis.SymType
+			return k == analysis.SymFunction || k == analysis.SymMacro
 		}
 
 		// Collect local (non-external) root-scope definitions by (name, package).
@@ -961,17 +961,17 @@ var AnalyzerDuplicateDefinition = &Analyzer{
 					continue
 				}
 				// Treat empty package as "user" (the default package).
-			extPkg := ext.Package
-			if extPkg == "" {
-				extPkg = "user"
-			}
-			localPkg := key.pkg
-			if localPkg == "" {
-				localPkg = "user"
-			}
-			if extPkg != localPkg {
-				continue
-			}
+				extPkg := ext.Package
+				if extPkg == "" {
+					extPkg = "user"
+				}
+				localPkg := key.pkg
+				if localPkg == "" {
+					localPkg = "user"
+				}
+				if extPkg != localPkg {
+					continue
+				}
 				pass.Report(Diagnostic{
 					Message: fmt.Sprintf("duplicate definition: %s '%s' is also defined externally", first.Kind, first.Name),
 					Pos:     posFromSource(first.Source),

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -902,7 +902,7 @@ var AnalyzerDuplicateDefinition = &Analyzer{
 	Name:     "duplicate-definition",
 	Severity: SeverityWarning,
 	Semantic: true,
-	Doc:      "Warn when a symbol is defined more than once at the top level.\n\nRequires semantic analysis (--workspace flag). Detects same-file duplicates (two defun with the same name) and cross-file duplicates (a local defun that shadows an imported definition). Only checks defun, defmacro, and deftype — repeated set is handled by set-usage.",
+	Doc:      "Warn when a symbol is defined more than once at the top level.\n\nRequires semantic analysis (--workspace flag). Detects same-file duplicates (two defun with the same name) and cross-file duplicates (a local defun that shadows an imported definition). Only checks defun and defmacro — repeated set is handled by set-usage.",
 	Run: func(pass *Pass) error {
 		if pass.Semantics == nil {
 			return nil

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -893,6 +893,97 @@ var AnalyzerUndefinedSymbol = &Analyzer{
 	},
 }
 
+// AnalyzerDuplicateDefinition warns when the same symbol is defined more than
+// once at the top level (e.g. two defun with the same name). Only flags
+// defun/defmacro/deftype duplicates — repeated set is already covered by
+// set-usage. Cross-file duplicates are detected when an External symbol
+// matches a local definition. Requires semantic analysis.
+var AnalyzerDuplicateDefinition = &Analyzer{
+	Name:     "duplicate-definition",
+	Severity: SeverityWarning,
+	Semantic: true,
+	Doc:      "Warn when a symbol is defined more than once at the top level.\n\nRequires semantic analysis (--workspace flag). Detects same-file duplicates (two defun with the same name) and cross-file duplicates (a local defun that shadows an imported definition). Only checks defun, defmacro, and deftype — repeated set is handled by set-usage.",
+	Run: func(pass *Pass) error {
+		if pass.Semantics == nil {
+			return nil
+		}
+
+		// definitionKinds are the symbol kinds we check for duplicates.
+		isDefKind := func(k analysis.SymbolKind) bool {
+			return k == analysis.SymFunction || k == analysis.SymMacro || k == analysis.SymType
+		}
+
+		// Collect local (non-external) root-scope definitions by (name, package).
+		type defKey struct {
+			name string
+			pkg  string
+		}
+		groups := make(map[defKey][]*analysis.Symbol)
+
+		for _, sym := range pass.Semantics.Symbols {
+			if sym.Scope != pass.Semantics.RootScope {
+				continue
+			}
+			if sym.External {
+				continue
+			}
+			if !isDefKind(sym.Kind) {
+				continue
+			}
+			if sym.Source == nil {
+				continue // skip builtins
+			}
+			key := defKey{name: sym.Name, pkg: sym.Package}
+			groups[key] = append(groups[key], sym)
+		}
+
+		for key, syms := range groups {
+			first := syms[0]
+
+			// Same-file duplicates: report on 2nd+ definitions.
+			for _, sym := range syms[1:] {
+				pass.Report(Diagnostic{
+					Message: fmt.Sprintf("duplicate definition: %s '%s' already defined", sym.Kind, sym.Name),
+					Pos:     posFromSource(sym.Source),
+					Notes:   []string{fmt.Sprintf("first defined at %s", sourceString(first.Source))},
+				})
+			}
+
+			// Cross-file: check if an external symbol with the same name
+			// exists in the root scope. External symbols from ExtraGlobals
+			// are in the scope but not in result.Symbols.
+			allLocal := pass.Semantics.RootScope.LookupAllLocal(key.name)
+			for _, ext := range allLocal {
+				if !ext.External || ext.Source == nil {
+					continue
+				}
+				if !isDefKind(ext.Kind) {
+					continue
+				}
+				// Treat empty package as "user" (the default package).
+			extPkg := ext.Package
+			if extPkg == "" {
+				extPkg = "user"
+			}
+			localPkg := key.pkg
+			if localPkg == "" {
+				localPkg = "user"
+			}
+			if extPkg != localPkg {
+				continue
+			}
+				pass.Report(Diagnostic{
+					Message: fmt.Sprintf("duplicate definition: %s '%s' is also defined externally", first.Kind, first.Name),
+					Pos:     posFromSource(first.Source),
+					Notes:   []string{fmt.Sprintf("also defined at %s", sourceString(ext.Source))},
+				})
+				break // one cross-file warning per local symbol is enough
+			}
+		}
+		return nil
+	},
+}
+
 // AnalyzerNames returns a sorted list of all default analyzer names.
 func AnalyzerNames() []string {
 	analyzers := DefaultAnalyzers()

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -674,5 +674,6 @@ func DefaultAnalyzers() []*Analyzer {
 		AnalyzerUnusedFunction,
 		AnalyzerShadowing,
 		AnalyzerUserArity,
+		AnalyzerDuplicateDefinition,
 	}
 }

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -2061,6 +2061,7 @@ func TestDuplicateDefinition_Positive_SameFileDefun(t *testing.T) {
 	assert.Len(t, diags, 1)
 	assertHasDiag(t, diags, "duplicate definition")
 	assertHasDiag(t, diags, "foo")
+	assert.Equal(t, 2, diags[0].Pos.Line, "diagnostic should point to the second definition")
 }
 
 func TestDuplicateDefinition_Positive_SameFileDefmacro(t *testing.T) {
@@ -2069,6 +2070,22 @@ func TestDuplicateDefinition_Positive_SameFileDefmacro(t *testing.T) {
 	assert.Len(t, diags, 1)
 	assertHasDiag(t, diags, "duplicate definition")
 	assertHasDiag(t, diags, "bar")
+	assert.Equal(t, 2, diags[0].Pos.Line, "diagnostic should point to the second definition")
+}
+
+func TestDuplicateDefinition_Negative_SameFileDeftype(t *testing.T) {
+	// deftype prescan skips duplicates (scope.LookupLocalInPackage guard),
+	// so only one symbol ends up in result.Symbols. This is a known
+	// limitation — deftype duplicates are caught at runtime instead.
+	source := "(deftype my-type () (list 'string))\n(deftype my-type () (list 'int))"
+	diags := lintCheckSemantic(t, AnalyzerDuplicateDefinition, source)
+	assertNoDiags(t, diags)
+}
+
+func TestDuplicateDefinition_Positive_TripleDuplicate(t *testing.T) {
+	source := "(defun foo () 1)\n(defun foo () 2)\n(defun foo () 3)"
+	diags := lintCheckSemantic(t, AnalyzerDuplicateDefinition, source)
+	assert.Len(t, diags, 2, "should report on 2nd and 3rd definitions")
 }
 
 func TestDuplicateDefinition_Negative_DifferentNames(t *testing.T) {
@@ -2124,6 +2141,53 @@ func TestDuplicateDefinition_CrossFile(t *testing.T) {
 	assert.Len(t, diags, 1)
 	assertHasDiag(t, diags, "also defined externally")
 	assertHasDiag(t, diags, "helper")
+	require.NotEmpty(t, diags[0].Notes)
+	assert.Contains(t, diags[0].Notes[0], "other.lisp:5")
+}
+
+func TestDuplicateDefinition_CrossFile_DifferentPackage(t *testing.T) {
+	// An external symbol in a different package should NOT trigger a warning.
+	source := "(defun helper () 42)"
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerDuplicateDefinition}}
+	cfg := &analysis.Config{
+		ExtraGlobals: []analysis.ExternalSymbol{
+			{
+				Name:    "helper",
+				Kind:    analysis.SymFunction,
+				Package: "other-pkg",
+				Source:  &token.Location{File: "other.lisp", Line: 5},
+			},
+		},
+	}
+	diags, err := l.LintFileWithAnalysis([]byte(source), "test.lisp", cfg)
+	require.NoError(t, err)
+	assertNoDiags(t, diags)
+}
+
+func TestDuplicateDefinition_CrossFile_UserPackageNormalization(t *testing.T) {
+	// When an external symbol has explicit Package:"user", it goes through
+	// DefineQualifiedOnly and lands at the same PackageSymbols key as the
+	// local defun — the scope overwrites it. This is a known limitation:
+	// same-package qualified externals are indistinguishable from locals
+	// after prescan. The empty-package path (tested in CrossFile above)
+	// works because the external lands in Symbols["helper"] while the
+	// local lands in PackageSymbols["user:helper"].
+	source := "(defun helper () 42)"
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerDuplicateDefinition}}
+	cfg := &analysis.Config{
+		ExtraGlobals: []analysis.ExternalSymbol{
+			{
+				Name:    "helper",
+				Kind:    analysis.SymFunction,
+				Package: "user",
+				Source:  &token.Location{File: "other.lisp", Line: 3},
+			},
+		},
+	}
+	diags, err := l.LintFileWithAnalysis([]byte(source), "test.lisp", cfg)
+	require.NoError(t, err)
+	// Cannot detect due to scope key collision — documented limitation.
+	assertNoDiags(t, diags)
 }
 
 func TestDuplicateDefinition_HasNotes(t *testing.T) {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1383,7 +1383,7 @@ func TestSeverity_AnalyzerDefaults(t *testing.T) {
 		"unused-variable":    SeverityWarning,
 		"unused-function":    SeverityWarning,
 		"shadowing":          SeverityInfo,
-		"user-arity":            SeverityError,
+		"user-arity":           SeverityError,
 		"duplicate-definition": SeverityWarning,
 	}
 	for _, a := range DefaultAnalyzers() {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1093,13 +1093,14 @@ func TestBracketListIgnored(t *testing.T) {
 
 func TestDefaultAnalyzers(t *testing.T) {
 	analyzers := DefaultAnalyzers()
-	assert.Len(t, analyzers, 16)
+	assert.Len(t, analyzers, 17)
 	names := AnalyzerNames()
 	assert.Equal(t, []string{
 		"builtin-arity",
 		"cond-missing-else",
 		"cond-structure",
 		"defun-structure",
+		"duplicate-definition",
 		"if-arity",
 		"in-package-toplevel",
 		"let-bindings",
@@ -1382,7 +1383,8 @@ func TestSeverity_AnalyzerDefaults(t *testing.T) {
 		"unused-variable":    SeverityWarning,
 		"unused-function":    SeverityWarning,
 		"shadowing":          SeverityInfo,
-		"user-arity":         SeverityError,
+		"user-arity":            SeverityError,
+		"duplicate-definition": SeverityWarning,
 	}
 	for _, a := range DefaultAnalyzers() {
 		want, ok := expected[a.Name]
@@ -2051,6 +2053,87 @@ func TestUserArity_Negative_LambdaParamShadow(t *testing.T) {
 	assertNoDiags(t, diags)
 }
 
+// --- duplicate-definition ---
+
+func TestDuplicateDefinition_Positive_SameFileDefun(t *testing.T) {
+	source := "(defun foo () 1)\n(defun foo () 2)"
+	diags := lintCheckSemantic(t, AnalyzerDuplicateDefinition, source)
+	assert.Len(t, diags, 1)
+	assertHasDiag(t, diags, "duplicate definition")
+	assertHasDiag(t, diags, "foo")
+}
+
+func TestDuplicateDefinition_Positive_SameFileDefmacro(t *testing.T) {
+	source := "(defmacro bar () 1)\n(defmacro bar () 2)"
+	diags := lintCheckSemantic(t, AnalyzerDuplicateDefinition, source)
+	assert.Len(t, diags, 1)
+	assertHasDiag(t, diags, "duplicate definition")
+	assertHasDiag(t, diags, "bar")
+}
+
+func TestDuplicateDefinition_Negative_DifferentNames(t *testing.T) {
+	source := "(defun foo () 1)\n(defun bar () 2)"
+	diags := lintCheckSemantic(t, AnalyzerDuplicateDefinition, source)
+	assertNoDiags(t, diags)
+}
+
+func TestDuplicateDefinition_Negative_DifferentPackages(t *testing.T) {
+	source := `(in-package "a")
+(defun foo () 1)
+(in-package "b")
+(defun foo () 2)`
+	diags := lintCheckSemantic(t, AnalyzerDuplicateDefinition, source)
+	assertNoDiags(t, diags)
+}
+
+func TestDuplicateDefinition_Negative_NilSemantics(t *testing.T) {
+	diags := lintCheck(t, AnalyzerDuplicateDefinition, "(defun foo () 1)\n(defun foo () 2)")
+	assertNoDiags(t, diags)
+}
+
+func TestDuplicateDefinition_Negative_SetNotFlagged(t *testing.T) {
+	// Repeated set is handled by set-usage, not duplicate-definition.
+	source := "(set 'x 1)\n(set 'x 2)"
+	diags := lintCheckSemantic(t, AnalyzerDuplicateDefinition, source)
+	assertNoDiags(t, diags)
+}
+
+func TestDuplicateDefinition_Nolint(t *testing.T) {
+	source := "(defun foo () 1)\n(defun foo () 2) ; nolint:duplicate-definition"
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerDuplicateDefinition}}
+	diags, err := l.LintFileWithAnalysis([]byte(source), "test.lisp", nil)
+	require.NoError(t, err)
+	assertNoDiags(t, diags)
+}
+
+func TestDuplicateDefinition_CrossFile(t *testing.T) {
+	// A local defun that matches an external symbol from workspace scan.
+	source := "(defun helper () 42)"
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerDuplicateDefinition}}
+	cfg := &analysis.Config{
+		ExtraGlobals: []analysis.ExternalSymbol{
+			{
+				Name:   "helper",
+				Kind:   analysis.SymFunction,
+				Source: &token.Location{File: "other.lisp", Line: 5},
+			},
+		},
+	}
+	diags, err := l.LintFileWithAnalysis([]byte(source), "test.lisp", cfg)
+	require.NoError(t, err)
+	assert.Len(t, diags, 1)
+	assertHasDiag(t, diags, "also defined externally")
+	assertHasDiag(t, diags, "helper")
+}
+
+func TestDuplicateDefinition_HasNotes(t *testing.T) {
+	source := "(defun foo () 1)\n(defun foo () 2)"
+	diags := lintCheckSemantic(t, AnalyzerDuplicateDefinition, source)
+	require.Len(t, diags, 1)
+	require.NotEmpty(t, diags[0].Notes)
+	assert.Contains(t, diags[0].Notes[0], "first defined at")
+}
+
 // --- unused-nolint ---
 
 func TestUnusedNolint_Unused(t *testing.T) {
@@ -2238,11 +2321,12 @@ func TestUnusedNolint_ChecksFilterStillFlagsUnknown(t *testing.T) {
 
 func TestDefaultAnalyzers_SemanticField(t *testing.T) {
 	semanticNames := map[string]bool{
-		"unused-variable": true,
-		"unused-function": true,
-		"undefined-symbol": true,
-		"shadowing":        true,
-		"user-arity":       true,
+		"unused-variable":      true,
+		"unused-function":      true,
+		"undefined-symbol":     true,
+		"shadowing":            true,
+		"user-arity":           true,
+		"duplicate-definition": true,
 	}
 	for _, a := range DefaultAnalyzers() {
 		if semanticNames[a.Name] {


### PR DESCRIPTION
## Summary
- Add `duplicate-definition` semantic lint analyzer that warns when defun/defmacro symbols are defined more than once at the top level
- Detects same-file duplicates (2nd+ definition reported with note pointing to first) and cross-file duplicates (local definition that shadows an external workspace symbol)
- Skips `set` duplicates (already handled by `set-usage` analyzer)

Closes #221

## Test plan
- [x] 13 tests covering same-file defun/defmacro, triple duplicates, different names, different packages, nil semantics, set exclusion, nolint suppression, cross-file detection (with note verification), cross-file different-package negative, user-package normalization limitation, and diagnostic notes
- [x] Updated `TestDefaultAnalyzers` (count 16→17), `TestDefaultAnalyzers_SemanticField`, and `TestSeverity_AnalyzerDefaults`
- [x] `go test ./lint/...` passes
- [x] `make test` passes (full Go + lisp test suite)
- [x] `make static-checks` clean (golangci-lint, 0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)