### PR TITLE
feat(vscode): bundle elps binary in platform-specific extension packages

### DIFF
--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -6,8 +6,108 @@ on:
       - "v*"
 
 jobs:
-  publish:
-    name: Publish to VS Code Marketplace
+  build-binaries:
+    name: Build elps (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            target: linux-x64
+          - goos: linux
+            goarch: arm64
+            target: linux-arm64
+          - goos: darwin
+            goarch: amd64
+            target: darwin-x64
+          - goos: darwin
+            goarch: arm64
+            target: darwin-arm64
+          - goos: windows
+            goarch: amd64
+            target: win32-x64
+            ext: .exe
+          - goos: windows
+            goarch: arm64
+            target: win32-arm64
+            ext: .exe
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: Build binary
+        run: |
+          mkdir -p editors/vscode/bin
+          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
+            go build -ldflags="-s -w" -trimpath \
+            -o editors/vscode/bin/elps${{ matrix.ext }} .
+          chmod +x editors/vscode/bin/elps${{ matrix.ext }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.target }}
+          path: editors/vscode/bin/
+
+  publish-platform:
+    name: Publish (${{ matrix.target }})
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: linux-x64
+          - target: linux-arm64
+          - target: darwin-x64
+          - target: darwin-arm64
+          - target: win32-x64
+          - target: win32-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: binary-${{ matrix.target }}
+          path: editors/vscode/bin/
+
+      - name: Ensure executable
+        run: chmod +x editors/vscode/bin/elps*
+
+      - name: Install dependencies
+        working-directory: editors/vscode
+        run: npm ci
+
+      - name: Set version in package.json
+        working-directory: editors/vscode
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+
+      - name: Build extension
+        working-directory: editors/vscode
+        run: npm run build
+
+      - name: Publish platform package
+        working-directory: editors/vscode
+        run: npx vsce publish --target ${{ matrix.target }} -p "$VSCE_PAT"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+  publish-universal:
+    name: Publish (universal)
+    needs: build-binaries
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +133,7 @@ jobs:
         working-directory: editors/vscode
         run: npm run build
 
-      - name: Publish to marketplace
+      - name: Publish universal package
         working-directory: editors/vscode
         run: npx vsce publish -p "$VSCE_PAT"
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ elps
 node_modules/
 *.vsix
 editors/vscode/dist/
+editors/vscode/bin/
 .vscode/
 .env

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -19,13 +19,13 @@ Full-featured VS Code extension for [ELPS](https://github.com/luthersystems/elps
 
 The extension includes the `elps` binary for supported platforms (macOS, Linux, Windows on x64 and arm64). **No separate installation required** — just install the extension and it works.
 
-To use a custom build instead, install via Go and the extension will auto-discover it:
+To use a custom build instead, set `elps.path` in VS Code settings to point to your binary:
 
-```bash
-go install github.com/luthersystems/elps@latest
+```json
+{
+  "elps.path": "/path/to/your/elps"
+}
 ```
-
-You can also set a specific path via the `elps.path` setting.
 
 ## Features
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -17,19 +17,15 @@
 
 Full-featured VS Code extension for [ELPS](https://github.com/luthersystems/elps), an embedded Lisp interpreter implemented in Go. Provides syntax highlighting, language server integration, and debugging.
 
-> **Requires the `elps` binary.** The extension provides editor features but needs the `elps` command-line tool installed separately. See [Prerequisites](#prerequisites) below.
+The extension includes the `elps` binary for supported platforms (macOS, Linux, Windows on x64 and arm64). **No separate installation required** — just install the extension and it works.
 
-## Prerequisites
-
-Install the `elps` binary using the Go toolchain (requires [Go 1.21+](https://go.dev/dl/)):
+To use a custom build instead, install via Go and the extension will auto-discover it:
 
 ```bash
 go install github.com/luthersystems/elps@latest
 ```
 
-This installs to `$GOPATH/bin` (typically `~/go/bin`). The extension auto-discovers the binary in common Go install locations (`~/go/bin`, `$GOPATH/bin`, `/usr/local/bin`, `/opt/homebrew/bin`).
-
-If the binary isn't found automatically, set the path in VS Code settings: `elps.path`.
+You can also set a specific path via the `elps.path` setting.
 
 ## Features
 

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -22,7 +22,7 @@ let extensionContext = null;
 // 4. Bare "elps" on PATH
 function getElpsPath() {
   const configured = vscode.workspace.getConfiguration("elps").get("path", "elps");
-  if (configured !== "elps") {
+  if (configured && configured !== "elps") {
     return configured;
   }
 

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -11,31 +11,47 @@ const os = require("os");
 const { LanguageClient } = require("vscode-languageclient/node");
 
 let client = null;
+let extensionContext = null;
 
 // --- Helpers ---
 
-// Resolve the elps binary path. If the user has set elps.path to something
-// other than the default "elps", use that. Otherwise, search common Go
-// install locations since VS Code on macOS doesn't inherit shell PATH.
+// Resolve the elps binary path. Priority:
+// 1. User-configured elps.path setting (if changed from default)
+// 2. Bundled binary in the extension's bin/ directory (platform-specific packages)
+// 3. Common Go install locations (GOBIN, GOPATH, ~/go/bin, etc.)
+// 4. Bare "elps" on PATH
 function getElpsPath() {
   const configured = vscode.workspace.getConfiguration("elps").get("path", "elps");
   if (configured !== "elps") {
     return configured;
   }
 
+  // Bundled binary (platform-specific extension package).
+  if (extensionContext) {
+    const ext = process.platform === "win32" ? ".exe" : "";
+    const bundled = path.join(extensionContext.extensionPath, "bin", "elps" + ext);
+    try {
+      fs.accessSync(bundled, fs.constants.X_OK);
+      return bundled;
+    } catch {
+      // Not bundled (universal package) — fall through to auto-discovery.
+    }
+  }
+
+  // Auto-discovery in common Go install locations.
   const home = os.homedir();
+  const ext = process.platform === "win32" ? ".exe" : "";
   const candidates = [
-    path.join(home, "go", "bin", "elps"),
-    path.join(home, ".local", "bin", "elps"),
+    path.join(home, "go", "bin", "elps" + ext),
+    path.join(home, ".local", "bin", "elps" + ext),
     "/usr/local/bin/elps",
     "/opt/homebrew/bin/elps",
   ];
 
-  // Also check GOPATH/bin and GOBIN if set in the process environment.
   if (process.env.GOBIN) {
-    candidates.unshift(path.join(process.env.GOBIN, "elps"));
+    candidates.unshift(path.join(process.env.GOBIN, "elps" + ext));
   } else if (process.env.GOPATH) {
-    candidates.unshift(path.join(process.env.GOPATH, "bin", "elps"));
+    candidates.unshift(path.join(process.env.GOPATH, "bin", "elps" + ext));
   }
 
   for (const candidate of candidates) {
@@ -141,6 +157,8 @@ async function stopLSP() {
 // --- Activation ---
 
 async function activate(context) {
+  extensionContext = context;
+
   // DAP
   context.subscriptions.push(
     vscode.debug.registerDebugAdapterDescriptorFactory(


### PR DESCRIPTION
## Summary

Bundle the `elps` binary directly into the VS Code extension using platform-specific packages. Users no longer need Go installed — just install the extension and it works.

### Platform targets (6 + universal)

| Package | Binary | Size |
|---------|--------|------|
| linux-x64 | `bin/elps` | ~14MB |
| linux-arm64 | `bin/elps` | ~14MB |
| darwin-x64 | `bin/elps` | ~14MB |
| darwin-arm64 | `bin/elps` | ~14MB |
| win32-x64 | `bin/elps.exe` | ~14MB |
| win32-arm64 | `bin/elps.exe` | ~14MB |
| universal (fallback) | none | ~350KB |

### Binary discovery priority

1. `elps.path` setting (user override) — always wins
2. Bundled binary at `<extensionPath>/bin/elps` — zero-config for marketplace users
3. Auto-discovery (`~/go/bin`, `GOPATH`, etc.) — fallback for universal package
4. Bare `elps` on PATH — last resort

### CI pipeline (3 jobs)

1. **build-binaries**: matrix cross-compile (6 targets, `CGO_ENABLED=0`, stripped)
2. **publish-platform**: per-target `vsce publish --target <platform>`
3. **publish-universal**: no-binary fallback for unsupported platforms

## Test plan

- [x] Grammar tests pass
- [x] Local platform-specific vsix builds and includes binary (10.27MB darwin-arm64)
- [x] Bundled binary is executable and LSP starts from it
- [x] `elps.path` setting still overrides bundled binary
- [x] Universal package (no bin/) falls back to auto-discovery
- [ ] CI: tag release, verify all 7 packages publish to marketplace

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)