### PR TITLE
feat: load-tree package inference, keyword hover docs, EndPos everywhere

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -38,6 +38,11 @@ type Config struct {
 	// (no in-package declaration). Derived from main.lisp's in-package.
 	DefaultPackage string
 
+	// WorkspaceRefs maps SymbolKey.String() to cross-file references.
+	// When set, analyzers can check whether a symbol is referenced from
+	// other files in the workspace.
+	WorkspaceRefs map[string][]FileReference
+
 	// Filename is the source file being analyzed.
 	Filename string
 }
@@ -73,6 +78,11 @@ type Result struct {
 	// for cross-file duplicates without relying on scope lookups that may
 	// have been overwritten by local definitions.
 	ExtraGlobals []ExternalSymbol
+
+	// WorkspaceRefs maps SymbolKey.String() to cross-file references.
+	// Copied from Config. Used by lint analyzers to check whether a symbol
+	// is referenced from other workspace files (e.g. unused-function check).
+	WorkspaceRefs map[string][]FileReference
 }
 
 // Analyze performs semantic analysis on a set of parsed expressions.
@@ -106,7 +116,7 @@ func Analyze(exprs []*lisp.LVal, cfg *Config) *Result {
 
 	a := &analyzer{
 		root:             root,
-		result:           &Result{RootScope: root, ExtraGlobals: cfg.ExtraGlobals},
+		result:           &Result{RootScope: root, ExtraGlobals: cfg.ExtraGlobals, WorkspaceRefs: cfg.WorkspaceRefs},
 		cfg:              cfg,
 		qualifiedSymbols: make(map[string]*Symbol),
 	}

--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -34,6 +34,10 @@ type Config struct {
 	// imported in other files (e.g. main.lisp) are available.
 	PackageImports map[string][]string
 
+	// DefaultPackage overrides the default "user" package for bare files
+	// (no in-package declaration). Derived from main.lisp's in-package.
+	DefaultPackage string
+
 	// Filename is the source file being analyzed.
 	Filename string
 }
@@ -111,7 +115,7 @@ func Analyze(exprs []*lisp.LVal, cfg *Config) *Result {
 	a.prescan(exprs, root)
 
 	// Phase 2: Deep recursive walk
-	currentPkg := "user"
+	currentPkg := a.defaultPackage()
 	for _, expr := range exprs {
 		a.analyzeExpr(expr, root, currentPkg)
 		if expr != nil && expr.Type == lisp.LSExpr && !expr.Quoted && len(expr.Cells) > 0 &&

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -1561,6 +1561,28 @@ func TestAnalyzeFile_PreservesPackageImports(t *testing.T) {
 		"AnalyzeFile should forward PackageImports so 'when' resolves")
 }
 
+func TestAnalyze_DefaultPackage_BareFile(t *testing.T) {
+	// Regression test: a bare file (no in-package) with DefaultPackage set
+	// should use the default package, enabling cross-file imports to work.
+	source := "(defun f () (helper-fn 42))"
+	cfg := &Config{
+		PackageExports: map[string][]ExternalSymbol{
+			"helpers": {{Name: "helper-fn", Kind: SymFunction, Package: "helpers"}},
+		},
+		PackageImports: map[string][]string{
+			"svc": {"helpers"},
+		},
+		DefaultPackage: "svc",
+	}
+	result := parseAndAnalyzeWithConfig(t, source, cfg)
+	unresolvedNames := make(map[string]bool)
+	for _, u := range result.Unresolved {
+		unresolvedNames[u.Name] = true
+	}
+	assert.False(t, unresolvedNames["helper-fn"],
+		"bare file with DefaultPackage should resolve symbols via cross-file imports")
+}
+
 // parseAndAnalyzeWithConfig is a test helper that parses source and runs
 // analysis with a custom Config.
 func parseAndAnalyzeWithConfig(t *testing.T, source string, cfg *Config) *Result {

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -15,6 +15,7 @@ type analyzer struct {
 	result           *Result
 	cfg              *Config
 	qualifiedSymbols map[string]*Symbol
+	insideMacroCall  int // depth counter for user-macro body analysis
 }
 
 // defaultPackage returns the default package for bare files. If a
@@ -1123,10 +1124,28 @@ func (a *analyzer) walkQuasiquoteTemplate(node *lisp.LVal, scope *Scope, current
 }
 
 func (a *analyzer) analyzeCall(node *lisp.LVal, scope *Scope, currentPkg string) {
-	// Head can be symbol or expression
+	// Check if head is a user-defined macro — unresolved symbols inside
+	// macro bodies get lower severity since macros may introduce bindings
+	// at expansion time that are invisible to static analysis.
+	if len(node.Cells) > 0 && node.Cells[0].Type == lisp.LSymbol {
+		if sym := scope.Lookup(node.Cells[0].Str); sym != nil && sym.Kind == SymMacro && isUserMacro(sym) {
+			a.insideMacroCall++
+			defer func() { a.insideMacroCall-- }()
+		}
+	}
 	for _, child := range node.Cells {
 		a.analyzeExpr(child, scope, currentPkg)
 	}
+}
+
+// isUserMacro returns true if the symbol is a user-defined macro (not a
+// built-in macro like defun, defmacro, etc). Built-in macros have nil
+// Source or negative Pos.
+func isUserMacro(sym *Symbol) bool {
+	if sym.Source == nil || sym.Source.Pos < 0 {
+		return false
+	}
+	return true
 }
 
 // addParams adds function parameter symbols to a scope.
@@ -1180,9 +1199,10 @@ func (a *analyzer) resolveSymbol(node *lisp.LVal, scope *Scope, currentPkg strin
 		})
 	} else {
 		a.result.Unresolved = append(a.result.Unresolved, &UnresolvedRef{
-			Name:   name,
-			Source: node.Source,
-			Node:   node,
+			Name:            name,
+			Source:          node.Source,
+			Node:            node,
+			InsideMacroCall: a.insideMacroCall > 0,
 		})
 	}
 }

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -17,12 +17,21 @@ type analyzer struct {
 	qualifiedSymbols map[string]*Symbol
 }
 
+// defaultPackage returns the default package for bare files. If a
+// DefaultPackage is configured (from main.lisp), use it; otherwise "user".
+func (a *analyzer) defaultPackage() string {
+	if a.cfg != nil && a.cfg.DefaultPackage != "" {
+		return a.cfg.DefaultPackage
+	}
+	return "user"
+}
+
 // prescan walks top-level expressions to register forward-referenceable
 // definitions (defun, defmacro, set, export). It runs in two phases so
 // that (export 'name) works regardless of source order — a common ELPS
 // convention is to place exports before the corresponding defun.
 func (a *analyzer) prescan(exprs []*lisp.LVal, scope *Scope) {
-	currentPkg := "user"
+	currentPkg := a.defaultPackage()
 	// Phase 1: Register all definitions.
 	for _, expr := range exprs {
 		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
@@ -52,7 +61,7 @@ func (a *analyzer) prescan(exprs []*lisp.LVal, scope *Scope) {
 		}
 	}
 	// Phase 2: Apply exports (all definitions now exist in scope).
-	currentPkg = "user"
+	currentPkg = a.defaultPackage()
 	for _, expr := range exprs {
 		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
 			continue
@@ -74,7 +83,8 @@ func (a *analyzer) prescan(exprs []*lisp.LVal, scope *Scope) {
 	// Collect ALL packages the file declares (files may have multiple
 	// in-package) and import for each.
 	if a.cfg != nil && len(a.cfg.PackageImports) > 0 {
-		filePkgs := map[string]bool{"user": true}
+		defaultPkg := a.defaultPackage()
+		filePkgs := map[string]bool{defaultPkg: true}
 		for _, expr := range exprs {
 			if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
 				continue

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -23,7 +23,7 @@ func (a *analyzer) defaultPackage() string {
 	if a.cfg != nil && a.cfg.DefaultPackage != "" {
 		return a.cfg.DefaultPackage
 	}
-	return "user"
+	return lisp.DefaultUserPackage
 }
 
 // prescan walks top-level expressions to register forward-referenceable

--- a/analysis/reference.go
+++ b/analysis/reference.go
@@ -19,4 +19,8 @@ type UnresolvedRef struct {
 	Name   string
 	Source *token.Location
 	Node   *lisp.LVal
+	// InsideMacroCall is true when the unresolved reference appears inside
+	// a user-defined macro call body. Macros may introduce bindings at
+	// expansion time that are invisible to static analysis.
+	InsideMacroCall bool
 }

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -573,6 +573,7 @@ func AnalyzeFile(source []byte, filename string, cfg *Config) *Result {
 		DefForms:       fileCfg.DefForms,
 		PackageImports: fileCfg.PackageImports,
 		DefaultPackage: fileCfg.DefaultPackage,
+		WorkspaceRefs:  fileCfg.WorkspaceRefs,
 		Filename:       filename,
 	}
 	return Analyze(exprs, fileCfg)

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -284,7 +284,9 @@ func buildLoadTree(mainPath string) map[string]string {
 }
 
 // walkLoadFile recursively parses a file and tracks package context through
-// in-package and load-file calls.
+// in-package and load-file calls. It only tracks package *context* (which
+// package is active), not use-package imports — those are handled separately
+// by scanUsePackages and PackageImports.
 func walkLoadFile(filePath, currentPkg string, result map[string]string, visited map[string]bool) {
 	absPath, err := filepath.Abs(filePath)
 	if err != nil {

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -252,20 +252,24 @@ func sliceContains(ss []string, s string) bool {
 	return false
 }
 
-// scanFilePackage returns the first in-package declaration in the expressions,
-// or "" if the file has no in-package (bare file).
-func scanFilePackage(exprs []*lisp.LVal) string {
+// scanFilePackage returns the first in-package declaration in the expressions
+// along with its 1-based line number. Returns ("", 0) for bare files.
+func scanFilePackage(exprs []*lisp.LVal) (string, int) {
 	for _, expr := range exprs {
 		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
 			continue
 		}
 		if astutil.HeadSymbol(expr) == "in-package" {
 			if name := scanPackageName(expr); name != "" {
-				return name
+				line := 0
+				if expr.Source != nil {
+					line = expr.Source.Line
+				}
+				return name, line
 			}
 		}
 	}
-	return ""
+	return "", 0
 }
 
 // buildLoadTree parses mainPath and recursively walks load-file calls to build
@@ -330,16 +334,16 @@ func walkLoadFile(filePath, currentPkg string, result map[string]string, visited
 // scanFileFull parses a file once and extracts exported globals, package-grouped
 // exports, all definitions, use-package declarations, and the file's primary
 // package ("" for bare files without in-package).
-func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, usePackages map[string][]string, filePkg string) {
+func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, usePackages map[string][]string, filePkg string, firstInPkgLine int) {
 	s := token.NewScanner(filename, bytes.NewReader(source))
 	p := rdparser.New(s)
 
 	exprs, err := p.ParseProgram()
 	if err != nil {
-		return nil, nil, nil, nil, ""
+		return nil, nil, nil, nil, "", 0
 	}
 
-	filePkg = scanFilePackage(exprs)
+	filePkg, firstInPkgLine = scanFilePackage(exprs)
 	defs := extractDefinitions(exprs)
 	exported := scanExportedDefinitionKeys(exprs)
 
@@ -351,7 +355,7 @@ func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkg
 		}
 	}
 	usePackages = scanUsePackages(exprs)
-	return globals, pkgs, defs, usePackages, filePkg
+	return globals, pkgs, defs, usePackages, filePkg, firstInPkgLine
 }
 
 // extractDefinitions collects top-level definitions from pre-parsed expressions.
@@ -860,12 +864,13 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 	}
 
 	type fileResult struct {
-		globals     []ExternalSymbol
-		pkgs        map[string][]ExternalSymbol
-		allDefs     []ExternalSymbol
-		defForms    []DefFormSpec
-		usePackages map[string][]string
-		filePkg     string // "" for bare files
+		globals        []ExternalSymbol
+		pkgs           map[string][]ExternalSymbol
+		allDefs        []ExternalSymbol
+		defForms       []DefFormSpec
+		usePackages    map[string][]string
+		filePkg        string // "" for bare files
+		firstInPkgLine int    // 1-based line of first in-package, 0 if none
 	}
 
 	results := make([]fileResult, len(paths))
@@ -893,9 +898,9 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 				if readErr != nil {
 					continue
 				}
-				g, p, d, up, fp := scanFileFull(fileSrc, paths[i])
+				g, p, d, up, fp, fpl := scanFileFull(fileSrc, paths[i])
 				df := extractDefFormSpecs(d)
-				results[i] = fileResult{globals: g, pkgs: p, allDefs: d, defForms: df, usePackages: up, filePkg: fp}
+				results[i] = fileResult{globals: g, pkgs: p, allDefs: d, defForms: df, usePackages: up, filePkg: fp, firstInPkgLine: fpl}
 			}
 		}()
 	}
@@ -941,17 +946,23 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		}
 	}
 
-	// Remap bare-file symbols from the default user package to their
-	// load-tree package. Only bare files (no in-package) are remapped —
-	// files with explicit in-package already have correct package assignments.
+	// Remap user-package symbols from the load tree to their correct package.
+	// Two cases: (1) bare files — all defs remapped, (2) non-bare files —
+	// only defs before the first in-package are remapped (they inherit the
+	// load context at runtime but extractDefinitions assigns them to "user").
 	if defaultPkg != "" && len(loadTree) > 0 {
-		// Build set of bare-file paths for targeted remapping.
 		bareFiles := make(map[string]bool)
+		firstPkgLine := make(map[string]int) // file → line of first in-package
 		for i, r := range results {
+			abs, absErr := filepath.Abs(paths[i])
+			if absErr != nil {
+				continue
+			}
 			if r.filePkg == "" {
-				if abs, err := filepath.Abs(paths[i]); err == nil {
-					bareFiles[abs] = true
-				}
+				bareFiles[abs] = true
+			}
+			if r.firstInPkgLine > 0 {
+				firstPkgLine[abs] = r.firstInPkgLine
 			}
 		}
 
@@ -960,11 +971,19 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 			if sym.Package != userPkg || sym.Source == nil {
 				return "", false
 			}
-			if !bareFiles[sym.Source.File] {
+			pkg, inTree := loadTree[sym.Source.File]
+			if !inTree {
 				return "", false
 			}
-			pkg, ok := loadTree[sym.Source.File]
-			return pkg, ok
+			// Bare file: remap all user-package defs.
+			if bareFiles[sym.Source.File] {
+				return pkg, true
+			}
+			// Non-bare file: remap user-package defs before the first in-package.
+			if line, ok := firstPkgLine[sym.Source.File]; ok && sym.Source.Line < line {
+				return pkg, true
+			}
+			return "", false
 		}
 
 		for i := range prescan.AllDefs {

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -275,7 +275,7 @@ func scanFilePackage(exprs []*lisp.LVal) string {
 func buildLoadTree(mainPath string) map[string]string {
 	result := make(map[string]string)
 	visited := make(map[string]bool)
-	walkLoadFile(mainPath, "user", result, visited)
+	walkLoadFile(mainPath, lisp.DefaultUserPackage, result, visited)
 	return result
 }
 
@@ -359,7 +359,7 @@ func extractDefinitions(exprs []*lisp.LVal) []ExternalSymbol {
 	// Collect top-level definitions keyed by package-qualified name so
 	// multi-package files can define the same symbol in different packages.
 	defs := make(map[string]*ExternalSymbol)
-	currentPkg := "user" // default package
+	currentPkg := lisp.DefaultUserPackage
 
 	for _, expr := range exprs {
 		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
@@ -407,7 +407,7 @@ func definitionKey(pkg, name string) string {
 
 func scanExportedDefinitionKeys(exprs []*lisp.LVal) map[string]bool {
 	exported := make(map[string]bool)
-	currentPkg := "user"
+	currentPkg := lisp.DefaultUserPackage
 	for _, expr := range exprs {
 		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
 			continue
@@ -526,7 +526,7 @@ func scanExportNames(expr *lisp.LVal) []string {
 // packages it imports via use-package.
 func scanUsePackages(exprs []*lisp.LVal) map[string][]string {
 	result := make(map[string][]string)
-	currentPkg := "user"
+	currentPkg := lisp.DefaultUserPackage
 	for _, expr := range exprs {
 		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
 			continue
@@ -941,54 +941,63 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		}
 	}
 
-	// Remap bare-file symbols from "user" to their load-tree package.
-	// Files loaded by main.lisp inherit the package context from the load point.
+	// Remap bare-file symbols from the default user package to their
+	// load-tree package. Only bare files (no in-package) are remapped —
+	// files with explicit in-package already have correct package assignments.
 	if defaultPkg != "" && len(loadTree) > 0 {
-		for i := range prescan.AllDefs {
-			if prescan.AllDefs[i].Package != "user" {
-				continue
-			}
-			if prescan.AllDefs[i].Source != nil {
-				absFile := prescan.AllDefs[i].Source.File
-				if pkg, ok := loadTree[absFile]; ok {
-					prescan.AllDefs[i].Package = pkg
+		// Build set of bare-file paths for targeted remapping.
+		bareFiles := make(map[string]bool)
+		for i, r := range results {
+			if r.filePkg == "" {
+				if abs, err := filepath.Abs(paths[i]); err == nil {
+					bareFiles[abs] = true
 				}
+			}
+		}
+
+		userPkg := lisp.DefaultUserPackage
+		shouldRemap := func(sym *ExternalSymbol) (string, bool) {
+			if sym.Package != userPkg || sym.Source == nil {
+				return "", false
+			}
+			if !bareFiles[sym.Source.File] {
+				return "", false
+			}
+			pkg, ok := loadTree[sym.Source.File]
+			return pkg, ok
+		}
+
+		for i := range prescan.AllDefs {
+			if pkg, ok := shouldRemap(&prescan.AllDefs[i]); ok {
+				prescan.AllDefs[i].Package = pkg
 			}
 		}
 		for i := range prescan.ExportedGlobals {
-			if prescan.ExportedGlobals[i].Package != "user" {
-				continue
-			}
-			if prescan.ExportedGlobals[i].Source != nil {
-				absFile := prescan.ExportedGlobals[i].Source.File
-				if pkg, ok := loadTree[absFile]; ok {
-					prescan.ExportedGlobals[i].Package = pkg
-				}
+			if pkg, ok := shouldRemap(&prescan.ExportedGlobals[i]); ok {
+				prescan.ExportedGlobals[i].Package = pkg
 			}
 		}
 		// Remap PkgExports: move remapped symbols out of "user".
-		if userExports, ok := prescan.PkgExports["user"]; ok {
+		if userExports, ok := prescan.PkgExports[userPkg]; ok {
 			var remaining []ExternalSymbol
 			for i := range userExports {
-				if userExports[i].Source != nil {
-					if pkg, ok := loadTree[userExports[i].Source.File]; ok {
-						userExports[i].Package = pkg
-						prescan.PkgExports[pkg] = append(prescan.PkgExports[pkg], userExports[i])
-						continue
-					}
+				if pkg, ok := shouldRemap(&userExports[i]); ok {
+					userExports[i].Package = pkg
+					prescan.PkgExports[pkg] = append(prescan.PkgExports[pkg], userExports[i])
+					continue
 				}
 				remaining = append(remaining, userExports[i])
 			}
 			if len(remaining) > 0 {
-				prescan.PkgExports["user"] = remaining
+				prescan.PkgExports[userPkg] = remaining
 			} else {
-				delete(prescan.PkgExports, "user")
+				delete(prescan.PkgExports, userPkg)
 			}
 		}
 		// Merge use-package imports from "user" into default package.
-		if userImports, ok := prescan.PackageImports["user"]; ok {
+		if userImports, ok := prescan.PackageImports[userPkg]; ok {
 			prescan.PackageImports[defaultPkg] = appendUnique(prescan.PackageImports[defaultPkg], userImports...)
-			delete(prescan.PackageImports, "user")
+			delete(prescan.PackageImports, userPkg)
 		}
 	}
 

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -252,17 +252,94 @@ func sliceContains(ss []string, s string) bool {
 	return false
 }
 
+// scanFilePackage returns the first in-package declaration in the expressions,
+// or "" if the file has no in-package (bare file).
+func scanFilePackage(exprs []*lisp.LVal) string {
+	for _, expr := range exprs {
+		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
+			continue
+		}
+		if astutil.HeadSymbol(expr) == "in-package" {
+			if name := scanPackageName(expr); name != "" {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+// buildLoadTree parses mainPath and recursively walks load-file calls to build
+// a map from absolute file path to the package context inherited from the load
+// chain. This mirrors the runtime behavior where load-file executes in the
+// caller's current package context.
+func buildLoadTree(mainPath string) map[string]string {
+	result := make(map[string]string)
+	visited := make(map[string]bool)
+	walkLoadFile(mainPath, "user", result, visited)
+	return result
+}
+
+// walkLoadFile recursively parses a file and tracks package context through
+// in-package and load-file calls.
+func walkLoadFile(filePath, currentPkg string, result map[string]string, visited map[string]bool) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return
+	}
+	if visited[absPath] {
+		return
+	}
+	visited[absPath] = true
+
+	src, err := os.ReadFile(absPath) //nolint:gosec // workspace file
+	if err != nil {
+		return
+	}
+	s := token.NewScanner(absPath, bytes.NewReader(src))
+	p := rdparser.New(s)
+	exprs, err := p.ParseProgram()
+	if err != nil {
+		return
+	}
+
+	dir := filepath.Dir(absPath)
+	for _, expr := range exprs {
+		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
+			continue
+		}
+		head := astutil.HeadSymbol(expr)
+		switch head {
+		case "in-package":
+			if name := scanPackageName(expr); name != "" {
+				currentPkg = name
+			}
+		case "load-file":
+			if len(expr.Cells) >= 2 && expr.Cells[1].Type == lisp.LString {
+				loadPath := filepath.Join(dir, expr.Cells[1].Str)
+				absLoad, absErr := filepath.Abs(loadPath)
+				if absErr != nil {
+					continue
+				}
+				result[absLoad] = currentPkg
+				walkLoadFile(absLoad, currentPkg, result, visited)
+			}
+		}
+	}
+}
+
 // scanFileFull parses a file once and extracts exported globals, package-grouped
-// exports, and all definitions in a single pass.
-func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, usePackages map[string][]string) {
+// exports, all definitions, use-package declarations, and the file's primary
+// package ("" for bare files without in-package).
+func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, usePackages map[string][]string, filePkg string) {
 	s := token.NewScanner(filename, bytes.NewReader(source))
 	p := rdparser.New(s)
 
 	exprs, err := p.ParseProgram()
 	if err != nil {
-		return nil, nil, nil, nil
+		return nil, nil, nil, nil, ""
 	}
 
+	filePkg = scanFilePackage(exprs)
 	defs := extractDefinitions(exprs)
 	exported := scanExportedDefinitionKeys(exprs)
 
@@ -274,7 +351,7 @@ func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkg
 		}
 	}
 	usePackages = scanUsePackages(exprs)
-	return globals, pkgs, defs, usePackages
+	return globals, pkgs, defs, usePackages, filePkg
 }
 
 // extractDefinitions collects top-level definitions from pre-parsed expressions.
@@ -491,6 +568,7 @@ func AnalyzeFile(source []byte, filename string, cfg *Config) *Result {
 		PackageExports: fileCfg.PackageExports,
 		DefForms:       fileCfg.DefForms,
 		PackageImports: fileCfg.PackageImports,
+		DefaultPackage: fileCfg.DefaultPackage,
 		Filename:       filename,
 	}
 	return Analyze(exprs, fileCfg)
@@ -764,6 +842,11 @@ type WorkspacePrescan struct {
 	// via use-package across all workspace files. This enables per-file
 	// analysis to resolve symbols from cross-file use-package declarations.
 	PackageImports map[string][]string
+	// DefaultPackage is the package declared in main.lisp (if present).
+	// Used as the default for bare files (no in-package) so that cross-file
+	// resolution works in projects where files inherit the package from
+	// load order.
+	DefaultPackage string
 }
 
 // PrescanWorkspace performs a single-pass workspace scan that collects
@@ -782,6 +865,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		allDefs     []ExternalSymbol
 		defForms    []DefFormSpec
 		usePackages map[string][]string
+		filePkg     string // "" for bare files
 	}
 
 	results := make([]fileResult, len(paths))
@@ -809,19 +893,41 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 				if readErr != nil {
 					continue
 				}
-				g, p, d, up := scanFileFull(fileSrc, paths[i])
+				g, p, d, up, fp := scanFileFull(fileSrc, paths[i])
 				df := extractDefFormSpecs(d)
-				results[i] = fileResult{globals: g, pkgs: p, allDefs: d, defForms: df, usePackages: up}
+				results[i] = fileResult{globals: g, pkgs: p, allDefs: d, defForms: df, usePackages: up, filePkg: fp}
 			}
 		}()
 	}
 	wg.Wait()
+
+	// Build load tree from main.lisp to infer packages for bare files.
+	var mainPath string
+	loadTree := make(map[string]string)
+	var defaultPkg string
+	for _, p := range paths {
+		if filepath.Base(p) == "main.lisp" {
+			mainPath = p
+			break
+		}
+	}
+	if mainPath != "" {
+		loadTree = buildLoadTree(mainPath)
+		// Find main.lisp's package from its fileResult.
+		for i, r := range results {
+			if paths[i] == mainPath && r.filePkg != "" {
+				defaultPkg = r.filePkg
+				break
+			}
+		}
+	}
 
 	prescan := &WorkspacePrescan{
 		Files:          paths,
 		Truncated:      truncated,
 		PkgExports:     make(map[string][]ExternalSymbol),
 		PackageImports: make(map[string][]string),
+		DefaultPackage: defaultPkg,
 	}
 	for _, r := range results {
 		prescan.ExportedGlobals = append(prescan.ExportedGlobals, r.globals...)
@@ -834,6 +940,58 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 			prescan.PackageImports[pkg] = appendUnique(prescan.PackageImports[pkg], imports...)
 		}
 	}
+
+	// Remap bare-file symbols from "user" to their load-tree package.
+	// Files loaded by main.lisp inherit the package context from the load point.
+	if defaultPkg != "" && len(loadTree) > 0 {
+		for i := range prescan.AllDefs {
+			if prescan.AllDefs[i].Package != "user" {
+				continue
+			}
+			if prescan.AllDefs[i].Source != nil {
+				absFile := prescan.AllDefs[i].Source.File
+				if pkg, ok := loadTree[absFile]; ok {
+					prescan.AllDefs[i].Package = pkg
+				}
+			}
+		}
+		for i := range prescan.ExportedGlobals {
+			if prescan.ExportedGlobals[i].Package != "user" {
+				continue
+			}
+			if prescan.ExportedGlobals[i].Source != nil {
+				absFile := prescan.ExportedGlobals[i].Source.File
+				if pkg, ok := loadTree[absFile]; ok {
+					prescan.ExportedGlobals[i].Package = pkg
+				}
+			}
+		}
+		// Remap PkgExports: move remapped symbols out of "user".
+		if userExports, ok := prescan.PkgExports["user"]; ok {
+			var remaining []ExternalSymbol
+			for i := range userExports {
+				if userExports[i].Source != nil {
+					if pkg, ok := loadTree[userExports[i].Source.File]; ok {
+						userExports[i].Package = pkg
+						prescan.PkgExports[pkg] = append(prescan.PkgExports[pkg], userExports[i])
+						continue
+					}
+				}
+				remaining = append(remaining, userExports[i])
+			}
+			if len(remaining) > 0 {
+				prescan.PkgExports["user"] = remaining
+			} else {
+				delete(prescan.PkgExports, "user")
+			}
+		}
+		// Merge use-package imports from "user" into default package.
+		if userImports, ok := prescan.PackageImports["user"]; ok {
+			prescan.PackageImports[defaultPkg] = appendUnique(prescan.PackageImports[defaultPkg], userImports...)
+			delete(prescan.PackageImports, "user")
+		}
+	}
+
 	return prescan, nil
 }
 

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -1448,6 +1448,93 @@ func TestBuildLoadTree_CycleDetection(t *testing.T) {
 	assert.Equal(t, "svc", tree[absB])
 }
 
+func TestPrescanWorkspace_DefsBeforeInPackage(t *testing.T) {
+	dir := t.TempDir()
+
+	// main.lisp loads mixed.lisp which has defs before its first in-package.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'svc)
+(load-file "mixed.lisp")
+(load-file "consumer.lisp")
+`), 0600))
+
+	// mixed.lisp: defs before in-package should inherit svc from load context.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mixed.lisp"), []byte(`
+(defun helper-a () 1)
+(defun helper-b () 2)
+
+(in-package 'internal)
+(defun internal-fn () 3)
+(export 'internal-fn)
+(in-package 'svc)
+`), 0600))
+
+	// consumer.lisp: bare file that uses helper-a.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "consumer.lisp"), []byte(`
+(defun do-work () (helper-a))
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+
+	defPkgs := make(map[string]string)
+	for _, d := range prescan.AllDefs {
+		defPkgs[d.Name] = d.Package
+	}
+
+	// Defs before in-package should be remapped to svc (inherited from load context).
+	assert.Equal(t, "svc", defPkgs["helper-a"],
+		"def before in-package should be remapped to load-tree package")
+	assert.Equal(t, "svc", defPkgs["helper-b"],
+		"def before in-package should be remapped to load-tree package")
+	// Def after in-package 'internal should stay in internal.
+	assert.Equal(t, "internal", defPkgs["internal-fn"],
+		"def after in-package should keep its explicit package")
+	// Bare file def should be remapped to svc.
+	assert.Equal(t, "svc", defPkgs["do-work"],
+		"bare file def should be remapped to load-tree package")
+}
+
+func TestAnalyze_DefsBeforeInPackage_Resolve(t *testing.T) {
+	dir := t.TempDir()
+
+	// Same workspace as above — verify consumer.lisp resolves helper-a.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'svc)
+(load-file "mixed.lisp")
+(load-file "consumer.lisp")
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mixed.lisp"), []byte(`
+(defun helper-a () 1)
+(in-package 'internal)
+(defun internal-fn () 3)
+(export 'internal-fn)
+(in-package 'svc)
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "consumer.lisp"), []byte(`
+(defun do-work () (helper-a))
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		ExtraGlobals:   prescan.AllDefs,
+		PackageExports: prescan.PkgExports,
+		PackageImports: prescan.PackageImports,
+		DefaultPackage: prescan.DefaultPackage,
+	}
+
+	consumerSrc, _ := os.ReadFile(filepath.Join(dir, "consumer.lisp"))
+	result := AnalyzeFile(consumerSrc, filepath.Join(dir, "consumer.lisp"), cfg)
+	require.NotNil(t, result)
+
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "helper-a", u.Name,
+			"helper-a should resolve — its pre-in-package def was remapped to svc")
+	}
+}
+
 func TestScanConfig_EffectiveDefaults(t *testing.T) {
 	// Verify the effective* methods return defaults for zero/nil.
 	var nilCfg *ScanConfig

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -1248,6 +1248,135 @@ func TestPrescanWorkspace_DefaultPackage(t *testing.T) {
 	assert.True(t, found, "do-work should be in AllDefs")
 }
 
+// TestPrescanWorkspace_PhylumPattern replicates a typical phylum workspace:
+// - main.lisp sets in-package and imports packages via use-package
+// - main.lisp loads a utils file that switches packages then switches back
+// - main.lisp loads many bare files that inherit the package context
+// - test files have explicit in-package + use-package 'testing
+// - cross-file symbol resolution must work for all patterns
+func TestPrescanWorkspace_PhylumPattern(t *testing.T) {
+	dir := t.TempDir()
+
+	// main.lisp: entry point — sets package, imports, loads files.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'myapp)
+(use-package 'router)
+(use-package 'myutils)
+
+(load-file "myutils.lisp")
+(load-file "auth.lisp")
+(load-file "client.lisp")
+(load-file "init.lisp")
+`), 0600))
+
+	// myutils.lisp: defines symbols in myutils package, then returns to myapp.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "myutils.lisp"), []byte(`
+(in-package 'myutils)
+(defun helper-fn (x) (+ x 1))
+(export 'helper-fn)
+(defun string-check (s) (not (nil? s)))
+(export 'string-check)
+(in-package 'myapp)
+`), 0600))
+
+	// router package: provides route-ok (simulates Go-registered package).
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "router.lisp"), []byte(`
+(in-package 'router)
+(defun route-ok (data) data)
+(export 'route-ok)
+`), 0600))
+
+	// auth.lisp: bare file — no in-package. Uses symbols from imported packages.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "auth.lisp"), []byte(`
+(defun authenticate (token)
+  (string-check token))
+
+(defun auth-route (req)
+  (route-ok (authenticate (get req "token"))))
+
+(export 'authenticate)
+(export 'auth-route)
+`), 0600))
+
+	// client.lisp: bare file — references symbols from auth.lisp (load order).
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "client.lisp"), []byte(`
+(defun get-client (id)
+  (helper-fn id))
+
+(export 'get-client)
+`), 0600))
+
+	// init.lisp: bare file — defines bootstrap constants.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "init.lisp"), []byte(`
+(set 'bootstrap-id "boot-001")
+`), 0600))
+
+	// auth_test.lisp: test file — explicit in-package + use-package 'testing.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "auth_test.lisp"), []byte(`
+(in-package 'myapp)
+(use-package 'testing)
+
+(test "auth works"
+  (assert-equal "ok" (authenticate "ok")))
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+
+	// Verify DefaultPackage is myapp (from main.lisp).
+	assert.Equal(t, "myapp", prescan.DefaultPackage)
+
+	// Verify bare file definitions are in myapp package.
+	defPkgs := make(map[string]string)
+	for _, d := range prescan.AllDefs {
+		defPkgs[d.Name] = d.Package
+	}
+	assert.Equal(t, "myapp", defPkgs["authenticate"], "bare file def should be in myapp")
+	assert.Equal(t, "myapp", defPkgs["auth-route"], "bare file def should be in myapp")
+	assert.Equal(t, "myapp", defPkgs["get-client"], "bare file def should be in myapp")
+	assert.Equal(t, "myapp", defPkgs["bootstrap-id"], "bare file constant should be in myapp")
+	assert.Equal(t, "myutils", defPkgs["helper-fn"], "myutils def stays in myutils")
+	assert.Equal(t, "myutils", defPkgs["string-check"], "myutils def stays in myutils")
+
+	// Verify PackageImports includes all use-package declarations.
+	assert.Contains(t, prescan.PackageImports["myapp"], "router")
+	assert.Contains(t, prescan.PackageImports["myapp"], "myutils")
+	assert.Contains(t, prescan.PackageImports["myapp"], "testing")
+
+	// Verify cross-file resolution works: analyze auth.lisp (bare file)
+	// with the prescan config — helper-fn and route-ok should resolve.
+	cfg := &Config{
+		ExtraGlobals:   prescan.AllDefs,
+		PackageExports: prescan.PkgExports,
+		PackageImports: prescan.PackageImports,
+		DefaultPackage: prescan.DefaultPackage,
+	}
+	authSrc, _ := os.ReadFile(filepath.Join(dir, "auth.lisp"))
+	result := AnalyzeFile(authSrc, filepath.Join(dir, "auth.lisp"), cfg)
+	require.NotNil(t, result)
+
+	unresolvedNames := make(map[string]bool)
+	for _, u := range result.Unresolved {
+		unresolvedNames[u.Name] = true
+	}
+	assert.False(t, unresolvedNames["string-check"],
+		"string-check from myutils should resolve via cross-file use-package")
+	assert.False(t, unresolvedNames["route-ok"],
+		"route-ok from router should resolve via cross-file use-package")
+
+	// Verify test file resolution: auth_test.lisp has explicit in-package.
+	testSrc, _ := os.ReadFile(filepath.Join(dir, "auth_test.lisp"))
+	testResult := AnalyzeFile(testSrc, filepath.Join(dir, "auth_test.lisp"), cfg)
+	require.NotNil(t, testResult)
+
+	testUnresolved := make(map[string]bool)
+	for _, u := range testResult.Unresolved {
+		testUnresolved[u.Name] = true
+	}
+	assert.False(t, testUnresolved["authenticate"],
+		"authenticate from auth.lisp should resolve in test file (same myapp package)")
+}
+
 func TestScanConfig_EffectiveDefaults(t *testing.T) {
 	// Verify the effective* methods return defaults for zero/nil.
 	var nilCfg *ScanConfig

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -1152,6 +1152,102 @@ func TestPrescanWorkspace_PackageImports_Dedup(t *testing.T) {
 	assert.Equal(t, []string{"utils"}, prescan.PackageImports["svc"])
 }
 
+func TestBuildLoadTree_Basic(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'svc)
+(load-file "a.lisp")
+(load-file "b.lisp")
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.lisp"), []byte(`(defun a-fn () 1)`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.lisp"), []byte(`(defun b-fn () 2)`), 0600))
+
+	tree := buildLoadTree(filepath.Join(dir, "main.lisp"))
+
+	absA, _ := filepath.Abs(filepath.Join(dir, "a.lisp"))
+	absB, _ := filepath.Abs(filepath.Join(dir, "b.lisp"))
+	assert.Equal(t, "svc", tree[absA])
+	assert.Equal(t, "svc", tree[absB])
+}
+
+func TestBuildLoadTree_PackageSwitch(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'svc)
+(load-file "a.lisp")
+(in-package 'other)
+(load-file "b.lisp")
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.lisp"), []byte(`(defun a-fn () 1)`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.lisp"), []byte(`(defun b-fn () 2)`), 0600))
+
+	tree := buildLoadTree(filepath.Join(dir, "main.lisp"))
+
+	absA, _ := filepath.Abs(filepath.Join(dir, "a.lisp"))
+	absB, _ := filepath.Abs(filepath.Join(dir, "b.lisp"))
+	assert.Equal(t, "svc", tree[absA])
+	assert.Equal(t, "other", tree[absB])
+}
+
+func TestBuildLoadTree_Nested(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'svc)
+(load-file "a.lisp")
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.lisp"), []byte(`
+(load-file "b.lisp")
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.lisp"), []byte(`(defun b-fn () 2)`), 0600))
+
+	tree := buildLoadTree(filepath.Join(dir, "main.lisp"))
+
+	absA, _ := filepath.Abs(filepath.Join(dir, "a.lisp"))
+	absB, _ := filepath.Abs(filepath.Join(dir, "b.lisp"))
+	assert.Equal(t, "svc", tree[absA], "a.lisp loaded from main in svc context")
+	assert.Equal(t, "svc", tree[absB], "b.lisp loaded from a.lisp which inherited svc context")
+}
+
+func TestPrescanWorkspace_DefaultPackage(t *testing.T) {
+	dir := t.TempDir()
+
+	// main.lisp sets the package and loads a bare file.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'svc)
+(use-package 'helpers)
+(load-file "consumer.lisp")
+`), 0600))
+	// helpers.lisp exports helper-fn.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "helpers.lisp"), []byte(`
+(in-package 'helpers)
+(defun helper-fn (x) (+ x 1))
+(export 'helper-fn)
+`), 0600))
+	// consumer.lisp is bare — no in-package.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "consumer.lisp"), []byte(`
+(defun do-work () (helper-fn 42))
+(export 'do-work)
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "svc", prescan.DefaultPackage)
+
+	// do-work from bare consumer.lisp should be in svc package (not user).
+	found := false
+	for _, d := range prescan.AllDefs {
+		if d.Name == "do-work" {
+			assert.Equal(t, "svc", d.Package, "bare file def should be remapped to main.lisp's package")
+			found = true
+		}
+	}
+	assert.True(t, found, "do-work should be in AllDefs")
+}
+
 func TestScanConfig_EffectiveDefaults(t *testing.T) {
 	// Verify the effective* methods return defaults for zero/nil.
 	var nilCfg *ScanConfig

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -1377,6 +1377,77 @@ func TestPrescanWorkspace_PhylumPattern(t *testing.T) {
 		"authenticate from auth.lisp should resolve in test file (same myapp package)")
 }
 
+func TestPrescanWorkspace_ExplicitUserPackageNotRemapped(t *testing.T) {
+	dir := t.TempDir()
+
+	// main.lisp sets svc and loads a file that explicitly declares user package.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'svc)
+(load-file "user-prefs.lisp")
+`), 0600))
+	// user-prefs.lisp EXPLICITLY declares user package — must NOT be remapped.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "user-prefs.lisp"), []byte(`
+(in-package 'user)
+(defun pref-fn () 1)
+(export 'pref-fn)
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "svc", prescan.DefaultPackage)
+
+	for _, d := range prescan.AllDefs {
+		if d.Name == "pref-fn" {
+			assert.Equal(t, "user", d.Package,
+				"explicit (in-package 'user) should NOT be remapped to svc")
+			return
+		}
+	}
+	t.Fatal("pref-fn should be in AllDefs")
+}
+
+func TestPrescanWorkspace_NoMainLisp(t *testing.T) {
+	dir := t.TempDir()
+
+	// Workspace without main.lisp — no DefaultPackage, defs stay in user.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.lisp"), []byte(`
+(defun lib-fn () 1)
+(export 'lib-fn)
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "", prescan.DefaultPackage)
+
+	for _, d := range prescan.AllDefs {
+		if d.Name == "lib-fn" {
+			assert.Equal(t, "user", d.Package,
+				"without main.lisp, defs should stay in user package")
+			return
+		}
+	}
+	t.Fatal("lib-fn should be in AllDefs")
+}
+
+func TestBuildLoadTree_CycleDetection(t *testing.T) {
+	dir := t.TempDir()
+
+	// a.lisp loads b.lisp, b.lisp loads a.lisp — must terminate.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.lisp"), []byte(`
+(in-package 'svc)
+(load-file "b.lisp")
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.lisp"), []byte(`
+(load-file "a.lisp")
+`), 0600))
+
+	tree := buildLoadTree(filepath.Join(dir, "a.lisp"))
+	assert.NotNil(t, tree, "should terminate without infinite loop")
+
+	absB, _ := filepath.Abs(filepath.Join(dir, "b.lisp"))
+	assert.Equal(t, "svc", tree[absB])
+}
+
 func TestScanConfig_EffectiveDefaults(t *testing.T) {
 	// Verify the effective* methods return defaults for zero/nil.
 	var nilCfg *ScanConfig

--- a/docs/lang.md
+++ b/docs/lang.md
@@ -594,6 +594,13 @@ application to create more powerful abstractions over typed data.
 Packages allow namespace isolation for components of a code base as its
 complexity increases.
 
+### The Default Package
+
+When the ELPS interpreter starts, all code executes in the `user` package.
+This is the default package for any file that does not contain an
+`(in-package ...)` declaration.  Files loaded via `load-file` inherit the
+caller's current package context at the point of the load call.
+
 ### Basics
 
 Packages are created/modified using the `in-package`

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -743,6 +743,23 @@ var AnalyzerUnusedFunction = &Analyzer{
 			if len(sym.Name) > 0 && sym.Name[0] == '_' {
 				continue
 			}
+			// Check cross-file references from workspace scanning.
+			// Per-file analysis can't see callers in other files.
+			if pass.Semantics.WorkspaceRefs != nil {
+				key := analysis.SymbolToKey(sym).String()
+				if refs, ok := pass.Semantics.WorkspaceRefs[key]; ok {
+					hasExternal := false
+					for _, ref := range refs {
+						if ref.File != pass.Filename {
+							hasExternal = true
+							break
+						}
+					}
+					if hasExternal {
+						continue
+					}
+				}
+			}
 			pass.Report(Diagnostic{
 				Message: fmt.Sprintf("unused %s: %s", sym.Kind, sym.Name),
 				Pos:     posFromSource(sym.Source),

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -54,6 +54,7 @@ var AnalyzerSetUsage = &Analyzer{
 				pass.Report(Diagnostic{
 					Message: fmt.Sprintf("use set! instead of set to mutate '%s (already bound)", name),
 					Pos:     posFromSource(src.Source),
+					EndPos:  endPosFromNode(src),
 					Notes:   []string{"set creates a new binding; set! mutates an existing one"},
 				})
 			}
@@ -150,6 +151,7 @@ var AnalyzerLetBindings = &Analyzer{
 					pass.Report(Diagnostic{
 						Message: fmt.Sprintf("%s binding %d is not a list (did you forget the outer parentheses?)", head, i+1),
 						Pos:     posFromSource(bindingSource(binding, src)),
+						EndPos:  endPosFromNode(binding),
 						Notes:   []string{"correct form: (let ((x 1) (y 2)) body...)"},
 					})
 					continue
@@ -200,6 +202,7 @@ var AnalyzerQuoteCall = &Analyzer{
 				pass.Report(Diagnostic{
 					Message: fmt.Sprintf("%s first argument should be quoted: (set '%s ...) not (set %s ...)", head, arg.Str, arg.Str),
 					Pos:     posFromSource(src.Source),
+					EndPos:  endPosFromNode(src),
 					Notes:   []string{fmt.Sprintf("did you mean (%s '%s ...)?", head, arg.Str)},
 				})
 			}
@@ -235,6 +238,7 @@ var AnalyzerCondMissingElse = &Analyzer{
 			pass.Report(Diagnostic{
 				Message: "cond has no default (else) clause",
 				Pos:     posFromSource(src.Source),
+				EndPos:  endPosFromNode(src),
 				Notes:   []string{"add (else ...) or (true ...) as the last clause to handle unmatched cases"},
 			})
 		})
@@ -346,6 +350,7 @@ var AnalyzerCondStructure = &Analyzer{
 					pass.Report(Diagnostic{
 						Message: fmt.Sprintf("cond clause %d is not a list", i),
 						Pos:     posFromSource(clauseSrc.Source),
+						EndPos:  endPosFromNode(clauseSrc),
 						Notes:   []string{"cond clauses must be lists: (cond ((test1) body1) ((test2) body2) (else default))"},
 					})
 					continue
@@ -542,6 +547,7 @@ var AnalyzerRethrowContext = &Analyzer{
 			pass.Report(Diagnostic{
 				Message: "rethrow used outside handler-bind",
 				Pos:     posFromSource(src.Source),
+				EndPos:  endPosFromNode(src),
 				Notes:   []string{"rethrow can only be called from within a handler-bind handler"},
 			})
 		})
@@ -640,6 +646,7 @@ var AnalyzerUnnecessaryProgn = &Analyzer{
 			pass.Report(Diagnostic{
 				Message: msg,
 				Pos:     posFromSource(src.Source),
+				EndPos:  endPosFromNode(src),
 				Notes:   []string{fmt.Sprintf("remove the progn and move its contents directly into the %s body", head)},
 			})
 		})
@@ -659,6 +666,7 @@ var AnalyzerUnnecessaryProgn = &Analyzer{
 					pass.Report(Diagnostic{
 						Message: "progn is unnecessary in cond clause body (it supports multiple expressions)",
 						Pos:     posFromSource(src.Source),
+						EndPos:  endPosFromNode(src),
 						Notes:   []string{"remove the progn and move its contents directly into the cond clause"},
 					})
 				}
@@ -697,6 +705,7 @@ var AnalyzerUnusedVariable = &Analyzer{
 			pass.Report(Diagnostic{
 				Message: fmt.Sprintf("unused %s: %s", sym.Kind, sym.Name),
 				Pos:     posFromSource(sym.Source),
+				EndPos:  endPosFromNode(sym.Node),
 				Notes:   []string{fmt.Sprintf("if '%s' is intentionally unused, prefix it with '_'", sym.Name)},
 			})
 		}
@@ -737,6 +746,7 @@ var AnalyzerUnusedFunction = &Analyzer{
 			pass.Report(Diagnostic{
 				Message: fmt.Sprintf("unused %s: %s", sym.Kind, sym.Name),
 				Pos:     posFromSource(sym.Source),
+				EndPos:  endPosFromNode(sym.Node),
 				Notes:   []string{"if this is a public API, add it to an (export ...) form"},
 			})
 		}
@@ -853,6 +863,7 @@ var AnalyzerUserArity = &Analyzer{
 				pass.Report(Diagnostic{
 					Message: fmt.Sprintf("%s requires at least %d argument(s), got %d", head, minArity, argc),
 					Pos:     posFromSource(src.Source),
+					EndPos:  endPosFromNode(src),
 					Notes:   []string{fmt.Sprintf("defined at %s", sourceString(sym.Source))},
 				})
 			}
@@ -861,6 +872,7 @@ var AnalyzerUserArity = &Analyzer{
 				pass.Report(Diagnostic{
 					Message: fmt.Sprintf("%s accepts at most %d argument(s), got %d", head, maxArity, argc),
 					Pos:     posFromSource(src.Source),
+					EndPos:  endPosFromNode(src),
 					Notes:   []string{fmt.Sprintf("defined at %s", sourceString(sym.Source))},
 				})
 			}
@@ -895,6 +907,7 @@ var AnalyzerUndefinedSymbol = &Analyzer{
 			pass.Report(Diagnostic{
 				Message: fmt.Sprintf("undefined symbol: %s", u.Name),
 				Pos:     posFromSource(u.Source),
+				EndPos:  endPosFromNode(u.Node),
 				Notes:   []string{fmt.Sprintf("'%s' is not defined in any enclosing scope; did you mean a different name?", u.Name)},
 			})
 		}
@@ -986,6 +999,7 @@ var AnalyzerDuplicateDefinition = &Analyzer{
 				pass.Report(Diagnostic{
 					Message: fmt.Sprintf("duplicate definition: %s '%s' already defined", sym.Kind, sym.Name),
 					Pos:     posFromSource(sym.Source),
+					EndPos:  endPosFromNode(sym.Node),
 					Notes:   []string{fmt.Sprintf("first defined at %s", sourceString(first.Source))},
 				})
 			}
@@ -1007,6 +1021,7 @@ var AnalyzerDuplicateDefinition = &Analyzer{
 				pass.Report(Diagnostic{
 					Message: fmt.Sprintf("duplicate definition: %s '%s' is also defined externally", first.Kind, first.Name),
 					Pos:     posFromSource(first.Source),
+					EndPos:  endPosFromNode(first.Node),
 					Notes:   []string{fmt.Sprintf("also defined at %s", sourceString(ext.Source))},
 				})
 			}

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -703,10 +703,11 @@ var AnalyzerUnusedVariable = &Analyzer{
 				continue
 			}
 			pass.Report(Diagnostic{
-				Message: fmt.Sprintf("unused %s: %s", sym.Kind, sym.Name),
-				Pos:     posFromSource(sym.Source),
-				EndPos:  endPosFromNode(sym.Node),
-				Notes:   []string{fmt.Sprintf("if '%s' is intentionally unused, prefix it with '_'", sym.Name)},
+				Message:     fmt.Sprintf("unused %s: %s", sym.Kind, sym.Name),
+				Pos:         posFromSource(sym.Source),
+				EndPos:      endPosFromNode(sym.Node),
+				Notes:       []string{fmt.Sprintf("if '%s' is intentionally unused, prefix it with '_'", sym.Name)},
+				Unnecessary: true,
 			})
 		}
 		return nil
@@ -761,10 +762,11 @@ var AnalyzerUnusedFunction = &Analyzer{
 				}
 			}
 			pass.Report(Diagnostic{
-				Message: fmt.Sprintf("unused %s: %s", sym.Kind, sym.Name),
-				Pos:     posFromSource(sym.Source),
-				EndPos:  endPosFromNode(sym.Node),
-				Notes:   []string{"if this is a public API, add it to an (export ...) form"},
+				Message:     fmt.Sprintf("unused %s: %s", sym.Kind, sym.Name),
+				Pos:         posFromSource(sym.Source),
+				EndPos:      endPosFromNode(sym.Node),
+				Notes:       []string{"if this is a public API, add it to an (export ...) form"},
+				Unnecessary: true,
 			})
 		}
 		return nil
@@ -921,11 +923,18 @@ var AnalyzerUndefinedSymbol = &Analyzer{
 			return nil
 		}
 		for _, u := range pass.Semantics.Unresolved {
+			sev := SeverityError
+			notes := []string{fmt.Sprintf("'%s' is not defined in any enclosing scope; did you mean a different name?", u.Name)}
+			if u.InsideMacroCall {
+				sev = SeverityWarning
+				notes = append(notes, "inside a macro call — the macro may introduce this binding at expansion time")
+			}
 			pass.Report(Diagnostic{
-				Message: fmt.Sprintf("undefined symbol: %s", u.Name),
-				Pos:     posFromSource(u.Source),
-				EndPos:  endPosFromNode(u.Node),
-				Notes:   []string{fmt.Sprintf("'%s' is not defined in any enclosing scope; did you mean a different name?", u.Name)},
+				Severity: sev,
+				Message:  fmt.Sprintf("undefined symbol: %s", u.Name),
+				Pos:      posFromSource(u.Source),
+				EndPos:   endPosFromNode(u.Node),
+				Notes:    notes,
 			})
 		}
 		return nil

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -233,6 +233,10 @@ type Diagnostic struct {
 
 	// Notes are optional hint text lines for the user.
 	Notes []string `json:"notes,omitempty"`
+
+	// Unnecessary marks the diagnostic as "unnecessary" code (e.g., unused
+	// variables). Editors may render these with faded text.
+	Unnecessary bool `json:"unnecessary,omitempty"`
 }
 
 // Position identifies a location in source code.

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -374,7 +374,9 @@ func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
 		DefaultPackage: prescan.DefaultPackage,
 	}
 
-	// Build workspace refs so lint analyzers can check cross-file references.
+	// Build workspace refs so lint analyzers (e.g. unused-function) can check
+	// cross-file references. This re-parses workspace files — acceptable for
+	// CLI lint runs (typically <1s for ~100 files).
 	acfg.WorkspaceRefs = analysis.ScanWorkspaceRefs(cfg.Workspace, acfg, scanCfg)
 
 	return acfg, nil

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -366,13 +366,18 @@ func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
 		pkgExports[pkg] = append(pkgExports[pkg], wsSyms...)
 	}
 
-	return &analysis.Config{
+	acfg := &analysis.Config{
 		ExtraGlobals:   prescan.ExportedGlobals,
 		PackageExports: pkgExports,
 		DefForms:       prescan.DefForms,
 		PackageImports: prescan.PackageImports,
 		DefaultPackage: prescan.DefaultPackage,
-	}, nil
+	}
+
+	// Build workspace refs so lint analyzers can check cross-file references.
+	acfg.WorkspaceRefs = analysis.ScanWorkspaceRefs(cfg.Workspace, acfg, scanCfg)
+
+	return acfg, nil
 }
 
 // defaultStdlibExports creates a temporary ELPS env, loads the standard

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -371,6 +371,7 @@ func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
 		PackageExports: pkgExports,
 		DefForms:       prescan.DefForms,
 		PackageImports: prescan.PackageImports,
+		DefaultPackage: prescan.DefaultPackage,
 	}, nil
 }
 

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1876,6 +1876,54 @@ func TestUnusedFunction_HasNotes(t *testing.T) {
 	assert.Contains(t, diags[0].Notes[0], "export")
 }
 
+func TestUnusedFunction_Negative_CrossFileRef(t *testing.T) {
+	// Function with 0 local refs but a cross-file ref should NOT be flagged.
+	source := `(defun helper () 42)`
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerUnusedFunction}}
+	// The symbol ends up in "user" package (default for bare source).
+	helperKey := analysis.SymbolKey{Package: "user", Name: "helper", Kind: analysis.SymFunction}.String()
+	cfg := &analysis.Config{
+		ExtraGlobals: []analysis.ExternalSymbol{
+			{Name: "helper", Kind: analysis.SymFunction},
+		},
+		WorkspaceRefs: map[string][]analysis.FileReference{
+			helperKey: {
+				{File: "/other/file.lisp"}, // referenced from another file
+			},
+		},
+	}
+	diags, err := l.LintFileWithAnalysis([]byte(source), "test.lisp", cfg)
+	require.NoError(t, err)
+	assertNoDiags(t, diags)
+}
+
+func TestUnusedFunction_Positive_OnlySameFileRef(t *testing.T) {
+	// Workspace refs exist but only from the same file — still unused.
+	source := `(defun helper () 42)`
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerUnusedFunction}}
+	helperKey := analysis.SymbolKey{Package: "user", Name: "helper", Kind: analysis.SymFunction}.String()
+	cfg := &analysis.Config{
+		ExtraGlobals: []analysis.ExternalSymbol{
+			{Name: "helper", Kind: analysis.SymFunction},
+		},
+		WorkspaceRefs: map[string][]analysis.FileReference{
+			helperKey: {
+				{File: "test.lisp"}, // same file — doesn't count
+			},
+		},
+	}
+	diags, err := l.LintFileWithAnalysis([]byte(source), "test.lisp", cfg)
+	require.NoError(t, err)
+	assert.Len(t, diags, 1, "same-file refs don't count as cross-file usage")
+}
+
+func TestUnusedFunction_Positive_NoWorkspaceRefs(t *testing.T) {
+	// Without workspace refs, still flagged (existing behavior).
+	source := `(defun helper () 42)`
+	diags := lintCheckSemantic(t, AnalyzerUnusedFunction, source)
+	assert.Len(t, diags, 1)
+}
+
 // --- shadowing ---
 
 func TestShadowing_Negative_ParamShadowsBuiltin(t *testing.T) {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -2055,6 +2055,60 @@ func TestUserArity_HasEndPos(t *testing.T) {
 	assert.Equal(t, 8, diags[0].EndPos.Col) // end of "(add 1)"
 }
 
+func TestUndefinedSymbol_Warning_InsideMacroBody(t *testing.T) {
+	// Unresolved symbols inside user-defined macro bodies should be
+	// warnings, not errors — the macro may introduce bindings.
+	source := `(my-macro (+ x 1))`
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerUndefinedSymbol}}
+	cfg := &analysis.Config{
+		ExtraGlobals: []analysis.ExternalSymbol{
+			{Name: "my-macro", Kind: analysis.SymMacro, Package: "user",
+				Source: &token.Location{File: "macros.lisp", Line: 1, Col: 1, Pos: 0}},
+		},
+	}
+	diags, err := l.LintFileWithAnalysis([]byte(source), "test.lisp", cfg)
+	require.NoError(t, err)
+	// x is unresolved but inside a user-macro call → warning not error
+	var xDiag *Diagnostic
+	for i := range diags {
+		for _, note := range diags[i].Notes {
+			if strings.Contains(note, "macro") {
+				xDiag = &diags[i]
+				break
+			}
+		}
+	}
+	require.NotNil(t, xDiag, "should have a diagnostic for x inside macro body")
+	assert.Equal(t, SeverityWarning, xDiag.Severity, "inside macro body should be warning, not error")
+}
+
+func TestUndefinedSymbol_Error_InsideBuiltinMacro(t *testing.T) {
+	// Unresolved symbols inside builtin macro bodies (defun) should
+	// still be errors — builtin macros have known semantics.
+	source := `(defun f () (unknown-fn 42))`
+	diags := lintCheckSemantic(t, AnalyzerUndefinedSymbol, source)
+	require.Len(t, diags, 1)
+	assert.Equal(t, SeverityError, diags[0].Severity)
+}
+
+func TestUndefinedSymbol_Error_InsideFunctionCall(t *testing.T) {
+	// Unresolved symbols inside regular function calls should still be errors.
+	source := `(my-fn (+ x 1))`
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerUndefinedSymbol}}
+	cfg := &analysis.Config{
+		ExtraGlobals: []analysis.ExternalSymbol{
+			{Name: "my-fn", Kind: analysis.SymFunction, Package: "user",
+				Source: &token.Location{File: "funcs.lisp", Line: 1, Col: 1, Pos: 0}},
+		},
+	}
+	diags, err := l.LintFileWithAnalysis([]byte(source), "test.lisp", cfg)
+	require.NoError(t, err)
+	for _, d := range diags {
+		assert.Equal(t, SeverityError, d.Severity,
+			"undefined symbol inside function call should be error, not warning")
+	}
+}
+
 func TestShadowing_Negative_ExternalSymbol(t *testing.T) {
 	// Parameters should not trigger shadowing when the outer symbol
 	// is from an external source (workspace scan / package import).

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -2109,6 +2109,90 @@ func TestUndefinedSymbol_Error_InsideFunctionCall(t *testing.T) {
 	}
 }
 
+func TestDiagnosticRanges_IssueExample(t *testing.T) {
+	// Reproduce issue #251: multiple diagnostics on nearby lines.
+	// Each diagnostic's Pos must point to its own token, and EndPos
+	// must produce a valid non-zero-width range.
+	source := `(in-package 'myapp)
+(use-package 'testing)
+
+(defun run-test ()
+  (let* ((unused-var (+ 1 2)))
+    (some-macro
+      (sorted-map "result" (equal? binding-a "expected")))))`
+
+	l := &Linter{Analyzers: DefaultAnalyzers()}
+	cfg := &analysis.Config{
+		ExtraGlobals: []analysis.ExternalSymbol{
+			{Name: "some-macro", Kind: analysis.SymMacro, Package: "myapp",
+				Source: &token.Location{File: "macros.lisp", Line: 1, Col: 1, Pos: 0}},
+		},
+		PackageExports: map[string][]analysis.ExternalSymbol{
+			"testing": {{Name: "assert-equal", Kind: analysis.SymFunction, Package: "testing"}},
+		},
+		PackageImports: map[string][]string{
+			"myapp": {"testing"},
+		},
+	}
+	diags, err := l.LintFileWithAnalysis([]byte(source), "test.lisp", cfg)
+	require.NoError(t, err)
+
+	// Log all diagnostics for debugging.
+	for _, d := range diags {
+		t.Logf("[%s] %s at line=%d col=%d endLine=%d endCol=%d: %s",
+			d.Severity, d.Analyzer, d.Pos.Line, d.Pos.Col,
+			d.EndPos.Line, d.EndPos.Col, d.Message)
+	}
+
+	// Every diagnostic must have a valid position.
+	for _, d := range diags {
+		assert.True(t, d.Pos.Line > 0,
+			"diagnostic %q should have Pos.Line > 0", d.Message)
+		assert.True(t, d.Pos.Col > 0,
+			"diagnostic %q should have Pos.Col > 0", d.Message)
+	}
+
+	// Every diagnostic with EndPos set must have EndPos >= Pos (not inverted).
+	for _, d := range diags {
+		if d.EndPos.Line > 0 {
+			if d.EndPos.Line == d.Pos.Line {
+				assert.True(t, d.EndPos.Col >= d.Pos.Col,
+					"diagnostic %q has inverted range: Pos.Col=%d > EndPos.Col=%d",
+					d.Message, d.Pos.Col, d.EndPos.Col)
+			}
+			assert.True(t, d.EndPos.Line >= d.Pos.Line,
+				"diagnostic %q has inverted range: Pos.Line=%d > EndPos.Line=%d",
+				d.Message, d.Pos.Line, d.EndPos.Line)
+		}
+	}
+
+	// No two diagnostics should have exactly the same Pos (they'd overlap in VS Code).
+	seen := make(map[string]string)
+	for _, d := range diags {
+		key := fmt.Sprintf("%d:%d", d.Pos.Line, d.Pos.Col)
+		if prev, ok := seen[key]; ok {
+			t.Errorf("diagnostics overlap at %s: %q and %q", key, prev, d.Message)
+		}
+		seen[key] = d.Message
+	}
+
+	// Verify each diagnostic points to the correct token in the source.
+	lines := strings.Split(source, "\n")
+	for _, d := range diags {
+		if d.Pos.Line > 0 && d.Pos.Line <= len(lines) && d.EndPos.Line > 0 && d.EndPos.Line <= len(lines) {
+			line := lines[d.Pos.Line-1]
+			if d.Pos.Col > 0 && d.EndPos.Col > 0 && d.Pos.Line == d.EndPos.Line {
+				startCol := d.Pos.Col - 1
+				endCol := d.EndPos.Col - 1
+				if endCol <= len(line) {
+					token := line[startCol:endCol]
+					t.Logf("  → token at range: %q", token)
+				}
+			}
+		}
+	}
+}
+
 func TestShadowing_Negative_ExternalSymbol(t *testing.T) {
 	// Parameters should not trigger shadowing when the outer symbol
 	// is from an external source (workspace scan / package import).

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1926,6 +1926,28 @@ func TestUnusedFunction_Positive_NoWorkspaceRefs(t *testing.T) {
 
 // --- shadowing ---
 
+func TestUnusedFunction_Negative_CrossFileRef_WithDefaultPackage(t *testing.T) {
+	// Bare file with DefaultPackage set — symbol ends up in "svc" package.
+	// WorkspaceRefs key must match the "svc" package for cross-file check.
+	source := `(defun helper () 42)`
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerUnusedFunction}}
+	helperKey := analysis.SymbolKey{Package: "svc", Name: "helper", Kind: analysis.SymFunction}.String()
+	cfg := &analysis.Config{
+		DefaultPackage: "svc",
+		ExtraGlobals: []analysis.ExternalSymbol{
+			{Name: "helper", Kind: analysis.SymFunction, Package: "svc"},
+		},
+		WorkspaceRefs: map[string][]analysis.FileReference{
+			helperKey: {
+				{File: "/other/file.lisp"},
+			},
+		},
+	}
+	diags, err := l.LintFileWithAnalysis([]byte(source), "test.lisp", cfg)
+	require.NoError(t, err)
+	assertNoDiags(t, diags)
+}
+
 func TestShadowing_Negative_ParamShadowsBuiltin(t *testing.T) {
 	// Parameters shadowing builtins should not be reported — names like
 	// car, map, expr are commonly used as parameter names.
@@ -2023,13 +2045,14 @@ func TestUndefinedSymbol_HasEndPos(t *testing.T) {
 }
 
 func TestUserArity_HasEndPos(t *testing.T) {
+	// "(add 1)" on line 2 — SourceOf returns the s-expression starting at col 1.
 	source := "(defun add (x y) (+ x y))\n(add 1)"
 	diags := lintCheckSemantic(t, AnalyzerUserArity, source)
 	require.Len(t, diags, 1)
-	assert.True(t, diags[0].Pos.Line > 0, "Pos should be set")
-	assert.True(t, diags[0].Pos.Col > 0, "Pos.Col should be set")
-	assert.True(t, diags[0].EndPos.Line > 0, "EndPos should be set")
-	assert.True(t, diags[0].EndPos.Col > 0, "EndPos.Col should be set")
+	assert.Equal(t, 2, diags[0].Pos.Line)
+	assert.Equal(t, 1, diags[0].Pos.Col)
+	assert.Equal(t, 2, diags[0].EndPos.Line)
+	assert.Equal(t, 8, diags[0].EndPos.Col) // end of "(add 1)"
 }
 
 func TestShadowing_Negative_ExternalSymbol(t *testing.T) {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1963,6 +1963,27 @@ func TestShadowing_DiagnosticPosition_NestedLambda(t *testing.T) {
 	assert.Equal(t, 26, diags[0].EndPos.Col) // 25 + len("x") = 26
 }
 
+func TestUndefinedSymbol_HasEndPos(t *testing.T) {
+	source := `(defun f () (unknown-fn 42))`
+	diags := lintCheckSemantic(t, AnalyzerUndefinedSymbol, source)
+	require.Len(t, diags, 1)
+	// "unknown-fn" starts at col 14: "(defun f () (" = 13 chars, then "unknown-fn"
+	assert.Equal(t, 1, diags[0].Pos.Line)
+	assert.Equal(t, 14, diags[0].Pos.Col)
+	assert.Equal(t, 1, diags[0].EndPos.Line)
+	assert.Equal(t, 24, diags[0].EndPos.Col) // 14 + len("unknown-fn") = 24
+}
+
+func TestUserArity_HasEndPos(t *testing.T) {
+	source := "(defun add (x y) (+ x y))\n(add 1)"
+	diags := lintCheckSemantic(t, AnalyzerUserArity, source)
+	require.Len(t, diags, 1)
+	assert.True(t, diags[0].Pos.Line > 0, "Pos should be set")
+	assert.True(t, diags[0].Pos.Col > 0, "Pos.Col should be set")
+	assert.True(t, diags[0].EndPos.Line > 0, "EndPos should be set")
+	assert.True(t, diags[0].EndPos.Col > 0, "EndPos.Col should be set")
+}
+
 func TestShadowing_Negative_ExternalSymbol(t *testing.T) {
 	// Parameters should not trigger shadowing when the outer symbol
 	// is from an external source (workspace scan / package import).

--- a/lsp/diagnostics.go
+++ b/lsp/diagnostics.go
@@ -220,13 +220,17 @@ func convertLintDiagnostic(d lint.Diagnostic) protocol.Diagnostic {
 		end = protocol.Position{Line: safeUint(endLine), Character: safeUint(endCol)}
 	}
 	sev := mapLintSeverity(d.Severity)
-	return protocol.Diagnostic{
+	diag := protocol.Diagnostic{
 		Range:    protocol.Range{Start: start, End: end},
 		Severity: &sev,
 		Source:   strPtr("elps-lint"),
 		Code:     &protocol.IntegerOrString{Value: d.Analyzer},
 		Message:  d.Message,
 	}
+	if d.Unnecessary {
+		diag.Tags = []protocol.DiagnosticTag{protocol.DiagnosticTagUnnecessary}
+	}
+	return diag
 }
 
 // mapLintSeverity converts a lint.Severity to a protocol.DiagnosticSeverity.

--- a/lsp/hover.go
+++ b/lsp/hover.go
@@ -59,7 +59,29 @@ func (s *Server) textDocumentHover(_ *glsp.Context, params *protocol.HoverParams
 		}, nil
 	}
 
+	// Fallback: language keywords (not callable, but used in special contexts).
+	if content, ok := keywordDocs[word]; ok {
+		return &protocol.Hover{
+			Contents: protocol.MarkupContent{
+				Kind:  protocol.MarkupKindMarkdown,
+				Value: content,
+			},
+		}, nil
+	}
+
 	return nil, nil
+}
+
+// keywordDocs provides hover documentation for language keywords that are
+// not registered as callable symbols but appear in source code.
+var keywordDocs = map[string]string{
+	"&rest":             "**&rest** — variadic parameter marker\n\nMarks the start of a variadic parameter in a formal argument list. The parameter after `&rest` collects all remaining arguments into a list.\n\n```lisp\n(defun f (x &rest args) args)\n```",
+	"&optional":         "**&optional** — optional parameter marker\n\nMarks the start of optional parameters in a formal argument list. Optional parameters are bound to `()` if not provided.\n\n```lisp\n(defun f (x &optional y) y)\n```",
+	"&key":              "**&key** — keyword parameter marker\n\nMarks the start of keyword parameters in a formal argument list. Keyword arguments are passed as `:name value` pairs.\n\n```lisp\n(defun f (&key x y) (list x y))\n```",
+	"unquote":           "**unquote** — evaluate inside quasiquote\n\nEvaluates an expression inside a `quasiquote` template. The result replaces the `unquote` form. Only valid inside `(quasiquote ...)`.\n\n```lisp\n(quasiquote (list (unquote x)))\n```",
+	"unquote-splicing":  "**unquote-splicing** — evaluate and splice inside quasiquote\n\nEvaluates an expression inside a `quasiquote` template and splices the result list into the parent. The expression must evaluate to a list.\n\n```lisp\n(quasiquote (list (unquote-splicing items)))\n```",
+	"condition":         "**condition** — catch-all error type\n\nUsed as the error type in a `handler-bind` clause to match any error.\n\n```lisp\n(handler-bind ((condition (lambda (e) e))) body)\n```",
+	"else":              "**else** — catch-all cond clause\n\nWhen used as the test in the last `cond` clause, it always matches.\n\n```lisp\n(cond ((= x 1) \"one\") (else \"other\"))\n```",
 }
 
 // qualifiedSymbolHover looks up a qualified symbol (e.g. "string:join") in

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -3538,6 +3538,103 @@ func TestHover_AllKeywords(t *testing.T) {
 	}
 }
 
+// --- Diagnostic position tests (issue #251) ---
+
+func TestDiagnosticPositions_Issue251_Repro(t *testing.T) {
+	// Minimal repro from issue #251: two diagnostics in the same file.
+	// "View Problem" on the warning at line 1 jumps to the error at line 4.
+	// Verify the LSP diagnostic ranges are correct and distinct.
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'test)
+(load-file "bug.lisp")
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bug.lisp"), []byte(
+		"(defun unused-fn () 42)\n\n(defun caller ()\n  (not 1 2 3))\n",
+	), 0600))
+
+	s := testServer()
+	s.rootPath = dir
+	s.buildWorkspaceIndex()
+
+	bugURI := pathToURI(filepath.Join(dir, "bug.lisp"))
+	bugSrc := "(defun unused-fn () 42)\n\n(defun caller ()\n  (not 1 2 3))\n"
+	doc := openDoc(s, bugURI, bugSrc)
+	s.ensureAnalysis(doc)
+
+	// Run the full LSP diagnostic pipeline.
+	lintDiags, err := s.linter.LintFileWithContext(
+		[]byte(bugSrc), uriToPath(bugURI), doc.analysis)
+	require.NoError(t, err)
+
+	// Convert to LSP protocol diagnostics (same as analyzeAndPublish).
+	var protoDiags []protocol.Diagnostic
+	for _, d := range lintDiags {
+		protoDiags = append(protoDiags, convertLintDiagnostic(d))
+	}
+
+	t.Logf("Total LSP diagnostics: %d", len(protoDiags))
+	for i, d := range protoDiags {
+		sev := "?"
+		if d.Severity != nil {
+			switch *d.Severity {
+			case protocol.DiagnosticSeverityError:
+				sev = "error"
+			case protocol.DiagnosticSeverityWarning:
+				sev = "warning"
+			case protocol.DiagnosticSeverityInformation:
+				sev = "info"
+			case protocol.DiagnosticSeverityHint:
+				sev = "hint"
+			}
+		}
+		code := ""
+		if d.Code != nil {
+			code = fmt.Sprintf("%v", d.Code.Value)
+		}
+		t.Logf("  [%d] %s (%s) L%d:C%d-L%d:C%d tags=%v: %s",
+			i, sev, code,
+			d.Range.Start.Line, d.Range.Start.Character,
+			d.Range.End.Line, d.Range.End.Character,
+			d.Tags, d.Message)
+	}
+
+	// Find the two key diagnostics by message content.
+	var unusedDiag, arityDiag *protocol.Diagnostic
+	for i := range protoDiags {
+		switch {
+		case strings.Contains(protoDiags[i].Message, "unused-fn"):
+			unusedDiag = &protoDiags[i]
+		case strings.Contains(protoDiags[i].Message, "not accepts"):
+			arityDiag = &protoDiags[i]
+		}
+	}
+
+	require.NotNil(t, unusedDiag, "should have unused-function diagnostic")
+	require.NotNil(t, arityDiag, "should have builtin-arity diagnostic")
+
+	// The unused-fn warning must be at line 0 (0-based), NOT at the arity error's line.
+	assert.Equal(t, protocol.UInteger(0), unusedDiag.Range.Start.Line,
+		"unused-fn warning should be at line 0 (0-based)")
+	assert.Equal(t, protocol.UInteger(3), arityDiag.Range.Start.Line,
+		"not arity error should be at line 3 (0-based)")
+
+	// Ranges must not overlap or point to same location.
+	assert.NotEqual(t, unusedDiag.Range.Start.Line, arityDiag.Range.Start.Line,
+		"diagnostics should be on different lines")
+
+	// Ranges must be non-zero-width.
+	assert.NotEqual(t, unusedDiag.Range.Start, unusedDiag.Range.End,
+		"unused-fn diagnostic should have non-zero-width range")
+	assert.NotEqual(t, arityDiag.Range.Start, arityDiag.Range.End,
+		"arity diagnostic should have non-zero-width range")
+
+	// The unused diagnostic must have the Unnecessary tag.
+	assert.Contains(t, unusedDiag.Tags, protocol.DiagnosticTagUnnecessary,
+		"unused-fn should have Unnecessary tag")
+}
+
 // --- Inlay hint tests ---
 
 func TestInlayHint_Basic(t *testing.T) {

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -3496,6 +3496,66 @@ func TestCrossFileUsePackage(t *testing.T) {
 	}
 }
 
+func TestHover_Keyword_Rest(t *testing.T) {
+	s := testServer()
+	content := `(defun foo (&rest args) args)`
+	doc := openDoc(s, "file:///test.lisp", content)
+	s.ensureAnalysis(doc)
+
+	// Hover on "&rest" at col 12 (0-based).
+	hover, err := s.textDocumentHover(nil, &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 0, Character: 12},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, hover, "&rest should have hover docs")
+	mc, ok := hover.Contents.(protocol.MarkupContent)
+	require.True(t, ok)
+	assert.Contains(t, mc.Value, "variadic parameter")
+}
+
+func TestHover_Keyword_Unquote(t *testing.T) {
+	s := testServer()
+	content := `(quasiquote (list (unquote x)))`
+	doc := openDoc(s, "file:///test.lisp", content)
+	s.ensureAnalysis(doc)
+
+	// Hover on "unquote" at col 19 (0-based).
+	hover, err := s.textDocumentHover(nil, &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 0, Character: 19},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, hover, "unquote should have hover docs")
+	mc, ok := hover.Contents.(protocol.MarkupContent)
+	require.True(t, ok)
+	assert.Contains(t, mc.Value, "quasiquote")
+}
+
+func TestHover_Keyword_Condition(t *testing.T) {
+	s := testServer()
+	content := `(handler-bind ((condition (lambda (e) e))) 1)`
+	doc := openDoc(s, "file:///test.lisp", content)
+	s.ensureAnalysis(doc)
+
+	// Hover on "condition" at col 16 (0-based).
+	hover, err := s.textDocumentHover(nil, &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 0, Character: 16},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, hover, "condition should have hover docs")
+	mc, ok := hover.Contents.(protocol.MarkupContent)
+	require.True(t, ok)
+	assert.Contains(t, mc.Value, "handler-bind")
+}
+
 // --- Inlay hint tests ---
 
 func TestInlayHint_Basic(t *testing.T) {

--- a/lsp/lsp_test.go
+++ b/lsp/lsp_test.go
@@ -162,6 +162,11 @@ func TestWordAtPosition(t *testing.T) {
 		assert.Equal(t, "*global*", wordAtPosition("*global*", 0, 0))
 		assert.Equal(t, "set!", wordAtPosition("(set! x 1)", 0, 1))
 	})
+	t.Run("ampersand keywords", func(t *testing.T) {
+		assert.Equal(t, "&rest", wordAtPosition("(defun f (&rest args) args)", 0, 10))
+		assert.Equal(t, "&optional", wordAtPosition("(defun f (&optional x) x)", 0, 10))
+		assert.Equal(t, "&key", wordAtPosition("(defun f (&key x) x)", 0, 10))
+	})
 }
 
 // --- Document store tests ---
@@ -3496,64 +3501,41 @@ func TestCrossFileUsePackage(t *testing.T) {
 	}
 }
 
-func TestHover_Keyword_Rest(t *testing.T) {
-	s := testServer()
-	content := `(defun foo (&rest args) args)`
-	doc := openDoc(s, "file:///test.lisp", content)
-	s.ensureAnalysis(doc)
+func TestHover_AllKeywords(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		col     uint32
+		expect  string
+	}{
+		{"&rest", `(defun f (&rest args) args)`, 10, "variadic"},
+		{"&optional", `(defun f (&optional x) x)`, 10, "optional"},
+		{"&key", `(defun f (&key x) x)`, 10, "keyword"},
+		{"unquote", `(quasiquote (list (unquote x)))`, 19, "quasiquote"},
+		{"unquote-splicing", `(quasiquote (list (unquote-splicing xs)))`, 19, "splices"},
+		{"condition", `(handler-bind ((condition (lambda (e) e))) 1)`, 16, "handler-bind"},
+		{"else", `(cond ((= x 1) "one") (else "other"))`, 23, "cond"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := testServer()
+			doc := openDoc(s, "file:///test.lisp", tt.content)
+			s.ensureAnalysis(doc)
 
-	// Hover on "&rest" at col 12 (0-based).
-	hover, err := s.textDocumentHover(nil, &protocol.HoverParams{
-		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
-			Position:     protocol.Position{Line: 0, Character: 12},
-		},
-	})
-	require.NoError(t, err)
-	require.NotNil(t, hover, "&rest should have hover docs")
-	mc, ok := hover.Contents.(protocol.MarkupContent)
-	require.True(t, ok)
-	assert.Contains(t, mc.Value, "variadic parameter")
-}
-
-func TestHover_Keyword_Unquote(t *testing.T) {
-	s := testServer()
-	content := `(quasiquote (list (unquote x)))`
-	doc := openDoc(s, "file:///test.lisp", content)
-	s.ensureAnalysis(doc)
-
-	// Hover on "unquote" at col 19 (0-based).
-	hover, err := s.textDocumentHover(nil, &protocol.HoverParams{
-		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
-			Position:     protocol.Position{Line: 0, Character: 19},
-		},
-	})
-	require.NoError(t, err)
-	require.NotNil(t, hover, "unquote should have hover docs")
-	mc, ok := hover.Contents.(protocol.MarkupContent)
-	require.True(t, ok)
-	assert.Contains(t, mc.Value, "quasiquote")
-}
-
-func TestHover_Keyword_Condition(t *testing.T) {
-	s := testServer()
-	content := `(handler-bind ((condition (lambda (e) e))) 1)`
-	doc := openDoc(s, "file:///test.lisp", content)
-	s.ensureAnalysis(doc)
-
-	// Hover on "condition" at col 16 (0-based).
-	hover, err := s.textDocumentHover(nil, &protocol.HoverParams{
-		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
-			Position:     protocol.Position{Line: 0, Character: 16},
-		},
-	})
-	require.NoError(t, err)
-	require.NotNil(t, hover, "condition should have hover docs")
-	mc, ok := hover.Contents.(protocol.MarkupContent)
-	require.True(t, ok)
-	assert.Contains(t, mc.Value, "handler-bind")
+			hover, err := s.textDocumentHover(nil, &protocol.HoverParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+					Position:     protocol.Position{Line: 0, Character: tt.col},
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, hover, "%s should have hover docs", tt.name)
+			mc, ok := hover.Contents.(protocol.MarkupContent)
+			require.True(t, ok)
+			assert.Contains(t, mc.Value, tt.expect,
+				"%s hover should contain %q", tt.name, tt.expect)
+		})
+	}
 }
 
 // --- Inlay hint tests ---

--- a/lsp/position.go
+++ b/lsp/position.go
@@ -145,7 +145,7 @@ func isSymbolChar(c byte) bool {
 		return true
 	}
 	switch c {
-	case '-', '_', '!', '?', '+', '*', '/', '<', '>', '=', ':', '.', '#', '^':
+	case '-', '_', '!', '?', '+', '*', '/', '<', '>', '=', ':', '.', '#', '^', '&':
 		return true
 	}
 	return false

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -372,17 +372,20 @@ func (s *Server) buildWorkspaceIndex() {
 		DefaultPackage: defaultPackage,
 	}
 
-	s.analysisCfgMu.Lock()
-	s.analysisCfg = cfg
-	s.analysisCfgMu.Unlock()
-
 	// Build workspace reference index using the populated config.
+	// Set it on the config so per-file analysis (and lint analyzers)
+	// can check cross-file references.
 	if s.rootPath != "" {
 		wsRefs := analysis.ScanWorkspaceRefs(s.rootPath, cfg, scanCfg)
+		cfg.WorkspaceRefs = wsRefs
 		s.workspaceRefsMu.Lock()
 		s.workspaceRefs = wsRefs
 		s.workspaceRefsMu.Unlock()
 	}
+
+	s.analysisCfgMu.Lock()
+	s.analysisCfg = cfg
+	s.analysisCfgMu.Unlock()
 }
 
 // reanalyzeOpenDocuments invalidates cached analysis for all open documents
@@ -433,6 +436,7 @@ func (s *Server) getAnalysisConfig(uri string) *analysis.Config {
 		cfg.DefForms = base.DefForms
 		cfg.PackageImports = base.PackageImports
 		cfg.DefaultPackage = base.DefaultPackage
+		cfg.WorkspaceRefs = base.WorkspaceRefs
 	}
 	return cfg
 }

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -307,6 +307,7 @@ func (s *Server) buildWorkspaceIndex() {
 	var pkgExports map[string][]analysis.ExternalSymbol
 	var defForms []analysis.DefFormSpec
 	var packageImports map[string][]string
+	var defaultPackage string
 
 	// Build scan config from server options. MaxFileBytes uses its own
 	// default (not maxDocumentBytes) since document analysis limits and
@@ -325,6 +326,7 @@ func (s *Server) buildWorkspaceIndex() {
 			pkgExports = prescan.PkgExports
 			defForms = prescan.DefForms
 			packageImports = prescan.PackageImports
+			defaultPackage = prescan.DefaultPackage
 			if prescan.Truncated {
 				s.sendNotification("window/showMessage", &protocol.ShowMessageParams{
 					Type:    protocol.MessageTypeWarning,
@@ -367,6 +369,7 @@ func (s *Server) buildWorkspaceIndex() {
 		PackageExports: pkgExports,
 		DefForms:       defForms,
 		PackageImports: packageImports,
+		DefaultPackage: defaultPackage,
 	}
 
 	s.analysisCfgMu.Lock()
@@ -429,6 +432,7 @@ func (s *Server) getAnalysisConfig(uri string) *analysis.Config {
 		cfg.PackageExports = base.PackageExports
 		cfg.DefForms = base.DefForms
 		cfg.PackageImports = base.PackageImports
+		cfg.DefaultPackage = base.DefaultPackage
 	}
 	return cfg
 }


### PR DESCRIPTION
## Summary

Builds on PR #252 to address remaining issues from #250 and #251:

- **Load-tree package inference**: Walk `main.lisp`'s `load-file` chain to build a file→package map. Bare files inherit the package context from the load point.
- **Pre-in-package def remapping**: Defs before first `in-package` are remapped to load-tree package via `firstInPkgLine` tracking.
- **Cross-file unused-function detection**: Wire `WorkspaceRefs` through `Config → Result → lint Pass`. Checks cross-file references before flagging.
- **Macro-body undefined-symbol → warning**: Unresolved symbols inside user-defined macro bodies are warnings (not errors) since macros may introduce bindings at expansion time. Built-in macros still produce errors.
- **DiagnosticTag.Unnecessary**: Unused-variable/function diagnostics include `DiagnosticTag.Unnecessary` so VS Code renders them with faded text, visually distinguishing them from errors.
- **Keyword hover docs**: `&rest`, `&optional`, `&key`, `unquote`, `unquote-splicing`, `condition`, `else`.
- **EndPos on all diagnostics**: 15 diagnostics across 12 analyzers.
- **`lisp.DefaultUserPackage` constant**: Replace all hardcoded `"user"` strings. Document default package in `docs/lang.md`.

Closes #250
Closes #251

## Test plan

- [x] Load tree: `TestBuildLoadTree_Basic/PackageSwitch/Nested/CycleDetection`
- [x] Package inference: `TestPrescanWorkspace_DefaultPackage/ExplicitUserPackageNotRemapped/NoMainLisp/DefsBeforeInPackage/PhylumPattern`
- [x] Cross-file resolution: `TestAnalyze_DefaultPackage_BareFile`, `TestAnalyze_DefsBeforeInPackage_Resolve`
- [x] Unused-function: `TestUnusedFunction_Negative_CrossFileRef` + `_WithDefaultPackage` + `_Positive_OnlySameFileRef` + `_NoWorkspaceRefs`
- [x] Macro-body severity: `TestUndefinedSymbol_Warning_InsideMacroBody`, `_Error_InsideBuiltinMacro`, `_Error_InsideFunctionCall`
- [x] Hover: `TestHover_AllKeywords` (7 subtests) + `TestWordAtPosition/ampersand_keywords`
- [x] EndPos: `TestUndefinedSymbol_HasEndPos` + `TestUserArity_HasEndPos` (exact positions)
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)