### PR TITLE
feat(lsp): harden workspace indexing pipeline

### DIFF
--- a/analysis/resolve.go
+++ b/analysis/resolve.go
@@ -11,6 +11,7 @@ import (
 // with the same name. The winner is chosen by: lexicographically smallest
 // Source.File, then earliest Source.Line, then earliest Source.Col.
 // Symbols with nil Source are ranked last. Returns nil if the slice is empty.
+// Note: sorts the input slice in-place as a side effect.
 func PreferredDefinition(syms []ExternalSymbol) *ExternalSymbol {
 	if len(syms) == 0 {
 		return nil

--- a/analysis/resolve.go
+++ b/analysis/resolve.go
@@ -1,0 +1,49 @@
+// Copyright © 2024 The ELPS authors
+
+package analysis
+
+import (
+	"cmp"
+	"slices"
+)
+
+// PreferredDefinition returns the preferred definition from a set of symbols
+// with the same name. The winner is chosen by: lexicographically smallest
+// Source.File, then earliest Source.Line, then earliest Source.Col.
+// Symbols with nil Source are ranked last. Returns nil if the slice is empty.
+func PreferredDefinition(syms []ExternalSymbol) *ExternalSymbol {
+	if len(syms) == 0 {
+		return nil
+	}
+	SortDefinitions(syms)
+	return &syms[0]
+}
+
+// SortDefinitions sorts external symbols in-place by deterministic priority:
+// lexicographically smallest Source.File, then earliest Source.Line, then
+// earliest Source.Col. Symbols with nil Source are pushed to the end.
+func SortDefinitions(syms []ExternalSymbol) {
+	slices.SortStableFunc(syms, compareExternalSymbol)
+}
+
+// compareExternalSymbol is the ordering used by SortDefinitions.
+func compareExternalSymbol(a, b ExternalSymbol) int {
+	aHas := a.Source != nil
+	bHas := b.Source != nil
+	if !aHas && !bHas {
+		return 0
+	}
+	if !aHas {
+		return 1 // nil Source goes to end
+	}
+	if !bHas {
+		return -1
+	}
+	if c := cmp.Compare(a.Source.File, b.Source.File); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(a.Source.Line, b.Source.Line); c != 0 {
+		return c
+	}
+	return cmp.Compare(a.Source.Col, b.Source.Col)
+}

--- a/analysis/resolve_test.go
+++ b/analysis/resolve_test.go
@@ -1,0 +1,94 @@
+// Copyright © 2024 The ELPS authors
+
+package analysis
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreferredDefinition_DifferentFiles(t *testing.T) {
+	syms := []ExternalSymbol{
+		{Name: "fn", Source: &token.Location{File: "z.lisp", Line: 1, Col: 1}},
+		{Name: "fn", Source: &token.Location{File: "a.lisp", Line: 1, Col: 1}},
+		{Name: "fn", Source: &token.Location{File: "m.lisp", Line: 1, Col: 1}},
+	}
+	winner := PreferredDefinition(syms)
+	require.NotNil(t, winner)
+	assert.Equal(t, "a.lisp", winner.Source.File)
+}
+
+func TestPreferredDefinition_SameFileDifferentLines(t *testing.T) {
+	syms := []ExternalSymbol{
+		{Name: "fn", Source: &token.Location{File: "lib.lisp", Line: 10, Col: 1}},
+		{Name: "fn", Source: &token.Location{File: "lib.lisp", Line: 3, Col: 1}},
+		{Name: "fn", Source: &token.Location{File: "lib.lisp", Line: 7, Col: 1}},
+	}
+	winner := PreferredDefinition(syms)
+	require.NotNil(t, winner)
+	assert.Equal(t, 3, winner.Source.Line)
+}
+
+func TestPreferredDefinition_SameFileSameLineDifferentCols(t *testing.T) {
+	syms := []ExternalSymbol{
+		{Name: "fn", Source: &token.Location{File: "lib.lisp", Line: 1, Col: 10}},
+		{Name: "fn", Source: &token.Location{File: "lib.lisp", Line: 1, Col: 3}},
+	}
+	winner := PreferredDefinition(syms)
+	require.NotNil(t, winner)
+	assert.Equal(t, 3, winner.Source.Col)
+}
+
+func TestPreferredDefinition_NilSourceLast(t *testing.T) {
+	syms := []ExternalSymbol{
+		{Name: "fn", Source: nil},
+		{Name: "fn", Source: &token.Location{File: "z.lisp", Line: 1, Col: 1}},
+	}
+	winner := PreferredDefinition(syms)
+	require.NotNil(t, winner)
+	assert.Equal(t, "z.lisp", winner.Source.File)
+}
+
+func TestPreferredDefinition_SingleEntry(t *testing.T) {
+	syms := []ExternalSymbol{
+		{Name: "fn", Source: &token.Location{File: "only.lisp", Line: 5, Col: 1}},
+	}
+	winner := PreferredDefinition(syms)
+	require.NotNil(t, winner)
+	assert.Equal(t, "only.lisp", winner.Source.File)
+}
+
+func TestPreferredDefinition_Empty(t *testing.T) {
+	winner := PreferredDefinition(nil)
+	assert.Nil(t, winner)
+}
+
+func TestSortDefinitions_StableOrder(t *testing.T) {
+	syms := []ExternalSymbol{
+		{Name: "c", Source: &token.Location{File: "z.lisp", Line: 1, Col: 1}},
+		{Name: "a", Source: &token.Location{File: "a.lisp", Line: 5, Col: 1}},
+		{Name: "b", Source: nil},
+		{Name: "d", Source: &token.Location{File: "a.lisp", Line: 1, Col: 1}},
+	}
+	SortDefinitions(syms)
+
+	// a.lisp:1 < a.lisp:5 < z.lisp:1 < nil
+	assert.Equal(t, "d", syms[0].Name)
+	assert.Equal(t, "a", syms[1].Name)
+	assert.Equal(t, "c", syms[2].Name)
+	assert.Equal(t, "b", syms[3].Name)
+}
+
+func TestPreferredDefinition_AllNilSource(t *testing.T) {
+	syms := []ExternalSymbol{
+		{Name: "fn1", Source: nil},
+		{Name: "fn2", Source: nil},
+	}
+	winner := PreferredDefinition(syms)
+	require.NotNil(t, winner)
+	// First one wins when all are nil (stable sort)
+	assert.Equal(t, "fn1", winner.Name)
+}

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -88,7 +88,7 @@ func ScanWorkspaceFull(root string) ([]ExternalSymbol, map[string][]ExternalSymb
 // extracted from the same AST.
 func ScanWorkspaceAll(root string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, err error) {
 	// Phase 1: Collect file paths (sequential walk).
-	paths, err := collectLispFiles(root)
+	paths, err := collectLispFiles(root, 0)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -145,8 +145,8 @@ func ScanWorkspaceAll(root string) (globals []ExternalSymbol, pkgs map[string][]
 }
 
 // collectLispFiles walks the directory tree and collects .lisp file paths,
-// up to maxWorkspaceFiles.
-func collectLispFiles(root string) ([]string, error) {
+// up to maxWorkspaceFiles. Files exceeding maxFileBytes are skipped.
+func collectLispFiles(root string, maxFileBytes int64) ([]string, error) {
 	var paths []string
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -159,6 +159,9 @@ func collectLispFiles(root string) ([]string, error) {
 			return nil
 		}
 		if filepath.Ext(path) != ".lisp" {
+			return nil
+		}
+		if maxFileBytes > 0 && info.Size() > maxFileBytes {
 			return nil
 		}
 		paths = append(paths, path)
@@ -583,7 +586,7 @@ func scopeContainingAnalysis(scope *Scope, line, col int) *Scope {
 //
 // Returns a map from SymbolKey.String() to FileReference slices.
 func ScanWorkspaceRefs(root string, cfg *Config) map[string][]FileReference {
-	paths, err := collectLispFiles(root)
+	paths, err := collectLispFiles(root, 0)
 	if err != nil || len(paths) == 0 {
 		return nil
 	}

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -699,6 +699,125 @@ func ScanWorkspaceRefs(root string, cfg *Config) map[string][]FileReference {
 	return refs
 }
 
+// WorkspacePrescan holds the results of a workspace prescan: file definitions,
+// package exports, and DefFormSpecs extracted from defmacro definitions.
+type WorkspacePrescan struct {
+	// Files is the list of .lisp file paths that were scanned.
+	Files []string
+	// Truncated is true if the file limit was reached during collection.
+	Truncated bool
+	// Globals are all top-level definitions (for ExtraGlobals).
+	Globals []ExternalSymbol
+	// PkgExports maps package name to exported symbols.
+	PkgExports map[string][]ExternalSymbol
+	// AllDefs are all definitions (exported and non-exported).
+	AllDefs []ExternalSymbol
+	// DefForms are DefFormSpecs derived from defmacro definitions whose
+	// names start with "def". These can be injected into Config.DefForms
+	// for per-file analysis.
+	DefForms []DefFormSpec
+}
+
+// PrescanWorkspace performs a single-pass workspace scan that collects
+// file definitions and extracts DefFormSpecs from def*-prefixed macros.
+// The result provides everything needed to build a Config for per-file
+// analysis, including macro-derived definition forms.
+func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, error) {
+	paths, truncated, err := collectLispFilesWithConfig(root, scanCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	type fileResult struct {
+		globals  []ExternalSymbol
+		pkgs     map[string][]ExternalSymbol
+		allDefs  []ExternalSymbol
+		defForms []DefFormSpec
+	}
+
+	results := make([]fileResult, len(paths))
+	numWorkers := runtime.NumCPU()
+	if numWorkers > len(paths) {
+		numWorkers = len(paths)
+	}
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
+
+	var wg sync.WaitGroup
+	work := make(chan int, len(paths))
+	for i := range paths {
+		work <- i
+	}
+	close(work)
+
+	wg.Add(numWorkers)
+	for range numWorkers {
+		go func() {
+			defer wg.Done()
+			for i := range work {
+				fileSrc, readErr := os.ReadFile(paths[i]) //nolint:gosec // CLI tool reads user-specified files
+				if readErr != nil {
+					continue
+				}
+				g, p, d := scanFileFull(fileSrc, paths[i])
+				df := extractDefFormSpecs(d)
+				results[i] = fileResult{globals: g, pkgs: p, allDefs: d, defForms: df}
+			}
+		}()
+	}
+	wg.Wait()
+
+	prescan := &WorkspacePrescan{
+		Files:      paths,
+		Truncated:  truncated,
+		PkgExports: make(map[string][]ExternalSymbol),
+	}
+	for _, r := range results {
+		prescan.Globals = append(prescan.Globals, r.globals...)
+		prescan.AllDefs = append(prescan.AllDefs, r.allDefs...)
+		prescan.DefForms = append(prescan.DefForms, r.defForms...)
+		for pkg, syms := range r.pkgs {
+			prescan.PkgExports[pkg] = append(prescan.PkgExports[pkg], syms...)
+		}
+	}
+	return prescan, nil
+}
+
+// extractDefFormSpecs derives DefFormSpecs from defmacro definitions whose
+// names start with "def". This enables the analyzer to recognize these macros
+// as definition forms in other files during per-file analysis.
+func extractDefFormSpecs(defs []ExternalSymbol) []DefFormSpec {
+	var specs []DefFormSpec
+	for _, sym := range defs {
+		if sym.Kind != SymMacro || !strings.HasPrefix(sym.Name, "def") {
+			continue
+		}
+		if sym.Signature == nil {
+			continue
+		}
+		// Heuristic: the macro defines a name at index 1 and has formals
+		// at the first parameter-list-like position. For macros like
+		// (defmacro def-handler (name routes) ...), the formals for the
+		// generated function are typically in the second argument position.
+		formalsIdx := 2 // default: (def-xxx name (formals) body...)
+		if sym.Signature.MinArity() < 2 {
+			formalsIdx = -1 // can't have both name and formals
+		}
+		if formalsIdx < 0 {
+			continue
+		}
+		specs = append(specs, DefFormSpec{
+			Head:         sym.Name,
+			FormalsIndex: formalsIdx,
+			BindsName:    true,
+			NameIndex:    1,
+			NameKind:     SymFunction,
+		})
+	}
+	return specs
+}
+
 // ExtractFileDefinitions parses source and returns all top-level definitions
 // from a single file. This is the public counterpart of extractDefinitions,
 // suitable for incremental workspace index updates.

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -124,62 +124,15 @@ func ScanWorkspaceAll(root string) (globals []ExternalSymbol, pkgs map[string][]
 // ScanWorkspaceAllWithConfig is like ScanWorkspaceAll but accepts a
 // ScanConfig for configurable limits. It also returns whether the file
 // list was truncated due to hitting the MaxFiles limit.
+//
+// Delegates to PrescanWorkspace internally to avoid duplicating the
+// concurrent worker pool logic.
 func ScanWorkspaceAllWithConfig(root string, scanCfg *ScanConfig) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, truncated bool, err error) {
-	// Phase 1: Collect file paths (sequential walk).
-	paths, truncated, err := collectLispFilesWithConfig(root, scanCfg)
+	prescan, err := PrescanWorkspace(root, scanCfg)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
-
-	// Phase 2: Parse concurrently with bounded worker pool.
-	type fileResult struct {
-		globals []ExternalSymbol
-		pkgs    map[string][]ExternalSymbol
-		allDefs []ExternalSymbol
-	}
-
-	results := make([]fileResult, len(paths))
-	numWorkers := runtime.NumCPU()
-	if numWorkers > len(paths) {
-		numWorkers = len(paths)
-	}
-	if numWorkers < 1 {
-		numWorkers = 1
-	}
-
-	var wg sync.WaitGroup
-	work := make(chan int, len(paths))
-	for i := range paths {
-		work <- i
-	}
-	close(work)
-
-	wg.Add(numWorkers)
-	for range numWorkers {
-		go func() {
-			defer wg.Done()
-			for i := range work {
-				fileSrc, readErr := os.ReadFile(paths[i]) //nolint:gosec // CLI tool reads user-specified files
-				if readErr != nil {
-					continue
-				}
-				g, p, d := scanFileFull(fileSrc, paths[i])
-				results[i] = fileResult{globals: g, pkgs: p, allDefs: d}
-			}
-		}()
-	}
-	wg.Wait()
-
-	// Phase 3: Merge results.
-	pkgs = make(map[string][]ExternalSymbol)
-	for _, r := range results {
-		globals = append(globals, r.globals...)
-		allDefs = append(allDefs, r.allDefs...)
-		for pkg, syms := range r.pkgs {
-			pkgs[pkg] = append(pkgs[pkg], syms...)
-		}
-	}
-	return globals, pkgs, allDefs, truncated, nil
+	return prescan.ExportedGlobals, prescan.PkgExports, prescan.AllDefs, prescan.Truncated, nil
 }
 
 // collectLispFilesWithConfig walks the directory tree and collects .lisp
@@ -698,11 +651,13 @@ type WorkspacePrescan struct {
 	Files []string
 	// Truncated is true if the file limit was reached during collection.
 	Truncated bool
-	// Globals are all top-level definitions (for ExtraGlobals).
-	Globals []ExternalSymbol
+	// ExportedGlobals are exported top-level definitions only.
+	// Used by ScanWorkspaceAllWithConfig for backwards compatibility.
+	ExportedGlobals []ExternalSymbol
 	// PkgExports maps package name to exported symbols.
 	PkgExports map[string][]ExternalSymbol
 	// AllDefs are all definitions (exported and non-exported).
+	// Typically used as Config.ExtraGlobals for cross-file resolution.
 	AllDefs []ExternalSymbol
 	// DefForms are DefFormSpecs derived from defmacro definitions whose
 	// names start with "def". These can be injected into Config.DefForms
@@ -766,7 +721,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		PkgExports: make(map[string][]ExternalSymbol),
 	}
 	for _, r := range results {
-		prescan.Globals = append(prescan.Globals, r.globals...)
+		prescan.ExportedGlobals = append(prescan.ExportedGlobals, r.globals...)
 		prescan.AllDefs = append(prescan.AllDefs, r.allDefs...)
 		prescan.DefForms = append(prescan.DefForms, r.defForms...)
 		for pkg, syms := range r.pkgs {

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -25,7 +25,6 @@ const (
 	DefaultMaxFileBytes = 5 * 1024 * 1024
 )
 
-
 // ScanConfig controls workspace file collection limits.
 type ScanConfig struct {
 	// MaxFiles is the maximum number of .lisp files to collect.
@@ -181,13 +180,6 @@ func ScanWorkspaceAllWithConfig(root string, scanCfg *ScanConfig) (globals []Ext
 		}
 	}
 	return globals, pkgs, allDefs, truncated, nil
-}
-
-// collectLispFiles walks the directory tree and collects .lisp file paths,
-// up to maxWorkspaceFiles. Files exceeding maxFileBytes are skipped.
-func collectLispFiles(root string, maxFileBytes int64) ([]string, error) {
-	paths, _, err := collectLispFilesWithConfig(root, &ScanConfig{MaxFileBytes: maxFileBytes})
-	return paths, err
 }
 
 // collectLispFilesWithConfig walks the directory tree and collects .lisp
@@ -638,7 +630,7 @@ func scopeContainingAnalysis(scope *Scope, line, col int) *Scope {
 //
 // Returns a map from SymbolKey.String() to FileReference slices.
 func ScanWorkspaceRefs(root string, cfg *Config) map[string][]FileReference {
-	paths, err := collectLispFiles(root, 0)
+	paths, _, err := collectLispFilesWithConfig(root, nil)
 	if err != nil || len(paths) == 0 {
 		return nil
 	}

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -17,9 +17,40 @@ import (
 	"github.com/luthersystems/elps/parser/token"
 )
 
-// maxWorkspaceFiles limits the number of .lisp files scanned during workspace
-// indexing. This prevents excessive memory/CPU usage in very large workspaces.
-const maxWorkspaceFiles = 5000
+// Default limits for workspace scanning.
+const (
+	// DefaultMaxWorkspaceFiles limits the number of .lisp files scanned.
+	DefaultMaxWorkspaceFiles = 5000
+	// DefaultMaxFileBytes limits individual file size (5 MB).
+	DefaultMaxFileBytes = 5 * 1024 * 1024
+)
+
+
+// ScanConfig controls workspace file collection limits.
+type ScanConfig struct {
+	// MaxFiles is the maximum number of .lisp files to collect.
+	// 0 means use DefaultMaxWorkspaceFiles.
+	MaxFiles int
+	// MaxFileBytes is the maximum size in bytes for a single file.
+	// Files exceeding this are skipped. 0 means use DefaultMaxFileBytes.
+	MaxFileBytes int64
+}
+
+// effectiveMaxFiles returns the file limit, applying the default if zero.
+func (c *ScanConfig) effectiveMaxFiles() int {
+	if c == nil || c.MaxFiles <= 0 {
+		return DefaultMaxWorkspaceFiles
+	}
+	return c.MaxFiles
+}
+
+// effectiveMaxFileBytes returns the file size limit, applying the default if zero.
+func (c *ScanConfig) effectiveMaxFileBytes() int64 {
+	if c == nil || c.MaxFileBytes <= 0 {
+		return DefaultMaxFileBytes
+	}
+	return c.MaxFileBytes
+}
 
 // SymbolKey identifies a symbol across files by name and kind.
 type SymbolKey struct {
@@ -87,10 +118,18 @@ func ScanWorkspaceFull(root string) ([]ExternalSymbol, map[string][]ExternalSymb
 // into a single pass: each file is parsed once and all three results are
 // extracted from the same AST.
 func ScanWorkspaceAll(root string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, err error) {
+	globals, pkgs, allDefs, _, err = ScanWorkspaceAllWithConfig(root, nil)
+	return
+}
+
+// ScanWorkspaceAllWithConfig is like ScanWorkspaceAll but accepts a
+// ScanConfig for configurable limits. It also returns whether the file
+// list was truncated due to hitting the MaxFiles limit.
+func ScanWorkspaceAllWithConfig(root string, scanCfg *ScanConfig) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, truncated bool, err error) {
 	// Phase 1: Collect file paths (sequential walk).
-	paths, err := collectLispFiles(root, 0)
+	paths, truncated, err := collectLispFilesWithConfig(root, scanCfg)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, false, err
 	}
 
 	// Phase 2: Parse concurrently with bounded worker pool.
@@ -141,13 +180,25 @@ func ScanWorkspaceAll(root string) (globals []ExternalSymbol, pkgs map[string][]
 			pkgs[pkg] = append(pkgs[pkg], syms...)
 		}
 	}
-	return globals, pkgs, allDefs, nil
+	return globals, pkgs, allDefs, truncated, nil
 }
 
 // collectLispFiles walks the directory tree and collects .lisp file paths,
 // up to maxWorkspaceFiles. Files exceeding maxFileBytes are skipped.
 func collectLispFiles(root string, maxFileBytes int64) ([]string, error) {
+	paths, _, err := collectLispFilesWithConfig(root, &ScanConfig{MaxFileBytes: maxFileBytes})
+	return paths, err
+}
+
+// collectLispFilesWithConfig walks the directory tree and collects .lisp
+// file paths, respecting ScanConfig limits. Returns the collected paths,
+// whether the MaxFiles limit was reached (truncated), and any walk error.
+func collectLispFilesWithConfig(root string, scanCfg *ScanConfig) ([]string, bool, error) {
+	maxFiles := scanCfg.effectiveMaxFiles()
+	maxBytes := scanCfg.effectiveMaxFileBytes()
+
 	var paths []string
+	var truncated bool
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
@@ -161,16 +212,17 @@ func collectLispFiles(root string, maxFileBytes int64) ([]string, error) {
 		if filepath.Ext(path) != ".lisp" {
 			return nil
 		}
-		if maxFileBytes > 0 && info.Size() > maxFileBytes {
+		if maxBytes > 0 && info.Size() > maxBytes {
 			return nil
 		}
 		paths = append(paths, path)
-		if len(paths) >= maxWorkspaceFiles {
+		if len(paths) >= maxFiles {
+			truncated = true
 			return filepath.SkipAll
 		}
 		return nil
 	})
-	return paths, err
+	return paths, truncated, err
 }
 
 // ShouldSkipDir returns true for directories that should not be walked.

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -874,3 +874,44 @@ func TestCollectLispFilesWithConfig_Defaults(t *testing.T) {
 	assert.Len(t, paths, 1)
 	assert.False(t, truncated)
 }
+
+func TestCollectLispFilesWithConfig_ZeroMaxFilesUsesDefault(t *testing.T) {
+	dir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(dir, "a.lisp"), []byte("()"), 0600)
+	require.NoError(t, err)
+
+	// MaxFiles: 0 should use DefaultMaxWorkspaceFiles, not collect zero files.
+	paths, truncated, err := collectLispFilesWithConfig(dir, &ScanConfig{MaxFiles: 0})
+	require.NoError(t, err)
+	assert.Len(t, paths, 1, "MaxFiles: 0 should use default, not collect zero files")
+	assert.False(t, truncated)
+}
+
+func TestCollectLispFilesWithConfig_ZeroMaxFileBytesUsesDefault(t *testing.T) {
+	dir := t.TempDir()
+
+	// A small file that would be excluded if MaxFileBytes: 0 meant "skip all".
+	err := os.WriteFile(filepath.Join(dir, "a.lisp"), []byte("()"), 0600)
+	require.NoError(t, err)
+
+	paths, _, err := collectLispFilesWithConfig(dir, &ScanConfig{MaxFileBytes: 0})
+	require.NoError(t, err)
+	assert.Len(t, paths, 1, "MaxFileBytes: 0 should use default, not skip all files")
+}
+
+func TestScanConfig_EffectiveDefaults(t *testing.T) {
+	// Verify the effective* methods return defaults for zero/nil.
+	var nilCfg *ScanConfig
+	assert.Equal(t, DefaultMaxWorkspaceFiles, nilCfg.effectiveMaxFiles())
+	assert.Equal(t, int64(DefaultMaxFileBytes), nilCfg.effectiveMaxFileBytes())
+
+	zeroCfg := &ScanConfig{MaxFiles: 0, MaxFileBytes: 0}
+	assert.Equal(t, DefaultMaxWorkspaceFiles, zeroCfg.effectiveMaxFiles())
+	assert.Equal(t, int64(DefaultMaxFileBytes), zeroCfg.effectiveMaxFileBytes())
+
+	// Negative values also use defaults.
+	negCfg := &ScanConfig{MaxFiles: -1, MaxFileBytes: -1}
+	assert.Equal(t, DefaultMaxWorkspaceFiles, negCfg.effectiveMaxFiles())
+	assert.Equal(t, int64(DefaultMaxFileBytes), negCfg.effectiveMaxFileBytes())
+}

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -3,6 +3,7 @@
 package analysis
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -653,4 +654,65 @@ func TestExtractFileDefinitions_InvalidSource(t *testing.T) {
 	// Unparseable source should return nil, not panic.
 	defs := ExtractFileDefinitions([]byte("(defun broken"), "bad.lisp")
 	assert.Nil(t, defs)
+}
+
+func TestCollectLispFilesWithConfig_MaxFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create 5 .lisp files.
+	for i := range 5 {
+		err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("f%d.lisp", i)), []byte("()"), 0600)
+		require.NoError(t, err)
+	}
+
+	// Limit to 3 files.
+	paths, truncated, err := collectLispFilesWithConfig(dir, &ScanConfig{MaxFiles: 3})
+	require.NoError(t, err)
+	assert.Len(t, paths, 3)
+	assert.True(t, truncated, "should be truncated when hitting MaxFiles limit")
+}
+
+func TestCollectLispFilesWithConfig_NoTruncation(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create 2 .lisp files.
+	for i := range 2 {
+		err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("f%d.lisp", i)), []byte("()"), 0600)
+		require.NoError(t, err)
+	}
+
+	paths, truncated, err := collectLispFilesWithConfig(dir, &ScanConfig{MaxFiles: 10})
+	require.NoError(t, err)
+	assert.Len(t, paths, 2)
+	assert.False(t, truncated, "should not be truncated when under limit")
+}
+
+func TestCollectLispFilesWithConfig_MaxFileBytes(t *testing.T) {
+	dir := t.TempDir()
+
+	// Small file (under limit).
+	err := os.WriteFile(filepath.Join(dir, "small.lisp"), []byte("(+ 1 1)"), 0600)
+	require.NoError(t, err)
+
+	// Large file (over limit).
+	err = os.WriteFile(filepath.Join(dir, "large.lisp"), make([]byte, 200), 0600)
+	require.NoError(t, err)
+
+	paths, _, err := collectLispFilesWithConfig(dir, &ScanConfig{MaxFileBytes: 100})
+	require.NoError(t, err)
+	assert.Len(t, paths, 1, "only the small file should be collected")
+	assert.Contains(t, paths[0], "small.lisp")
+}
+
+func TestCollectLispFilesWithConfig_Defaults(t *testing.T) {
+	dir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(dir, "a.lisp"), []byte("()"), 0600)
+	require.NoError(t, err)
+
+	// nil config uses defaults.
+	paths, truncated, err := collectLispFilesWithConfig(dir, nil)
+	require.NoError(t, err)
+	assert.Len(t, paths, 1)
+	assert.False(t, truncated)
 }

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -747,6 +747,55 @@ func TestExtractDefFormSpecs_MinArity(t *testing.T) {
 	assert.Empty(t, specs, "macro with < 2 params should not produce DefFormSpec")
 }
 
+func TestExtractDefFormSpecs_ValidMacro(t *testing.T) {
+	// A def-prefixed macro with arity >= 2 should produce a DefFormSpec.
+	defs := []ExternalSymbol{
+		{
+			Name: "def-handler",
+			Kind: SymMacro,
+			Signature: &Signature{
+				Params: []lisp.ParamInfo{
+					{Name: "name", Kind: lisp.ParamRequired},
+					{Name: "routes", Kind: lisp.ParamRequired},
+				},
+			},
+		},
+	}
+	specs := extractDefFormSpecs(defs)
+	require.Len(t, specs, 1)
+	assert.Equal(t, "def-handler", specs[0].Head)
+	assert.True(t, specs[0].BindsName)
+	assert.Equal(t, 1, specs[0].NameIndex)
+	assert.Equal(t, 2, specs[0].FormalsIndex)
+	assert.Equal(t, SymFunction, specs[0].NameKind)
+}
+
+func TestExtractDefFormSpecs_NonMacroSkipped(t *testing.T) {
+	// A function (not macro) with "def" prefix should NOT produce a DefFormSpec.
+	defs := []ExternalSymbol{
+		{
+			Name: "def-helper",
+			Kind: SymFunction,
+			Signature: &Signature{
+				Params: []lisp.ParamInfo{
+					{Name: "name", Kind: lisp.ParamRequired},
+					{Name: "value", Kind: lisp.ParamRequired},
+				},
+			},
+		},
+	}
+	specs := extractDefFormSpecs(defs)
+	assert.Empty(t, specs, "non-macro symbols should not produce DefFormSpecs")
+}
+
+func TestExtractDefFormSpecs_NilSignatureSkipped(t *testing.T) {
+	defs := []ExternalSymbol{
+		{Name: "def-broken", Kind: SymMacro, Signature: nil},
+	}
+	specs := extractDefFormSpecs(defs)
+	assert.Empty(t, specs, "macro with nil signature should not produce DefFormSpec")
+}
+
 func TestCollectLispFilesWithConfig_MaxFiles(t *testing.T) {
 	dir := t.TempDir()
 
@@ -793,6 +842,24 @@ func TestCollectLispFilesWithConfig_MaxFileBytes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, paths, 1, "only the small file should be collected")
 	assert.Contains(t, paths[0], "small.lisp")
+}
+
+func TestCollectLispFilesWithConfig_MaxFileBytesExactBoundary(t *testing.T) {
+	dir := t.TempDir()
+
+	// File exactly at the limit (100 bytes). The implementation uses
+	// strict > so exactly-at-limit files should be included.
+	err := os.WriteFile(filepath.Join(dir, "exact.lisp"), make([]byte, 100), 0600)
+	require.NoError(t, err)
+
+	// File 1 byte over the limit.
+	err = os.WriteFile(filepath.Join(dir, "over.lisp"), make([]byte, 101), 0600)
+	require.NoError(t, err)
+
+	paths, _, err := collectLispFilesWithConfig(dir, &ScanConfig{MaxFileBytes: 100})
+	require.NoError(t, err)
+	assert.Len(t, paths, 1, "file exactly at limit should be included, over should be excluded")
+	assert.Contains(t, paths[0], "exact.lisp")
 }
 
 func TestCollectLispFilesWithConfig_Defaults(t *testing.T) {

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/parser/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -654,6 +655,96 @@ func TestExtractFileDefinitions_InvalidSource(t *testing.T) {
 	// Unparseable source should return nil, not panic.
 	defs := ExtractFileDefinitions([]byte("(defun broken"), "bad.lisp")
 	assert.Nil(t, defs)
+}
+
+func TestPrescanWorkspace_DefForms(t *testing.T) {
+	dir := t.TempDir()
+
+	// File A defines a def-prefixed macro with 2+ params.
+	err := os.WriteFile(filepath.Join(dir, "macros.lisp"), []byte(`
+(defmacro def-handler (name routes)
+  "Define a handler with routes."
+  (list 'defun name (list 'req) routes))
+(export 'def-handler)
+`), 0600)
+	require.NoError(t, err)
+
+	// File B uses the macro — (def-handler name (formals) body...).
+	err = os.WriteFile(filepath.Join(dir, "handlers.lisp"), []byte(`
+(def-handler my-api (req)
+  (respond req "ok"))
+`), 0600)
+	require.NoError(t, err)
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+	require.NotNil(t, prescan)
+
+	// Should produce a DefFormSpec for def-handler.
+	var found *DefFormSpec
+	for i := range prescan.DefForms {
+		if prescan.DefForms[i].Head == "def-handler" {
+			found = &prescan.DefForms[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "should produce DefFormSpec for def-handler")
+	assert.True(t, found.BindsName, "def-handler should bind a name")
+	assert.Equal(t, 1, found.NameIndex, "name should be at index 1")
+	assert.Equal(t, 2, found.FormalsIndex, "formals should be at index 2")
+
+	// Verify that analysis with the DefForms recognizes my-api as a definition.
+	cfg := &Config{
+		ExtraGlobals:   prescan.AllDefs,
+		PackageExports: prescan.PkgExports,
+		DefForms:       prescan.DefForms,
+		Filename:       filepath.Join(dir, "handlers.lisp"),
+	}
+	handlerSrc, _ := os.ReadFile(filepath.Join(dir, "handlers.lisp")) //nolint:gosec // test file
+	result := AnalyzeFile(handlerSrc, filepath.Join(dir, "handlers.lisp"), cfg)
+	require.NotNil(t, result)
+
+	// my-api should be in the symbols list as a definition.
+	var myAPI *Symbol
+	for _, sym := range result.Symbols {
+		if sym.Name == "my-api" {
+			myAPI = sym
+			break
+		}
+	}
+	assert.NotNil(t, myAPI, "my-api should be recognized as a definition via def-handler DefFormSpec")
+}
+
+func TestPrescanWorkspace_NoDefPrefixMacroSkipped(t *testing.T) {
+	dir := t.TempDir()
+
+	// Macro without "def" prefix should NOT produce a DefFormSpec.
+	err := os.WriteFile(filepath.Join(dir, "macros.lisp"), []byte(`
+(defmacro with-logging (body)
+  (list 'progn (list 'log "start") body (list 'log "end")))
+(export 'with-logging)
+`), 0600)
+	require.NoError(t, err)
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+	assert.Empty(t, prescan.DefForms, "non-def-prefixed macros should not produce DefFormSpecs")
+}
+
+func TestExtractDefFormSpecs_MinArity(t *testing.T) {
+	// A macro with only 1 required param (arity < 2) can't have both
+	// name and formals, so no DefFormSpec should be produced.
+	defs := []ExternalSymbol{
+		{
+			Name: "def-simple",
+			Kind: SymMacro,
+			Signature: &Signature{
+				Params: []lisp.ParamInfo{{Name: "body", Kind: lisp.ParamRequired}},
+			},
+		},
+	}
+	specs := extractDefFormSpecs(defs)
+	assert.Empty(t, specs, "macro with < 2 params should not produce DefFormSpec")
 }
 
 func TestCollectLispFilesWithConfig_MaxFiles(t *testing.T) {

--- a/lsp/diagnostics.go
+++ b/lsp/diagnostics.go
@@ -134,13 +134,17 @@ func (s *Server) analyzeAndPublish(doc *Document) {
 
 	s.ensureAnalysis(doc)
 
-	// Re-snapshot after analysis to capture the analysis result.
+	// Re-snapshot after analysis to capture the result and the current
+	// version atomically. We use doc.Version (not snap.Version) so the
+	// version guard compares the version that matches the content/analysis
+	// we actually read here — avoiding a TOCTOU window where the doc
+	// could have been updated between the initial snapshot and now.
 	doc.mu.Lock()
 	parseErrors := doc.parseErrors
 	content := doc.Content
 	docAnalysis := doc.analysis
 	uri := doc.URI
-	snapVersion := snap.Version
+	currentVersion := doc.Version
 	doc.mu.Unlock()
 
 	var diags []protocol.Diagnostic
@@ -169,17 +173,17 @@ func (s *Server) analyzeAndPublish(doc *Document) {
 
 	// Version guard: discard stale results from debounced analysis.
 	doc.mu.Lock()
-	if snapVersion < doc.Version {
-		// Document changed since we started — discard these stale results.
+	if currentVersion < doc.Version {
+		// Document changed since we read it — discard these stale results.
 		doc.mu.Unlock()
 		return
 	}
-	if snapVersion < doc.publishedVersion {
+	if currentVersion < doc.publishedVersion {
 		// A strictly newer version was already published — skip.
 		doc.mu.Unlock()
 		return
 	}
-	doc.publishedVersion = snapVersion
+	doc.publishedVersion = currentVersion
 	doc.mu.Unlock()
 
 	s.sendNotification(protocol.ServerTextDocumentPublishDiagnostics, &protocol.PublishDiagnosticsParams{

--- a/lsp/diagnostics.go
+++ b/lsp/diagnostics.go
@@ -115,21 +115,27 @@ func (s *Server) textDocumentDidClose(_ *glsp.Context, params *protocol.DidClose
 // analyzeAndPublish runs analysis and lint on a document and publishes
 // the resulting diagnostics to the client.
 func (s *Server) analyzeAndPublish(doc *Document) {
-	// Take a snapshot for size check and version tracking.
-	snap := doc.Snapshot()
+	// Check document size before running analysis. Use a cheap lock-and-read
+	// rather than a full Snapshot() to avoid unnecessary slice cloning.
+	if s.maxDocumentBytes > 0 {
+		doc.mu.Lock()
+		contentLen := len(doc.Content)
+		uri := doc.URI
+		doc.mu.Unlock()
 
-	if s.maxDocumentBytes > 0 && len(snap.Content) > s.maxDocumentBytes {
-		sev := protocol.DiagnosticSeverityInformation
-		s.sendNotification(protocol.ServerTextDocumentPublishDiagnostics, &protocol.PublishDiagnosticsParams{
-			URI: snap.URI,
-			Diagnostics: []protocol.Diagnostic{{
-				Range:    protocol.Range{},
-				Severity: &sev,
-				Source:   strPtr("elps"),
-				Message:  "File exceeds size limit for semantic analysis",
-			}},
-		})
-		return
+		if contentLen > s.maxDocumentBytes {
+			sev := protocol.DiagnosticSeverityInformation
+			s.sendNotification(protocol.ServerTextDocumentPublishDiagnostics, &protocol.PublishDiagnosticsParams{
+				URI: uri,
+				Diagnostics: []protocol.Diagnostic{{
+					Range:    protocol.Range{},
+					Severity: &sev,
+					Source:   strPtr("elps"),
+					Message:  "File exceeds size limit for semantic analysis",
+				}},
+			})
+			return
+		}
 	}
 
 	s.ensureAnalysis(doc)

--- a/lsp/diagnostics.go
+++ b/lsp/diagnostics.go
@@ -115,14 +115,34 @@ func (s *Server) textDocumentDidClose(_ *glsp.Context, params *protocol.DidClose
 // analyzeAndPublish runs analysis and lint on a document and publishes
 // the resulting diagnostics to the client.
 func (s *Server) analyzeAndPublish(doc *Document) {
+	// Check document size before running analysis.
+	doc.mu.Lock()
+	content := doc.Content
+	uri := doc.URI
+	doc.mu.Unlock()
+
+	if s.maxDocumentBytes > 0 && len(content) > s.maxDocumentBytes {
+		sev := protocol.DiagnosticSeverityInformation
+		s.sendNotification(protocol.ServerTextDocumentPublishDiagnostics, &protocol.PublishDiagnosticsParams{
+			URI: uri,
+			Diagnostics: []protocol.Diagnostic{{
+				Range:    protocol.Range{},
+				Severity: &sev,
+				Source:   strPtr("elps"),
+				Message:  "File exceeds size limit for semantic analysis",
+			}},
+		})
+		return
+	}
+
 	s.ensureAnalysis(doc)
 
 	// Snapshot document fields under the lock.
 	doc.mu.Lock()
 	parseErrors := doc.parseErrors
-	content := doc.Content
+	content = doc.Content
 	docAnalysis := doc.analysis
-	uri := doc.URI
+	uri = doc.URI
 	doc.mu.Unlock()
 
 	var diags []protocol.Diagnostic

--- a/lsp/diagnostics.go
+++ b/lsp/diagnostics.go
@@ -115,16 +115,13 @@ func (s *Server) textDocumentDidClose(_ *glsp.Context, params *protocol.DidClose
 // analyzeAndPublish runs analysis and lint on a document and publishes
 // the resulting diagnostics to the client.
 func (s *Server) analyzeAndPublish(doc *Document) {
-	// Check document size before running analysis.
-	doc.mu.Lock()
-	content := doc.Content
-	uri := doc.URI
-	doc.mu.Unlock()
+	// Take a snapshot for size check and version tracking.
+	snap := doc.Snapshot()
 
-	if s.maxDocumentBytes > 0 && len(content) > s.maxDocumentBytes {
+	if s.maxDocumentBytes > 0 && len(snap.Content) > s.maxDocumentBytes {
 		sev := protocol.DiagnosticSeverityInformation
 		s.sendNotification(protocol.ServerTextDocumentPublishDiagnostics, &protocol.PublishDiagnosticsParams{
-			URI: uri,
+			URI: snap.URI,
 			Diagnostics: []protocol.Diagnostic{{
 				Range:    protocol.Range{},
 				Severity: &sev,
@@ -137,12 +134,13 @@ func (s *Server) analyzeAndPublish(doc *Document) {
 
 	s.ensureAnalysis(doc)
 
-	// Snapshot document fields under the lock.
+	// Re-snapshot after analysis to capture the analysis result.
 	doc.mu.Lock()
 	parseErrors := doc.parseErrors
-	content = doc.Content
+	content := doc.Content
 	docAnalysis := doc.analysis
-	uri = doc.URI
+	uri := doc.URI
+	snapVersion := snap.Version
 	doc.mu.Unlock()
 
 	var diags []protocol.Diagnostic
@@ -168,6 +166,21 @@ func (s *Server) analyzeAndPublish(doc *Document) {
 			diags = append(diags, convertLintDiagnostic(d))
 		}
 	}
+
+	// Version guard: discard stale results from debounced analysis.
+	doc.mu.Lock()
+	if snapVersion < doc.Version {
+		// Document changed since we started — discard these stale results.
+		doc.mu.Unlock()
+		return
+	}
+	if snapVersion < doc.publishedVersion {
+		// A strictly newer version was already published — skip.
+		doc.mu.Unlock()
+		return
+	}
+	doc.publishedVersion = snapVersion
+	doc.mu.Unlock()
 
 	s.sendNotification(protocol.ServerTextDocumentPublishDiagnostics, &protocol.PublishDiagnosticsParams{
 		URI:         uri,

--- a/lsp/document.go
+++ b/lsp/document.go
@@ -21,6 +21,33 @@ type Document struct {
 	ast         []*lisp.LVal
 	analysis    *analysis.Result
 	parseErrors []error
+
+	// publishedVersion tracks the latest version whose diagnostics were
+	// successfully published. Used to discard stale debounced results.
+	publishedVersion int32
+}
+
+// DocumentSnapshot is an immutable copy of a document's state at a point
+// in time. Used to run analysis without holding the document lock.
+type DocumentSnapshot struct {
+	URI         string
+	Version     int32
+	Content     string
+	AST         []*lisp.LVal
+	ParseErrors []error
+}
+
+// Snapshot returns an immutable copy of the document's current state.
+func (d *Document) Snapshot() DocumentSnapshot {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return DocumentSnapshot{
+		URI:         d.URI,
+		Version:     d.Version,
+		Content:     d.Content,
+		AST:         d.ast,
+		ParseErrors: d.parseErrors,
+	}
 }
 
 // parse parses the document content and caches the AST using the

--- a/lsp/document.go
+++ b/lsp/document.go
@@ -3,6 +3,7 @@
 package lsp
 
 import (
+	"slices"
 	"strings"
 	"sync"
 
@@ -28,7 +29,8 @@ type Document struct {
 }
 
 // DocumentSnapshot is an immutable copy of a document's state at a point
-// in time. Used to run analysis without holding the document lock.
+// in time. Slice fields are shallow-copied so the snapshot remains safe
+// even if the document's slices are replaced by a concurrent parse().
 type DocumentSnapshot struct {
 	URI         string
 	Version     int32
@@ -38,6 +40,8 @@ type DocumentSnapshot struct {
 }
 
 // Snapshot returns an immutable copy of the document's current state.
+// Slice fields are copied so the snapshot is safe to use after the
+// document's lock is released.
 func (d *Document) Snapshot() DocumentSnapshot {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -45,8 +49,8 @@ func (d *Document) Snapshot() DocumentSnapshot {
 		URI:         d.URI,
 		Version:     d.Version,
 		Content:     d.Content,
-		AST:         d.ast,
-		ParseErrors: d.parseErrors,
+		AST:         slices.Clone(d.ast),
+		ParseErrors: slices.Clone(d.parseErrors),
 	}
 }
 

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -3808,6 +3808,76 @@ func TestDocumentSizeGuard_OversizedDoc(t *testing.T) {
 	doc.mu.Unlock()
 }
 
+func TestDocumentSizeGuard_ExactBoundary(t *testing.T) {
+	// A document exactly at the limit should pass through to analysis
+	// (strict > semantics). One byte over should be skipped.
+	limit := 50
+	s := New(WithMaxDocumentBytes(limit))
+	ctx, captured := capturingContext()
+	s.captureNotify(ctx)
+	setTestAnalysisCfg(s, &analysis.Config{})
+
+	// Exactly at limit — should analyze normally.
+	exactContent := strings.Repeat("x", limit)
+	doc := s.docs.Open("file:///exact.lisp", 1, exactContent)
+	s.analyzeAndPublish(doc)
+
+	require.Len(t, *captured, 1)
+	for _, d := range (*captured)[0].Diagnostics {
+		assert.NotContains(t, d.Message, "size limit",
+			"document at exact limit should not be skipped")
+	}
+	doc.mu.Lock()
+	assert.NotNil(t, doc.analysis, "analysis should run for document at exact limit")
+	doc.mu.Unlock()
+
+	// One byte over — should be skipped.
+	overContent := strings.Repeat("x", limit+1)
+	doc2 := s.docs.Open("file:///over.lisp", 1, overContent)
+	s.analyzeAndPublish(doc2)
+
+	require.Len(t, *captured, 2)
+	require.Len(t, (*captured)[1].Diagnostics, 1)
+	assert.Contains(t, (*captured)[1].Diagnostics[0].Message, "size limit")
+	doc2.mu.Lock()
+	assert.Nil(t, doc2.analysis, "analysis should be skipped for document over limit")
+	doc2.mu.Unlock()
+}
+
+func TestDocumentSizeGuard_ZeroMeansNoLimit(t *testing.T) {
+	// Default (no WithMaxDocumentBytes) means maxDocumentBytes=0 → no limit.
+	s := New()
+	ctx, captured := capturingContext()
+	s.captureNotify(ctx)
+	setTestAnalysisCfg(s, &analysis.Config{})
+
+	// Even a large document should not be skipped.
+	largeContent := strings.Repeat("(+ 1 1)\n", 1000)
+	doc := s.docs.Open("file:///large.lisp", 1, largeContent)
+	s.analyzeAndPublish(doc)
+
+	require.Len(t, *captured, 1)
+	for _, d := range (*captured)[0].Diagnostics {
+		assert.NotContains(t, d.Message, "size limit",
+			"no limit should be applied when maxDocumentBytes is 0")
+	}
+	doc.mu.Lock()
+	assert.NotNil(t, doc.analysis, "analysis should run with no size limit")
+	doc.mu.Unlock()
+}
+
+func TestWithMaxDocumentBytes_NegativeClamped(t *testing.T) {
+	s := New(WithMaxDocumentBytes(-5))
+	assert.Equal(t, 0, s.maxDocumentBytes,
+		"negative value should be clamped to 0")
+}
+
+func TestWithMaxWorkspaceFiles_NegativeClamped(t *testing.T) {
+	s := New(WithMaxWorkspaceFiles(-10))
+	assert.Equal(t, 0, s.maxWorkspaceFiles,
+		"negative value should be clamped to 0")
+}
+
 func TestDocumentSizeGuard_NormalDoc(t *testing.T) {
 	s := New(WithMaxDocumentBytes(10000))
 	ctx, captured := capturingContext()

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -3801,6 +3801,11 @@ func TestDocumentSizeGuard_OversizedDoc(t *testing.T) {
 	require.Len(t, pub.Diagnostics, 1)
 	assert.Equal(t, protocol.DiagnosticSeverityInformation, *pub.Diagnostics[0].Severity)
 	assert.Contains(t, pub.Diagnostics[0].Message, "size limit")
+
+	// Verify analysis was actually skipped — doc.analysis should remain nil.
+	doc.mu.Lock()
+	assert.Nil(t, doc.analysis, "analysis should be skipped for oversized documents")
+	doc.mu.Unlock()
 }
 
 func TestDocumentSizeGuard_NormalDoc(t *testing.T) {
@@ -3819,6 +3824,11 @@ func TestDocumentSizeGuard_NormalDoc(t *testing.T) {
 		assert.NotContains(t, d.Message, "size limit",
 			"normal-sized document should not get size limit diagnostic")
 	}
+
+	// Verify analysis actually ran — doc.analysis should be populated.
+	doc.mu.Lock()
+	assert.NotNil(t, doc.analysis, "analysis should run for normal-sized documents")
+	doc.mu.Unlock()
 }
 
 func TestVersionGuard_StalePublishDiscarded(t *testing.T) {
@@ -3827,25 +3837,55 @@ func TestVersionGuard_StalePublishDiscarded(t *testing.T) {
 	s.captureNotify(ctx)
 	setTestAnalysisCfg(s, &analysis.Config{})
 
-	// Open v1 and publish it.
+	// Publish v1, v2, then attempt v1 again — v1 should be discarded.
 	doc := s.docs.Open("file:///test.lisp", 1, "(+ 1 1)")
 	s.analyzeAndPublish(doc)
 	require.Len(t, *captured, 1, "v1 should publish")
 
-	// Simulate v5 being published (e.g., by a concurrent didSave).
-	doc.mu.Lock()
-	doc.publishedVersion = 5
-	doc.mu.Unlock()
+	// Change to v2 and publish.
+	s.docs.Change("file:///test.lisp", 2, "(+ 2 2)")
+	s.analyzeAndPublish(doc)
+	require.Len(t, *captured, 2, "v2 should publish")
 
-	// Now try to publish v3 — should be discarded as stale.
+	// Now revert version to 1 (simulating a stale debounce timer firing
+	// with old content after v2 was already published).
 	doc.mu.Lock()
-	doc.Version = 3
+	doc.Version = 1
 	doc.analysis = nil
 	doc.mu.Unlock()
 	s.analyzeAndPublish(doc)
 
-	// Only the original v1 publication should exist — v3 was discarded.
-	assert.Len(t, *captured, 1, "stale v3 publish should be discarded when v5 already published")
+	// Stale v1 should be discarded — still only 2 publications.
+	assert.Len(t, *captured, 2,
+		"stale v1 should be discarded since v2 was already published")
+}
+
+func TestVersionGuard_PublishedVersionBlocksOlderVersion(t *testing.T) {
+	s := testServer()
+	ctx, captured := capturingContext()
+	s.captureNotify(ctx)
+	setTestAnalysisCfg(s, &analysis.Config{})
+
+	// Publish v3, then attempt to publish v1 — v1 should be blocked by
+	// the publishedVersion check (not just the doc.Version check).
+	doc := s.docs.Open("file:///test.lisp", 3, "(+ 3 3)")
+	s.analyzeAndPublish(doc)
+	require.Len(t, *captured, 1, "v3 should publish")
+
+	// Simulate v5 published by another path (e.g., concurrent didSave).
+	doc.mu.Lock()
+	doc.publishedVersion = 5
+	doc.mu.Unlock()
+
+	// Attempt to publish v3 again — should be blocked because v5 was
+	// already published (tests the publishedVersion guard specifically).
+	doc.mu.Lock()
+	doc.analysis = nil
+	doc.mu.Unlock()
+	s.analyzeAndPublish(doc)
+
+	assert.Len(t, *captured, 1,
+		"v3 re-publish should be blocked when publishedVersion is 5")
 }
 
 func TestVersionGuard_NewerVersionPublishes(t *testing.T) {
@@ -3854,18 +3894,27 @@ func TestVersionGuard_NewerVersionPublishes(t *testing.T) {
 	s.captureNotify(ctx)
 	setTestAnalysisCfg(s, &analysis.Config{})
 
-	// Open v1.
+	// Open v1 and publish.
 	doc := s.docs.Open("file:///test.lisp", 1, "(+ 1 1)")
 	s.analyzeAndPublish(doc)
 	require.Len(t, *captured, 1, "v1 should publish")
 
-	// Change to v2.
+	// Change to v2 and publish — must succeed since v2 > v1.
 	s.docs.Change("file:///test.lisp", 2, "(+ 2 2)")
 	s.analyzeAndPublish(doc)
-	assert.Len(t, *captured, 2, "v2 should publish since it's newer than v1")
+	require.Len(t, *captured, 2, "v2 should publish since it's newer than v1")
+
+	// Attempt to publish v1 — should be blocked since v2 was published.
+	doc.mu.Lock()
+	doc.Version = 1
+	doc.analysis = nil
+	doc.mu.Unlock()
+	s.analyzeAndPublish(doc)
+	assert.Len(t, *captured, 2,
+		"v1 should be blocked after v2 was published")
 }
 
-func TestDocumentSnapshot(t *testing.T) {
+func TestDocumentSnapshot_CopiesFields(t *testing.T) {
 	doc := &Document{
 		URI:     "file:///test.lisp",
 		Version: 5,
@@ -3875,4 +3924,48 @@ func TestDocumentSnapshot(t *testing.T) {
 	assert.Equal(t, "file:///test.lisp", snap.URI)
 	assert.Equal(t, int32(5), snap.Version)
 	assert.Equal(t, "(+ 1 1)", snap.Content)
+}
+
+func TestDocumentSnapshot_IsolatedFromMutation(t *testing.T) {
+	// Verify that snapshot slices are isolated from the document's slices,
+	// so a concurrent parse() replacing doc.ast won't affect the snapshot.
+	store := NewDocumentStore()
+	doc := store.Open("file:///test.lisp", 1, "(defun f () 1)")
+	require.NotNil(t, doc)
+
+	// Take snapshot while document has parsed AST.
+	snap := doc.Snapshot()
+	require.NotEmpty(t, snap.AST, "snapshot should have AST from parsed content")
+	originalASTLen := len(snap.AST)
+
+	// Mutate the document (simulates concurrent parse with different content).
+	doc.mu.Lock()
+	doc.Content = "(+ 1 1)"
+	doc.parse()
+	doc.mu.Unlock()
+
+	// Snapshot's AST should be unchanged despite the document being re-parsed.
+	assert.Len(t, snap.AST, originalASTLen,
+		"snapshot AST should be isolated from document mutations")
+}
+
+func TestDocumentSnapshot_ParseErrorsIsolated(t *testing.T) {
+	store := NewDocumentStore()
+	// Open with a parse error.
+	doc := store.Open("file:///test.lisp", 1, "(defun broken (x y")
+	require.NotNil(t, doc)
+
+	snap := doc.Snapshot()
+	require.NotEmpty(t, snap.ParseErrors, "snapshot should capture parse errors")
+	originalErrCount := len(snap.ParseErrors)
+
+	// Re-parse with valid content (no errors).
+	doc.mu.Lock()
+	doc.Content = "(+ 1 1)"
+	doc.parse()
+	doc.mu.Unlock()
+
+	// Snapshot's parse errors should be unchanged.
+	assert.Len(t, snap.ParseErrors, originalErrCount,
+		"snapshot parse errors should be isolated from document mutations")
 }

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -3820,3 +3820,59 @@ func TestDocumentSizeGuard_NormalDoc(t *testing.T) {
 			"normal-sized document should not get size limit diagnostic")
 	}
 }
+
+func TestVersionGuard_StalePublishDiscarded(t *testing.T) {
+	s := testServer()
+	ctx, captured := capturingContext()
+	s.captureNotify(ctx)
+	setTestAnalysisCfg(s, &analysis.Config{})
+
+	// Open v1 and publish it.
+	doc := s.docs.Open("file:///test.lisp", 1, "(+ 1 1)")
+	s.analyzeAndPublish(doc)
+	require.Len(t, *captured, 1, "v1 should publish")
+
+	// Simulate v5 being published (e.g., by a concurrent didSave).
+	doc.mu.Lock()
+	doc.publishedVersion = 5
+	doc.mu.Unlock()
+
+	// Now try to publish v3 — should be discarded as stale.
+	doc.mu.Lock()
+	doc.Version = 3
+	doc.analysis = nil
+	doc.mu.Unlock()
+	s.analyzeAndPublish(doc)
+
+	// Only the original v1 publication should exist — v3 was discarded.
+	assert.Len(t, *captured, 1, "stale v3 publish should be discarded when v5 already published")
+}
+
+func TestVersionGuard_NewerVersionPublishes(t *testing.T) {
+	s := testServer()
+	ctx, captured := capturingContext()
+	s.captureNotify(ctx)
+	setTestAnalysisCfg(s, &analysis.Config{})
+
+	// Open v1.
+	doc := s.docs.Open("file:///test.lisp", 1, "(+ 1 1)")
+	s.analyzeAndPublish(doc)
+	require.Len(t, *captured, 1, "v1 should publish")
+
+	// Change to v2.
+	s.docs.Change("file:///test.lisp", 2, "(+ 2 2)")
+	s.analyzeAndPublish(doc)
+	assert.Len(t, *captured, 2, "v2 should publish since it's newer than v1")
+}
+
+func TestDocumentSnapshot(t *testing.T) {
+	doc := &Document{
+		URI:     "file:///test.lisp",
+		Version: 5,
+		Content: "(+ 1 1)",
+	}
+	snap := doc.Snapshot()
+	assert.Equal(t, "file:///test.lisp", snap.URI)
+	assert.Equal(t, int32(5), snap.Version)
+	assert.Equal(t, "(+ 1 1)", snap.Content)
+}

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -3784,3 +3784,39 @@ func TestWatchedFiles_UpdatesDefinitions(t *testing.T) {
 
 	assert.Empty(t, globals, "all definitions should be removed after file deletion")
 }
+
+func TestDocumentSizeGuard_OversizedDoc(t *testing.T) {
+	s := New(WithMaxDocumentBytes(100))
+	ctx, captured := capturingContext()
+	s.captureNotify(ctx)
+	setTestAnalysisCfg(s, &analysis.Config{})
+
+	// Open a document exceeding the size limit.
+	largeContent := strings.Repeat("(+ 1 1)\n", 20) // ~160 bytes
+	doc := s.docs.Open("file:///big.lisp", 1, largeContent)
+	s.analyzeAndPublish(doc)
+
+	require.Len(t, *captured, 1)
+	pub := (*captured)[0]
+	require.Len(t, pub.Diagnostics, 1)
+	assert.Equal(t, protocol.DiagnosticSeverityInformation, *pub.Diagnostics[0].Severity)
+	assert.Contains(t, pub.Diagnostics[0].Message, "size limit")
+}
+
+func TestDocumentSizeGuard_NormalDoc(t *testing.T) {
+	s := New(WithMaxDocumentBytes(10000))
+	ctx, captured := capturingContext()
+	s.captureNotify(ctx)
+	setTestAnalysisCfg(s, &analysis.Config{})
+
+	// Open a small document — should get normal analysis, not size warning.
+	doc := s.docs.Open("file:///small.lisp", 1, "(defun add (x y) (+ x y))")
+	s.analyzeAndPublish(doc)
+
+	require.Len(t, *captured, 1)
+	pub := (*captured)[0]
+	for _, d := range pub.Diagnostics {
+		assert.NotContains(t, d.Message, "size limit",
+			"normal-sized document should not get size limit diagnostic")
+	}
+}

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -284,10 +284,11 @@ func (s *Server) buildWorkspaceIndex() {
 	var pkgExports map[string][]analysis.ExternalSymbol
 	var defForms []analysis.DefFormSpec
 
-	// Build scan config from server options.
+	// Build scan config from server options. MaxFileBytes uses its own
+	// default (not maxDocumentBytes) since document analysis limits and
+	// workspace scan limits serve different purposes.
 	scanCfg := &analysis.ScanConfig{
-		MaxFiles:     s.maxWorkspaceFiles,
-		MaxFileBytes: int64(s.maxDocumentBytes),
+		MaxFiles: s.maxWorkspaceFiles,
 	}
 
 	// Two-phase workspace scan: prescan extracts definitions AND

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -86,15 +86,15 @@ func WithEnv(env *lisp.LEnv) Option {
 
 // WithMaxDocumentBytes sets the maximum document size for semantic analysis.
 // Documents exceeding this limit receive an informational diagnostic instead.
-// A value of 0 disables the limit (default).
+// A value <= 0 disables the limit (default).
 func WithMaxDocumentBytes(n int) Option {
-	return func(s *Server) { s.maxDocumentBytes = n }
+	return func(s *Server) { s.maxDocumentBytes = max(n, 0) }
 }
 
 // WithMaxWorkspaceFiles sets the maximum number of .lisp files scanned
-// during workspace indexing. A value of 0 uses the default (5000).
+// during workspace indexing. A value <= 0 uses the default (5000).
 func WithMaxWorkspaceFiles(n int) Option {
-	return func(s *Server) { s.maxWorkspaceFiles = n }
+	return func(s *Server) { s.maxWorkspaceFiles = max(n, 0) }
 }
 
 // New creates a new ELPS LSP server.

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -357,6 +357,9 @@ func (s *Server) reanalyzeOpenDocuments() {
 	for _, doc := range s.docs.All() {
 		doc.mu.Lock()
 		doc.analysis = nil
+		// Reset publishedVersion so the version guard allows republishing
+		// with the updated workspace config.
+		doc.publishedVersion = 0
 		doc.mu.Unlock()
 		s.analyzeAndPublish(doc)
 	}

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -65,6 +65,10 @@ type Server struct {
 	// analysis. Documents exceeding this limit receive an informational
 	// diagnostic instead of full analysis. 0 means no limit.
 	maxDocumentBytes int
+
+	// maxWorkspaceFiles is the maximum number of .lisp files to scan during
+	// workspace indexing. 0 means use the default (5000).
+	maxWorkspaceFiles int
 }
 
 // Option configures the LSP server.
@@ -85,6 +89,12 @@ func WithEnv(env *lisp.LEnv) Option {
 // A value of 0 disables the limit (default).
 func WithMaxDocumentBytes(n int) Option {
 	return func(s *Server) { s.maxDocumentBytes = n }
+}
+
+// WithMaxWorkspaceFiles sets the maximum number of .lisp files scanned
+// during workspace indexing. A value of 0 uses the default (5000).
+func WithMaxWorkspaceFiles(n int) Option {
+	return func(s *Server) { s.maxWorkspaceFiles = n }
 }
 
 // New creates a new ELPS LSP server.
@@ -273,13 +283,25 @@ func (s *Server) buildWorkspaceIndex() {
 	var extraGlobals []analysis.ExternalSymbol
 	var pkgExports map[string][]analysis.ExternalSymbol
 
+	// Build scan config from server options.
+	scanCfg := &analysis.ScanConfig{
+		MaxFiles:     s.maxWorkspaceFiles,
+		MaxFileBytes: int64(s.maxDocumentBytes),
+	}
+
 	// Scan workspace files in a single pass (only if we have a root path).
 	// Use allDefs (all top-level definitions, not just exports) so that
 	// cross-file duplicate-definition detection works for non-exported symbols.
 	if s.rootPath != "" {
-		if _, pkgs, allDefs, err := analysis.ScanWorkspaceAll(s.rootPath); err == nil {
+		if _, pkgs, allDefs, truncated, err := analysis.ScanWorkspaceAllWithConfig(s.rootPath, scanCfg); err == nil {
 			extraGlobals = allDefs
 			pkgExports = pkgs
+			if truncated {
+				s.sendNotification("window/showMessage", &protocol.ShowMessageParams{
+					Type:    protocol.MessageTypeWarning,
+					Message: "Workspace file limit reached; some files were not indexed for cross-file analysis.",
+				})
+			}
 		}
 	}
 

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -60,6 +60,11 @@ type Server struct {
 	// exitFn is called on the LSP exit notification. Defaults to os.Exit.
 	// Overridable for testing.
 	exitFn func(int)
+
+	// maxDocumentBytes is the maximum document size (in bytes) for semantic
+	// analysis. Documents exceeding this limit receive an informational
+	// diagnostic instead of full analysis. 0 means no limit.
+	maxDocumentBytes int
 }
 
 // Option configures the LSP server.
@@ -73,6 +78,13 @@ func WithRegistry(reg *lisp.PackageRegistry) Option {
 // WithEnv injects a fully initialized ELPS environment.
 func WithEnv(env *lisp.LEnv) Option {
 	return func(s *Server) { s.env = env }
+}
+
+// WithMaxDocumentBytes sets the maximum document size for semantic analysis.
+// Documents exceeding this limit receive an informational diagnostic instead.
+// A value of 0 disables the limit (default).
+func WithMaxDocumentBytes(n int) Option {
+	return func(s *Server) { s.maxDocumentBytes = n }
 }
 
 // New creates a new ELPS LSP server.

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -282,6 +282,7 @@ func (s *Server) buildWorkspaceIndex() {
 
 	var extraGlobals []analysis.ExternalSymbol
 	var pkgExports map[string][]analysis.ExternalSymbol
+	var defForms []analysis.DefFormSpec
 
 	// Build scan config from server options.
 	scanCfg := &analysis.ScanConfig{
@@ -289,14 +290,14 @@ func (s *Server) buildWorkspaceIndex() {
 		MaxFileBytes: int64(s.maxDocumentBytes),
 	}
 
-	// Scan workspace files in a single pass (only if we have a root path).
-	// Use allDefs (all top-level definitions, not just exports) so that
-	// cross-file duplicate-definition detection works for non-exported symbols.
+	// Two-phase workspace scan: prescan extracts definitions AND
+	// macro-derived DefFormSpecs for cross-file def-like form recognition.
 	if s.rootPath != "" {
-		if _, pkgs, allDefs, truncated, err := analysis.ScanWorkspaceAllWithConfig(s.rootPath, scanCfg); err == nil {
-			extraGlobals = allDefs
-			pkgExports = pkgs
-			if truncated {
+		if prescan, err := analysis.PrescanWorkspace(s.rootPath, scanCfg); err == nil {
+			extraGlobals = prescan.AllDefs
+			pkgExports = prescan.PkgExports
+			defForms = prescan.DefForms
+			if prescan.Truncated {
 				s.sendNotification("window/showMessage", &protocol.ShowMessageParams{
 					Type:    protocol.MessageTypeWarning,
 					Message: "Workspace file limit reached; some files were not indexed for cross-file analysis.",
@@ -336,6 +337,7 @@ func (s *Server) buildWorkspaceIndex() {
 	cfg := &analysis.Config{
 		ExtraGlobals:   extraGlobals,
 		PackageExports: pkgExports,
+		DefForms:       defForms,
 	}
 
 	s.analysisCfgMu.Lock()
@@ -396,6 +398,7 @@ func (s *Server) getAnalysisConfig(uri string) *analysis.Config {
 	if base != nil {
 		cfg.ExtraGlobals = base.ExtraGlobals
 		cfg.PackageExports = base.PackageExports
+		cfg.DefForms = base.DefForms
 	}
 	return cfg
 }

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -289,9 +289,15 @@ func (s *Server) buildWorkspaceIndex() {
 
 	// Deduplicate package exports by symbol name. Prefer registry entries
 	// (richer type info) over workspace entries when both exist.
+	// Sort after dedup for deterministic resolution order.
 	for pkg, syms := range pkgExports {
-		pkgExports[pkg] = deduplicateExports(syms)
+		deduped := deduplicateExports(syms)
+		analysis.SortDefinitions(deduped)
+		pkgExports[pkg] = deduped
 	}
+
+	// Sort extraGlobals for deterministic duplicate resolution.
+	analysis.SortDefinitions(extraGlobals)
 
 	cfg := &analysis.Config{
 		ExtraGlobals:   extraGlobals,


### PR DESCRIPTION
## Summary

Implements the five hardening improvements from #220 for the LSP workspace indexing pipeline:

- **Deterministic duplicate/global resolution** — `SortDefinitions` ensures stable ordering by file path, line, col. Applied to `extraGlobals` and deduplicated package exports
- **Document-size guard** — `WithMaxDocumentBytes` option skips semantic analysis for oversized documents, publishing an informational diagnostic instead. `collectLispFiles` also skips large files during workspace scanning
- **Configurable workspace file limits** — `ScanConfig` struct with `MaxFiles` and `MaxFileBytes` replaces the hardcoded constant. `WithMaxWorkspaceFiles` server option. Truncation triggers a `window/showMessage` warning
- **Version-guarded diagnostic publication** — `DocumentSnapshot` and `publishedVersion` tracking prevent stale debounced analysis from overwriting newer results
- **Two-phase workspace scan with macro preload** — `PrescanWorkspace` extracts `DefFormSpec`s from `def*`-prefixed macros, enabling cross-file recognition of user-defined definition forms

Plus a fix commit addressing code review findings:
- [P0] Fix version guard TOCTOU: use `doc.Version` from post-analysis lock grab
- [P1] Copy slice fields in `DocumentSnapshot` via `slices.Clone` for safety
- [P1] Decouple `maxDocumentBytes` from workspace `MaxFileBytes`
- [P3] Remove stale blank line, document `PreferredDefinition` mutation, inline wrapper

Closes #220

## Test plan

- [x] `go test ./analysis/...` — resolve, workspace config, prescan, def form extraction tests
- [x] `go test ./lsp/...` — document size guard, version guard, snapshot tests
- [x] `go test ./lint/...` — no regressions
- [x] `go test ./...` — full suite passes
- [x] `make static-checks` — golangci-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)