### PR TITLE
fix: resolve quasiquote template symbols as references

### DIFF
--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -666,6 +666,40 @@ func TestAnalyze_Quasiquote_UnquoteInBracketList(t *testing.T) {
 	t.Fatal("parameter patt not found in symbols")
 }
 
+func TestAnalyze_Quasiquote_TemplateFunctionReference(t *testing.T) {
+	// A function used inside a quasiquote template should be counted as
+	// referenced, even though the template is data. This prevents false
+	// "unused function" warnings for functions called in macro-generated code.
+	result := parseAndAnalyze(t, `
+(defun helper () 42)
+
+(defmacro my-macro (x)
+  (quasiquote
+    (begin
+      (helper)
+      (unquote x))))`)
+	var helperSym *Symbol
+	for _, sym := range result.Symbols {
+		if sym.Name == "helper" && sym.Kind == SymFunction {
+			helperSym = sym
+			break
+		}
+	}
+	require.NotNil(t, helperSym, "helper function should be in symbols")
+	assert.Greater(t, helperSym.References, 0,
+		"helper should be referenced via quasiquote template")
+	assert.Empty(t, result.Unresolved,
+		"template symbols that resolve should not produce unresolved entries")
+}
+
+func TestAnalyze_Quasiquote_TemplateUnknownNoUnresolved(t *testing.T) {
+	// Unknown symbols in quasiquote templates must NOT produce unresolved
+	// entries — they may be introduced at macro expansion time.
+	result := parseAndAnalyze(t, `(quasiquote (unknown-fn x y))`)
+	assert.Empty(t, result.Unresolved,
+		"quasiquote template should not produce unresolved symbols")
+}
+
 // --- Analyze: reference counting ---
 
 func TestAnalyze_ReferenceCount(t *testing.T) {

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -623,8 +623,9 @@ func TestAnalyze_PrefixLambda_UnqualifiedExpr(t *testing.T) {
 
 // --- Analyze: quasiquote ---
 
-func TestAnalyze_Quasiquote_TemplateIgnored(t *testing.T) {
-	// Symbols inside quasiquote template are data, not code references
+func TestAnalyze_Quasiquote_TemplateUnknownNotUnresolved(t *testing.T) {
+	// Unknown symbols in quasiquote templates must NOT produce unresolved
+	// entries — they may be introduced at macro expansion time.
 	result := parseAndAnalyze(t, `(quasiquote (unknown-fn x y))`)
 	assert.Empty(t, result.Unresolved, "quasiquote template should not produce unresolved symbols")
 }
@@ -686,18 +687,30 @@ func TestAnalyze_Quasiquote_TemplateFunctionReference(t *testing.T) {
 		}
 	}
 	require.NotNil(t, helperSym, "helper function should be in symbols")
-	assert.Greater(t, helperSym.References, 0,
-		"helper should be referenced via quasiquote template")
+	assert.Equal(t, 1, helperSym.References,
+		"helper should be referenced exactly once via quasiquote template")
+	// Verify the Reference entry exists in the result slice too.
+	var found bool
+	for _, ref := range result.References {
+		if ref.Symbol.Name == "helper" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "result.References should contain an entry for helper")
 	assert.Empty(t, result.Unresolved,
 		"template symbols that resolve should not produce unresolved entries")
 }
 
-func TestAnalyze_Quasiquote_TemplateUnknownNoUnresolved(t *testing.T) {
-	// Unknown symbols in quasiquote templates must NOT produce unresolved
-	// entries — they may be introduced at macro expansion time.
-	result := parseAndAnalyze(t, `(quasiquote (unknown-fn x y))`)
-	assert.Empty(t, result.Unresolved,
-		"quasiquote template should not produce unresolved symbols")
+func TestAnalyze_Quasiquote_TemplateKeywordsSkipped(t *testing.T) {
+	// Keyword symbols (starting with :) in quasiquote templates should be
+	// skipped — they are data, not function/variable references.
+	result := parseAndAnalyze(t, `(quasiquote (my-fn :key 1 :value 2))`)
+	assert.Empty(t, result.Unresolved)
+	for _, ref := range result.References {
+		assert.NotEqual(t, ':', rune(ref.Symbol.Name[0]),
+			"keywords should not be resolved as references")
+	}
 }
 
 // --- Analyze: reference counting ---

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -1093,9 +1093,19 @@ func (a *analyzer) analyzeQuasiquote(node *lisp.LVal, scope *Scope, currentPkg s
 }
 
 // walkQuasiquoteTemplate walks a quasiquote template, only analyzing
-// expressions inside unquote and unquote-splicing forms.
+// expressions inside unquote and unquote-splicing forms. Bare symbols
+// in the template are resolved as references (to avoid false "unused"
+// warnings) but unknown symbols are not flagged as unresolved since
+// they may be introduced at macro expansion time.
 func (a *analyzer) walkQuasiquoteTemplate(node *lisp.LVal, scope *Scope, currentPkg string) {
 	if node == nil {
+		return
+	}
+	// Resolve bare symbols as template references without unresolved tracking.
+	if node.Type == lisp.LSymbol {
+		if !node.Quoted {
+			a.resolveTemplateSymbol(node, scope, currentPkg)
+		}
 		return
 	}
 	if node.Type != lisp.LSExpr || len(node.Cells) == 0 {
@@ -1263,4 +1273,41 @@ func (a *analyzer) resolveQualifiedSymbol(node *lisp.LVal, scope *Scope, pkgName
 		Source: node.Source,
 		Node:   node,
 	})
+}
+
+// resolveTemplateSymbol resolves a symbol inside a quasiquote template.
+// It increments References for known symbols but does NOT add to Unresolved
+// when the symbol is not found, since template symbols may be introduced
+// at macro expansion time.
+func (a *analyzer) resolveTemplateSymbol(node *lisp.LVal, scope *Scope, currentPkg string) {
+	if node.Type != lisp.LSymbol {
+		return
+	}
+	name := node.Str
+
+	// Skip keywords (start with :)
+	if len(name) > 0 && name[0] == ':' {
+		return
+	}
+
+	// Handle qualified symbols (contain :) — resolveQualifiedSymbol already
+	// returns silently when the package/symbol is not found.
+	for i := 1; i < len(name); i++ {
+		if name[i] == ':' {
+			a.resolveQualifiedSymbol(node, scope, name[:i], name[i+1:])
+			return
+		}
+	}
+
+	sym := scope.LookupInPackage(name, currentPkg)
+	if sym != nil {
+		sym.References++
+		a.result.References = append(a.result.References, &Reference{
+			Symbol: sym,
+			Source: node.Source,
+			Node:   node,
+		})
+	}
+	// Unlike resolveSymbol, we intentionally do NOT append to Unresolved here.
+	// Template symbols may refer to names introduced at macro expansion time.
 }

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1924,6 +1924,22 @@ func TestUnusedFunction_Positive_NoWorkspaceRefs(t *testing.T) {
 	assert.Len(t, diags, 1)
 }
 
+func TestUnusedFunction_Negative_UsedInQuasiquoteTemplate(t *testing.T) {
+	// A function referenced inside a defmacro's quasiquote template is
+	// used — the macro generates code that calls it. Must not be flagged.
+	source := `
+(defun get-valid-me () 42)
+
+(export 'my-macro)
+(defmacro my-macro (x)
+  (quasiquote
+    (begin
+      (get-valid-me)
+      (unquote x))))`
+	diags := lintCheckSemantic(t, AnalyzerUnusedFunction, source)
+	assertNoDiags(t, diags)
+}
+
 // --- shadowing ---
 
 func TestUnusedFunction_Negative_CrossFileRef_WithDefaultPackage(t *testing.T) {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1940,6 +1940,23 @@ func TestUnusedFunction_Negative_UsedInQuasiquoteTemplate(t *testing.T) {
 	assertNoDiags(t, diags)
 }
 
+func TestUnusedFunction_Positive_NotInQuasiquoteTemplate(t *testing.T) {
+	// A function that coexists with a defmacro but is NOT referenced in
+	// its quasiquote template should still be flagged as unused.
+	source := `
+(defun unused-helper () 99)
+
+(export 'my-macro)
+(defmacro my-macro (x)
+  (quasiquote
+    (begin
+      (other-fn)
+      (unquote x))))`
+	diags := lintCheckSemantic(t, AnalyzerUnusedFunction, source)
+	assert.Len(t, diags, 1)
+	assertHasDiag(t, diags, "unused function: unused-helper")
+}
+
 // --- shadowing ---
 
 func TestUnusedFunction_Negative_CrossFileRef_WithDefaultPackage(t *testing.T) {


### PR DESCRIPTION
## Summary
- Functions referenced inside `defmacro` quasiquote templates were falsely flagged as "unused" by the `unused-function` lint analyzer
- Added `resolveTemplateSymbol` that counts references for known symbols in templates without flagging unknown symbols as unresolved (they may be introduced at macro expansion time)
- Updated `walkQuasiquoteTemplate` to handle `LSymbol` nodes by calling the new resolver

Fixes #255

## Test plan
- [x] New analysis test: `TestAnalyze_Quasiquote_TemplateFunctionReference` — function used in template has References > 0
- [x] New analysis test: `TestAnalyze_Quasiquote_TemplateUnknownNoUnresolved` — unknown template symbols stay silent
- [x] New lint test: `TestUnusedFunction_Negative_UsedInQuasiquoteTemplate` — no false positive
- [x] All existing quasiquote tests still pass (template ignored, unquote analyzed, etc.)
- [x] Full `go test ./analysis/... ./lint/... ./lsp/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>