### PR TITLE
fix: resolve qualified symbols against all package defs, not just exports

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -22,6 +22,13 @@ type Config struct {
 	// Used to resolve use-package imports from stdlib and workspace packages.
 	PackageExports map[string][]ExternalSymbol
 
+	// PackageSymbols maps package names to ALL symbols (exported and
+	// non-exported). Used by resolveQualifiedSymbol as a fallback when
+	// a qualified reference (pkg:sym) targets a non-exported symbol.
+	// ELPS runtime allows qualified access to any symbol in a package,
+	// not just exported ones.
+	PackageSymbols map[string][]ExternalSymbol
+
 	// DefForms declares additional definition-form heads for embedding programs.
 	// Head is matched exactly against the form head symbol. FormalsIndex must
 	// point at the parameter list cell. If BindsName is true, NameIndex points

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -1227,9 +1227,10 @@ func (a *analyzer) resolveQualifiedSymbol(node *lisp.LVal, scope *Scope, pkgName
 	}
 
 	// Look up in exports first, then fall back to all symbols.
-	ext := findExternalSymbol(a.cfg.PackageExports, pkgName, symName)
+	ext := FindExternalSymbol(a.cfg.PackageExports, pkgName, symName)
+	exported := ext != nil
 	if ext == nil {
-		ext = findExternalSymbol(a.cfg.PackageSymbols, pkgName, symName)
+		ext = FindExternalSymbol(a.cfg.PackageSymbols, pkgName, symName)
 	}
 	if ext == nil {
 		return
@@ -1245,7 +1246,6 @@ func (a *analyzer) resolveQualifiedSymbol(node *lisp.LVal, scope *Scope, pkgName
 		sym = a.qualifiedSymbols[key]
 	}
 	if sym == nil {
-		exported := findExternalSymbol(a.cfg.PackageExports, pkgName, symName) != nil
 		sym = &Symbol{
 			Name:      ext.Name,
 			Package:   ext.Package,
@@ -1268,8 +1268,8 @@ func (a *analyzer) resolveQualifiedSymbol(node *lisp.LVal, scope *Scope, pkgName
 	})
 }
 
-// findExternalSymbol looks up a symbol by name in a package-to-symbols map.
-func findExternalSymbol(pkgMap map[string][]ExternalSymbol, pkgName, symName string) *ExternalSymbol {
+// FindExternalSymbol looks up a symbol by name in a package-to-symbols map.
+func FindExternalSymbol(pkgMap map[string][]ExternalSymbol, pkgName, symName string) *ExternalSymbol {
 	if pkgMap == nil {
 		return nil
 	}

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -1218,26 +1218,18 @@ func (a *analyzer) resolveSymbol(node *lisp.LVal, scope *Scope, currentPkg strin
 }
 
 // resolveQualifiedSymbol handles a qualified symbol like "pkg:sym".
-// It looks up the unqualified name in PackageExports for the given package,
-// and if found, records a reference using the unqualified symbol name (matching
-// the convention used by prescanUsePackage).
+// It first checks PackageExports, then falls back to PackageSymbols
+// (all definitions) because ELPS runtime allows qualified access to
+// any symbol in a package, not just exported ones.
 func (a *analyzer) resolveQualifiedSymbol(node *lisp.LVal, scope *Scope, pkgName, symName string) {
-	if a.cfg == nil || a.cfg.PackageExports == nil {
+	if a.cfg == nil {
 		return
 	}
 
-	exports, ok := a.cfg.PackageExports[pkgName]
-	if !ok {
-		return
-	}
-
-	// Find the exported symbol definition.
-	var ext *ExternalSymbol
-	for i := range exports {
-		if exports[i].Name == symName {
-			ext = &exports[i]
-			break
-		}
+	// Look up in exports first, then fall back to all symbols.
+	ext := findExternalSymbol(a.cfg.PackageExports, pkgName, symName)
+	if ext == nil {
+		ext = findExternalSymbol(a.cfg.PackageSymbols, pkgName, symName)
 	}
 	if ext == nil {
 		return
@@ -1253,6 +1245,7 @@ func (a *analyzer) resolveQualifiedSymbol(node *lisp.LVal, scope *Scope, pkgName
 		sym = a.qualifiedSymbols[key]
 	}
 	if sym == nil {
+		exported := findExternalSymbol(a.cfg.PackageExports, pkgName, symName) != nil
 		sym = &Symbol{
 			Name:      ext.Name,
 			Package:   ext.Package,
@@ -1260,7 +1253,7 @@ func (a *analyzer) resolveQualifiedSymbol(node *lisp.LVal, scope *Scope, pkgName
 			Source:    ext.Source,
 			Signature: ext.Signature,
 			DocString: ext.DocString,
-			Exported:  true,
+			Exported:  exported,
 			External:  true,
 		}
 		a.qualifiedSymbols[SymbolKey{Package: ext.Package, Name: ext.Name, Kind: ext.Kind}.String()] = sym
@@ -1273,6 +1266,23 @@ func (a *analyzer) resolveQualifiedSymbol(node *lisp.LVal, scope *Scope, pkgName
 		Source: node.Source,
 		Node:   node,
 	})
+}
+
+// findExternalSymbol looks up a symbol by name in a package-to-symbols map.
+func findExternalSymbol(pkgMap map[string][]ExternalSymbol, pkgName, symName string) *ExternalSymbol {
+	if pkgMap == nil {
+		return nil
+	}
+	syms, ok := pkgMap[pkgName]
+	if !ok {
+		return nil
+	}
+	for i := range syms {
+		if syms[i].Name == symName {
+			return &syms[i]
+		}
+	}
+	return nil
 }
 
 // resolveTemplateSymbol resolves a symbol inside a quasiquote template.

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -336,13 +336,13 @@ func walkLoadFile(filePath, currentPkg string, result map[string]string, visited
 // scanFileFull parses a file once and extracts exported globals, package-grouped
 // exports, all definitions, use-package declarations, and the file's primary
 // package ("" for bare files without in-package).
-func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, usePackages map[string][]string, filePkg string, firstInPkgLine int) {
+func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, pkgAll map[string][]ExternalSymbol, usePackages map[string][]string, filePkg string, firstInPkgLine int) {
 	s := token.NewScanner(filename, bytes.NewReader(source))
 	p := rdparser.New(s)
 
 	exprs, err := p.ParseProgram()
 	if err != nil {
-		return nil, nil, nil, nil, "", 0
+		return nil, nil, nil, nil, nil, "", 0
 	}
 
 	filePkg, firstInPkgLine = scanFilePackage(exprs)
@@ -350,14 +350,16 @@ func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkg
 	exported := scanExportedDefinitionKeys(exprs)
 
 	pkgs = make(map[string][]ExternalSymbol)
+	pkgAll = make(map[string][]ExternalSymbol)
 	for _, sym := range defs {
+		pkgAll[sym.Package] = append(pkgAll[sym.Package], sym)
 		if exported[definitionKey(sym.Package, sym.Name)] {
 			globals = append(globals, sym)
 			pkgs[sym.Package] = append(pkgs[sym.Package], sym)
 		}
 	}
 	usePackages = scanUsePackages(exprs)
-	return globals, pkgs, defs, usePackages, filePkg, firstInPkgLine
+	return globals, pkgs, defs, pkgAll, usePackages, filePkg, firstInPkgLine
 }
 
 // extractDefinitions collects top-level definitions from pre-parsed expressions.
@@ -572,6 +574,7 @@ func AnalyzeFile(source []byte, filename string, cfg *Config) *Result {
 	fileCfg = &Config{
 		ExtraGlobals:   fileCfg.ExtraGlobals,
 		PackageExports: fileCfg.PackageExports,
+		PackageSymbols: fileCfg.PackageSymbols,
 		DefForms:       fileCfg.DefForms,
 		PackageImports: fileCfg.PackageImports,
 		DefaultPackage: fileCfg.DefaultPackage,
@@ -841,6 +844,10 @@ type WorkspacePrescan struct {
 	// AllDefs are all definitions (exported and non-exported).
 	// Typically used as Config.ExtraGlobals for cross-file resolution.
 	AllDefs []ExternalSymbol
+	// PkgAllSymbols maps package name to ALL symbols (exported and
+	// non-exported). Used for qualified symbol resolution since ELPS
+	// runtime allows pkg:sym access to any symbol in a package.
+	PkgAllSymbols map[string][]ExternalSymbol
 	// DefForms are DefFormSpecs derived from defmacro definitions whose
 	// names start with "def". These can be injected into Config.DefForms
 	// for per-file analysis.
@@ -870,6 +877,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		globals        []ExternalSymbol
 		pkgs           map[string][]ExternalSymbol
 		allDefs        []ExternalSymbol
+		pkgAll         map[string][]ExternalSymbol
 		defForms       []DefFormSpec
 		usePackages    map[string][]string
 		filePkg        string // "" for bare files
@@ -901,9 +909,9 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 				if readErr != nil {
 					continue
 				}
-				g, p, d, up, fp, fpl := scanFileFull(fileSrc, paths[i])
+				g, p, d, pa, up, fp, fpl := scanFileFull(fileSrc, paths[i])
 				df := extractDefFormSpecs(d)
-				results[i] = fileResult{globals: g, pkgs: p, allDefs: d, defForms: df, usePackages: up, filePkg: fp, firstInPkgLine: fpl}
+				results[i] = fileResult{globals: g, pkgs: p, allDefs: d, pkgAll: pa, defForms: df, usePackages: up, filePkg: fp, firstInPkgLine: fpl}
 			}
 		}()
 	}
@@ -934,6 +942,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		Files:          paths,
 		Truncated:      truncated,
 		PkgExports:     make(map[string][]ExternalSymbol),
+		PkgAllSymbols:  make(map[string][]ExternalSymbol),
 		PackageImports: make(map[string][]string),
 		DefaultPackage: defaultPkg,
 	}
@@ -943,6 +952,9 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		prescan.DefForms = append(prescan.DefForms, r.defForms...)
 		for pkg, syms := range r.pkgs {
 			prescan.PkgExports[pkg] = append(prescan.PkgExports[pkg], syms...)
+		}
+		for pkg, syms := range r.pkgAll {
+			prescan.PkgAllSymbols[pkg] = append(prescan.PkgAllSymbols[pkg], syms...)
 		}
 		for pkg, imports := range r.usePackages {
 			prescan.PackageImports[pkg] = appendUnique(prescan.PackageImports[pkg], imports...)

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -1011,40 +1011,8 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 				prescan.ExportedGlobals[i].Package = pkg
 			}
 		}
-		// Remap PkgExports: move remapped symbols out of "user".
-		if userExports, ok := prescan.PkgExports[userPkg]; ok {
-			var remaining []ExternalSymbol
-			for i := range userExports {
-				if pkg, ok := shouldRemap(&userExports[i]); ok {
-					userExports[i].Package = pkg
-					prescan.PkgExports[pkg] = append(prescan.PkgExports[pkg], userExports[i])
-					continue
-				}
-				remaining = append(remaining, userExports[i])
-			}
-			if len(remaining) > 0 {
-				prescan.PkgExports[userPkg] = remaining
-			} else {
-				delete(prescan.PkgExports, userPkg)
-			}
-		}
-		// Remap PkgAllSymbols: same treatment as PkgExports.
-		if userAll, ok := prescan.PkgAllSymbols[userPkg]; ok {
-			var remaining []ExternalSymbol
-			for i := range userAll {
-				if pkg, ok := shouldRemap(&userAll[i]); ok {
-					userAll[i].Package = pkg
-					prescan.PkgAllSymbols[pkg] = append(prescan.PkgAllSymbols[pkg], userAll[i])
-					continue
-				}
-				remaining = append(remaining, userAll[i])
-			}
-			if len(remaining) > 0 {
-				prescan.PkgAllSymbols[userPkg] = remaining
-			} else {
-				delete(prescan.PkgAllSymbols, userPkg)
-			}
-		}
+		remapPackageMap(prescan.PkgExports, userPkg, shouldRemap)
+		remapPackageMap(prescan.PkgAllSymbols, userPkg, shouldRemap)
 		// Merge use-package imports from "user" into default package.
 		if userImports, ok := prescan.PackageImports[userPkg]; ok {
 			prescan.PackageImports[defaultPkg] = appendUnique(prescan.PackageImports[defaultPkg], userImports...)
@@ -1053,6 +1021,30 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 	}
 
 	return prescan, nil
+}
+
+// remapPackageMap moves symbols from srcPkg to their correct package based
+// on shouldRemap. Used to fix bare-file symbols that start in "user" but
+// should be in the package inherited from the load tree.
+func remapPackageMap(m map[string][]ExternalSymbol, srcPkg string, shouldRemap func(*ExternalSymbol) (string, bool)) {
+	syms, ok := m[srcPkg]
+	if !ok {
+		return
+	}
+	var remaining []ExternalSymbol
+	for i := range syms {
+		if pkg, ok := shouldRemap(&syms[i]); ok {
+			syms[i].Package = pkg
+			m[pkg] = append(m[pkg], syms[i])
+			continue
+		}
+		remaining = append(remaining, syms[i])
+	}
+	if len(remaining) > 0 {
+		m[srcPkg] = remaining
+	} else {
+		delete(m, srcPkg)
+	}
 }
 
 // extractDefFormSpecs derives DefFormSpecs from defmacro definitions whose

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -1028,6 +1028,23 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 				delete(prescan.PkgExports, userPkg)
 			}
 		}
+		// Remap PkgAllSymbols: same treatment as PkgExports.
+		if userAll, ok := prescan.PkgAllSymbols[userPkg]; ok {
+			var remaining []ExternalSymbol
+			for i := range userAll {
+				if pkg, ok := shouldRemap(&userAll[i]); ok {
+					userAll[i].Package = pkg
+					prescan.PkgAllSymbols[pkg] = append(prescan.PkgAllSymbols[pkg], userAll[i])
+					continue
+				}
+				remaining = append(remaining, userAll[i])
+			}
+			if len(remaining) > 0 {
+				prescan.PkgAllSymbols[userPkg] = remaining
+			} else {
+				delete(prescan.PkgAllSymbols, userPkg)
+			}
+		}
 		// Merge use-package imports from "user" into default package.
 		if userImports, ok := prescan.PackageImports[userPkg]; ok {
 			prescan.PackageImports[defaultPkg] = appendUnique(prescan.PackageImports[defaultPkg], userImports...)

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -531,6 +531,58 @@ func TestScanWorkspaceRefs_CrossFile(t *testing.T) {
 	assert.True(t, found, "should find helper reference from b.lisp")
 }
 
+func TestScanWorkspaceRefs_QuasiquoteTemplateCrossFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// helpers.lisp defines and exports "get-valid-me" in the helpers package.
+	err := os.WriteFile(filepath.Join(dir, "helpers.lisp"), []byte(`(in-package 'helpers)
+(export 'get-valid-me)
+(defun get-valid-me () 42)
+`), 0600)
+	require.NoError(t, err)
+
+	// macro.lisp defines a macro whose quasiquote template references
+	// helpers:get-valid-me. This is the pattern from def-acre-route.
+	err = os.WriteFile(filepath.Join(dir, "macro.lisp"), []byte(`(in-package 'myapp)
+(export 'my-macro)
+(defmacro my-macro (name)
+  (quasiquote
+    (begin
+      (helpers:get-valid-me)
+      (unquote name))))
+`), 0600)
+	require.NoError(t, err)
+
+	// Phase 1: Scan definitions.
+	globals, pkgs, err := ScanWorkspaceFull(dir)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		ExtraGlobals:   globals,
+		PackageExports: pkgs,
+	}
+
+	// Phase 2: Scan references.
+	refs := ScanWorkspaceRefs(dir, cfg, nil)
+
+	// There should be a cross-file reference to "get-valid-me" from macro.lisp.
+	key := SymbolKey{Package: "helpers", Name: "get-valid-me", Kind: SymFunction}.String()
+	fnRefs := refs[key]
+	require.NotEmpty(t, fnRefs,
+		"should have cross-file reference to get-valid-me via quasiquote template")
+
+	macroPath := filepath.Join(dir, "macro.lisp")
+	var found bool
+	for _, ref := range fnRefs {
+		if ref.File == macroPath {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"should find get-valid-me reference from macro.lisp's quasiquote template")
+}
+
 func TestExtractFileRefs_SkipsBuiltinsAndLocals(t *testing.T) {
 	// "my-fn" calls "other-fn" (a global), plus uses builtin "+", param "x", and local "local-var".
 	src := []byte(`(defun other-fn () 1)
@@ -761,6 +813,56 @@ func TestExtractFileRefs_QualifiedSymbol(t *testing.T) {
 
 	// Note: trailing colon (e.g. "helpers:") is a parse-level concern —
 	// the parser either rejects it or splits it, so we don't test it here.
+
+	t.Run("qualified symbol in quasiquote template", func(t *testing.T) {
+		// A qualified symbol inside a defmacro's quasiquote template should
+		// produce a cross-file reference, just like a direct call would.
+		// This is the pattern used by def-acre-route: the macro template
+		// references acre:get-valid-me which is defined in another file.
+		cfgWithPkg := &Config{
+			PackageExports: map[string][]ExternalSymbol{
+				"helpers": {
+					{
+						Name:    "add-one",
+						Kind:    SymFunction,
+						Package: "helpers",
+						Source:  &token.Location{File: "helpers.lisp", Line: 3, Col: 1, Pos: 40},
+					},
+				},
+			},
+		}
+		src := []byte(`(in-package 'myapp)
+(export 'my-macro)
+(defmacro my-macro (name)
+  (quasiquote
+    (begin
+      (helpers:add-one 1)
+      (unquote name))))
+`)
+		result := AnalyzeFile(src, "macro.lisp", cfgWithPkg)
+		require.NotNil(t, result)
+
+		var foundRef *Reference
+		for _, ref := range result.References {
+			if ref.Symbol.Name == "add-one" && ref.Symbol.Kind == SymFunction {
+				foundRef = ref
+				break
+			}
+		}
+		require.NotNil(t, foundRef,
+			"quasiquote template should resolve helpers:add-one as a reference")
+
+		fileRefs := ExtractFileRefs(result, "macro.lisp")
+		var found bool
+		for _, fref := range fileRefs {
+			if fref.SymbolKey.Name == "add-one" && fref.SymbolKey.Package == "helpers" {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found,
+			"ExtractFileRefs should include the quasiquote template reference")
+	})
 }
 
 func TestExtractFileDefinitions(t *testing.T) {

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -583,6 +583,54 @@ func TestScanWorkspaceRefs_QuasiquoteTemplateCrossFile(t *testing.T) {
 		"should find get-valid-me reference from macro.lisp's quasiquote template")
 }
 
+func TestScanWorkspaceRefs_NonExportedQualifiedCrossFile(t *testing.T) {
+	// A non-exported function referenced via qualified symbol in another
+	// file's quasiquote template must produce a cross-file reference.
+	// This exercises the PackageSymbols fallback (not PackageExports).
+	dir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(dir, "helpers.lisp"), []byte(`(in-package 'helpers)
+(defun do-work () 42)
+`), 0600)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(dir, "macro.lisp"), []byte(`(in-package 'myapp)
+(defmacro my-macro (name)
+  (quasiquote
+    (begin
+      (helpers:do-work)
+      (unquote name))))
+`), 0600)
+	require.NoError(t, err)
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+
+	cfg := &Config{
+		ExtraGlobals:   prescan.AllDefs,
+		PackageExports: prescan.PkgExports,
+		PackageSymbols: prescan.PkgAllSymbols,
+	}
+
+	refs := ScanWorkspaceRefs(dir, cfg, nil)
+
+	key := SymbolKey{Package: "helpers", Name: "do-work", Kind: SymFunction}.String()
+	fnRefs := refs[key]
+	require.NotEmpty(t, fnRefs,
+		"non-exported function should be found via PackageSymbols fallback")
+
+	macroPath := filepath.Join(dir, "macro.lisp")
+	var found bool
+	for _, ref := range fnRefs {
+		if ref.File == macroPath {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"should find do-work reference from macro.lisp")
+}
+
 func TestExtractFileRefs_SkipsBuiltinsAndLocals(t *testing.T) {
 	// "my-fn" calls "other-fn" (a global), plus uses builtin "+", param "x", and local "local-var".
 	src := []byte(`(defun other-fn () 1)
@@ -862,6 +910,41 @@ func TestExtractFileRefs_QualifiedSymbol(t *testing.T) {
 		}
 		assert.True(t, found,
 			"ExtractFileRefs should include the quasiquote template reference")
+	})
+
+	t.Run("non-exported qualified symbol via PackageSymbols", func(t *testing.T) {
+		// Symbol is ONLY in PackageSymbols (not PackageExports).
+		// This exercises the resolveQualifiedSymbol fallback.
+		cfgNonExported := &Config{
+			PackageSymbols: map[string][]ExternalSymbol{
+				"helpers": {
+					{
+						Name:    "do-work",
+						Kind:    SymFunction,
+						Package: "helpers",
+						Source:  &token.Location{File: "helpers.lisp", Line: 2, Col: 1, Pos: 22},
+					},
+				},
+			},
+		}
+		src := []byte(`(in-package 'myapp)
+(defun caller () (helpers:do-work))`)
+		result := AnalyzeFile(src, "test.lisp", cfgNonExported)
+		require.NotNil(t, result)
+
+		var foundRef *Reference
+		for _, ref := range result.References {
+			if ref.Symbol.Name == "do-work" {
+				foundRef = ref
+				break
+			}
+		}
+		require.NotNil(t, foundRef,
+			"should resolve non-exported helpers:do-work via PackageSymbols")
+		assert.False(t, foundRef.Symbol.Exported,
+			"symbol resolved via PackageSymbols should NOT be marked Exported")
+		assert.True(t, foundRef.Symbol.External,
+			"symbol should be marked External")
 	})
 }
 

--- a/docs/lang.md
+++ b/docs/lang.md
@@ -616,13 +616,18 @@ function, which changes the environment's working package.  Symbols bound using
 ```
 
 Outside of the `my-new-package` package, the symbol `my-special-function` may
-be bound to other values.  Symbols defined inside `my-new-package` may be
-explicitly accessed by qualifying the symbol using the package name.
+be bound to other values.  Any symbol defined inside a package may be
+explicitly accessed by qualifying the symbol using the package name, regardless
+of whether it was exported.
 
 ```lisp
 (my-new-package:my-special-function)  ; prints "something special"
 (my-new-package:my-other-function)    ; prints "something else"
 ```
+
+NOTE:  Qualified access (`pkg:sym`) works for all symbols in a package, not
+just exported ones.  Exports only control what `use-package` imports into the
+caller's namespace — they do not restrict visibility.
 
 Scheme-like symbol bindings and assignment are also possible using the `define`
 and `set!` operators.

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -371,8 +371,9 @@ func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
 	}
 
 	acfg := &analysis.Config{
-		ExtraGlobals:   prescan.ExportedGlobals,
+		ExtraGlobals:   prescan.AllDefs,
 		PackageExports: pkgExports,
+		PackageSymbols: prescan.PkgAllSymbols,
 		DefForms:       prescan.DefForms,
 		PackageImports: prescan.PackageImports,
 		DefaultPackage: prescan.DefaultPackage,

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -2890,8 +2890,6 @@ func TestLintFiles_UnusedFunction_CrossFileQuasiquoteTemplate(t *testing.T) {
 	// End-to-end: a non-exported function referenced via qualified symbol
 	// in another file's quasiquote template must not be flagged as unused.
 	// This is the def-acre-route pattern where the helper is internal.
-	// TODO(#255): fix resolveQualifiedSymbol to check all defs, not just exports.
-	t.Skip("known bug: resolveQualifiedSymbol only checks PackageExports")
 	dir := t.TempDir()
 
 	writeTempLisp(t, dir, "macro.lisp", `(in-package 'myapp)

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -2914,6 +2914,34 @@ func TestLintFiles_UnusedFunction_CrossFileQuasiquoteTemplate(t *testing.T) {
 	}
 }
 
+func TestLintFiles_UnusedFunction_CrossFileBareFile(t *testing.T) {
+	// End-to-end: the real phylum pattern — helpers.lisp is a bare file
+	// (no in-package) that inherits the package from DefaultPackage.
+	// main.lisp's macro references myapp:do-work in its quasiquote template.
+	dir := t.TempDir()
+
+	writeTempLisp(t, dir, "main.lisp", `(in-package 'myapp)
+(load-file "helpers.lisp")
+
+(export 'my-macro)
+(defmacro my-macro (name)
+  (quasiquote
+    (begin
+      (myapp:do-work)
+      (unquote name))))`)
+
+	// Bare file — no (in-package). Inherits 'myapp via load-file from main.lisp.
+	helpers := writeTempLisp(t, dir, "helpers.lisp", `(defun do-work () 42)`)
+
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerUnusedFunction}}
+	diags, err := l.LintFiles(&LintConfig{Workspace: dir}, []string{helpers})
+	require.NoError(t, err)
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, "do-work",
+			"do-work should not be flagged — it is used in main.lisp's quasiquote template")
+	}
+}
+
 func TestBuildAnalysisConfig_Basic(t *testing.T) {
 	dir := t.TempDir()
 	writeTempLisp(t, dir, "lib.lisp", `(defun my-fn () 42)

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -2886,6 +2886,36 @@ func TestLintFiles_FileNotFound(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestLintFiles_UnusedFunction_CrossFileQuasiquoteTemplate(t *testing.T) {
+	// End-to-end: a non-exported function referenced via qualified symbol
+	// in another file's quasiquote template must not be flagged as unused.
+	// This is the def-acre-route pattern where the helper is internal.
+	// TODO(#255): fix resolveQualifiedSymbol to check all defs, not just exports.
+	t.Skip("known bug: resolveQualifiedSymbol only checks PackageExports")
+	dir := t.TempDir()
+
+	writeTempLisp(t, dir, "macro.lisp", `(in-package 'myapp)
+(use-package 'helpers)
+(export 'my-macro)
+(defmacro my-macro (name)
+  (quasiquote
+    (begin
+      (helpers:do-work)
+      (unquote name))))`)
+
+	// do-work is NOT exported — forces reliance on cross-file WorkspaceRefs.
+	helpers := writeTempLisp(t, dir, "helpers.lisp", `(in-package 'helpers)
+(defun do-work () 42)`)
+
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerUnusedFunction}}
+	diags, err := l.LintFiles(&LintConfig{Workspace: dir}, []string{helpers})
+	require.NoError(t, err)
+	for _, d := range diags {
+		assert.NotContains(t, d.Message, "do-work",
+			"do-work should not be flagged — it is used in macro.lisp's quasiquote template")
+	}
+}
+
 func TestBuildAnalysisConfig_Basic(t *testing.T) {
 	dir := t.TempDir()
 	writeTempLisp(t, dir, "lib.lisp", `(defun my-fn () 42)

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1957,6 +1957,35 @@ func TestUnusedFunction_Positive_NotInQuasiquoteTemplate(t *testing.T) {
 	assertHasDiag(t, diags, "unused function: unused-helper")
 }
 
+func TestUnusedFunction_Negative_CrossFileRef_QuasiquoteTemplate(t *testing.T) {
+	// A function defined in one file, referenced via qualified symbol in
+	// another file's defmacro quasiquote template, should NOT be flagged.
+	// This simulates the acre:get-valid-me pattern.
+	source := `(in-package 'helpers)
+(export 'get-valid-me)
+(defun get-valid-me () 42)`
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerUnusedFunction}}
+	key := analysis.SymbolKey{Package: "helpers", Name: "get-valid-me", Kind: analysis.SymFunction}.String()
+	cfg := &analysis.Config{
+		ExtraGlobals: []analysis.ExternalSymbol{
+			{Name: "get-valid-me", Kind: analysis.SymFunction, Package: "helpers"},
+		},
+		PackageExports: map[string][]analysis.ExternalSymbol{
+			"helpers": {
+				{Name: "get-valid-me", Kind: analysis.SymFunction, Package: "helpers"},
+			},
+		},
+		WorkspaceRefs: map[string][]analysis.FileReference{
+			key: {
+				{File: "/other/macro.lisp"}, // cross-file ref from quasiquote template
+			},
+		},
+	}
+	diags, err := l.LintFileWithAnalysis([]byte(source), "helpers.lisp", cfg)
+	require.NoError(t, err)
+	assertNoDiags(t, diags)
+}
+
 // --- shadowing ---
 
 func TestUnusedFunction_Negative_CrossFileRef_WithDefaultPackage(t *testing.T) {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -2908,10 +2908,7 @@ func TestLintFiles_UnusedFunction_CrossFileQuasiquoteTemplate(t *testing.T) {
 	l := &Linter{Analyzers: []*Analyzer{AnalyzerUnusedFunction}}
 	diags, err := l.LintFiles(&LintConfig{Workspace: dir}, []string{helpers})
 	require.NoError(t, err)
-	for _, d := range diags {
-		assert.NotContains(t, d.Message, "do-work",
-			"do-work should not be flagged — it is used in macro.lisp's quasiquote template")
-	}
+	assertNoDiags(t, diags)
 }
 
 func TestLintFiles_UnusedFunction_CrossFileBareFile(t *testing.T) {
@@ -2936,10 +2933,7 @@ func TestLintFiles_UnusedFunction_CrossFileBareFile(t *testing.T) {
 	l := &Linter{Analyzers: []*Analyzer{AnalyzerUnusedFunction}}
 	diags, err := l.LintFiles(&LintConfig{Workspace: dir}, []string{helpers})
 	require.NoError(t, err)
-	for _, d := range diags {
-		assert.NotContains(t, d.Message, "do-work",
-			"do-work should not be flagged — it is used in main.lisp's quasiquote template")
-	}
+	assertNoDiags(t, diags)
 }
 
 func TestBuildAnalysisConfig_Basic(t *testing.T) {

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -5,6 +5,7 @@ package lsp
 import (
 	"strings"
 
+	"github.com/luthersystems/elps/analysis"
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
@@ -48,7 +49,9 @@ func splitPackageQualified(prefix string) (pkg, partial string, ok bool) {
 	return prefix[:idx], prefix[idx+1:], true
 }
 
-// packageCompletions returns completion items from a package's exports.
+// packageCompletions returns completion items from a package's symbols.
+// Includes both exported and non-exported symbols since ELPS allows
+// qualified access (pkg:sym) to any symbol in a package.
 func (s *Server) packageCompletions(doc *Document, pkgName, partial string) []protocol.CompletionItem {
 	s.ensureWorkspaceIndex()
 
@@ -56,37 +59,45 @@ func (s *Server) packageCompletions(doc *Document, pkgName, partial string) []pr
 	cfg := s.analysisCfg
 	s.analysisCfgMu.RUnlock()
 
-	if cfg == nil || cfg.PackageExports == nil {
+	if cfg == nil {
 		return nil
 	}
 
-	exports, ok := cfg.PackageExports[pkgName]
-	if !ok {
-		return nil
-	}
-
+	// Collect symbols from both exports and all-symbols, deduplicating
+	// by name (exports take priority for richer metadata).
+	seen := make(map[string]bool)
 	var items []protocol.CompletionItem
-	for _, ext := range exports {
-		if partial != "" && !strings.HasPrefix(ext.Name, partial) {
-			continue
-		}
-		kind := mapCompletionItemKind(ext.Kind)
-		label := pkgName + ":" + ext.Name
-		item := protocol.CompletionItem{
-			Label: label,
-			Kind:  &kind,
-		}
-		if ext.Signature != nil {
-			detail := formatSignature(ext.Signature)
-			item.Detail = &detail
-		}
-		if ext.DocString != "" {
-			item.Documentation = &protocol.MarkupContent{
-				Kind:  protocol.MarkupKindMarkdown,
-				Value: ext.DocString,
+
+	for _, syms := range [][]analysis.ExternalSymbol{
+		cfg.PackageExports[pkgName],
+		cfg.PackageSymbols[pkgName],
+	} {
+		for _, ext := range syms {
+			if seen[ext.Name] {
+				continue
 			}
+			seen[ext.Name] = true
+			if partial != "" && !strings.HasPrefix(ext.Name, partial) {
+				continue
+			}
+			kind := mapCompletionItemKind(ext.Kind)
+			label := pkgName + ":" + ext.Name
+			item := protocol.CompletionItem{
+				Label: label,
+				Kind:  &kind,
+			}
+			if ext.Signature != nil {
+				detail := formatSignature(ext.Signature)
+				item.Detail = &detail
+			}
+			if ext.DocString != "" {
+				item.Documentation = &protocol.MarkupContent{
+					Kind:  protocol.MarkupKindMarkdown,
+					Value: ext.DocString,
+				}
+			}
+			items = append(items, item)
 		}
-		items = append(items, item)
 	}
 	return items
 }
@@ -129,12 +140,19 @@ func (s *Server) scopeCompletions(doc *Document, line, col int, prefix string) [
 		items = append(items, item)
 	}
 
-	// Also add package-qualified completions from workspace exports.
+	// Also add package-qualified completions from workspace packages.
 	s.analysisCfgMu.RLock()
 	cfg := s.analysisCfg
 	s.analysisCfgMu.RUnlock()
-	if cfg != nil && cfg.PackageExports != nil {
+	if cfg != nil {
+		pkgNames := make(map[string]bool)
 		for pkgName := range cfg.PackageExports {
+			pkgNames[pkgName] = true
+		}
+		for pkgName := range cfg.PackageSymbols {
+			pkgNames[pkgName] = true
+		}
+		for pkgName := range pkgNames {
 			if prefix != "" && !strings.HasPrefix(pkgName+":", prefix) {
 				continue
 			}

--- a/lsp/definition.go
+++ b/lsp/definition.go
@@ -91,37 +91,36 @@ func (s *Server) qualifiedSymbolDefinition(word string) *protocol.Location {
 	cfg := s.analysisCfg
 	s.analysisCfgMu.RUnlock()
 
-	if cfg == nil || cfg.PackageExports == nil {
+	if cfg == nil {
 		return nil
 	}
 
-	exports, ok := cfg.PackageExports[pkgName]
-	if !ok {
+	// Check exports first, then fall back to all symbols.
+	// ELPS runtime allows pkg:sym access to any symbol, not just exported ones.
+	ext := analysis.FindExternalSymbol(cfg.PackageExports, pkgName, symName)
+	if ext == nil {
+		ext = analysis.FindExternalSymbol(cfg.PackageSymbols, pkgName, symName)
+	}
+	if ext == nil {
 		return nil
 	}
 
-	for _, ext := range exports {
-		if ext.Name != symName {
-			continue
+	sym := externalToSymbol(ext)
+	if isBuiltin(sym) {
+		loc := builtinLocation(pkgName, symName)
+		return &loc
+	}
+	// User-defined symbol with real source.
+	if sym.Source != nil && sym.Source.File != "" {
+		defPath := sym.Source.File
+		if !filepath.IsAbs(defPath) && s.rootPath != "" {
+			defPath = filepath.Join(s.rootPath, defPath)
 		}
-		sym := externalToSymbol(&ext)
-		if isBuiltin(sym) {
-			loc := builtinLocation(pkgName, symName)
-			return &loc
+		loc := protocol.Location{
+			URI:   pathToURI(defPath),
+			Range: elpsToLSPRange(sym.Source, len(sym.Name)),
 		}
-		// User-defined symbol with real source.
-		if sym.Source != nil && sym.Source.File != "" {
-			defPath := sym.Source.File
-			if !filepath.IsAbs(defPath) && s.rootPath != "" {
-				defPath = filepath.Join(s.rootPath, defPath)
-			}
-			loc := protocol.Location{
-				URI:   pathToURI(defPath),
-				Range: elpsToLSPRange(sym.Source, len(sym.Name)),
-			}
-			return &loc
-		}
-		return nil
+		return &loc
 	}
 	return nil
 }

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -305,6 +305,7 @@ func (s *Server) buildWorkspaceIndex() {
 
 	var extraGlobals []analysis.ExternalSymbol
 	var pkgExports map[string][]analysis.ExternalSymbol
+	var pkgAllSymbols map[string][]analysis.ExternalSymbol
 	var defForms []analysis.DefFormSpec
 	var packageImports map[string][]string
 	var defaultPackage string
@@ -324,6 +325,7 @@ func (s *Server) buildWorkspaceIndex() {
 		if prescan, err := analysis.PrescanWorkspace(s.rootPath, scanCfg); err == nil {
 			extraGlobals = prescan.AllDefs
 			pkgExports = prescan.PkgExports
+			pkgAllSymbols = prescan.PkgAllSymbols
 			defForms = prescan.DefForms
 			packageImports = prescan.PackageImports
 			defaultPackage = prescan.DefaultPackage
@@ -367,6 +369,7 @@ func (s *Server) buildWorkspaceIndex() {
 	cfg := &analysis.Config{
 		ExtraGlobals:   extraGlobals,
 		PackageExports: pkgExports,
+		PackageSymbols: pkgAllSymbols,
 		DefForms:       defForms,
 		PackageImports: packageImports,
 		DefaultPackage: defaultPackage,
@@ -433,6 +436,7 @@ func (s *Server) getAnalysisConfig(uri string) *analysis.Config {
 	if base != nil {
 		cfg.ExtraGlobals = base.ExtraGlobals
 		cfg.PackageExports = base.PackageExports
+		cfg.PackageSymbols = base.PackageSymbols
 		cfg.DefForms = base.DefForms
 		cfg.PackageImports = base.PackageImports
 		cfg.DefaultPackage = base.DefaultPackage


### PR DESCRIPTION
## Summary
- ELPS runtime allows `pkg:sym` access to any symbol in a package, not just exported ones. But `resolveQualifiedSymbol` only checked `PackageExports`, so non-exported symbols referenced via qualified access were invisible to the analyzer.
- Added `PackageSymbols` (all defs by package) to `Config` as a fallback lookup for `resolveQualifiedSymbol`
- Wired through `WorkspacePrescan`, lint `BuildAnalysisConfig`, LSP server, and `AnalyzeFile`
- Fixed `BuildAnalysisConfig` to use `AllDefs` instead of `ExportedGlobals` for `ExtraGlobals`
- Fixed bare-file remap to also update `PkgAllSymbols` (the customer phylum pattern: bare files inheriting package via `load-file`)
- Clarified in `docs/lang.md` that qualified access works for all symbols, not just exported ones

Fixes #255

## Test plan
- [x] `TestLintFiles_UnusedFunction_CrossFileQuasiquoteTemplate` — non-exported function with explicit `in-package`, referenced via qualified symbol in quasiquote template
- [x] `TestLintFiles_UnusedFunction_CrossFileBareFile` — bare file inheriting package via `load-file` from `main.lisp` (exact customer phylum pattern)
- [x] `TestScanWorkspaceRefs_QuasiquoteTemplateCrossFile` — workspace-level cross-file ref propagation
- [x] `TestExtractFileRefs_QualifiedSymbol/qualified_symbol_in_quasiquote_template` — per-file extraction
- [x] `TestUnusedFunction_Negative_CrossFileRef_QuasiquoteTemplate` — lint-level with workspace refs
- [x] Full `go test ./analysis/... ./lint/... ./lsp/... ./minifier/...` passes