### PR TITLE
chore(vscode): placeholder version + highlight #^ same as lambda

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "elps-lang",
   "displayName": "ELPS Lisp",
   "description": "ELPS — embedded Lisp interpreter for Go. Syntax highlighting, language server, and debugger.",
-  "version": "0.2.0",
+  "version": "0.0.0",
   "publisher": "LutherSystems",
   "license": "BSD-3-Clause",
   "repository": {

--- a/editors/vscode/syntaxes/elps.tmLanguage.json
+++ b/editors/vscode/syntaxes/elps.tmLanguage.json
@@ -111,7 +111,7 @@
     },
 
     "expr-shorthand": {
-      "name": "keyword.operator.expr-shorthand.elps",
+      "name": "keyword.control.definition.elps",
       "match": "#\\^"
     },
 

--- a/editors/vscode/test/grammar/basics.lisp
+++ b/editors/vscode/test/grammar/basics.lisp
@@ -49,7 +49,7 @@
 ; <- keyword.operator.function-quote.elps
 
 #^expr-shorthand
-; <- keyword.operator.expr-shorthand.elps
+; <- keyword.control.definition.elps
 
 (defun f (x &optional y)
 ;           ^^^^^^^^^ variable.parameter.elps


### PR DESCRIPTION
- Set package.json version to `0.0.0` placeholder (CI sets it from git tag)
- Change `#^` expr shorthand scope to `keyword.control.definition.elps` to match `lambda` highlighting

Fixes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)