### PR TITLE
Wire LintConfig.Excludes through to workspace scanning

### DIFF
--- a/analysis/exclude.go
+++ b/analysis/exclude.go
@@ -8,20 +8,17 @@ import (
 )
 
 // MatchesExclude returns true if the given path matches any of the exclude
-// patterns. Each pattern is matched against the full path, the base name,
-// and each directory component, using filepath.Match semantics.
+// patterns. Each pattern is matched against the full path and each path
+// component (directories + filename), using filepath.Match semantics.
 func MatchesExclude(path string, patterns []string) bool {
 	for _, pattern := range patterns {
 		// Match against full path
 		if matched, _ := filepath.Match(pattern, path); matched {
 			return true
 		}
-		// Match against base name (e.g. "shirocore.lisp")
-		if matched, _ := filepath.Match(pattern, filepath.Base(path)); matched {
-			return true
-		}
-		// Match against each path component for directory patterns
-		// (e.g. "build" matches any/build/file.lisp)
+		// Match against each path component (directories + filename).
+		// splitPath includes the base name, so patterns like
+		// "shirocore.lisp" or "build" match anywhere in the path.
 		for _, component := range splitPath(path) {
 			if matched, _ := filepath.Match(pattern, component); matched {
 				return true

--- a/analysis/exclude.go
+++ b/analysis/exclude.go
@@ -1,0 +1,53 @@
+// Copyright © 2024 The ELPS authors
+
+package analysis
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// MatchesExclude returns true if the given path matches any of the exclude
+// patterns. Each pattern is matched against the full path, the base name,
+// and each directory component, using filepath.Match semantics.
+func MatchesExclude(path string, patterns []string) bool {
+	for _, pattern := range patterns {
+		// Match against full path
+		if matched, _ := filepath.Match(pattern, path); matched {
+			return true
+		}
+		// Match against base name (e.g. "shirocore.lisp")
+		if matched, _ := filepath.Match(pattern, filepath.Base(path)); matched {
+			return true
+		}
+		// Match against each path component for directory patterns
+		// (e.g. "build" matches any/build/file.lisp)
+		for _, component := range splitPath(path) {
+			if matched, _ := filepath.Match(pattern, component); matched {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// splitPath returns all directory components and the filename of a path.
+func splitPath(path string) []string {
+	var components []string
+	dir, file := filepath.Split(path)
+	if file != "" {
+		components = append(components, file)
+	}
+	for dir != "" && dir != "/" && dir != "." {
+		dir = strings.TrimRight(dir, string(filepath.Separator))
+		parent, base := filepath.Split(dir)
+		if base != "" {
+			components = append(components, base)
+		}
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return components
+}

--- a/analysis/exclude_test.go
+++ b/analysis/exclude_test.go
@@ -1,0 +1,41 @@
+// Copyright © 2024 The ELPS authors
+
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchesExclude_BaseName(t *testing.T) {
+	assert.True(t, MatchesExclude("project/build/shirocore.lisp", []string{"shirocore.lisp"}))
+}
+
+func TestMatchesExclude_DirectoryComponent(t *testing.T) {
+	assert.True(t, MatchesExclude("project/build/output.lisp", []string{"build"}))
+}
+
+func TestMatchesExclude_FullPath(t *testing.T) {
+	assert.True(t, MatchesExclude("shirocore.lisp", []string{"shirocore.lisp"}))
+}
+
+func TestMatchesExclude_GlobPattern(t *testing.T) {
+	assert.True(t, MatchesExclude("gen/output.lisp", []string{"*.lisp"}))
+}
+
+func TestMatchesExclude_NoMatch(t *testing.T) {
+	assert.False(t, MatchesExclude("src/main.lisp", []string{"shirocore.lisp", "build"}))
+}
+
+func TestMatchesExclude_EmptyPatterns(t *testing.T) {
+	assert.False(t, MatchesExclude("anything.lisp", nil))
+	assert.False(t, MatchesExclude("anything.lisp", []string{}))
+}
+
+func TestMatchesExclude_MultiplePatterns(t *testing.T) {
+	patterns := []string{"generated.lisp", "build"}
+	assert.True(t, MatchesExclude("out/generated.lisp", patterns))
+	assert.True(t, MatchesExclude("build/lib.lisp", patterns))
+	assert.False(t, MatchesExclude("src/lib.lisp", patterns))
+}

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -33,6 +33,10 @@ type ScanConfig struct {
 	// MaxFileBytes is the maximum size in bytes for a single file.
 	// Files exceeding this are skipped. 0 means use DefaultMaxFileBytes.
 	MaxFileBytes int64
+	// Excludes are glob patterns for files to skip during collection.
+	// Patterns are matched against the full path, base name, and each
+	// directory component using filepath.Match semantics.
+	Excludes []string
 }
 
 // effectiveMaxFiles returns the file limit, applying the default if zero.
@@ -49,6 +53,14 @@ func (c *ScanConfig) effectiveMaxFileBytes() int64 {
 		return DefaultMaxFileBytes
 	}
 	return c.MaxFileBytes
+}
+
+// effectiveExcludes returns the exclude patterns, or nil if none configured.
+func (c *ScanConfig) effectiveExcludes() []string {
+	if c == nil {
+		return nil
+	}
+	return c.Excludes
 }
 
 // SymbolKey identifies a symbol across files by name and kind.
@@ -142,6 +154,8 @@ func collectLispFilesWithConfig(root string, scanCfg *ScanConfig) ([]string, boo
 	maxFiles := scanCfg.effectiveMaxFiles()
 	maxBytes := scanCfg.effectiveMaxFileBytes()
 
+	excludes := scanCfg.effectiveExcludes()
+
 	var paths []string
 	var truncated bool
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
@@ -155,6 +169,9 @@ func collectLispFilesWithConfig(root string, scanCfg *ScanConfig) ([]string, boo
 			return nil
 		}
 		if filepath.Ext(path) != ".lisp" {
+			return nil
+		}
+		if len(excludes) > 0 && MatchesExclude(path, excludes) {
 			return nil
 		}
 		if maxBytes > 0 && info.Size() > maxBytes {
@@ -580,10 +597,11 @@ func scopeContainingAnalysis(scope *Scope, line, col int) *Scope {
 // analysis on each .lisp file, and extracts cross-file references.
 // The cfg should have ExtraGlobals and PackageExports populated from
 // a prior ScanWorkspaceFull call. Parsing is done concurrently.
+// The optional scanCfg controls file collection limits and excludes.
 //
 // Returns a map from SymbolKey.String() to FileReference slices.
-func ScanWorkspaceRefs(root string, cfg *Config) map[string][]FileReference {
-	paths, _, err := collectLispFilesWithConfig(root, nil)
+func ScanWorkspaceRefs(root string, cfg *Config, scanCfg *ScanConfig) map[string][]FileReference {
+	paths, _, err := collectLispFilesWithConfig(root, scanCfg)
 	if err != nil || len(paths) == 0 {
 		return nil
 	}

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -374,7 +374,7 @@ func TestScanWorkspaceRefs_CrossFile(t *testing.T) {
 	}
 
 	// Phase 2: Scan references.
-	refs := ScanWorkspaceRefs(dir, cfg)
+	refs := ScanWorkspaceRefs(dir, cfg, nil)
 
 	// There should be a reference to "helper" from file B.
 	helperKey := SymbolKey{Package: "user", Name: "helper", Kind: SymFunction}.String()
@@ -523,7 +523,7 @@ func TestScanWorkspaceRefs_QualifiedSymbol(t *testing.T) {
 	}
 
 	// Phase 2: Scan references.
-	refs := ScanWorkspaceRefs(dir, cfg)
+	refs := ScanWorkspaceRefs(dir, cfg, nil)
 
 	// There should be a reference to "add-one" (unqualified key) from consumer.lisp.
 	addOneKey := SymbolKey{Package: "helpers", Name: "add-one", Kind: SymFunction}.String()
@@ -898,6 +898,45 @@ func TestCollectLispFilesWithConfig_ZeroMaxFileBytesUsesDefault(t *testing.T) {
 	paths, _, err := collectLispFilesWithConfig(dir, &ScanConfig{MaxFileBytes: 0})
 	require.NoError(t, err)
 	assert.Len(t, paths, 1, "MaxFileBytes: 0 should use default, not skip all files")
+}
+
+func TestCollectLispFilesWithConfig_Excludes(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create 3 .lisp files.
+	for _, name := range []string{"main.lisp", "generated.lisp", "utils.lisp"} {
+		err := os.WriteFile(filepath.Join(dir, name), []byte("()"), 0600)
+		require.NoError(t, err)
+	}
+
+	// Exclude "generated.lisp" by base name.
+	paths, truncated, err := collectLispFilesWithConfig(dir, &ScanConfig{Excludes: []string{"generated.lisp"}})
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	assert.Len(t, paths, 2, "generated.lisp should be excluded")
+	for _, p := range paths {
+		assert.NotContains(t, p, "generated.lisp")
+	}
+}
+
+func TestCollectLispFilesWithConfig_ExcludesDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a "build" subdirectory with a file.
+	buildDir := filepath.Join(dir, "build")
+	err := os.MkdirAll(buildDir, 0750)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(buildDir, "output.lisp"), []byte("()"), 0600)
+	require.NoError(t, err)
+
+	// And a regular file.
+	err = os.WriteFile(filepath.Join(dir, "main.lisp"), []byte("()"), 0600)
+	require.NoError(t, err)
+
+	paths, _, err := collectLispFilesWithConfig(dir, &ScanConfig{Excludes: []string{"build"}})
+	require.NoError(t, err)
+	assert.Len(t, paths, 1, "build directory files should be excluded")
+	assert.Contains(t, paths[0], "main.lisp")
 }
 
 func TestScanConfig_EffectiveDefaults(t *testing.T) {

--- a/cmd/glob.go
+++ b/cmd/glob.go
@@ -38,22 +38,17 @@ func expandArgs(args []string, excludes []string) ([]string, error) {
 }
 
 // filterExcludes removes paths matching any of the given glob patterns.
-// Each pattern is matched against both the full path and the base name,
-// so --exclude='shirocore.lisp' matches any file with that name and
-// --exclude='**/build/**' matches paths containing a build directory.
+// Delegates to analysis.MatchesExclude which matches against the full path,
+// each directory component, and the filename.
 func filterExcludes(paths []string, excludes []string) []string {
 	var filtered []string
 	for _, p := range paths {
-		if matchesAny(p, excludes) {
+		if analysis.MatchesExclude(p, excludes) {
 			continue
 		}
 		filtered = append(filtered, p)
 	}
 	return filtered
-}
-
-func matchesAny(path string, patterns []string) bool {
-	return analysis.MatchesExclude(path, patterns)
 }
 
 func findLispFiles(root string) ([]string, error) {

--- a/cmd/glob.go
+++ b/cmd/glob.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/luthersystems/elps/analysis"
 )
 
 // expandArgs expands arguments, resolving patterns ending with "/..." to all
@@ -51,45 +53,7 @@ func filterExcludes(paths []string, excludes []string) []string {
 }
 
 func matchesAny(path string, patterns []string) bool {
-	for _, pattern := range patterns {
-		// Match against full path
-		if matched, _ := filepath.Match(pattern, path); matched {
-			return true
-		}
-		// Match against base name (e.g. --exclude='shirocore.lisp')
-		if matched, _ := filepath.Match(pattern, filepath.Base(path)); matched {
-			return true
-		}
-		// Match against each path component for directory patterns
-		// (e.g. --exclude='build' matches any/build/file.lisp)
-		for _, component := range splitPath(path) {
-			if matched, _ := filepath.Match(pattern, component); matched {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// splitPath returns all directory components and the filename of a path.
-func splitPath(path string) []string {
-	var components []string
-	dir, file := filepath.Split(path)
-	if file != "" {
-		components = append(components, file)
-	}
-	for dir != "" && dir != "/" && dir != "." {
-		dir = strings.TrimRight(dir, string(filepath.Separator))
-		parent, base := filepath.Split(dir)
-		if base != "" {
-			components = append(components, base)
-		}
-		if parent == dir {
-			break
-		}
-		dir = parent
-	}
-	return components
+	return analysis.MatchesExclude(path, patterns)
 }
 
 func findLispFiles(root string) ([]string, error) {

--- a/cmd/glob_test.go
+++ b/cmd/glob_test.go
@@ -65,26 +65,3 @@ func TestFilterExcludes_EmptyExcludes(t *testing.T) {
 	result := filterExcludes(paths, nil)
 	assert.Equal(t, []string{"src/main.lisp"}, result)
 }
-
-func TestMatchesAny_FullPath(t *testing.T) {
-	// filepath.Match on the full path
-	assert.True(t, matchesAny("src/main.lisp", []string{"src/*.lisp"}))
-	assert.False(t, matchesAny("lib/main.lisp", []string{"src/*.lisp"}))
-}
-
-func TestMatchesAny_BaseName(t *testing.T) {
-	assert.True(t, matchesAny("deep/nested/shirocore.lisp", []string{"shirocore.lisp"}))
-}
-
-func TestMatchesAny_Component(t *testing.T) {
-	assert.True(t, matchesAny("project/build/output.lisp", []string{"build"}))
-	assert.False(t, matchesAny("project/src/output.lisp", []string{"build"}))
-}
-
-func TestMatchesAny_DirectoryDeep(t *testing.T) {
-	// Verifies directory component matching works through the delegation.
-	assert.True(t, matchesAny("a/b/c.lisp", []string{"b"}))
-	assert.True(t, matchesAny("a/b/c.lisp", []string{"c.lisp"}))
-	assert.True(t, matchesAny("a/b/c.lisp", []string{"a"}))
-	assert.False(t, matchesAny("a/b/c.lisp", []string{"d"}))
-}

--- a/cmd/glob_test.go
+++ b/cmd/glob_test.go
@@ -81,9 +81,10 @@ func TestMatchesAny_Component(t *testing.T) {
 	assert.False(t, matchesAny("project/src/output.lisp", []string{"build"}))
 }
 
-func TestSplitPath(t *testing.T) {
-	components := splitPath("a/b/c.lisp")
-	assert.Contains(t, components, "c.lisp")
-	assert.Contains(t, components, "b")
-	assert.Contains(t, components, "a")
+func TestMatchesAny_DirectoryDeep(t *testing.T) {
+	// Verifies directory component matching works through the delegation.
+	assert.True(t, matchesAny("a/b/c.lisp", []string{"b"}))
+	assert.True(t, matchesAny("a/b/c.lisp", []string{"c.lisp"}))
+	assert.True(t, matchesAny("a/b/c.lisp", []string{"a"}))
+	assert.False(t, matchesAny("a/b/c.lisp", []string{"d"}))
 }

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -332,7 +332,11 @@ func (l *Linter) LintFiles(cfg *LintConfig, files []string) ([]Diagnostic, error
 // registry symbols. This is exported for callers (like the CLI stdin path)
 // that need to build the config separately from file linting.
 func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
-	syms, err := analysis.ScanWorkspace(cfg.Workspace)
+	scanCfg := &analysis.ScanConfig{
+		Excludes: cfg.Excludes,
+	}
+
+	prescan, err := analysis.PrescanWorkspace(cfg.Workspace, scanCfg)
 	if err != nil {
 		return nil, fmt.Errorf("scanning workspace %s: %w", cfg.Workspace, err)
 	}
@@ -352,17 +356,14 @@ func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
 	}
 
 	// Merge workspace package exports
-	wsPkgs, err := analysis.ScanWorkspacePackages(cfg.Workspace)
-	if err != nil {
-		return nil, fmt.Errorf("scanning workspace packages %s: %w", cfg.Workspace, err)
-	}
-	for pkg, wsSyms := range wsPkgs {
+	for pkg, wsSyms := range prescan.PkgExports {
 		pkgExports[pkg] = append(pkgExports[pkg], wsSyms...)
 	}
 
 	return &analysis.Config{
-		ExtraGlobals:   syms,
+		ExtraGlobals:   prescan.ExportedGlobals,
 		PackageExports: pkgExports,
+		DefForms:       prescan.DefForms,
 	}, nil
 }
 

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -2618,3 +2618,48 @@ func TestBuildAnalysisConfig_StdlibExportsOverride(t *testing.T) {
 	_, ok := cfg.PackageExports["custom-pkg"]
 	assert.True(t, ok, "custom-pkg should be in PackageExports")
 }
+
+func TestBuildAnalysisConfig_Excludes(t *testing.T) {
+	dir := t.TempDir()
+
+	// File A exports "helper".
+	writeTempLisp(t, dir, "lib.lisp", `
+(defun helper () 1)
+(export 'helper)
+`)
+	// File B (generated) also exports "helper" — would cause duplicate-definition.
+	writeTempLisp(t, dir, "generated.lisp", `
+(defun helper () 1)
+(export 'helper)
+`)
+
+	// Without excludes: both files contribute symbols.
+	cfgAll, err := BuildAnalysisConfig(&LintConfig{
+		Workspace:     dir,
+		StdlibExports: map[string][]analysis.ExternalSymbol{},
+	})
+	require.NoError(t, err)
+	countAll := 0
+	for _, sym := range cfgAll.ExtraGlobals {
+		if sym.Name == "helper" {
+			countAll++
+		}
+	}
+
+	// With excludes: generated.lisp is excluded.
+	cfgExcluded, err := BuildAnalysisConfig(&LintConfig{
+		Workspace:     dir,
+		Excludes:      []string{"generated.lisp"},
+		StdlibExports: map[string][]analysis.ExternalSymbol{},
+	})
+	require.NoError(t, err)
+	countExcluded := 0
+	for _, sym := range cfgExcluded.ExtraGlobals {
+		if sym.Name == "helper" {
+			countExcluded++
+		}
+	}
+
+	assert.Greater(t, countAll, countExcluded, "excluding a file should reduce symbols")
+	assert.Equal(t, 1, countExcluded, "only one helper should remain after excluding generated.lisp")
+}

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -347,7 +347,7 @@ func (s *Server) buildWorkspaceIndex() {
 
 	// Build workspace reference index using the populated config.
 	if s.rootPath != "" {
-		wsRefs := analysis.ScanWorkspaceRefs(s.rootPath, cfg)
+		wsRefs := analysis.ScanWorkspaceRefs(s.rootPath, cfg, scanCfg)
 		s.workspaceRefsMu.Lock()
 		s.workspaceRefs = wsRefs
 		s.workspaceRefsMu.Unlock()

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -69,6 +69,10 @@ type Server struct {
 	// maxWorkspaceFiles is the maximum number of .lisp files to scan during
 	// workspace indexing. 0 means use the default (5000).
 	maxWorkspaceFiles int
+
+	// excludePatterns are glob patterns for files to skip during workspace
+	// scanning. Matched against full path, base name, and directory components.
+	excludePatterns []string
 }
 
 // Option configures the LSP server.
@@ -95,6 +99,13 @@ func WithMaxDocumentBytes(n int) Option {
 // during workspace indexing. A value <= 0 uses the default (5000).
 func WithMaxWorkspaceFiles(n int) Option {
 	return func(s *Server) { s.maxWorkspaceFiles = max(n, 0) }
+}
+
+// WithExcludes sets glob patterns for files to skip during workspace scanning.
+// Patterns are matched against the full path, base name, and each directory
+// component using filepath.Match semantics.
+func WithExcludes(patterns []string) Option {
+	return func(s *Server) { s.excludePatterns = patterns }
 }
 
 // New creates a new ELPS LSP server.
@@ -289,6 +300,7 @@ func (s *Server) buildWorkspaceIndex() {
 	// workspace scan limits serve different purposes.
 	scanCfg := &analysis.ScanConfig{
 		MaxFiles: s.maxWorkspaceFiles,
+		Excludes: s.excludePatterns,
 	}
 
 	// Two-phase workspace scan: prescan extracts definitions AND

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -19,14 +19,15 @@ const (
 type Option func(*Server)
 
 type Server struct {
-	registry      *lisp.PackageRegistry
-	env           *lisp.LEnv
-	workspaceRoot string
-	perfConfig    *perf.Config
-	impl          *mcp.Implementation
-	instructions  string
-	logger        *slog.Logger
-	registrars    []func(*mcp.Server) error
+	registry        *lisp.PackageRegistry
+	env             *lisp.LEnv
+	workspaceRoot   string
+	perfConfig      *perf.Config
+	excludePatterns []string
+	impl            *mcp.Implementation
+	instructions    string
+	logger          *slog.Logger
+	registrars      []func(*mcp.Server) error
 
 	service  *service
 	server   *mcp.Server
@@ -56,6 +57,11 @@ func WithImplementation(impl *mcp.Implementation) Option {
 
 func WithInstructions(instructions string) Option {
 	return func(s *Server) { s.instructions = instructions }
+}
+
+// WithExcludes sets glob patterns for files to skip during workspace scanning.
+func WithExcludes(patterns []string) Option {
+	return func(s *Server) { s.excludePatterns = patterns }
 }
 
 func WithLogger(logger *slog.Logger) Option {
@@ -98,12 +104,13 @@ func New(opts ...Option) *Server {
 	}
 
 	s.service = newService(serviceConfig{
-		registry:      s.registry,
-		env:           s.env,
-		workspaceRoot: s.workspaceRoot,
-		perfConfig:    s.perfConfig,
-		linter:        &lint.Linter{Analyzers: lint.DefaultAnalyzers()},
-		logger:        s.logger,
+		registry:        s.registry,
+		env:             s.env,
+		workspaceRoot:   s.workspaceRoot,
+		perfConfig:      s.perfConfig,
+		excludePatterns: s.excludePatterns,
+		linter:          &lint.Linter{Analyzers: lint.DefaultAnalyzers()},
+		logger:          s.logger,
 	})
 	s.server = mcp.NewServer(s.impl, &mcp.ServerOptions{
 		Instructions: s.instructions,

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -28,21 +28,23 @@ import (
 const builtinScheme = "elps-builtin"
 
 type serviceConfig struct {
-	registry      *lisp.PackageRegistry
-	env           *lisp.LEnv
-	workspaceRoot string
-	perfConfig    *perf.Config
-	linter        *lint.Linter
-	logger        *slog.Logger
+	registry        *lisp.PackageRegistry
+	env             *lisp.LEnv
+	workspaceRoot   string
+	perfConfig      *perf.Config
+	excludePatterns []string
+	linter          *lint.Linter
+	logger          *slog.Logger
 }
 
 type service struct {
-	registry      *lisp.PackageRegistry
-	env           *lisp.LEnv
-	workspaceRoot string
-	perfConfig    *perf.Config
-	linter        *lint.Linter
-	logger        *slog.Logger
+	registry        *lisp.PackageRegistry
+	env             *lisp.LEnv
+	workspaceRoot   string
+	perfConfig      *perf.Config
+	excludePatterns []string
+	linter          *lint.Linter
+	logger          *slog.Logger
 
 	mu         sync.RWMutex
 	workspaces map[string]*workspaceState
@@ -73,6 +75,7 @@ func newService(cfg serviceConfig) *service {
 		env:                         cfg.env,
 		workspaceRoot:               cfg.workspaceRoot,
 		perfConfig:                  clonePerfConfig(cfg.perfConfig),
+		excludePatterns:             cfg.excludePatterns,
 		linter:                      cfg.linter,
 		logger:                      cfg.logger,
 		workspaces:                  make(map[string]*workspaceState),
@@ -519,8 +522,11 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 		fingerprint: fingerprint,
 	}
 	state.validatedAt.Store(validatedAt.UnixNano())
+	scanCfg := &analysis.ScanConfig{
+		Excludes: s.excludePatterns,
+	}
 	if root != "" {
-		globals, pkgs, symbols, err := analysis.ScanWorkspaceAll(root)
+		globals, pkgs, symbols, _, err := analysis.ScanWorkspaceAllWithConfig(root, scanCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -547,7 +553,7 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 		state.cfg.PackageExports[pkgName] = deduplicateExports(syms)
 	}
 	if root != "" {
-		state.refs = analysis.ScanWorkspaceRefs(root, state.cfg, nil)
+		state.refs = analysis.ScanWorkspaceRefs(root, state.cfg, scanCfg)
 	}
 	return state, nil
 }

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -547,7 +547,7 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 		state.cfg.PackageExports[pkgName] = deduplicateExports(syms)
 	}
 	if root != "" {
-		state.refs = analysis.ScanWorkspaceRefs(root, state.cfg)
+		state.refs = analysis.ScanWorkspaceRefs(root, state.cfg, nil)
 	}
 	return state, nil
 }


### PR DESCRIPTION
## Summary

- Move glob matching logic (`matchesAny`, `splitPath`) from `cmd/glob.go` to `analysis/exclude.go` as `MatchesExclude` so it can be imported by the `analysis` package
- Add `Excludes []string` field to `analysis.ScanConfig` and apply filtering in `collectLispFilesWithConfig`
- Update `ScanWorkspaceRefs` to accept a `*ScanConfig` parameter
- `BuildAnalysisConfig` now uses `PrescanWorkspace` with excludes (single pass instead of two separate walks)
- LSP server gains `WithExcludes` option, wired through to workspace scanning
- MCP server gains `WithExcludes` option, wired through to `ScanWorkspaceAllWithConfig` and `ScanWorkspaceRefs`

## Test plan

- [x] `analysis/exclude_test.go`: base name, directory component, full path, glob, and no-match cases
- [x] `analysis/workspace_test.go`: `TestCollectLispFilesWithConfig_Excludes` and `_ExcludesDirectory`
- [x] `lint/lint_test.go`: `TestBuildAnalysisConfig_Excludes` verifies excluded file symbols are not in result
- [x] `cmd/glob_test.go`: existing tests pass with delegated matching
- [x] All existing LSP, MCP, and analysis tests pass
- [x] `make static-checks` clean

Fixes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)