### PR TITLE
docs: update release skill with vscode changelog and publish steps

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 # /release — Create a GitHub Release
 
-Creates a tagged release on GitHub with auto-generated release notes from merged PRs.
+Creates a tagged release on GitHub with auto-generated release notes from merged PRs. Releases also trigger the VS Code extension publish pipeline.
 
 ## Trigger
 
@@ -9,9 +9,9 @@ Use when asked to create a release, tag a release, cut a release, or ship a vers
 ## Arguments
 
 Optional: version bump type or explicit version.
-- `patch` (default) — bump patch: v1.16.14 -> v1.16.15
-- `minor` — bump minor: v1.16.14 -> v1.17.0
-- `major` — bump major: v1.16.14 -> v2.0.0
+- `patch` (default) — bump patch: v1.44.0 -> v1.44.1
+- `minor` — bump minor: v1.44.0 -> v1.45.0
+- `major` — bump major: v1.44.0 -> v2.0.0
 - `vX.Y.Z` — explicit version
 
 ## Workflow
@@ -49,7 +49,26 @@ Parse the latest tag (format: `vMAJOR.MINOR.PATCH`) and bump based on the argume
 
 Confirm the new version with the user before proceeding.
 
-### 4. Collect Release Notes
+### 4. Update VS Code Extension Changelog
+
+If any changes affect the VS Code extension (grammar, LSP, DAP, formatter, minifier, binary bundling), update `editors/vscode/CHANGELOG.md`:
+
+```markdown
+## X.Y.Z
+
+- Brief description of extension-relevant changes
+```
+
+Add the new section at the top of the file. Only include changes that affect the extension — skip internal refactors, test-only changes, or CI tweaks that don't change the extension behavior.
+
+Commit the changelog:
+```bash
+git add editors/vscode/CHANGELOG.md
+git commit -m "docs: update vscode changelog for vX.Y.Z"
+git push
+```
+
+### 5. Collect Release Notes
 
 Get merged PRs since the last release:
 ```bash
@@ -68,7 +87,7 @@ Format release notes as:
 **Full Changelog**: https://github.com/<owner>/<repo>/compare/<prev-tag>...<new-tag>
 ```
 
-### 5. Create the Release
+### 6. Create the Release
 
 ```bash
 gh release create <new-tag> \
@@ -81,13 +100,21 @@ EOF
 
 This creates both the git tag and the GitHub release in one step.
 
-### 6. Verify
+### 7. Monitor Pipelines
+
+The tag push triggers the VS Code extension publish workflow:
 
 ```bash
-gh release view <new-tag>
+# VS Code extension publish
+gh run list --workflow vscode-publish.yml --limit 3
 ```
 
-### 7. Report
+Verify all 9 jobs pass (4 binary builds + 4 platform publishes + 1 universal).
+
+The extension is published at:
+https://marketplace.visualstudio.com/items?itemName=LutherSystems.elps-lang
+
+### 8. Report
 
 Return the release URL and a summary of what was included.
 
@@ -103,6 +130,8 @@ This project uses semantic versioning: `vMAJOR.MINOR.PATCH`
 - [ ] On main branch with latest pulled
 - [ ] New commits exist since last release
 - [ ] Version number confirmed with user
+- [ ] VS Code changelog updated (if extension-relevant changes)
 - [ ] Release notes include all merged PRs
 - [ ] Release created successfully
+- [ ] VS Code extension publish workflow passed
 - [ ] Release URL returned to user


### PR DESCRIPTION
## Summary

Update the release skill to include:
- VS Code extension changelog update step for extension-relevant changes
- Pipeline monitoring for the vscode-publish workflow
- Checklist item for VS Code extension publish verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)