### PR TITLE
fix: inlay hint quote positioning, F5 without launch.json, minifier --preserve-params, FmtCommand factory

### DIFF
--- a/cmd/fmt.go
+++ b/cmd/fmt.go
@@ -11,18 +11,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	fmtWrite      bool
-	fmtDiff       bool
-	fmtList       bool
-	fmtIndentSize int
-	fmtExcludes   []string
-)
+// FmtCommand creates the "fmt" cobra command. Embedders can add this
+// to their own CLI (e.g., shirotester fmt) without duplicating the
+// implementation.
+func FmtCommand(opts ...Option) *cobra.Command {
+	var cfg cmdConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
 
-var fmtCmd = &cobra.Command{
-	Use:   "fmt [flags] [files...]",
-	Short: "Format ELPS source files",
-	Long: `Format ELPS Lisp source files, similar to gofmt for Go.
+	var (
+		fmtWrite      bool
+		fmtDiff       bool
+		fmtList       bool
+		fmtIndentSize int
+		fmtExcludes   []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "fmt [flags] [files...]",
+		Short: "Format ELPS source files",
+		Long: `Format ELPS Lisp source files, similar to gofmt for Go.
 
 Normalizes whitespace and indentation, aligns forms according to Lisp
 conventions, and preserves comments. The formatter is idempotent.
@@ -44,36 +53,50 @@ Examples:
   elps fmt -l *.lisp               List files needing formatting
   cat file.lisp | elps fmt         Format from stdin
   elps fmt --indent-size 4 f.lisp  Use 4-space indentation`,
-	Run: func(cmd *cobra.Command, args []string) {
-		cfg := formatter.DefaultConfig()
-		cfg.IndentSize = fmtIndentSize
+		Run: func(cmd *cobra.Command, args []string) {
+			fmtCfg := formatter.DefaultConfig()
+			fmtCfg.IndentSize = fmtIndentSize
 
-		if len(args) == 0 {
-			if err := fmtStdin(cfg); err != nil {
+			if len(args) == 0 {
+				if err := fmtStdin(fmtCfg); err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+				return
+			}
+
+			expanded, err := expandArgs(args, fmtExcludes)
+			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
-			return
-		}
 
-		expanded, err := expandArgs(args, fmtExcludes)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-
-		exitCode := 0
-		for _, path := range expanded {
-			changed, err := fmtFile(path, cfg)
-			if err != nil {
-				fmt.Fprintln(os.Stderr, err)
-				exitCode = 1
-			} else if fmtList && changed {
-				exitCode = 1
+			exitCode := 0
+			for _, path := range expanded {
+				changed, err := fmtFile(path, fmtCfg, fmtWrite, fmtDiff, fmtList)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					exitCode = 1
+				} else if fmtList && changed {
+					exitCode = 1
+				}
 			}
-		}
-		os.Exit(exitCode)
-	},
+			os.Exit(exitCode)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&fmtWrite, "write", "w", false,
+		"Write result to (source) file instead of stdout.")
+	cmd.Flags().BoolVarP(&fmtDiff, "diff", "d", false,
+		"Display diffs instead of rewriting files.")
+	cmd.Flags().BoolVarP(&fmtList, "list", "l", false,
+		"List files whose formatting differs from elps fmt's.")
+	cmd.Flags().IntVar(&fmtIndentSize, "indent-size", 2,
+		"Number of spaces per indentation level.")
+	cmd.Flags().StringArrayVar(&fmtExcludes, "exclude", nil,
+		"Glob pattern for files to exclude (may be repeated).")
+
+	return cmd
 }
 
 func fmtStdin(cfg *formatter.Config) error {
@@ -89,7 +112,7 @@ func fmtStdin(cfg *formatter.Config) error {
 	return err
 }
 
-func fmtFile(path string, cfg *formatter.Config) (bool, error) {
+func fmtFile(path string, cfg *formatter.Config, write, diff, list bool) (bool, error) {
 	src, err := os.ReadFile(path) //nolint:gosec // CLI tool reads user-specified files
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", path, err)
@@ -101,21 +124,21 @@ func fmtFile(path string, cfg *formatter.Config) (bool, error) {
 
 	changed := string(src) != string(out)
 
-	if fmtList {
+	if list {
 		if changed {
 			fmt.Println(path)
 		}
 		return changed, nil
 	}
 
-	if fmtDiff {
+	if diff {
 		if changed {
 			printUnifiedDiff(path, src, out)
 		}
 		return changed, nil
 	}
 
-	if fmtWrite {
+	if write {
 		if !changed {
 			return false, nil
 		}
@@ -171,16 +194,5 @@ func splitLines(data []byte) []string {
 }
 
 func init() {
-	rootCmd.AddCommand(fmtCmd)
-
-	fmtCmd.Flags().BoolVarP(&fmtWrite, "write", "w", false,
-		"Write result to (source) file instead of stdout.")
-	fmtCmd.Flags().BoolVarP(&fmtDiff, "diff", "d", false,
-		"Display diffs instead of rewriting files.")
-	fmtCmd.Flags().BoolVarP(&fmtList, "list", "l", false,
-		"List files whose formatting differs from elps fmt's.")
-	fmtCmd.Flags().IntVar(&fmtIndentSize, "indent-size", 2,
-		"Number of spaces per indentation level.")
-	fmtCmd.Flags().StringArrayVar(&fmtExcludes, "exclude", nil,
-		"Glob pattern for files to exclude (may be repeated).")
+	rootCmd.AddCommand(FmtCommand())
 }

--- a/cmd/minify.go
+++ b/cmd/minify.go
@@ -174,6 +174,6 @@ func init() {
 		"Workspace root for cross-file semantic resolution.")
 	minifyCmd.Flags().BoolVar(&minifyRenameExports, "rename-exports", false,
 		"Rename exported top-level symbols and rewrite matching export forms.")
-	minifyCmd.Flags().BoolVar(&minifyPreserveParams, "preserve-params", false,
-		"Preserve function and macro parameter names instead of renaming them.")
+	minifyCmd.Flags().BoolVar(&minifyPreserveParams, "preserve-params", true,
+		"Preserve function and macro parameter names (default: true). Use --preserve-params=false to rename them.")
 }

--- a/cmd/minify.go
+++ b/cmd/minify.go
@@ -14,12 +14,13 @@ import (
 )
 
 var (
-	minifyWrite         bool
-	minifyMapPath       string
-	minifyExcludeFiles  []string
-	minifyExcludes      []string
-	minifyWorkspace     string
-	minifyRenameExports bool
+	minifyWrite          bool
+	minifyMapPath        string
+	minifyExcludeFiles   []string
+	minifyExcludes       []string
+	minifyWorkspace      string
+	minifyRenameExports  bool
+	minifyPreserveParams bool
 )
 
 var minifyCmd = &cobra.Command{
@@ -58,9 +59,10 @@ func buildMinifyConfig() (*minifier.Config, error) {
 	}
 
 	cfg := &minifier.Config{
-		Exclusions:    exclusions,
-		RenameExports: minifyRenameExports,
-		Formatter:     formatter.DefaultConfig(),
+		Exclusions:     exclusions,
+		RenameExports:  minifyRenameExports,
+		PreserveParams: minifyPreserveParams,
+		Formatter:      formatter.DefaultConfig(),
 	}
 	cfg.Formatter.Compact = true
 	cfg.Formatter.StripComments = true
@@ -172,4 +174,6 @@ func init() {
 		"Workspace root for cross-file semantic resolution.")
 	minifyCmd.Flags().BoolVar(&minifyRenameExports, "rename-exports", false,
 		"Rename exported top-level symbols and rewrite matching export forms.")
+	minifyCmd.Flags().BoolVar(&minifyPreserveParams, "preserve-params", false,
+		"Preserve function and macro parameter names instead of renaming them.")
 }

--- a/cmd/minify_test.go
+++ b/cmd/minify_test.go
@@ -24,6 +24,7 @@ func TestMinifyCommand_DefaultFlags(t *testing.T) {
 
 func TestRunMinify_StdoutSingleFile(t *testing.T) {
 	resetMinifyFlags()
+	minifyPreserveParams = false
 	dir := t.TempDir()
 	path := filepath.Join(dir, "demo.lisp")
 	require.NoError(t, os.WriteFile(path, []byte("(defun outer (value) value)\n"), 0o600))
@@ -40,6 +41,7 @@ func TestRunMinify_StdoutSingleFile(t *testing.T) {
 
 func TestRunMinify_WriteAndMap(t *testing.T) {
 	resetMinifyFlags()
+	minifyPreserveParams = false
 	minifyWrite = true
 	dir := t.TempDir()
 	path := filepath.Join(dir, "demo.lisp")
@@ -66,6 +68,7 @@ func TestRunMinify_WriteAndMap(t *testing.T) {
 
 func TestRunMinify_Stdin(t *testing.T) {
 	resetMinifyFlags()
+	minifyPreserveParams = false
 
 	var out bytes.Buffer
 	err := runMinify(nil, bytes.NewBufferString("(defun outer (value) value)\n"), &out)
@@ -82,6 +85,7 @@ func TestRunMinify_MultipleFilesRequireWrite(t *testing.T) {
 
 func TestRunMinify_RenameExports(t *testing.T) {
 	resetMinifyFlags()
+	minifyPreserveParams = false
 	minifyRenameExports = true
 	dir := t.TempDir()
 	path := filepath.Join(dir, "exports.lisp")
@@ -100,5 +104,5 @@ func resetMinifyFlags() {
 	minifyExcludes = nil
 	minifyWorkspace = ""
 	minifyRenameExports = false
-	minifyPreserveParams = false
+	minifyPreserveParams = true // default is true
 }

--- a/cmd/minify_test.go
+++ b/cmd/minify_test.go
@@ -17,7 +17,7 @@ import (
 func TestMinifyCommand_DefaultFlags(t *testing.T) {
 	assert.Equal(t, "minify [flags] [files...]", minifyCmd.Use)
 
-	for _, name := range []string{"write", "map", "exclude", "exclude-file", "workspace", "rename-exports"} {
+	for _, name := range []string{"write", "map", "exclude", "exclude-file", "workspace", "rename-exports", "preserve-params"} {
 		assert.NotNil(t, minifyCmd.Flags().Lookup(name), "missing flag: %s", name)
 	}
 }
@@ -100,4 +100,5 @@ func resetMinifyFlags() {
 	minifyExcludes = nil
 	minifyWorkspace = ""
 	minifyRenameExports = false
+	minifyPreserveParams = false
 }

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -69,6 +69,25 @@ function getElpsPath() {
 
 // --- DAP ---
 
+// Provides a default debug configuration when the user presses F5 without
+// a launch.json. VS Code calls resolveDebugConfiguration with an empty
+// config object; we fill in the launch defaults.
+class ElpsDebugConfigurationProvider {
+  resolveDebugConfiguration(_folder, config) {
+    if (!config.type && !config.request && !config.name) {
+      const editor = vscode.window.activeTextEditor;
+      if (editor && editor.document.languageId === "elps") {
+        config.type = "elps";
+        config.request = "launch";
+        config.name = "Debug ELPS";
+        config.program = editor.document.uri.fsPath;
+        config.stopOnEntry = true;
+      }
+    }
+    return config;
+  }
+}
+
 class ElpsDebugAdapterFactory {
   createDebugAdapterDescriptor(session) {
     const config = session.configuration;
@@ -161,6 +180,10 @@ async function activate(context) {
 
   // DAP
   context.subscriptions.push(
+    vscode.debug.registerDebugConfigurationProvider(
+      "elps",
+      new ElpsDebugConfigurationProvider(),
+    ),
     vscode.debug.registerDebugAdapterDescriptorFactory(
       "elps",
       new ElpsDebugAdapterFactory(),

--- a/lisp/macro_test.go
+++ b/lisp/macro_test.go
@@ -38,8 +38,8 @@ func TestMacros(t *testing.T) {
 			{"(quasiquote (list (unquote-splicing 1 2)))", "test:1:19: lisp:quasiquote: unquote-splicing: one argument expected (got 2)", ""},
 			{"(quasiquote (list (unquote 1 2)))", "test:1:19: lisp:quasiquote: unquote: one argument expected (got 2)", ""},
 			{"(quasiquote (unquote-splicing '(+ 2 3)))", "test:1:13: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
-			{"(quasiquote '(unquote-splicing '(+ 2 3)))", "test:1:40: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
-			{"(quasiquote ''(unquote-splicing '(+ 2 3)))", "test:1:41: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
+			{"(quasiquote '(unquote-splicing '(+ 2 3)))", "test:1:13: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
+			{"(quasiquote ''(unquote-splicing '(+ 2 3)))", "test:1:13: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
 			{"(quasiquote ((unquote-splicing '(+ 2 3))))", "'(+ 2 3)", ""},
 		}},
 		{"defmacro", elpstest.TestSequence{

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -4062,3 +4062,33 @@ func TestDocumentSnapshot_ParseErrorsIsolated(t *testing.T) {
 	assert.Len(t, snap.ParseErrors, originalErrCount,
 		"snapshot parse errors should be isolated from document mutations")
 }
+
+func TestInlayHint_QuotedArg(t *testing.T) {
+	// Regression test: inlay hints for quoted args like '() should be
+	// positioned at the quote prefix, not inside the parens.
+	s := testServer()
+	content := `(defun put-data (key data)
+  "Store data."
+  data)
+
+(put-data "k" '())`
+	openDoc(s, "file:///test.lisp", content)
+
+	hints, err := s.textDocumentInlayHint(&InlayHintParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 5, Character: 0},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, hints, 2, "should have hints for key and data")
+
+	assert.Equal(t, "key:", hints[0].Label)
+	assert.Equal(t, "data:", hints[1].Label)
+
+	// The "data:" hint should be at the ' character (column 14, 0-indexed),
+	// not at ( (column 15) which was the bug.
+	assert.Equal(t, protocol.UInteger(14), hints[1].Position.Character,
+		"hint should be at the ' quote prefix, not inside the parens")
+}

--- a/minifier/minifier.go
+++ b/minifier/minifier.go
@@ -32,6 +32,7 @@ type Config struct {
 	Analysis            *analysis.Config
 	Exclusions          map[string]bool
 	RenameExports       bool
+	PreserveParams      bool
 	PackageSurfaceForms []PackageSurfaceFormSpec
 	Formatter           *formatter.Config
 }
@@ -569,6 +570,9 @@ func renameable(sym *analysis.Symbol, cfg *Config, preserved *preservationSet) b
 		return false
 	}
 	if sym.Exported && !cfg.RenameExports {
+		return false
+	}
+	if cfg.PreserveParams && sym.Kind == analysis.SymParameter {
 		return false
 	}
 	name := sym.Name

--- a/minifier/minifier_test.go
+++ b/minifier/minifier_test.go
@@ -78,6 +78,38 @@ func TestMinifySource_RenameExportsOptionRewritesExportForms(t *testing.T) {
 	assert.Equal(t, "public", symMap.MinifiedToOriginal["x1"])
 }
 
+func TestMinifySource_PreserveParams(t *testing.T) {
+	src := []byte(`(defun greet (name greeting)
+  (format-string "%s, %s!" greeting name))
+`)
+
+	cfg := &Config{PreserveParams: true}
+	out, symMap, err := MinifySource(src, "test.lisp", cfg)
+	require.NoError(t, err)
+
+	result := string(out)
+	// Function name should be renamed
+	assert.Contains(t, symMap.OriginalToMinified, "greet")
+	// Parameter names should be preserved
+	assert.Contains(t, result, "name")
+	assert.Contains(t, result, "greeting")
+	assert.NotContains(t, symMap.OriginalToMinified, "name")
+	assert.NotContains(t, symMap.OriginalToMinified, "greeting")
+}
+
+func TestMinifySource_PreserveParams_Lambda(t *testing.T) {
+	src := []byte(`(set handler (lambda (request response) response))
+`)
+
+	cfg := &Config{PreserveParams: true}
+	out, _, err := MinifySource(src, "test.lisp", cfg)
+	require.NoError(t, err)
+
+	result := string(out)
+	assert.Contains(t, result, "request")
+	assert.Contains(t, result, "response")
+}
+
 func TestMinify_ExclusionsAndMultiFileSession(t *testing.T) {
 	inputs := []InputFile{
 		{

--- a/minifier/minifier_test.go
+++ b/minifier/minifier_test.go
@@ -87,14 +87,10 @@ func TestMinifySource_PreserveParams(t *testing.T) {
 	out, symMap, err := MinifySource(src, "test.lisp", cfg)
 	require.NoError(t, err)
 
-	result := string(out)
-	// Function name should be renamed
-	assert.Contains(t, symMap.OriginalToMinified, "greet")
-	// Parameter names should be preserved
-	assert.Contains(t, result, "name")
-	assert.Contains(t, result, "greeting")
-	assert.NotContains(t, symMap.OriginalToMinified, "name")
-	assert.NotContains(t, symMap.OriginalToMinified, "greeting")
+	// Exact output: function name renamed, params and body refs preserved.
+	assert.Equal(t, "(defun x1 (name greeting) (format-string \"%s, %s!\" greeting name))\n", string(out))
+	assert.Equal(t, "greet", symMap.MinifiedToOriginal["x1"])
+	assert.Len(t, symMap.Entries, 1, "only the function name should be renamed")
 }
 
 func TestMinifySource_PreserveParams_Lambda(t *testing.T) {
@@ -102,12 +98,30 @@ func TestMinifySource_PreserveParams_Lambda(t *testing.T) {
 `)
 
 	cfg := &Config{PreserveParams: true}
-	out, _, err := MinifySource(src, "test.lisp", cfg)
+	out, symMap, err := MinifySource(src, "test.lisp", cfg)
+	require.NoError(t, err)
+
+	// handler is a top-level set binding — preserved by default (not renamed).
+	// Lambda params are preserved by PreserveParams.
+	assert.Equal(t, "(set handler (lambda (request response) response))\n", string(out))
+	assert.Empty(t, symMap.Entries, "nothing should be renamed")
+}
+
+func TestMinifySource_PreserveParams_Defmacro(t *testing.T) {
+	src := []byte(`(defmacro with-retry (retries body)
+  (list 'dotimes (list retries) body))
+`)
+
+	cfg := &Config{PreserveParams: true}
+	out, symMap, err := MinifySource(src, "test.lisp", cfg)
 	require.NoError(t, err)
 
 	result := string(out)
-	assert.Contains(t, result, "request")
-	assert.Contains(t, result, "response")
+	// Macro name preserved (global macros are not renamed by default).
+	// Params should be preserved.
+	assert.Contains(t, result, "(retries body)")
+	assert.NotContains(t, symMap.OriginalToMinified, "retries")
+	assert.NotContains(t, symMap.OriginalToMinified, "body")
 }
 
 func TestMinify_ExclusionsAndMultiFileSession(t *testing.T) {

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -322,9 +322,11 @@ func (p *Parser) ParseQuote() *lisp.LVal {
 	}
 	prefixNewlines := p.src.Token.PrecedingNewlines
 	prefixSpaces := p.src.Token.PrecedingSpaces
+	quoteLoc := p.Location() // save ' location before parsing inner expression
 	inner := p.ParseExpression()
 	result := p.Quote(inner)
 	inheritEndPos(result, inner)
+	applyPrefixLocation(result, quoteLoc)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
 }
@@ -335,6 +337,7 @@ func (p *Parser) ParseUnbound() *lisp.LVal {
 	}
 	prefixNewlines := p.src.Token.PrecedingNewlines
 	prefixSpaces := p.src.Token.PrecedingSpaces
+	prefixLoc := p.Location() // save #^ location before parsing inner expression
 	expr := p.ParseExpression()
 	if expr.Type == lisp.LError {
 		return expr
@@ -349,6 +352,7 @@ func (p *Parser) ParseUnbound() *lisp.LVal {
 	}
 	result := p.SExpr([]*lisp.LVal{sym, expr})
 	inheritEndPos(result, expr)
+	applyPrefixLocation(result, prefixLoc)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
 }
@@ -360,12 +364,14 @@ func (p *Parser) ParseFunRef() *lisp.LVal {
 	}
 	prefixNewlines := p.src.Token.PrecedingNewlines
 	prefixSpaces := p.src.Token.PrecedingSpaces
+	prefixLoc := p.Location() // save #' location before parsing inner expression
 	name := p.ParseSymbol()
 	if name.Type == lisp.LError {
 		return name
 	}
 	result := p.SExpr([]*lisp.LVal{op, name})
 	inheritEndPos(result, name)
+	applyPrefixLocation(result, prefixLoc)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
 }
@@ -378,6 +384,21 @@ func inheritEndPos(outer, inner *lisp.LVal) {
 		outer.Source.EndPos = inner.Source.EndPos
 		outer.Source.EndLine = inner.Source.EndLine
 		outer.Source.EndCol = inner.Source.EndCol
+	}
+}
+
+// applyPrefixLocation overwrites the start position of a prefix form (quote,
+// #', #^) with the prefix token's location. tokenLVal sets Source from the
+// last consumed token, which for prefix forms is the inner expression — not
+// the prefix. This corrects it so that e.g. '() has its Source at the '
+// rather than at the (.
+func applyPrefixLocation(v *lisp.LVal, loc *token.Location) {
+	if v.Source != nil && loc != nil {
+		v.Source.File = loc.File
+		v.Source.Path = loc.Path
+		v.Source.Line = loc.Line
+		v.Source.Col = loc.Col
+		v.Source.Pos = loc.Pos
 	}
 }
 

--- a/parser/rdparser/parser_test.go
+++ b/parser/rdparser/parser_test.go
@@ -187,20 +187,19 @@ func TestEndPos_Nested(t *testing.T) {
 }
 
 func TestEndPos_Quote(t *testing.T) {
-	// 'foo — the quote wrapper gets its Source from the inner expression,
-	// so Source.Col is 2 (start of "foo"), and EndCol is from inner too.
+	// 'foo — the quote wrapper Source starts at the ' prefix token.
 	v := parseOne(t, "'foo")
 	assert.Equal(t, 1, v.Source.Line)
-	assert.Equal(t, 2, v.Source.Col)     // from inner "foo" token
+	assert.Equal(t, 1, v.Source.Col)     // ' starts at col 1
 	assert.Equal(t, 1, v.Source.EndLine)
 	assert.Equal(t, 5, v.Source.EndCol)  // "foo" ends at col 4, EndCol is 5
 }
 
 func TestEndPos_FunRef(t *testing.T) {
-	// #'myfun — the fun-ref wrapper gets Source from inner "myfun" token.
+	// #'myfun — the fun-ref wrapper Source starts at the #' prefix token.
 	v := parseOne(t, "#'myfun")
 	assert.Equal(t, 1, v.Source.Line)
-	assert.Equal(t, 3, v.Source.Col)     // "myfun" starts at col 3
+	assert.Equal(t, 1, v.Source.Col)     // #' starts at col 1
 	assert.Equal(t, 1, v.Source.EndLine)
 	assert.Equal(t, 8, v.Source.EndCol)  // "myfun" ends at col 7, EndCol is 8
 }
@@ -212,11 +211,10 @@ func TestEndPos_Float(t *testing.T) {
 }
 
 func TestEndPos_ExprPrefix(t *testing.T) {
-	// #^(+ 1 2) — the expr prefix wrapper gets Source from tokenLVal after
-	// inner expression is parsed, so Col reflects the closing bracket position.
+	// #^(+ 1 2) — the expr prefix wrapper Source starts at the #^ prefix token.
 	v := parseOne(t, "#^(+ 1 2)")
 	assert.Equal(t, 1, v.Source.Line)
-	assert.Equal(t, 9, v.Source.Col)     // from ")" at col 9 (last consumed token)
+	assert.Equal(t, 1, v.Source.Col)     // #^ starts at col 1
 	assert.Equal(t, 1, v.Source.EndLine)
 	assert.Equal(t, 10, v.Source.EndCol) // inherited from inner expr: ")" at col 9, EndCol is 10
 }


### PR DESCRIPTION
## Summary

Four improvements:

### fix(parser): inlay hint positioned inside quoted empty list (#240)
`ParseQuote`, `ParseFunRef`, and `ParseUnbound` set `Source` from the inner expression instead of the prefix token. Fix: `applyPrefixLocation()` helper saves and applies prefix token location.

### feat(vscode): F5 works without launch.json (#239)
`ElpsDebugConfigurationProvider` auto-generates a launch config when none exists.

### feat(minifier): --preserve-params, default true (#238)
Parameter names are preserved by default during minification. This fixes LSP hover/signature help showing `x600` instead of `key`. Use `--preserve-params=false` for the old behavior.

### feat(cmd): export FmtCommand factory (#243)
`FmtCommand()` exported following the same pattern as `LintCommand`, `DocCommand`, etc. Allows embedders (shirotester) to add `fmt` to their CLI.

## Test plan

- [x] `TestInlayHint_QuotedArg` — hint at `'` column, not inside parens
- [x] Updated parser EndPos tests for `'foo`, `#'myfun`, `#^(+ 1 2)`
- [x] Updated quasiquote error location tests
- [x] `TestMinifySource_PreserveParams` — exact output equality
- [x] `TestMinifySource_PreserveParams_Lambda` — exact output equality
- [x] `TestMinifySource_PreserveParams_Defmacro` — macro params preserved
- [x] All 29 packages pass

Fixes #238, #239, #240, #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)