### PR TITLE
fix: analyzer false positives, MCP cross-file diagnostics, macro expansion, and semantic audit

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -63,8 +63,6 @@ gh pr create --title "<concise title>" --body "$(cat <<'EOF'
 - [ ] `./elps doc -m` reports no missing docs
 
 Closes #<N>
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
 ```

--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -50,6 +50,12 @@ type Config struct {
 	// other files in the workspace.
 	WorkspaceRefs map[string][]FileReference
 
+	// MacroExpander optionally expands user-macro calls at analysis time.
+	// When set, the analyzer expands macro calls and analyzes the expanded
+	// code, resolving symbols introduced by the macro (e.g. lambda params).
+	// If expansion fails, the analyzer falls back to opaque macro handling.
+	MacroExpander MacroExpander
+
 	// Filename is the source file being analyzed.
 	Filename string
 }

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -490,7 +490,14 @@ func TestAnalyze_Set_InLambdaCreatesGlobalIfMissing(t *testing.T) {
     (set 'y 1)))`)
 
 	sym := result.RootScope.LookupLocal("y")
-	assert.NotNil(t, sym, "'y' should be defined in global scope by set inside lambda")
+	require.NotNil(t, sym, "'y' should be defined in global scope by set inside lambda")
+	assert.Equal(t, SymVariable, sym.Kind)
+	// Verify 'y' was NOT defined in any non-global scope.
+	for _, s := range result.Symbols {
+		if s.Name == "y" && s.Scope != result.RootScope {
+			t.Errorf("'y' should not be defined in a non-global scope (found in %v)", s.Scope.Kind)
+		}
+	}
 }
 
 // --- Analyze: function (#') ---
@@ -1809,6 +1816,13 @@ func TestAnalyze_MacroExpansion_NestedMacros(t *testing.T) {
 	for _, u := range result.Unresolved {
 		assert.NotEqual(t, "req", u.Name, "req should resolve via nested macro expansion")
 	}
+
+	// Verify req actually resolved as a reference (not just absent from Unresolved).
+	refNames := make(map[string]bool)
+	for _, ref := range result.References {
+		refNames[ref.Symbol.Name] = true
+	}
+	assert.True(t, refNames["req"], "req should appear in References after nested expansion")
 }
 
 func TestAnalyze_MacroExpansion_WhenMacro(t *testing.T) {
@@ -1849,6 +1863,23 @@ func TestAnalyze_MacroExpansion_FailureFallback(t *testing.T) {
 	// Should not crash — falls back to opaque analysis.
 	// 42 inside the macro call gets InsideMacroCall treatment.
 	assert.NotNil(t, result)
+}
+
+func TestAnalyze_MacroExpansion_DepthLimit(t *testing.T) {
+	// A self-expanding macro should not cause a stack overflow.
+	// The analyzer caps expansion at maxMacroExpansionDepth and falls
+	// back to opaque analysis.
+	result := parseAndAnalyzeWithExpander(t,
+		`(defmacro loop-forever (&rest body)
+		   (quasiquote (loop-forever (unquote-splicing body))))`,
+		`(loop-forever 42)`)
+
+	// Should complete without panic or hang.
+	assert.NotNil(t, result)
+	// The macro call should still appear (as unresolved or via opaque walk),
+	// not silently disappear.
+	assert.True(t, len(result.Unresolved) > 0 || len(result.References) > 0,
+		"self-expanding macro should produce some analysis output")
 }
 
 func TestAnalyze_MacroExpansion_UnresolvedInExpandedCode(t *testing.T) {

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -1456,6 +1456,7 @@ func TestScopeKind_String(t *testing.T) {
 	assert.Equal(t, "lambda", ScopeLambda.String())
 	assert.Equal(t, "let", ScopeLet.String())
 	assert.Equal(t, "flet", ScopeFlet.String())
+	assert.Equal(t, "macrolet", ScopeMacrolet.String())
 	assert.Equal(t, "dotimes", ScopeDotimes.String())
 }
 
@@ -1739,6 +1740,162 @@ func TestAnalyze_DefaultPackage_BareFile(t *testing.T) {
 	}
 	assert.False(t, unresolvedNames["helper-fn"],
 		"bare file with DefaultPackage should resolve symbols via cross-file imports")
+}
+
+// --- Macrolet ---
+
+func TestAnalyze_Macrolet_BodyResolves(t *testing.T) {
+	// Local macros defined in macrolet should be visible in the body.
+	result := parseAndAnalyze(t, `
+(defun f ()
+  (macrolet ((my-add (a b) (quasiquote (+ (unquote a) (unquote b)))))
+    (my-add 1 2)))`)
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "my-add", u.Name,
+			"macrolet-defined macro should not be flagged as undefined")
+	}
+}
+
+func TestAnalyze_Macrolet_MultipleMacros(t *testing.T) {
+	// Multiple macros in one macrolet should all be in scope.
+	result := parseAndAnalyze(t, `
+(macrolet ((m1 () '1)
+           (m2 () '2))
+  (m1)
+  (m2))`)
+	unresolvedNames := make(map[string]bool)
+	for _, u := range result.Unresolved {
+		unresolvedNames[u.Name] = true
+	}
+	assert.False(t, unresolvedNames["m1"], "m1 should resolve in macrolet body")
+	assert.False(t, unresolvedNames["m2"], "m2 should resolve in macrolet body")
+}
+
+func TestAnalyze_Macrolet_MacroNotVisibleOutside(t *testing.T) {
+	// Macros defined in macrolet should NOT be visible outside its body.
+	result := parseAndAnalyze(t, `
+(macrolet ((local-mac () '1))
+  (local-mac))
+(local-mac)`)
+	found := false
+	for _, u := range result.Unresolved {
+		if u.Name == "local-mac" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"macrolet-defined macro should be undefined outside macrolet body")
+}
+
+func TestAnalyze_Macrolet_BodyUndefinedFlagged(t *testing.T) {
+	// Undefined symbols in macrolet body should still be flagged.
+	result := parseAndAnalyze(t, `
+(macrolet ((m () '1))
+  (undefined-fn 42))`)
+	found := false
+	for _, u := range result.Unresolved {
+		if u.Name == "undefined-fn" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"undefined symbol in macrolet body should be flagged")
+}
+
+func TestAnalyze_Macrolet_TemplateBodyNotAnalyzed(t *testing.T) {
+	// Template variables in macro bodies should NOT be flagged as undefined.
+	// Macro bodies are templates — they contain quasiquote/unquote patterns
+	// with variables that don't exist in the lexical scope.
+	result := parseAndAnalyze(t, `
+(macrolet ((wrap (body) (quasiquote (progn (unquote body)))))
+  (wrap (+ 1 2)))`)
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "body", u.Name,
+			"macro template variable should not be flagged as undefined")
+	}
+}
+
+func TestAnalyze_Macrolet_DefinedAsMacroSymbol(t *testing.T) {
+	// Macrolet bindings should be registered as SymMacro symbols.
+	result := parseAndAnalyze(t, `
+(macrolet ((my-mac () '1))
+  (my-mac))`)
+	found := false
+	for _, sym := range result.Symbols {
+		if sym.Name == "my-mac" && sym.Kind == SymMacro {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "macrolet binding should appear as a SymMacro in result.Symbols")
+}
+
+// --- Qualified-symbol ---
+
+func TestAnalyze_QualifiedSymbol_ArgNotFlagged(t *testing.T) {
+	// The argument to qualified-symbol is data (a name), not a symbol
+	// reference. It should not be flagged as undefined.
+	result := parseAndAnalyze(t, `(qualified-symbol some-name)`)
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "some-name", u.Name,
+			"qualified-symbol argument should not be flagged as undefined")
+	}
+}
+
+func TestAnalyze_QualifiedSymbol_HeadResolved(t *testing.T) {
+	// The qualified-symbol operator itself should still be resolved.
+	result := parseAndAnalyze(t, `(qualified-symbol foo)`)
+	// qualified-symbol is a builtin special op — should be resolved.
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "qualified-symbol", u.Name,
+			"qualified-symbol head should be resolved as a builtin")
+	}
+}
+
+// --- Thread-first / Thread-last ---
+
+func TestAnalyze_ThreadFirst_SymbolsResolved(t *testing.T) {
+	// Symbols used in thread-first forms should still be resolved.
+	result := parseAndAnalyze(t, `
+(defun f (x) x)
+(defun g (x y) (+ x y))
+(thread-first 1 (f) (g 2))`)
+	unresolvedNames := make(map[string]bool)
+	for _, u := range result.Unresolved {
+		unresolvedNames[u.Name] = true
+	}
+	assert.False(t, unresolvedNames["f"], "f should resolve in thread-first")
+	assert.False(t, unresolvedNames["g"], "g should resolve in thread-first")
+}
+
+func TestAnalyze_ThreadLast_SymbolsResolved(t *testing.T) {
+	// Symbols used in thread-last forms should still be resolved.
+	result := parseAndAnalyze(t, `
+(defun f (x) x)
+(defun g (x y) (+ x y))
+(thread-last 1 (f) (g 2))`)
+	unresolvedNames := make(map[string]bool)
+	for _, u := range result.Unresolved {
+		unresolvedNames[u.Name] = true
+	}
+	assert.False(t, unresolvedNames["f"], "f should resolve in thread-last")
+	assert.False(t, unresolvedNames["g"], "g should resolve in thread-last")
+}
+
+func TestAnalyze_ThreadFirst_UndefinedFlagged(t *testing.T) {
+	// Undefined symbols in thread-first should still be flagged.
+	result := parseAndAnalyze(t, `(thread-first 1 (unknown-fn 2))`)
+	found := false
+	for _, u := range result.Unresolved {
+		if u.Name == "unknown-fn" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"undefined symbol in thread-first should be flagged")
 }
 
 // parseAndAnalyzeWithConfig is a test helper that parses source and runs

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -1832,6 +1832,18 @@ func TestAnalyze_Macrolet_DefinedAsMacroSymbol(t *testing.T) {
 	assert.True(t, found, "macrolet binding should appear as a SymMacro in result.Symbols")
 }
 
+func TestAnalyze_Macrolet_Nested(t *testing.T) {
+	// Nested macrolet: inner scope sees both inner and outer macros.
+	result := parseAndAnalyze(t, `
+(macrolet ((m1 () '1))
+  (macrolet ((m2 () '2))
+    (list (m1) (m2))))`)
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "m1", u.Name, "outer macrolet binding should be visible in nested scope")
+		assert.NotEqual(t, "m2", u.Name, "inner macrolet binding should be visible")
+	}
+}
+
 // --- Qualified-symbol ---
 
 func TestAnalyze_QualifiedSymbol_ArgNotFlagged(t *testing.T) {
@@ -1852,6 +1864,21 @@ func TestAnalyze_QualifiedSymbol_HeadResolved(t *testing.T) {
 		assert.NotEqual(t, "qualified-symbol", u.Name,
 			"qualified-symbol head should be resolved as a builtin")
 	}
+}
+
+func TestAnalyze_QualifiedSymbol_ExtraArgsAnalyzed(t *testing.T) {
+	// Arguments beyond Cells[1] should still be analyzed normally.
+	result := parseAndAnalyze(t, `(qualified-symbol some-name undefined-extra)`)
+	found := false
+	for _, u := range result.Unresolved {
+		if u.Name == "undefined-extra" {
+			found = true
+		}
+		assert.NotEqual(t, "some-name", u.Name,
+			"first arg is still data, not a reference")
+	}
+	assert.True(t, found,
+		"extra arguments to qualified-symbol should still be analyzed")
 }
 
 // --- Thread-first / Thread-last ---
@@ -1896,6 +1923,20 @@ func TestAnalyze_ThreadFirst_UndefinedFlagged(t *testing.T) {
 	}
 	assert.True(t, found,
 		"undefined symbol in thread-first should be flagged")
+}
+
+func TestAnalyze_ThreadLast_UndefinedFlagged(t *testing.T) {
+	// Undefined symbols in thread-last should still be flagged.
+	result := parseAndAnalyze(t, `(thread-last 1 (unknown-fn 2))`)
+	found := false
+	for _, u := range result.Unresolved {
+		if u.Name == "unknown-fn" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"undefined symbol in thread-last should be flagged")
 }
 
 // parseAndAnalyzeWithConfig is a test helper that parses source and runs
@@ -2044,10 +2085,25 @@ func TestAnalyze_MacroExpansion_DepthLimit(t *testing.T) {
 
 	// Should complete without panic or hang.
 	assert.NotNil(t, result)
-	// The macro call should still appear (as unresolved or via opaque walk),
-	// not silently disappear.
-	assert.True(t, len(result.Unresolved) > 0 || len(result.References) > 0,
-		"self-expanding macro should produce some analysis output")
+	// After hitting the depth limit, the macro name should appear somewhere
+	// in the analysis output (as an unresolved ref from the opaque fallback).
+	var loopForeverSeen bool
+	for _, u := range result.Unresolved {
+		if u.Name == "loop-forever" {
+			loopForeverSeen = true
+			break
+		}
+	}
+	if !loopForeverSeen {
+		for _, r := range result.References {
+			if r.Symbol.Name == "loop-forever" {
+				loopForeverSeen = true
+				break
+			}
+		}
+	}
+	assert.True(t, loopForeverSeen,
+		"self-expanding macro should produce analysis output for 'loop-forever'")
 }
 
 func TestAnalyze_MacroExpansion_UnresolvedInExpandedCode(t *testing.T) {

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -1739,3 +1739,112 @@ func parseAndAnalyzeWithConfig(t *testing.T, source string, cfg *Config) *Result
 	}
 	return Analyze(exprs, cfg)
 }
+
+// --- Analyze: macro expansion at analysis time ---
+
+// parseAndAnalyzeWithExpander creates an env, evaluates macroSource in it,
+// then analyzes callSource with the expander enabled.
+func parseAndAnalyzeWithExpander(t *testing.T, macroSource, callSource string) *Result {
+	t.Helper()
+	env := newTestEnv(t)
+	evalSource(t, env, macroSource)
+	return parseAndAnalyzeWithConfig(t, callSource, &Config{
+		MacroExpander: &EnvMacroExpander{Env: env},
+	})
+}
+
+func TestAnalyze_MacroExpansion_LambdaParams(t *testing.T) {
+	// Pattern from def-acre-route: macro introduces lambda parameters.
+	// Without expansion: req/resp flagged as undefined.
+	// With expansion: they resolve as lambda params.
+	result := parseAndAnalyzeWithExpander(t,
+		`(defmacro def-handler (name args &rest exprs)
+		   (quasiquote
+		     (set (quote (unquote name))
+		       (lambda (unquote args)
+		         (progn (unquote-splicing exprs))))))`,
+		`(def-handler handle-request (req resp)
+		   (list req resp))`)
+
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "req", u.Name, "req should resolve as lambda param after expansion")
+		assert.NotEqual(t, "resp", u.Name, "resp should resolve as lambda param after expansion")
+	}
+}
+
+func TestAnalyze_MacroExpansion_NestedMacros(t *testing.T) {
+	// Pattern from def-acre-route-get calling def-acre-route.
+	// Outer macro expands, inner macro expands on next recursion.
+	result := parseAndAnalyzeWithExpander(t,
+		`(defmacro def-route (name args &rest exprs)
+		   (quasiquote
+		     (set (quote (unquote name))
+		       (lambda (unquote args)
+		         (progn (unquote-splicing exprs))))))
+		 (defmacro def-route-get (name args &rest exprs)
+		   (quasiquote
+		     (def-route (unquote name) (unquote args)
+		       (unquote-splicing exprs))))`,
+		`(def-route-get my-handler (req)
+		   (+ req 1))`)
+
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "req", u.Name, "req should resolve via nested macro expansion")
+	}
+}
+
+func TestAnalyze_MacroExpansion_WhenMacro(t *testing.T) {
+	// Simple when macro — very common pattern.
+	result := parseAndAnalyzeWithExpander(t,
+		`(defmacro my-when (cond &rest body)
+		   (quasiquote (if (unquote cond) (progn (unquote-splicing body)))))`,
+		`(defun f (x) (my-when (> x 0) (+ x 1)))`)
+
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "x", u.Name, "x should resolve through macro expansion")
+	}
+}
+
+func TestAnalyze_MacroExpansion_WithoutExpander(t *testing.T) {
+	// Without an expander, behavior should be unchanged (opaque + downgraded severity).
+	result := parseAndAnalyze(t, `
+(defmacro my-when (cond &rest body)
+  (quasiquote (if (unquote cond) (progn (unquote-splicing body)))))
+(defun f (x) (my-when (> x 0) (+ x 1)))`)
+
+	// x inside my-when call should still resolve (it's a symbol ref to the param)
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "x", u.Name, "x should resolve as defun param")
+	}
+}
+
+func TestAnalyze_MacroExpansion_FailureFallback(t *testing.T) {
+	// If expansion fails (e.g. macro not in env), fall back to opaque analysis.
+	env := newTestEnv(t)
+	// Don't define the macro in the env — only in the source for prescan.
+	result := parseAndAnalyzeWithConfig(t, `
+(defmacro my-macro (x) (quasiquote (+ (unquote x) 1)))
+(my-macro 42)`, &Config{
+		MacroExpander: &EnvMacroExpander{Env: env},
+	})
+
+	// Should not crash — falls back to opaque analysis.
+	// 42 inside the macro call gets InsideMacroCall treatment.
+	assert.NotNil(t, result)
+}
+
+func TestAnalyze_MacroExpansion_HandlerBindPattern(t *testing.T) {
+	// Pattern from assert-not-error: macro wraps handler-bind.
+	result := parseAndAnalyzeWithExpander(t,
+		`(defmacro with-handler (handler &rest body)
+		   (quasiquote
+		     (handler-bind ((condition (unquote handler)))
+		       (unquote-splicing body))))`,
+		`(defun safe-call (f)
+		   (with-handler (lambda (&rest e) ()) (f)))`)
+
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "f", u.Name, "f should resolve through expansion")
+		assert.NotEqual(t, "e", u.Name, "e should resolve as lambda param")
+	}
+}

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -471,6 +471,14 @@ func TestAnalyze_Set_InLambdaReferencesGlobal(t *testing.T) {
 	for _, u := range result.Unresolved {
 		assert.NotEqual(t, "now", u.Name, "'now' should be resolved")
 	}
+
+	// Verify 'now' exists in the global scope with expected properties.
+	globalNow := result.RootScope.LookupLocal("now")
+	require.NotNil(t, globalNow, "'now' should be defined in the global scope")
+	assert.Equal(t, SymVariable, globalNow.Kind)
+	// The lambda's (set 'now 42) should increment References on the global symbol.
+	assert.GreaterOrEqual(t, globalNow.References, 1,
+		"global 'now' should have references from the lambda set and use-now")
 }
 
 func TestAnalyze_Set_InLambdaCreatesGlobalIfMissing(t *testing.T) {
@@ -1757,35 +1765,45 @@ func TestAnalyze_MacroExpansion_LambdaParams(t *testing.T) {
 	// Pattern from def-acre-route: macro introduces lambda parameters.
 	// Without expansion: req/resp flagged as undefined.
 	// With expansion: they resolve as lambda params.
+	// Note: macro name intentionally doesn't start with "def" to avoid
+	// the heuristic def-like matching, ensuring expansion is actually tested.
 	result := parseAndAnalyzeWithExpander(t,
-		`(defmacro def-handler (name args &rest exprs)
+		`(defmacro make-handler (name args &rest exprs)
 		   (quasiquote
 		     (set (quote (unquote name))
 		       (lambda (unquote args)
 		         (progn (unquote-splicing exprs))))))`,
-		`(def-handler handle-request (req resp)
+		`(make-handler handle-request (req resp)
 		   (list req resp))`)
 
 	for _, u := range result.Unresolved {
 		assert.NotEqual(t, "req", u.Name, "req should resolve as lambda param after expansion")
 		assert.NotEqual(t, "resp", u.Name, "resp should resolve as lambda param after expansion")
 	}
+
+	// Verify symbols actually resolved as references (not just absent from Unresolved).
+	refNames := make(map[string]bool)
+	for _, ref := range result.References {
+		refNames[ref.Symbol.Name] = true
+	}
+	assert.True(t, refNames["req"], "req should appear in References after macro expansion")
+	assert.True(t, refNames["resp"], "resp should appear in References after macro expansion")
 }
 
 func TestAnalyze_MacroExpansion_NestedMacros(t *testing.T) {
 	// Pattern from def-acre-route-get calling def-acre-route.
 	// Outer macro expands, inner macro expands on next recursion.
 	result := parseAndAnalyzeWithExpander(t,
-		`(defmacro def-route (name args &rest exprs)
+		`(defmacro make-route (name args &rest exprs)
 		   (quasiquote
 		     (set (quote (unquote name))
 		       (lambda (unquote args)
 		         (progn (unquote-splicing exprs))))))
-		 (defmacro def-route-get (name args &rest exprs)
+		 (defmacro make-route-get (name args &rest exprs)
 		   (quasiquote
-		     (def-route (unquote name) (unquote args)
+		     (make-route (unquote name) (unquote args)
 		       (unquote-splicing exprs))))`,
-		`(def-route-get my-handler (req)
+		`(make-route-get my-handler (req)
 		   (+ req 1))`)
 
 	for _, u := range result.Unresolved {
@@ -1831,6 +1849,26 @@ func TestAnalyze_MacroExpansion_FailureFallback(t *testing.T) {
 	// Should not crash — falls back to opaque analysis.
 	// 42 inside the macro call gets InsideMacroCall treatment.
 	assert.NotNil(t, result)
+}
+
+func TestAnalyze_MacroExpansion_UnresolvedInExpandedCode(t *testing.T) {
+	// Symbols that are genuinely undefined in expanded code should still
+	// appear in Unresolved, but with InsideMacroCall=true (downgraded severity).
+	result := parseAndAnalyzeWithExpander(t,
+		`(defmacro wrap-body (&rest body)
+		   (quasiquote (progn (unquote-splicing body))))`,
+		`(wrap-body (totally-unknown-fn 42))`)
+
+	var found *UnresolvedRef
+	for _, u := range result.Unresolved {
+		if u.Name == "totally-unknown-fn" {
+			found = u
+			break
+		}
+	}
+	require.NotNil(t, found, "genuinely undefined symbol in expanded code should still be flagged")
+	assert.True(t, found.InsideMacroCall,
+		"undefined symbol in expanded code should have InsideMacroCall=true for downgraded severity")
 }
 
 func TestAnalyze_MacroExpansion_HandlerBindPattern(t *testing.T) {

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -1826,15 +1826,26 @@ func TestAnalyze_MacroExpansion_NestedMacros(t *testing.T) {
 }
 
 func TestAnalyze_MacroExpansion_WhenMacro(t *testing.T) {
-	// Simple when macro — very common pattern.
+	// Macro that introduces a let binding — 'default-val' only exists after
+	// expansion, so this test proves expansion actually adds value (the previous
+	// version used a defun param which resolved without expansion).
 	result := parseAndAnalyzeWithExpander(t,
-		`(defmacro my-when (cond &rest body)
-		   (quasiquote (if (unquote cond) (progn (unquote-splicing body)))))`,
-		`(defun f (x) (my-when (> x 0) (+ x 1)))`)
+		`(defmacro with-default (name val &rest body)
+		   (quasiquote (let (((unquote name) (unquote val))) (unquote-splicing body))))`,
+		`(with-default default-val 42 (+ default-val 1))`)
 
 	for _, u := range result.Unresolved {
-		assert.NotEqual(t, "x", u.Name, "x should resolve through macro expansion")
+		assert.NotEqual(t, "default-val", u.Name,
+			"default-val should resolve through macro expansion (let binding introduced by macro)")
 	}
+
+	// Verify default-val actually resolved as a reference, not just absent from Unresolved.
+	refNames := make(map[string]bool)
+	for _, ref := range result.References {
+		refNames[ref.Symbol.Name] = true
+	}
+	assert.True(t, refNames["default-val"],
+		"default-val should appear in References after expansion introduces the let binding")
 }
 
 func TestAnalyze_MacroExpansion_WithoutExpander(t *testing.T) {

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -451,6 +451,40 @@ func TestAnalyze_SetBang(t *testing.T) {
 	}
 }
 
+func TestAnalyze_Set_InLambdaReferencesGlobal(t *testing.T) {
+	// Regression test for #260: (set 'x ...) inside a lambda writes to the
+	// package-global scope (PutGlobal), not a lambda-local binding. The
+	// analyzer should not create a spurious local variable.
+	result := parseAndAnalyze(t, `
+(set 'now 0)
+(defun setup ()
+  (lambda ()
+    (set 'now 42)))
+(defun use-now () now)`)
+
+	// 'now' should NOT appear as an unused variable.
+	for _, sym := range result.Symbols {
+		if sym.Name == "now" && sym.Scope != result.RootScope {
+			t.Errorf("'now' should not be defined in a non-global scope (found in %v)", sym.Scope.Kind)
+		}
+	}
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "now", u.Name, "'now' should be resolved")
+	}
+}
+
+func TestAnalyze_Set_InLambdaCreatesGlobalIfMissing(t *testing.T) {
+	// When set creates a new variable from inside a lambda, the symbol
+	// should be registered in the root/global scope.
+	result := parseAndAnalyze(t, `
+(defun f ()
+  (lambda ()
+    (set 'y 1)))`)
+
+	sym := result.RootScope.LookupLocal("y")
+	assert.NotNil(t, sym, "'y' should be defined in global scope by set inside lambda")
+}
+
 // --- Analyze: function (#') ---
 
 func TestAnalyze_FunctionRef(t *testing.T) {
@@ -544,6 +578,68 @@ func TestAnalyze_HandlerBind_HandlerBodyStillAnalyzed(t *testing.T) {
 	}
 	assert.True(t, found,
 		"undefined symbol in handler-bind handler body should be flagged as unresolved")
+}
+
+// --- Analyze: cond ---
+
+func TestAnalyze_Cond_ElseNotFlagged(t *testing.T) {
+	// Bare 'else' in cond test position is a language keyword, not a symbol reference.
+	result := parseAndAnalyze(t, `
+(defun classify (x)
+  (cond
+    ((number? x) "number")
+    (else "other")))`)
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "else", u.Name,
+			"bare 'else' in cond test position should not be flagged as undefined")
+	}
+}
+
+func TestAnalyze_Cond_TrueNotFlagged(t *testing.T) {
+	// Bare 'true' in cond test position is a recognized default clause.
+	result := parseAndAnalyze(t, `
+(defun classify (x)
+  (cond
+    ((number? x) "number")
+    (true "other")))`)
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "true", u.Name,
+			"bare 'true' in cond test position should not be flagged as undefined")
+	}
+}
+
+func TestAnalyze_Cond_UndefinedTestStillFlagged(t *testing.T) {
+	// A non-keyword symbol in cond test position should still be flagged.
+	result := parseAndAnalyze(t, `
+(defun classify (x)
+  (cond
+    ((number? x) "number")
+    (bogus "other")))`)
+	found := false
+	for _, u := range result.Unresolved {
+		if u.Name == "bogus" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"undefined symbol in cond test position should still be flagged as unresolved")
+}
+
+func TestAnalyze_Cond_BodyStillAnalyzed(t *testing.T) {
+	// Body expressions in cond clauses should still be analyzed.
+	result := parseAndAnalyze(t, `
+(cond
+  (else (unknown-body-fn)))`)
+	found := false
+	for _, u := range result.Unresolved {
+		if u.Name == "unknown-body-fn" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found,
+		"undefined symbol in cond body should still be flagged")
 }
 
 // --- Analyze: test-let / test-let* ---

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -1091,16 +1091,17 @@ func (a *analyzer) analyzeHandlerBind(node *lisp.LVal, scope *Scope, currentPkg 
 
 func (a *analyzer) analyzeCond(node *lisp.LVal, scope *Scope, currentPkg string) {
 	// cond form: (cond (test body...)*)
-	// The test position of the final clause may be the bare symbol 'else'
-	// or 'true', which the runtime treats as a catch-all (op.go:729).
-	// Skip resolving these symbols to avoid false "undefined symbol" reports.
+	// The runtime special-cases bare 'else' as a catch-all keyword (op.go:729).
+	// Bare 'true' is not special-cased by the runtime but evaluates to a
+	// truthy value (well-known symbol from populateBuiltins), so it also
+	// serves as a default clause. Skip resolving both to avoid noise.
 	for _, clause := range node.Cells[1:] {
 		if clause.Type != lisp.LSExpr || clause.Quoted || len(clause.Cells) == 0 {
 			continue
 		}
 		test := clause.Cells[0]
 		if test.Type == lisp.LSymbol && !test.Quoted && isCondDefaultSymbol(test.Str) {
-			// Skip — 'else' and 'true' are recognized keywords in cond test position.
+			// Skip — 'else' is a runtime keyword; 'true' is a well-known truthy symbol.
 		} else {
 			a.analyzeExpr(test, scope, currentPkg)
 		}

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -1193,11 +1193,29 @@ func (a *analyzer) walkQuasiquoteTemplate(node *lisp.LVal, scope *Scope, current
 }
 
 func (a *analyzer) analyzeCall(node *lisp.LVal, scope *Scope, currentPkg string) {
-	// Check if head is a user-defined macro — unresolved symbols inside
-	// macro bodies get lower severity since macros may introduce bindings
-	// at expansion time that are invisible to static analysis.
+	// Check if head is a user-defined macro — try expansion if an expander
+	// is available, otherwise fall back to opaque analysis with lowered
+	// severity for unresolved symbols.
 	if len(node.Cells) > 0 && node.Cells[0].Type == lisp.LSymbol {
 		if sym := scope.Lookup(node.Cells[0].Str); sym != nil && sym.Kind == SymMacro && isUserMacro(sym) {
+			sym.References++
+			a.result.References = append(a.result.References, &Reference{
+				Symbol: sym,
+				Source:  node.Cells[0].Source,
+				Node:    node.Cells[0],
+			})
+			if a.cfg != nil && a.cfg.MacroExpander != nil {
+				if expanded := a.cfg.MacroExpander.ExpandMacro(node); expanded != nil {
+					// Analyze expanded code. Keep insideMacroCall
+					// incremented so template-generated symbols that
+					// can't be resolved get warning severity, not error.
+					a.insideMacroCall++
+					a.analyzeExpr(expanded, scope, currentPkg)
+					a.insideMacroCall--
+					return
+				}
+			}
+			// No expander or expansion failed — opaque walk.
 			a.insideMacroCall++
 			defer func() { a.insideMacroCall-- }()
 		}

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -1197,24 +1197,32 @@ func (a *analyzer) analyzeCall(node *lisp.LVal, scope *Scope, currentPkg string)
 	// is available, otherwise fall back to opaque analysis with lowered
 	// severity for unresolved symbols.
 	if len(node.Cells) > 0 && node.Cells[0].Type == lisp.LSymbol {
-		if sym := scope.Lookup(node.Cells[0].Str); sym != nil && sym.Kind == SymMacro && isUserMacro(sym) {
+		sym := scope.Lookup(node.Cells[0].Str)
+		isMacro := sym != nil && sym.Kind == SymMacro && isUserMacro(sym)
+
+		if isMacro {
 			sym.References++
 			a.result.References = append(a.result.References, &Reference{
 				Symbol: sym,
 				Source:  node.Cells[0].Source,
 				Node:    node.Cells[0],
 			})
-			if a.cfg != nil && a.cfg.MacroExpander != nil {
-				if expanded := a.cfg.MacroExpander.ExpandMacro(node); expanded != nil {
-					// Analyze expanded code. Keep insideMacroCall
-					// incremented so template-generated symbols that
-					// can't be resolved get warning severity, not error.
-					a.insideMacroCall++
-					a.analyzeExpr(expanded, scope, currentPkg)
-					a.insideMacroCall--
-					return
-				}
+		}
+
+		// Try macro expansion: either the symbol is a known user-macro,
+		// or the expander recognizes it (the macro may be defined in the
+		// runtime env but not in the analyzed source, e.g. cross-file macros
+		// or macros from the embedder's registry).
+		if a.cfg != nil && a.cfg.MacroExpander != nil && (isMacro || sym == nil) {
+			if expanded := a.cfg.MacroExpander.ExpandMacro(node); expanded != nil {
+				a.insideMacroCall++
+				a.analyzeExpr(expanded, scope, currentPkg)
+				a.insideMacroCall--
+				return
 			}
+		}
+
+		if isMacro {
 			// No expander or expansion failed — opaque walk.
 			a.insideMacroCall++
 			defer func() { a.insideMacroCall-- }()

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -403,6 +403,8 @@ func (a *analyzer) analyzeExpr(node *lisp.LVal, scope *Scope, currentPkg string)
 		a.analyzePrefixLambda(node, scope, currentPkg)
 	case "handler-bind":
 		a.analyzeHandlerBind(node, scope, currentPkg)
+	case "cond":
+		a.analyzeCond(node, scope, currentPkg)
 	case "test":
 		a.analyzeTest(node, scope, currentPkg)
 	default:
@@ -961,12 +963,41 @@ func (a *analyzer) analyzeSet(node *lisp.LVal, scope *Scope, currentPkg string) 
 	// Analyze the value expression
 	a.analyzeExpr(node.Cells[2], scope, currentPkg)
 
-	// For set, the name might be a new binding or overwrite
 	name := extractSetSymbolName(node.Cells[1])
 	if name == "" {
 		return
 	}
-	// If not already defined at top level, define it
+
+	// At runtime, set always calls PutGlobal — it writes to the package-
+	// level scope regardless of where the call appears. Model this by:
+	// - In non-global scopes: treat as a reference to the existing global
+	//   binding (or create one in the root scope if none exists).
+	// - In global scope: create or overwrite in the current scope (existing
+	//   behavior, matches prescan).
+	if scope.Kind != ScopeGlobal {
+		if existing := scope.LookupInPackage(name, currentPkg); existing != nil {
+			existing.References++
+			a.result.References = append(a.result.References, &Reference{
+				Symbol: existing,
+				Source:  node.Cells[1].Source,
+				Node:    extractSetSymbolNode(node.Cells[1]),
+			})
+			return
+		}
+		// No existing global — set will create it at package scope.
+		sym := &Symbol{
+			Name:    name,
+			Package: currentPkg,
+			Kind:    SymVariable,
+			Source:  node.Cells[1].Source,
+			Node:    extractSetSymbolNode(node.Cells[1]),
+		}
+		a.root.Define(sym)
+		a.result.Symbols = append(a.result.Symbols, sym)
+		return
+	}
+
+	// Global scope: define locally if not already present.
 	defPkg := packageForScope(scope, currentPkg)
 	if scope.LookupLocalInPackage(name, defPkg) == nil {
 		sym := &Symbol{
@@ -1038,6 +1069,34 @@ func (a *analyzer) analyzeHandlerBind(node *lisp.LVal, scope *Scope, currentPkg 
 	for _, child := range node.Cells[2:] {
 		a.analyzeExpr(child, scope, currentPkg)
 	}
+}
+
+func (a *analyzer) analyzeCond(node *lisp.LVal, scope *Scope, currentPkg string) {
+	// cond form: (cond (test body...)*)
+	// The test position of the final clause may be the bare symbol 'else'
+	// or 'true', which the runtime treats as a catch-all (op.go:729).
+	// Skip resolving these symbols to avoid false "undefined symbol" reports.
+	for _, clause := range node.Cells[1:] {
+		if clause.Type != lisp.LSExpr || clause.Quoted || len(clause.Cells) == 0 {
+			continue
+		}
+		test := clause.Cells[0]
+		if test.Type == lisp.LSymbol && !test.Quoted && isCondDefaultSymbol(test.Str) {
+			// Skip — 'else' and 'true' are recognized keywords in cond test position.
+		} else {
+			a.analyzeExpr(test, scope, currentPkg)
+		}
+		for _, body := range clause.Cells[1:] {
+			a.analyzeExpr(body, scope, currentPkg)
+		}
+	}
+}
+
+// isCondDefaultSymbol returns true if name is a bare symbol recognized as
+// a default clause test in cond. Keywords (:else, :true) are already
+// skipped by resolveSymbol so only bare forms need checking here.
+func isCondDefaultSymbol(name string) bool {
+	return name == "else" || name == "true"
 }
 
 func (a *analyzer) analyzePrefixLambda(node *lisp.LVal, scope *Scope, currentPkg string) {

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -1296,7 +1296,7 @@ func (a *analyzer) analyzeCall(node *lisp.LVal, scope *Scope, currentPkg string)
 		// Depth-limited to prevent stack overflow on self-expanding macros.
 		if a.cfg != nil && a.cfg.MacroExpander != nil && (isMacro || sym == nil) &&
 			a.expansionDepth < maxMacroExpansionDepth {
-			if expanded := a.cfg.MacroExpander.ExpandMacro(node); expanded != nil {
+			if expanded := a.cfg.MacroExpander.ExpandMacro(node, currentPkg); expanded != nil {
 				a.insideMacroCall++
 				a.expansionDepth++
 				a.analyzeExpr(expanded, scope, currentPkg)

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -410,6 +410,16 @@ func (a *analyzer) analyzeExpr(node *lisp.LVal, scope *Scope, currentPkg string)
 		a.analyzeHandlerBind(node, scope, currentPkg)
 	case "cond":
 		a.analyzeCond(node, scope, currentPkg)
+	case "macrolet":
+		a.analyzeMacrolet(node, scope, currentPkg)
+	case "qualified-symbol":
+		a.analyzeQualifiedSymbol(node, scope, currentPkg)
+	case "thread-first", "thread-last":
+		// Threading macros transform expressions at expansion time by
+		// inserting the threaded value as the first/last argument of each
+		// form. For symbol resolution purposes the same symbols appear
+		// regardless of the transformation, so analyzeCall is correct.
+		a.analyzeCall(node, scope, currentPkg)
 	case "test":
 		a.analyzeTest(node, scope, currentPkg)
 	default:
@@ -1106,6 +1116,66 @@ func (a *analyzer) analyzeCond(node *lisp.LVal, scope *Scope, currentPkg string)
 // See also: lint/analyzers.go isCondDefault (same logic, used by lint checks).
 func isCondDefaultSymbol(name string) bool {
 	return name == "else" || name == "true"
+}
+
+func (a *analyzer) analyzeMacrolet(node *lisp.LVal, scope *Scope, currentPkg string) {
+	// macrolet form: (macrolet ((name formals body...) ...) body...)
+	// Creates a new scope with locally-bound macros, then evaluates body in
+	// that scope. Macro bodies are templates (like defmacro) — we skip
+	// analyzing them to avoid false positives from template variables.
+	if astutil.ArgCount(node) < 1 {
+		return
+	}
+	bindings := node.Cells[1]
+	if bindings.Type != lisp.LSExpr {
+		return
+	}
+
+	macroletScope := NewScope(ScopeMacrolet, scope, node)
+
+	for _, binding := range bindings.Cells {
+		if binding.Type != lisp.LSExpr || len(binding.Cells) < 2 {
+			continue
+		}
+		nameVal := binding.Cells[0]
+		if nameVal.Type != lisp.LSymbol {
+			continue
+		}
+		sym := &Symbol{
+			Name:   nameVal.Str,
+			Kind:   SymMacro,
+			Source: nameVal.Source,
+			Node:   nameVal,
+		}
+		macroletScope.Define(sym)
+		a.result.Symbols = append(a.result.Symbols, sym)
+		// Skip analyzing macro bodies — they are templates, not executable
+		// code in this scope. Like defmacro, template variables (from
+		// quasiquote/unquote) would produce false "undefined symbol" reports.
+	}
+
+	// Analyze body forms in the macrolet scope
+	for i := 2; i < len(node.Cells); i++ {
+		a.analyzeExpr(node.Cells[i], macroletScope, currentPkg)
+	}
+}
+
+func (a *analyzer) analyzeQualifiedSymbol(node *lisp.LVal, scope *Scope, currentPkg string) {
+	// qualified-symbol form: (qualified-symbol name)
+	// The argument is a bare symbol treated as data (a name to construct a
+	// qualified symbol from), not a variable reference. Skip resolving it to
+	// avoid false "undefined symbol" reports, similar to how handler-bind
+	// skips condition type names.
+	//
+	// Analyze the head (qualified-symbol itself) so it gets resolved.
+	if len(node.Cells) > 0 {
+		a.analyzeExpr(node.Cells[0], scope, currentPkg)
+	}
+	// Skip Cells[1] — it's data, not a symbol reference.
+	// Analyze any remaining args (unlikely but for completeness).
+	for i := 2; i < len(node.Cells); i++ {
+		a.analyzeExpr(node.Cells[i], scope, currentPkg)
+	}
 }
 
 func (a *analyzer) analyzePrefixLambda(node *lisp.LVal, scope *Scope, currentPkg string) {

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -9,6 +9,10 @@ import (
 	"github.com/luthersystems/elps/lisp"
 )
 
+// maxMacroExpansionDepth caps recursive macro expansion in the analyzer
+// to prevent stack overflow on pathological macros (e.g. self-expanding).
+const maxMacroExpansionDepth = 64
+
 // analyzer is the internal state for a single analysis run.
 type analyzer struct {
 	root             *Scope
@@ -16,6 +20,7 @@ type analyzer struct {
 	cfg              *Config
 	qualifiedSymbols map[string]*Symbol
 	insideMacroCall  int // depth counter for user-macro body analysis
+	expansionDepth   int // current macro expansion nesting depth
 }
 
 // defaultPackage returns the default package for bare files. If a
@@ -975,7 +980,10 @@ func (a *analyzer) analyzeSet(node *lisp.LVal, scope *Scope, currentPkg string) 
 	// - In global scope: create or overwrite in the current scope (existing
 	//   behavior, matches prescan).
 	if scope.Kind != ScopeGlobal {
-		if existing := scope.LookupInPackage(name, currentPkg); existing != nil {
+		// Look up in the root (global) scope specifically — set always
+		// targets the package scope via PutGlobal, so let/lambda-local
+		// bindings with the same name should not be found here.
+		if existing := a.root.LookupLocalInPackage(name, currentPkg); existing != nil {
 			existing.References++
 			a.result.References = append(a.result.References, &Reference{
 				Symbol: existing,
@@ -1095,6 +1103,7 @@ func (a *analyzer) analyzeCond(node *lisp.LVal, scope *Scope, currentPkg string)
 // isCondDefaultSymbol returns true if name is a bare symbol recognized as
 // a default clause test in cond. Keywords (:else, :true) are already
 // skipped by resolveSymbol so only bare forms need checking here.
+// See also: lint/analyzers.go isCondDefault (same logic, used by lint checks).
 func isCondDefaultSymbol(name string) bool {
 	return name == "else" || name == "true"
 }
@@ -1213,10 +1222,14 @@ func (a *analyzer) analyzeCall(node *lisp.LVal, scope *Scope, currentPkg string)
 		// or the expander recognizes it (the macro may be defined in the
 		// runtime env but not in the analyzed source, e.g. cross-file macros
 		// or macros from the embedder's registry).
-		if a.cfg != nil && a.cfg.MacroExpander != nil && (isMacro || sym == nil) {
+		// Depth-limited to prevent stack overflow on self-expanding macros.
+		if a.cfg != nil && a.cfg.MacroExpander != nil && (isMacro || sym == nil) &&
+			a.expansionDepth < maxMacroExpansionDepth {
 			if expanded := a.cfg.MacroExpander.ExpandMacro(node); expanded != nil {
 				a.insideMacroCall++
+				a.expansionDepth++
 				a.analyzeExpr(expanded, scope, currentPkg)
+				a.expansionDepth--
 				a.insideMacroCall--
 				return
 			}

--- a/analysis/expander.go
+++ b/analysis/expander.go
@@ -12,11 +12,14 @@ import (
 
 // MacroExpander expands a macro call form at analysis time.
 // The form includes the macro name as Cells[0] and arguments as Cells[1:].
+// pkg is the current package context from the analyzer — the expander
+// should resolve the macro name relative to this package, matching the
+// runtime's package-scoped symbol resolution.
 // Returns the expanded AST, or nil if expansion is not possible (macro not
 // found, expansion error, wrong arity, etc.). Returning nil causes the
 // analyzer to fall back to treating the call as an opaque macro invocation.
 type MacroExpander interface {
-	ExpandMacro(form *lisp.LVal) *lisp.LVal
+	ExpandMacro(form *lisp.LVal, pkg string) *lisp.LVal
 }
 
 // EnvMacroExpander uses a live LEnv to expand user-defined macros.
@@ -45,11 +48,12 @@ func (e *EnvMacroExpander) Reset() {
 	e.mu.Unlock()
 }
 
-// ExpandMacro looks up the head symbol in the environment, verifies it is
-// a macro, and calls MacroCall to expand it. Returns the expanded AST or
-// nil on any failure. Results for non-macro symbols are cached to avoid
-// repeated env lookups on every unresolved call.
-func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal) (result *lisp.LVal) {
+// ExpandMacro looks up the head symbol in the environment relative to
+// the given package, verifies it is a macro, and calls MacroCall to
+// expand it. The env is temporarily switched to pkg so that unqualified
+// symbol resolution matches the file's package context — the same way
+// the runtime resolves symbols during eval.
+func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal, pkg string) (result *lisp.LVal) {
 	defer func() {
 		if r := recover(); r != nil {
 			result = nil
@@ -65,8 +69,17 @@ func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal) (result *lisp.LVal) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Fast path: already know this symbol is not a macro.
-	if e.notMacro != nil && e.notMacro[name] {
+	// Switch to the file's package for correct symbol resolution.
+	// Save and restore — MacroCall may also switch packages internally.
+	prevPkg := e.Env.Runtime.Package
+	if pkg != "" {
+		e.Env.InPackage(lisp.String(pkg))
+	}
+	defer func() { e.Env.Runtime.Package = prevPkg }()
+
+	// Fast path: already know this symbol is not a macro in this package.
+	cacheKey := pkg + "\x00" + name
+	if e.notMacro != nil && e.notMacro[cacheKey] {
 		return nil
 	}
 
@@ -76,7 +89,7 @@ func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal) (result *lisp.LVal) {
 		if e.notMacro == nil {
 			e.notMacro = make(map[string]bool)
 		}
-		e.notMacro[name] = true
+		e.notMacro[cacheKey] = true
 		return nil
 	}
 

--- a/analysis/expander.go
+++ b/analysis/expander.go
@@ -1,8 +1,10 @@
-// Copyright © 2024 The ELPS authors
+// Copyright © 2026 The ELPS authors
 
 package analysis
 
 import (
+	"sync"
+
 	"github.com/luthersystems/elps/lisp"
 )
 
@@ -18,13 +20,21 @@ type MacroExpander interface {
 // EnvMacroExpander uses a live LEnv to expand user-defined macros.
 // Expansion errors and panics are caught — the analyzer falls back to
 // opaque analysis when ExpandMacro returns nil.
+//
+// Thread-safe: a mutex serializes expansion calls since MacroCall mutates
+// shared Runtime state (call stack, package pointer). The mutex is only
+// contended when multiple LSP handlers trigger concurrent analyses.
 type EnvMacroExpander struct {
 	Env *lisp.LEnv
+
+	mu       sync.Mutex
+	notMacro map[string]bool // cache: symbols that are not macros in the env
 }
 
 // ExpandMacro looks up the head symbol in the environment, verifies it is
 // a macro, and calls MacroCall to expand it. Returns the expanded AST or
-// nil on any failure.
+// nil on any failure. Results for non-macro symbols are cached to avoid
+// repeated env lookups on every unresolved call.
 func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal) (result *lisp.LVal) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -36,8 +46,23 @@ func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal) (result *lisp.LVal) {
 		return nil
 	}
 
+	name := form.Cells[0].Str
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Fast path: already know this symbol is not a macro.
+	if e.notMacro != nil && e.notMacro[name] {
+		return nil
+	}
+
 	mac := e.Env.Get(form.Cells[0])
 	if mac.Type != lisp.LFun || !mac.IsMacro() {
+		// Cache the negative result to avoid future lookups.
+		if e.notMacro == nil {
+			e.notMacro = make(map[string]bool)
+		}
+		e.notMacro[name] = true
 		return nil
 	}
 

--- a/analysis/expander.go
+++ b/analysis/expander.go
@@ -1,0 +1,51 @@
+// Copyright © 2024 The ELPS authors
+
+package analysis
+
+import (
+	"github.com/luthersystems/elps/lisp"
+)
+
+// MacroExpander expands a macro call form at analysis time.
+// The form includes the macro name as Cells[0] and arguments as Cells[1:].
+// Returns the expanded AST, or nil if expansion is not possible (macro not
+// found, expansion error, wrong arity, etc.). Returning nil causes the
+// analyzer to fall back to treating the call as an opaque macro invocation.
+type MacroExpander interface {
+	ExpandMacro(form *lisp.LVal) *lisp.LVal
+}
+
+// EnvMacroExpander uses a live LEnv to expand user-defined macros.
+// Expansion errors and panics are caught — the analyzer falls back to
+// opaque analysis when ExpandMacro returns nil.
+type EnvMacroExpander struct {
+	Env *lisp.LEnv
+}
+
+// ExpandMacro looks up the head symbol in the environment, verifies it is
+// a macro, and calls MacroCall to expand it. Returns the expanded AST or
+// nil on any failure.
+func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal) (result *lisp.LVal) {
+	defer func() {
+		if r := recover(); r != nil {
+			result = nil
+		}
+	}()
+
+	if e.Env == nil || len(form.Cells) == 0 || form.Cells[0].Type != lisp.LSymbol {
+		return nil
+	}
+
+	mac := e.Env.Get(form.Cells[0])
+	if mac.Type != lisp.LFun || !mac.IsMacro() {
+		return nil
+	}
+
+	args := lisp.SExpr(form.Cells[1:])
+	mark := e.Env.MacroCall(mac, args)
+	if mark.Type == lisp.LError || mark.Type != lisp.LMarkMacExpand {
+		return nil
+	}
+
+	return mark.Cells[0]
+}

--- a/analysis/expander.go
+++ b/analysis/expander.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/luthersystems/elps/astutil"
 	"github.com/luthersystems/elps/lisp"
 )
 
@@ -88,76 +89,72 @@ func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal) (result *lisp.LVal) {
 	return mark.Cells[0]
 }
 
-// LoadWorkspaceMacros evaluates workspace defmacro AST nodes into the
-// given environment so that EnvMacroExpander can expand them. Each macro
-// is evaluated in the package it was defined in (from the prescan's
-// in-package tracking), ensuring macros register in the correct package.
+// LoadWorkspaceMacros replays workspace preamble forms (in-package,
+// use-package, export, defmacro) into the given environment. This mirrors
+// what the runtime's (load) does — forms are eval'd in source order so
+// package context, imports, and macro definitions build up naturally.
 //
-// packageImports provides cross-file use-package declarations (from
-// prescan.PackageImports). These are applied to each workspace package
-// before eval'ing its macros so that functions from imported packages
-// (e.g. flatten from utils) are available during macro expansion.
-// Pass nil if no cross-file imports are needed.
+// Workspace packages that don't exist in the boot env are auto-created.
+// The env's active package is saved and restored after loading.
 //
-// Malformed macros are skipped — the returned errors slice contains one
-// entry per failed defmacro with the macro name and cause. Callers
-// should log these for visibility (e.g. as warnings in the LSP or CLI).
-func LoadWorkspaceMacros(env *lisp.LEnv, defs []MacroDef, packageImports map[string][]string) []error {
-	// Ensure all workspace packages exist and have their imports applied
-	// before any macros are eval'd (a macro in pkg A may depend on a
-	// function from pkg B that was imported via use-package in pkg A).
-	preparedPkgs := make(map[string]bool)
-	for _, def := range defs {
-		if def.Package != "" && !preparedPkgs[def.Package] {
-			preparePackage(env, def.Package, packageImports)
-			preparedPkgs[def.Package] = true
-		}
-	}
+// Malformed forms are skipped — the returned errors slice contains one
+// entry per failure. Callers should log these for visibility.
+func LoadWorkspaceMacros(env *lisp.LEnv, preamble []*lisp.LVal) []error {
+	// Save and restore the env's active package, same as env.load().
+	currPkg := env.Runtime.Package
+	defer func() { env.Runtime.Package = currPkg }()
 
 	var errs []error
-	for _, def := range defs {
-		if err := loadOneMacro(env, def); err != nil {
+	for _, form := range preamble {
+		if err := evalPreambleForm(env, form); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errs
 }
 
-// preparePackage ensures a workspace package exists in the env with the
-// lang package and any cross-file use-package imports applied.
-func preparePackage(env *lisp.LEnv, pkg string, packageImports map[string][]string) {
-	env.Runtime.Registry.DefinePackage(pkg)
-	env.InPackage(lisp.String(pkg))
-	env.UsePackage(lisp.Symbol(env.Runtime.Registry.Lang))
-	for _, imp := range packageImports[pkg] {
-		// Ensure imported package exists too (it may be a workspace package).
-		env.Runtime.Registry.DefinePackage(imp)
-		env.UsePackage(lisp.Symbol(imp))
-	}
-}
-
-func loadOneMacro(env *lisp.LEnv, def MacroDef) (retErr error) {
+func evalPreambleForm(env *lisp.LEnv, form *lisp.LVal) (retErr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			retErr = fmt.Errorf("panic loading macro %s: %v", macroDefName(def.Node), r)
+			retErr = fmt.Errorf("panic in preamble form: %v", r)
 		}
 	}()
-	if def.Package != "" {
-		rc := env.InPackage(lisp.String(def.Package))
-		if rc.Type == lisp.LError {
-			return fmt.Errorf("error setting package %q for macro %s: %v",
-				def.Package, macroDefName(def.Node), rc)
+	// Auto-create workspace packages so in-package doesn't fail.
+	// Import the lang package so builtins (defmacro, use-package, etc.) work.
+	head := astutil.HeadSymbol(form)
+	if head == "in-package" && len(form.Cells) > 1 {
+		if name := preamblePkgName(form.Cells[1]); name != "" {
+			env.Runtime.Registry.DefinePackage(name)
+			// Temporarily switch to the new package to import lang builtins,
+			// then let the actual (in-package ...) eval do the real switch.
+			env.InPackage(lisp.String(name))
+			env.UsePackage(lisp.Symbol(env.Runtime.Registry.Lang))
 		}
 	}
-	result := env.Eval(def.Node)
+	result := env.Eval(form)
 	if result.Type == lisp.LError {
-		return fmt.Errorf("error loading macro %s: %v", macroDefName(def.Node), result)
+		if head == "defmacro" {
+			return fmt.Errorf("error loading macro %s: %v", preambleDefName(form), result)
+		}
+		return fmt.Errorf("error in preamble (%s): %v", head, result)
 	}
 	return nil
 }
 
-// macroDefName extracts the name from a (defmacro name ...) AST node.
-func macroDefName(def *lisp.LVal) string {
+// preamblePkgName extracts a package name from a quoted or bare symbol.
+func preamblePkgName(v *lisp.LVal) string {
+	if v.Type == lisp.LSymbol {
+		return v.Str
+	}
+	// (quote sym) or 'sym
+	if v.Type == lisp.LSExpr && v.Quoted && len(v.Cells) > 0 && v.Cells[0].Type == lisp.LSymbol {
+		return v.Cells[0].Str
+	}
+	return ""
+}
+
+// preambleDefName extracts the name from a (defmacro name ...) AST node.
+func preambleDefName(def *lisp.LVal) string {
 	if def != nil && len(def.Cells) > 1 && def.Cells[1].Type == lisp.LSymbol {
 		return def.Cells[1].Str
 	}

--- a/analysis/expander.go
+++ b/analysis/expander.go
@@ -113,8 +113,17 @@ func loadOneMacro(env *lisp.LEnv, def MacroDef) (retErr error) {
 		}
 	}()
 	// Switch to the macro's source package so it registers in the right scope.
+	// DefinePackage is idempotent — safe for packages that already exist.
+	// Workspace packages (e.g. "acre") won't exist in the boot env, so we
+	// create them and import the lang package so builtins like defmacro work.
 	if def.Package != "" {
+		env.Runtime.Registry.DefinePackage(def.Package)
 		rc := env.InPackage(lisp.String(def.Package))
+		if rc.Type == lisp.LError {
+			return fmt.Errorf("error setting package %q for macro %s: %v",
+				def.Package, macroDefName(def.Node), rc)
+		}
+		rc = env.UsePackage(lisp.Symbol(env.Runtime.Registry.Lang))
 		if rc.Type == lisp.LError {
 			return fmt.Errorf("error setting package %q for macro %s: %v",
 				def.Package, macroDefName(def.Node), rc)

--- a/analysis/expander.go
+++ b/analysis/expander.go
@@ -93,10 +93,27 @@ func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal) (result *lisp.LVal) {
 // is evaluated in the package it was defined in (from the prescan's
 // in-package tracking), ensuring macros register in the correct package.
 //
+// packageImports provides cross-file use-package declarations (from
+// prescan.PackageImports). These are applied to each workspace package
+// before eval'ing its macros so that functions from imported packages
+// (e.g. flatten from utils) are available during macro expansion.
+// Pass nil if no cross-file imports are needed.
+//
 // Malformed macros are skipped — the returned errors slice contains one
 // entry per failed defmacro with the macro name and cause. Callers
 // should log these for visibility (e.g. as warnings in the LSP or CLI).
-func LoadWorkspaceMacros(env *lisp.LEnv, defs []MacroDef) []error {
+func LoadWorkspaceMacros(env *lisp.LEnv, defs []MacroDef, packageImports map[string][]string) []error {
+	// Ensure all workspace packages exist and have their imports applied
+	// before any macros are eval'd (a macro in pkg A may depend on a
+	// function from pkg B that was imported via use-package in pkg A).
+	preparedPkgs := make(map[string]bool)
+	for _, def := range defs {
+		if def.Package != "" && !preparedPkgs[def.Package] {
+			preparePackage(env, def.Package, packageImports)
+			preparedPkgs[def.Package] = true
+		}
+	}
+
 	var errs []error
 	for _, def := range defs {
 		if err := loadOneMacro(env, def); err != nil {
@@ -106,24 +123,27 @@ func LoadWorkspaceMacros(env *lisp.LEnv, defs []MacroDef) []error {
 	return errs
 }
 
+// preparePackage ensures a workspace package exists in the env with the
+// lang package and any cross-file use-package imports applied.
+func preparePackage(env *lisp.LEnv, pkg string, packageImports map[string][]string) {
+	env.Runtime.Registry.DefinePackage(pkg)
+	env.InPackage(lisp.String(pkg))
+	env.UsePackage(lisp.Symbol(env.Runtime.Registry.Lang))
+	for _, imp := range packageImports[pkg] {
+		// Ensure imported package exists too (it may be a workspace package).
+		env.Runtime.Registry.DefinePackage(imp)
+		env.UsePackage(lisp.Symbol(imp))
+	}
+}
+
 func loadOneMacro(env *lisp.LEnv, def MacroDef) (retErr error) {
 	defer func() {
 		if r := recover(); r != nil {
 			retErr = fmt.Errorf("panic loading macro %s: %v", macroDefName(def.Node), r)
 		}
 	}()
-	// Switch to the macro's source package so it registers in the right scope.
-	// DefinePackage is idempotent — safe for packages that already exist.
-	// Workspace packages (e.g. "acre") won't exist in the boot env, so we
-	// create them and import the lang package so builtins like defmacro work.
 	if def.Package != "" {
-		env.Runtime.Registry.DefinePackage(def.Package)
 		rc := env.InPackage(lisp.String(def.Package))
-		if rc.Type == lisp.LError {
-			return fmt.Errorf("error setting package %q for macro %s: %v",
-				def.Package, macroDefName(def.Node), rc)
-		}
-		rc = env.UsePackage(lisp.Symbol(env.Runtime.Registry.Lang))
 		if rc.Type == lisp.LError {
 			return fmt.Errorf("error setting package %q for macro %s: %v",
 				def.Package, macroDefName(def.Node), rc)

--- a/analysis/expander.go
+++ b/analysis/expander.go
@@ -30,6 +30,18 @@ type EnvMacroExpander struct {
 
 	mu       sync.Mutex
 	notMacro map[string]bool // cache: symbols that are not macros in the env
+	// NOTE: notMacro assumes the env's macro set is stable for this
+	// expander's lifetime. If macros are added to the env after creation
+	// (e.g. LoadWorkspaceMacros), create a new EnvMacroExpander or call
+	// Reset() to clear the cache.
+}
+
+// Reset clears the not-a-macro cache. Call this after loading new macros
+// into the env (e.g. via LoadWorkspaceMacros) if the expander is reused.
+func (e *EnvMacroExpander) Reset() {
+	e.mu.Lock()
+	e.notMacro = nil
+	e.mu.Unlock()
 }
 
 // ExpandMacro looks up the head symbol in the environment, verifies it is
@@ -77,14 +89,14 @@ func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal) (result *lisp.LVal) {
 }
 
 // LoadWorkspaceMacros evaluates workspace defmacro AST nodes into the
-// given environment so that EnvMacroExpander can expand them. A defmacro
-// evaluation registers the macro in the env's package scope with no
-// other side effects.
+// given environment so that EnvMacroExpander can expand them. Each macro
+// is evaluated in the package it was defined in (from the prescan's
+// in-package tracking), ensuring macros register in the correct package.
 //
 // Malformed macros are skipped — the returned errors slice contains one
 // entry per failed defmacro with the macro name and cause. Callers
 // should log these for visibility (e.g. as warnings in the LSP or CLI).
-func LoadWorkspaceMacros(env *lisp.LEnv, defs []*lisp.LVal) []error {
+func LoadWorkspaceMacros(env *lisp.LEnv, defs []MacroDef) []error {
 	var errs []error
 	for _, def := range defs {
 		if err := loadOneMacro(env, def); err != nil {
@@ -94,15 +106,23 @@ func LoadWorkspaceMacros(env *lisp.LEnv, defs []*lisp.LVal) []error {
 	return errs
 }
 
-func loadOneMacro(env *lisp.LEnv, def *lisp.LVal) (retErr error) {
+func loadOneMacro(env *lisp.LEnv, def MacroDef) (retErr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			retErr = fmt.Errorf("panic loading macro %s: %v", macroDefName(def), r)
+			retErr = fmt.Errorf("panic loading macro %s: %v", macroDefName(def.Node), r)
 		}
 	}()
-	result := env.Eval(def)
+	// Switch to the macro's source package so it registers in the right scope.
+	if def.Package != "" {
+		rc := env.InPackage(lisp.String(def.Package))
+		if rc.Type == lisp.LError {
+			return fmt.Errorf("error setting package %q for macro %s: %v",
+				def.Package, macroDefName(def.Node), rc)
+		}
+	}
+	result := env.Eval(def.Node)
 	if result.Type == lisp.LError {
-		return fmt.Errorf("error loading macro %s: %v", macroDefName(def), result)
+		return fmt.Errorf("error loading macro %s: %v", macroDefName(def.Node), result)
 	}
 	return nil
 }

--- a/analysis/expander.go
+++ b/analysis/expander.go
@@ -3,6 +3,7 @@
 package analysis
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/luthersystems/elps/lisp"
@@ -73,4 +74,43 @@ func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal) (result *lisp.LVal) {
 	}
 
 	return mark.Cells[0]
+}
+
+// LoadWorkspaceMacros evaluates workspace defmacro AST nodes into the
+// given environment so that EnvMacroExpander can expand them. A defmacro
+// evaluation registers the macro in the env's package scope with no
+// other side effects.
+//
+// Malformed macros are skipped — the returned errors slice contains one
+// entry per failed defmacro with the macro name and cause. Callers
+// should log these for visibility (e.g. as warnings in the LSP or CLI).
+func LoadWorkspaceMacros(env *lisp.LEnv, defs []*lisp.LVal) []error {
+	var errs []error
+	for _, def := range defs {
+		if err := loadOneMacro(env, def); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+func loadOneMacro(env *lisp.LEnv, def *lisp.LVal) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = fmt.Errorf("panic loading macro %s: %v", macroDefName(def), r)
+		}
+	}()
+	result := env.Eval(def)
+	if result.Type == lisp.LError {
+		return fmt.Errorf("error loading macro %s: %v", macroDefName(def), result)
+	}
+	return nil
+}
+
+// macroDefName extracts the name from a (defmacro name ...) AST node.
+func macroDefName(def *lisp.LVal) string {
+	if def != nil && len(def.Cells) > 1 && def.Cells[1].Type == lisp.LSymbol {
+		return def.Cells[1].Str
+	}
+	return "<unknown>"
 }

--- a/analysis/expander.go
+++ b/analysis/expander.go
@@ -103,9 +103,9 @@ func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal, pkg string) (result *lis
 }
 
 // LoadWorkspaceMacros replays workspace preamble forms (in-package,
-// use-package, export, defmacro) into the given environment. This mirrors
-// what the runtime's (load) does — forms are eval'd in source order so
-// package context, imports, and macro definitions build up naturally.
+// use-package, export, defmacro, defun, set) into the given environment.
+// This mirrors what the runtime's (load) does — forms are eval'd in source
+// order so package context, imports, and definitions build up naturally.
 //
 // Workspace packages that don't exist in the boot env are auto-created.
 // The env's active package is saved and restored after loading.

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -116,10 +116,10 @@ func TestEnvMacroExpander_EmptyForm(t *testing.T) {
 	assert.Nil(t, expander.ExpandMacro(form))
 }
 
-func TestEnvMacroExpander_PanicRecovery(t *testing.T) {
-	// Verify that a panic during macro expansion returns nil gracefully.
-	// We test the recover() path by using a custom expander that panics,
-	// then verify the analysis doesn't crash.
+func TestEnvMacroExpander_ExpansionErrorGracefulReturn(t *testing.T) {
+	// Verify that an ELPS error during macro expansion returns nil gracefully.
+	// The macro body raises an error condition, which MacroCall returns as
+	// LError. ExpandMacro catches this and returns nil (fallback to opaque).
 	env := newTestEnv(t)
 	evalSource(t, env, `
 (defmacro bad-macro (&rest args)

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -3,6 +3,8 @@
 package analysis
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -300,6 +302,68 @@ func TestLoadWorkspaceMacros_DefunAvailableForMacroExpansion(t *testing.T) {
 		assert.NotEqual(t, "x", u.Name, "x should resolve as lambda param after macro expansion")
 		assert.NotEqual(t, "y", u.Name, "y should resolve as lambda param after macro expansion")
 	}
+}
+
+func TestLoadWorkspaceMacros_RecursiveDefun(t *testing.T) {
+	// Recursive defun should work in preamble loading. defun binds the
+	// function name before the body is evaluated, so self-references resolve.
+	env := newTestEnv(t)
+
+	preamble := parsePreamble(t, `
+(in-package 'myapp)
+(defun my-flatten (seq)
+  (if (not (list? seq)) (list seq)
+    (if (empty? seq) '()
+      (concat 'list
+        (my-flatten (car seq))
+        (my-flatten (cdr seq))))))`)
+
+	errs := LoadWorkspaceMacros(env, preamble)
+	assert.Empty(t, errs, "recursive defun should load without error")
+
+	// Verify the recursive function is callable.
+	env.InPackage(lisp.String("myapp"))
+	fn := env.Get(lisp.Symbol("my-flatten"))
+	assert.Equal(t, lisp.LFun, fn.Type, "my-flatten should be defined")
+}
+
+func TestLoadWorkspaceMacros_BareFileDefunUsesDefaultPackage(t *testing.T) {
+	// Edge case: files without in-package should use DefaultPackage.
+	// At runtime, (load-file "helpers.lisp") inherits the caller's package.
+	// The prescan computes DefaultPackage from main.lisp; bare files'
+	// preamble forms should be prefixed with in-package for that package
+	// so defuns register in the right package.
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'myapp)
+(defmacro my-macro () '42)
+`), 0600))
+
+	// helpers.lisp has NO in-package — at runtime it inherits myapp.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "helpers.lisp"), []byte(`
+(defun ws-helper () 99)
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "myapp", prescan.DefaultPackage)
+
+	env := newTestEnv(t)
+	errs := LoadWorkspaceMacros(env, prescan.Preamble)
+	assert.Empty(t, errs)
+
+	// ws-helper should be defined in myapp (DefaultPackage), not user.
+	env.InPackage(lisp.String("myapp"))
+	fn := env.Get(lisp.Symbol("ws-helper"))
+	assert.Equal(t, lisp.LFun, fn.Type,
+		"bare file defun should be defined in myapp (DefaultPackage)")
+
+	// Verify NOT in user package.
+	env.InPackage(lisp.String(lisp.DefaultUserPackage))
+	notFound := env.Get(lisp.Symbol("ws-helper"))
+	assert.NotEqual(t, lisp.LFun, notFound.Type,
+		"bare file defun should NOT be defined in user package")
 }
 
 func TestLoadWorkspaceMacros_ErrorReturned(t *testing.T) {

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -56,7 +56,7 @@ func TestEnvMacroExpander_SimpleExpansion(t *testing.T) {
 		lisp.Int(42),
 	})
 
-	expanded := expander.ExpandMacro(form)
+	expanded := expander.ExpandMacro(form, lisp.DefaultUserPackage)
 	require.NotNil(t, expanded, "expansion should succeed")
 	// Expanded form should be (if true (progn 42))
 	require.Equal(t, lisp.LSExpr, expanded.Type)
@@ -83,7 +83,7 @@ func TestEnvMacroExpander_NotAMacro(t *testing.T) {
 		lisp.Int(1),
 		lisp.Int(2),
 	})
-	assert.Nil(t, expander.ExpandMacro(form))
+	assert.Nil(t, expander.ExpandMacro(form, lisp.DefaultUserPackage))
 }
 
 func TestEnvMacroExpander_ExpansionError(t *testing.T) {
@@ -100,20 +100,20 @@ func TestEnvMacroExpander_ExpansionError(t *testing.T) {
 		lisp.Int(1),
 		// missing second arg
 	})
-	assert.Nil(t, expander.ExpandMacro(form))
+	assert.Nil(t, expander.ExpandMacro(form, lisp.DefaultUserPackage))
 }
 
 func TestEnvMacroExpander_NilEnv(t *testing.T) {
 	expander := &EnvMacroExpander{Env: nil}
 	form := lisp.SExpr([]*lisp.LVal{lisp.Symbol("foo")})
-	assert.Nil(t, expander.ExpandMacro(form))
+	assert.Nil(t, expander.ExpandMacro(form, lisp.DefaultUserPackage))
 }
 
 func TestEnvMacroExpander_EmptyForm(t *testing.T) {
 	env := newTestEnv(t)
 	expander := &EnvMacroExpander{Env: env}
 	form := lisp.SExpr([]*lisp.LVal{})
-	assert.Nil(t, expander.ExpandMacro(form))
+	assert.Nil(t, expander.ExpandMacro(form, lisp.DefaultUserPackage))
 }
 
 func TestEnvMacroExpander_NotMacroCached(t *testing.T) {
@@ -126,13 +126,14 @@ func TestEnvMacroExpander_NotMacroCached(t *testing.T) {
 	})
 
 	// First call — should populate the notMacro cache.
-	assert.Nil(t, expander.ExpandMacro(form))
+	assert.Nil(t, expander.ExpandMacro(form, lisp.DefaultUserPackage))
 	require.NotNil(t, expander.notMacro, "notMacro cache should be initialized")
-	assert.True(t, expander.notMacro["+"], "should cache '+' as not-a-macro")
+	cacheKey := lisp.DefaultUserPackage + "\x00+"
+	assert.True(t, expander.notMacro[cacheKey], "should cache '+' as not-a-macro")
 
 	// Second call — hits cache (no env.Get needed).
-	assert.Nil(t, expander.ExpandMacro(form))
-	assert.True(t, expander.notMacro["+"], "cache entry should persist across calls")
+	assert.Nil(t, expander.ExpandMacro(form, lisp.DefaultUserPackage))
+	assert.True(t, expander.notMacro[cacheKey], "cache entry should persist across calls")
 }
 
 func TestEnvMacroExpander_ExpansionErrorGracefulReturn(t *testing.T) {
@@ -150,7 +151,7 @@ func TestEnvMacroExpander_ExpansionErrorGracefulReturn(t *testing.T) {
 		lisp.Int(1),
 	})
 	// Should return nil (error caught), not panic
-	assert.Nil(t, expander.ExpandMacro(form))
+	assert.Nil(t, expander.ExpandMacro(form, lisp.DefaultUserPackage))
 }
 
 // --- LoadWorkspaceMacros tests ---
@@ -303,20 +304,20 @@ func TestEnvMacroExpander_Reset_ClearsCache(t *testing.T) {
 		lisp.Symbol("true"),
 		lisp.Int(42),
 	})
-	assert.Nil(t, expander.ExpandMacro(form))
-	assert.True(t, expander.notMacro["my-when"], "should be cached as not-a-macro")
+	assert.Nil(t, expander.ExpandMacro(form, lisp.DefaultUserPackage))
+	assert.True(t, expander.notMacro[lisp.DefaultUserPackage+"\x00my-when"], "should be cached as not-a-macro")
 
 	// Define the macro in the env.
 	evalSource(t, env, `(defmacro my-when (cond &rest body)
 	  (quasiquote (if (unquote cond) (progn (unquote-splicing body)))))`)
 
 	// Without Reset, stale cache prevents expansion.
-	assert.Nil(t, expander.ExpandMacro(form), "stale cache should prevent expansion")
+	assert.Nil(t, expander.ExpandMacro(form, lisp.DefaultUserPackage), "stale cache should prevent expansion")
 
 	// After Reset, expansion succeeds.
 	expander.Reset()
 	assert.Nil(t, expander.notMacro, "Reset should clear the cache")
-	expanded := expander.ExpandMacro(form)
+	expanded := expander.ExpandMacro(form, lisp.DefaultUserPackage)
 	require.NotNil(t, expanded, "after Reset, newly-defined macro should expand")
 	assert.Equal(t, "if", expanded.Cells[0].Str)
 }

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -59,7 +59,18 @@ func TestEnvMacroExpander_SimpleExpansion(t *testing.T) {
 	expanded := expander.ExpandMacro(form)
 	require.NotNil(t, expanded, "expansion should succeed")
 	// Expanded form should be (if true (progn 42))
-	assert.Equal(t, lisp.LSExpr, expanded.Type)
+	require.Equal(t, lisp.LSExpr, expanded.Type)
+	require.GreaterOrEqual(t, len(expanded.Cells), 3, "expanded form should have at least 3 cells")
+	assert.Equal(t, lisp.LSymbol, expanded.Cells[0].Type)
+	assert.Equal(t, "if", expanded.Cells[0].Str, "head should be 'if'")
+	assert.Equal(t, lisp.LSymbol, expanded.Cells[1].Type)
+	assert.Equal(t, "true", expanded.Cells[1].Str, "condition should be 'true'")
+	// Third element: (progn 42)
+	progn := expanded.Cells[2]
+	require.Equal(t, lisp.LSExpr, progn.Type)
+	require.GreaterOrEqual(t, len(progn.Cells), 2)
+	assert.Equal(t, "progn", progn.Cells[0].Str)
+	assert.Equal(t, 42, progn.Cells[1].Int)
 }
 
 func TestEnvMacroExpander_NotAMacro(t *testing.T) {
@@ -95,5 +106,30 @@ func TestEnvMacroExpander_ExpansionError(t *testing.T) {
 func TestEnvMacroExpander_NilEnv(t *testing.T) {
 	expander := &EnvMacroExpander{Env: nil}
 	form := lisp.SExpr([]*lisp.LVal{lisp.Symbol("foo")})
+	assert.Nil(t, expander.ExpandMacro(form))
+}
+
+func TestEnvMacroExpander_EmptyForm(t *testing.T) {
+	env := newTestEnv(t)
+	expander := &EnvMacroExpander{Env: env}
+	form := lisp.SExpr([]*lisp.LVal{})
+	assert.Nil(t, expander.ExpandMacro(form))
+}
+
+func TestEnvMacroExpander_PanicRecovery(t *testing.T) {
+	// Verify that a panic during macro expansion returns nil gracefully.
+	// We test the recover() path by using a custom expander that panics,
+	// then verify the analysis doesn't crash.
+	env := newTestEnv(t)
+	evalSource(t, env, `
+(defmacro bad-macro (&rest args)
+  (error 'logic "expansion failure"))`)
+
+	expander := &EnvMacroExpander{Env: env}
+	form := lisp.SExpr([]*lisp.LVal{
+		lisp.Symbol("bad-macro"),
+		lisp.Int(1),
+	})
+	// Should return nil (error caught), not panic
 	assert.Nil(t, expander.ExpandMacro(form))
 }

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -155,18 +155,25 @@ func TestEnvMacroExpander_ExpansionErrorGracefulReturn(t *testing.T) {
 
 // --- LoadWorkspaceMacros tests ---
 
-func TestLoadWorkspaceMacros_Success(t *testing.T) {
-	env := newTestEnv(t)
-
-	// Parse a defmacro form as raw AST (simulating what prescan collects).
-	s := token.NewScanner("test.lisp", strings.NewReader(
-		`(defmacro my-when (cond &rest body) (quasiquote (if (unquote cond) (progn (unquote-splicing body)))))`))
+// parseMacroDef parses a single defmacro source string and returns it as a MacroDef.
+func parseMacroDef(t *testing.T, source, pkg string) MacroDef {
+	t.Helper()
+	s := token.NewScanner("test.lisp", strings.NewReader(source))
 	p := rdparser.New(s)
 	exprs, err := p.ParseProgram()
 	require.NoError(t, err)
 	require.Len(t, exprs, 1)
+	return MacroDef{Package: pkg, Node: exprs[0]}
+}
 
-	errs := LoadWorkspaceMacros(env, exprs)
+func TestLoadWorkspaceMacros_Success(t *testing.T) {
+	env := newTestEnv(t)
+
+	def := parseMacroDef(t,
+		`(defmacro my-when (cond &rest body) (quasiquote (if (unquote cond) (progn (unquote-splicing body)))))`,
+		lisp.DefaultUserPackage)
+
+	errs := LoadWorkspaceMacros(env, []MacroDef{def})
 	assert.Empty(t, errs, "loading a valid defmacro should produce no errors")
 
 	// Verify the macro is now callable in the env.
@@ -175,16 +182,44 @@ func TestLoadWorkspaceMacros_Success(t *testing.T) {
 	assert.True(t, mac.IsMacro(), "my-when should be a macro")
 }
 
+func TestLoadWorkspaceMacros_PackageContext(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Register the package and import lang builtins so defmacro is available.
+	env.Runtime.Registry.DefinePackage("mypkg")
+	env.InPackage(lisp.String("mypkg"))
+	env.UsePackage(lisp.Symbol(env.Runtime.Registry.Lang))
+
+	def := parseMacroDef(t,
+		`(defmacro pkg-macro () '42)`,
+		"mypkg")
+
+	// Switch to user package first to confirm LoadWorkspaceMacros switches back.
+	env.InPackage(lisp.String(lisp.DefaultUserPackage))
+
+	errs := LoadWorkspaceMacros(env, []MacroDef{def})
+	assert.Empty(t, errs)
+
+	// Verify the macro was registered in mypkg, not user.
+	env.InPackage(lisp.String("mypkg"))
+	mac := env.Get(lisp.Symbol("pkg-macro"))
+	assert.Equal(t, lisp.LFun, mac.Type, "pkg-macro should be defined in mypkg")
+	assert.True(t, mac.IsMacro())
+
+	// Verify it's NOT in the user package.
+	env.InPackage(lisp.String(lisp.DefaultUserPackage))
+	notFound := env.Get(lisp.Symbol("pkg-macro"))
+	assert.NotEqual(t, lisp.LFun, notFound.Type,
+		"pkg-macro should NOT be defined in user package")
+}
+
 func TestLoadWorkspaceMacros_ErrorReturned(t *testing.T) {
 	env := newTestEnv(t)
 
 	// A malformed defmacro — missing body.
-	s := token.NewScanner("test.lisp", strings.NewReader(`(defmacro)`))
-	p := rdparser.New(s)
-	exprs, err := p.ParseProgram()
-	require.NoError(t, err)
+	def := parseMacroDef(t, `(defmacro)`, lisp.DefaultUserPackage)
 
-	errs := LoadWorkspaceMacros(env, exprs)
+	errs := LoadWorkspaceMacros(env, []MacroDef{def})
 	require.NotEmpty(t, errs, "malformed defmacro should return an error")
 	assert.Contains(t, errs[0].Error(), "loading macro", "error should describe the failure")
 }
@@ -193,13 +228,9 @@ func TestLoadWorkspaceMacros_ErrorIncludesMacroName(t *testing.T) {
 	env := newTestEnv(t)
 
 	// A defmacro where the name is not a symbol — will error during eval.
-	s := token.NewScanner("test.lisp", strings.NewReader(
-		`(defmacro 42 () '1)`))
-	p := rdparser.New(s)
-	exprs, err := p.ParseProgram()
-	require.NoError(t, err)
+	def := parseMacroDef(t, `(defmacro 42 () '1)`, lisp.DefaultUserPackage)
 
-	errs := LoadWorkspaceMacros(env, exprs)
+	errs := LoadWorkspaceMacros(env, []MacroDef{def})
 	require.NotEmpty(t, errs)
 	assert.Contains(t, errs[0].Error(), "loading macro", "error should describe the failure")
 }

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -152,3 +152,54 @@ func TestEnvMacroExpander_ExpansionErrorGracefulReturn(t *testing.T) {
 	// Should return nil (error caught), not panic
 	assert.Nil(t, expander.ExpandMacro(form))
 }
+
+// --- LoadWorkspaceMacros tests ---
+
+func TestLoadWorkspaceMacros_Success(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Parse a defmacro form as raw AST (simulating what prescan collects).
+	s := token.NewScanner("test.lisp", strings.NewReader(
+		`(defmacro my-when (cond &rest body) (quasiquote (if (unquote cond) (progn (unquote-splicing body)))))`))
+	p := rdparser.New(s)
+	exprs, err := p.ParseProgram()
+	require.NoError(t, err)
+	require.Len(t, exprs, 1)
+
+	errs := LoadWorkspaceMacros(env, exprs)
+	assert.Empty(t, errs, "loading a valid defmacro should produce no errors")
+
+	// Verify the macro is now callable in the env.
+	mac := env.Get(lisp.Symbol("my-when"))
+	assert.Equal(t, lisp.LFun, mac.Type, "my-when should be a function in the env")
+	assert.True(t, mac.IsMacro(), "my-when should be a macro")
+}
+
+func TestLoadWorkspaceMacros_ErrorReturned(t *testing.T) {
+	env := newTestEnv(t)
+
+	// A malformed defmacro — missing body.
+	s := token.NewScanner("test.lisp", strings.NewReader(`(defmacro)`))
+	p := rdparser.New(s)
+	exprs, err := p.ParseProgram()
+	require.NoError(t, err)
+
+	errs := LoadWorkspaceMacros(env, exprs)
+	require.NotEmpty(t, errs, "malformed defmacro should return an error")
+	assert.Contains(t, errs[0].Error(), "loading macro", "error should describe the failure")
+}
+
+func TestLoadWorkspaceMacros_ErrorIncludesMacroName(t *testing.T) {
+	env := newTestEnv(t)
+
+	// A defmacro where the name is not a symbol — will error during eval.
+	s := token.NewScanner("test.lisp", strings.NewReader(
+		`(defmacro 42 () '1)`))
+	p := rdparser.New(s)
+	exprs, err := p.ParseProgram()
+	require.NoError(t, err)
+
+	errs := LoadWorkspaceMacros(env, exprs)
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errs[0].Error(), "loading macro", "error should describe the failure")
+}

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -155,49 +155,39 @@ func TestEnvMacroExpander_ExpansionErrorGracefulReturn(t *testing.T) {
 
 // --- LoadWorkspaceMacros tests ---
 
-// parseMacroDef parses a single defmacro source string and returns it as a MacroDef.
-func parseMacroDef(t *testing.T, source, pkg string) MacroDef {
+// parsePreamble parses source containing preamble forms and returns them.
+func parsePreamble(t *testing.T, source string) []*lisp.LVal {
 	t.Helper()
 	s := token.NewScanner("test.lisp", strings.NewReader(source))
 	p := rdparser.New(s)
 	exprs, err := p.ParseProgram()
 	require.NoError(t, err)
-	require.Len(t, exprs, 1)
-	return MacroDef{Package: pkg, Node: exprs[0]}
+	return exprs
 }
 
 func TestLoadWorkspaceMacros_Success(t *testing.T) {
 	env := newTestEnv(t)
 
-	def := parseMacroDef(t,
-		`(defmacro my-when (cond &rest body) (quasiquote (if (unquote cond) (progn (unquote-splicing body)))))`,
-		lisp.DefaultUserPackage)
+	preamble := parsePreamble(t,
+		`(defmacro my-when (cond &rest body) (quasiquote (if (unquote cond) (progn (unquote-splicing body)))))`)
 
-	errs := LoadWorkspaceMacros(env, []MacroDef{def}, nil)
+	errs := LoadWorkspaceMacros(env, preamble)
 	assert.Empty(t, errs, "loading a valid defmacro should produce no errors")
 
-	// Verify the macro is now callable in the env.
 	mac := env.Get(lisp.Symbol("my-when"))
 	assert.Equal(t, lisp.LFun, mac.Type, "my-when should be a function in the env")
 	assert.True(t, mac.IsMacro(), "my-when should be a macro")
 }
 
 func TestLoadWorkspaceMacros_PackageContext(t *testing.T) {
+	// Preamble with in-package switches context naturally.
 	env := newTestEnv(t)
 
-	// Register the package and import lang builtins so defmacro is available.
-	env.Runtime.Registry.DefinePackage("mypkg")
-	env.InPackage(lisp.String("mypkg"))
-	env.UsePackage(lisp.Symbol(env.Runtime.Registry.Lang))
+	preamble := parsePreamble(t, `
+(in-package 'mypkg)
+(defmacro pkg-macro () '42)`)
 
-	def := parseMacroDef(t,
-		`(defmacro pkg-macro () '42)`,
-		"mypkg")
-
-	// Switch to user package first to confirm LoadWorkspaceMacros switches back.
-	env.InPackage(lisp.String(lisp.DefaultUserPackage))
-
-	errs := LoadWorkspaceMacros(env, []MacroDef{def}, nil)
+	errs := LoadWorkspaceMacros(env, preamble)
 	assert.Empty(t, errs)
 
 	// Verify the macro was registered in mypkg, not user.
@@ -215,76 +205,87 @@ func TestLoadWorkspaceMacros_PackageContext(t *testing.T) {
 
 func TestLoadWorkspaceMacros_PackageAutoCreated(t *testing.T) {
 	// Workspace packages (e.g. "acre") don't exist in the boot env.
-	// LoadWorkspaceMacros should auto-create them via DefinePackage.
+	// in-package in the preamble auto-creates them.
 	env := newTestEnv(t)
 
-	// "newpkg" is NOT pre-defined — simulates a workspace-only package.
-	def := parseMacroDef(t,
-		`(defmacro ws-macro () '99)`,
-		"newpkg")
+	preamble := parsePreamble(t, `
+(in-package 'newpkg)
+(defmacro ws-macro () '99)`)
 
-	errs := LoadWorkspaceMacros(env, []MacroDef{def}, nil)
+	errs := LoadWorkspaceMacros(env, preamble)
 	assert.Empty(t, errs, "should auto-create the package, not error")
 
-	// Verify the macro was registered in the auto-created package.
 	env.InPackage(lisp.String("newpkg"))
 	mac := env.Get(lisp.Symbol("ws-macro"))
 	assert.Equal(t, lisp.LFun, mac.Type, "ws-macro should be defined in newpkg")
 	assert.True(t, mac.IsMacro())
 }
 
+func TestLoadWorkspaceMacros_PackageRestored(t *testing.T) {
+	// The env's active package should be restored after loading.
+	env := newTestEnv(t)
+	env.InPackage(lisp.String(lisp.DefaultUserPackage))
+
+	preamble := parsePreamble(t, `
+(in-package 'otherpkg)
+(defmacro m () '1)`)
+
+	LoadWorkspaceMacros(env, preamble)
+
+	// Should be back in user package.
+	assert.Equal(t, lisp.DefaultUserPackage, env.Runtime.Package.Name,
+		"env package should be restored after LoadWorkspaceMacros")
+}
+
+func TestLoadWorkspaceMacros_UsePackageImports(t *testing.T) {
+	// use-package in the preamble should make imported functions available
+	// during macro expansion. This mirrors the runtime's file loading.
+	env := newTestEnv(t)
+
+	// Define a helper in a "utils" package.
+	evalSource(t, env, `
+(in-package 'utils)
+(export 'helper)
+(defun helper () 42)`)
+	env.InPackage(lisp.String(lisp.DefaultUserPackage))
+
+	// Preamble: switch to mypkg, import utils, define macro that uses helper.
+	preamble := parsePreamble(t, `
+(in-package 'mypkg)
+(use-package 'utils)
+(defmacro my-macro () (quasiquote (helper)))`)
+
+	errs := LoadWorkspaceMacros(env, preamble)
+	assert.Empty(t, errs, "macro using imported function should load without error")
+}
+
 func TestLoadWorkspaceMacros_ErrorReturned(t *testing.T) {
 	env := newTestEnv(t)
 
-	// A malformed defmacro — missing body.
-	def := parseMacroDef(t, `(defmacro)`, lisp.DefaultUserPackage)
+	preamble := parsePreamble(t, `(defmacro)`)
 
-	errs := LoadWorkspaceMacros(env, []MacroDef{def}, nil)
+	errs := LoadWorkspaceMacros(env, preamble)
 	require.NotEmpty(t, errs, "malformed defmacro should return an error")
-	assert.Contains(t, errs[0].Error(), "loading macro", "error should describe the failure")
-}
-
-func TestLoadWorkspaceMacros_ErrorWithNonSymbolName(t *testing.T) {
-	env := newTestEnv(t)
-
-	// A defmacro where the name is not a symbol — will error during eval.
-	// macroDefName returns "<unknown>" for non-symbol names.
-	def := parseMacroDef(t, `(defmacro 42 () '1)`, lisp.DefaultUserPackage)
-
-	errs := LoadWorkspaceMacros(env, []MacroDef{def}, nil)
-	require.NotEmpty(t, errs)
-	assert.Contains(t, errs[0].Error(), "<unknown>",
-		"error for non-symbol macro name should show <unknown>")
 }
 
 func TestLoadWorkspaceMacros_MultiplePackages(t *testing.T) {
-	// Verify sequential loading of macros from different packages —
-	// each macro registers in its own package, not the previous one's.
+	// Macros in different packages via in-package switching.
 	env := newTestEnv(t)
 
-	env.Runtime.Registry.DefinePackage("pkgA")
-	env.InPackage(lisp.String("pkgA"))
-	env.UsePackage(lisp.Symbol(env.Runtime.Registry.Lang))
+	preamble := parsePreamble(t, `
+(in-package 'pkgA)
+(defmacro mac-a () '1)
+(in-package 'pkgB)
+(defmacro mac-b () '2)`)
 
-	env.Runtime.Registry.DefinePackage("pkgB")
-	env.InPackage(lisp.String("pkgB"))
-	env.UsePackage(lisp.Symbol(env.Runtime.Registry.Lang))
-
-	defs := []MacroDef{
-		parseMacroDef(t, `(defmacro mac-a () '1)`, "pkgA"),
-		parseMacroDef(t, `(defmacro mac-b () '2)`, "pkgB"),
-	}
-	errs := LoadWorkspaceMacros(env, defs, nil)
+	errs := LoadWorkspaceMacros(env, preamble)
 	assert.Empty(t, errs)
 
-	// Each macro should be in its own package.
 	env.InPackage(lisp.String("pkgA"))
-	assert.Equal(t, lisp.LFun, env.Get(lisp.Symbol("mac-a")).Type,
-		"mac-a should be in pkgA")
+	assert.Equal(t, lisp.LFun, env.Get(lisp.Symbol("mac-a")).Type, "mac-a should be in pkgA")
 
 	env.InPackage(lisp.String("pkgB"))
-	assert.Equal(t, lisp.LFun, env.Get(lisp.Symbol("mac-b")).Type,
-		"mac-b should be in pkgB")
+	assert.Equal(t, lisp.LFun, env.Get(lisp.Symbol("mac-b")).Type, "mac-b should be in pkgB")
 
 	// Cross-check: mac-b should NOT be in pkgA.
 	env.InPackage(lisp.String("pkgA"))

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 The ELPS authors
+// Copyright © 2026 The ELPS authors
 
 package analysis
 

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -403,6 +403,83 @@ func TestLoadWorkspaceMacros_BareFileInheritsPackageSwitch(t *testing.T) {
 		"fn-b should NOT leak into pkgA")
 }
 
+func TestLoadWorkspaceMacros_LoadOrderMatters(t *testing.T) {
+	// Preamble forms must be in load-tree DFS order so that definitions
+	// are available when later macros need them during expansion.
+	// helpers.lisp defines a function, macros.lisp defines a macro that
+	// calls it. main.lisp loads helpers first — matching load order.
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'myapp)
+(load-file "helpers.lisp")
+(load-file "macros.lisp")
+`), 0600))
+
+	// helpers.lisp defines the function (loaded first).
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "helpers.lisp"), []byte(`
+(in-package 'myapp)
+(defun double (x) (+ x x))
+`), 0600))
+
+	// macros.lisp defines a macro that calls double (loaded second).
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "macros.lisp"), []byte(`
+(in-package 'myapp)
+(defmacro with-double (val &rest body)
+  (quasiquote (let ([doubled (double (unquote val))]) (unquote-splicing body))))
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+
+	env := newTestEnv(t)
+	errs := LoadWorkspaceMacros(env, prescan.Preamble)
+	assert.Empty(t, errs, "helpers loaded before macros — double should be available")
+
+	// Verify the macro expands correctly using the workspace helper.
+	result := parseAndAnalyzeWithConfig(t,
+		`(in-package 'myapp)
+(defun test (x) (with-double x (+ doubled 1)))`,
+		&Config{
+			MacroExpander: &EnvMacroExpander{Env: env},
+		})
+
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "doubled", u.Name,
+			"doubled should resolve as let binding from macro expansion")
+	}
+}
+
+func TestLoadWorkspaceMacros_SetInBareFile(t *testing.T) {
+	// set definitions in bare template files should be loaded into the
+	// correct package, making globals available during macro expansion.
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'myapp)
+(load-file "template.lisp")
+`), 0600))
+
+	// template.lisp — no in-package, uses set for a global.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "template.lisp"), []byte(`
+(set 'default-template "hello world")
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+
+	env := newTestEnv(t)
+	errs := LoadWorkspaceMacros(env, prescan.Preamble)
+	assert.Empty(t, errs)
+
+	// default-template should be in myapp (inherited from load context).
+	env.InPackage(lisp.String("myapp"))
+	val := env.Get(lisp.Symbol("default-template"))
+	assert.Equal(t, lisp.LString, val.Type,
+		"set global in bare file should be in myapp package")
+	assert.Equal(t, "hello world", val.Str)
+}
+
 func TestLoadWorkspaceMacros_ErrorReturned(t *testing.T) {
 	env := newTestEnv(t)
 

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -327,43 +327,80 @@ func TestLoadWorkspaceMacros_RecursiveDefun(t *testing.T) {
 	assert.Equal(t, lisp.LFun, fn.Type, "my-flatten should be defined")
 }
 
-func TestLoadWorkspaceMacros_BareFileDefunUsesDefaultPackage(t *testing.T) {
-	// Edge case: files without in-package should use DefaultPackage.
-	// At runtime, (load-file "helpers.lisp") inherits the caller's package.
-	// The prescan computes DefaultPackage from main.lisp; bare files'
-	// preamble forms should be prefixed with in-package for that package
-	// so defuns register in the right package.
+func TestLoadWorkspaceMacros_BareFileInheritsLoadContext(t *testing.T) {
+	// Bare files (no in-package) inherit the caller's package from the
+	// load-file call site, matching runtime behavior. The prescan's
+	// loadTree tracks this per-file context.
 	dir := t.TempDir()
 
+	// main.lisp loads helpers.lisp while in myapp package.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
 (in-package 'myapp)
-(defmacro my-macro () '42)
+(load-file "helpers.lisp")
 `), 0600))
 
-	// helpers.lisp has NO in-package — at runtime it inherits myapp.
+	// helpers.lisp has NO in-package — inherits myapp from load context.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "helpers.lisp"), []byte(`
 (defun ws-helper () 99)
 `), 0600))
 
 	prescan, err := PrescanWorkspace(dir, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "myapp", prescan.DefaultPackage)
 
 	env := newTestEnv(t)
 	errs := LoadWorkspaceMacros(env, prescan.Preamble)
 	assert.Empty(t, errs)
 
-	// ws-helper should be defined in myapp (DefaultPackage), not user.
+	// ws-helper should be in myapp (inherited from load context), not user.
 	env.InPackage(lisp.String("myapp"))
 	fn := env.Get(lisp.Symbol("ws-helper"))
 	assert.Equal(t, lisp.LFun, fn.Type,
-		"bare file defun should be defined in myapp (DefaultPackage)")
+		"bare file defun should inherit load context package (myapp)")
 
-	// Verify NOT in user package.
 	env.InPackage(lisp.String(lisp.DefaultUserPackage))
 	notFound := env.Get(lisp.Symbol("ws-helper"))
 	assert.NotEqual(t, lisp.LFun, notFound.Type,
-		"bare file defun should NOT be defined in user package")
+		"bare file defun should NOT be in user package")
+}
+
+func TestLoadWorkspaceMacros_BareFileInheritsPackageSwitch(t *testing.T) {
+	// When main.lisp switches packages between load-file calls, each
+	// bare file inherits the package active at its load-file call site.
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'pkgA)
+(load-file "a.lisp")
+(in-package 'pkgB)
+(load-file "b.lisp")
+`), 0600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.lisp"), []byte(`
+(defun fn-a () 1)
+`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.lisp"), []byte(`
+(defun fn-b () 2)
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+
+	env := newTestEnv(t)
+	errs := LoadWorkspaceMacros(env, prescan.Preamble)
+	assert.Empty(t, errs)
+
+	// fn-a should be in pkgA, fn-b in pkgB.
+	env.InPackage(lisp.String("pkgA"))
+	assert.Equal(t, lisp.LFun, env.Get(lisp.Symbol("fn-a")).Type,
+		"fn-a should inherit pkgA from load context")
+	env.InPackage(lisp.String("pkgB"))
+	assert.Equal(t, lisp.LFun, env.Get(lisp.Symbol("fn-b")).Type,
+		"fn-b should inherit pkgB from load context")
+
+	// Cross-check: fn-b NOT in pkgA.
+	env.InPackage(lisp.String("pkgA"))
+	assert.NotEqual(t, lisp.LFun, env.Get(lisp.Symbol("fn-b")).Type,
+		"fn-b should NOT leak into pkgA")
 }
 
 func TestLoadWorkspaceMacros_ErrorReturned(t *testing.T) {

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -116,6 +116,25 @@ func TestEnvMacroExpander_EmptyForm(t *testing.T) {
 	assert.Nil(t, expander.ExpandMacro(form))
 }
 
+func TestEnvMacroExpander_NotMacroCached(t *testing.T) {
+	env := newTestEnv(t)
+	expander := &EnvMacroExpander{Env: env}
+
+	form := lisp.SExpr([]*lisp.LVal{
+		lisp.Symbol("+"),
+		lisp.Int(1),
+	})
+
+	// First call — should populate the notMacro cache.
+	assert.Nil(t, expander.ExpandMacro(form))
+	require.NotNil(t, expander.notMacro, "notMacro cache should be initialized")
+	assert.True(t, expander.notMacro["+"], "should cache '+' as not-a-macro")
+
+	// Second call — hits cache (no env.Get needed).
+	assert.Nil(t, expander.ExpandMacro(form))
+	assert.True(t, expander.notMacro["+"], "cache entry should persist across calls")
+}
+
 func TestEnvMacroExpander_ExpansionErrorGracefulReturn(t *testing.T) {
 	// Verify that an ELPS error during macro expansion returns nil gracefully.
 	// The macro body raises an error condition, which MacroCall returns as

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -1,0 +1,99 @@
+// Copyright © 2024 The ELPS authors
+
+package analysis
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser/rdparser"
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestEnv creates a minimal ELPS environment with builtins and stdlib.
+func newTestEnv(t *testing.T) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = rdparser.NewReader()
+	rc := lisp.InitializeUserEnv(env)
+	require.True(t, rc.IsNil(), "InitializeUserEnv failed: %v", rc)
+	rc = lisplib.LoadLibrary(env)
+	require.True(t, rc.IsNil(), "LoadLibrary failed: %v", rc)
+	rc = env.InPackage(lisp.String(lisp.DefaultUserPackage))
+	require.True(t, rc.IsNil(), "InPackage failed: %v", rc)
+	return env
+}
+
+// evalSource evaluates ELPS source in the given environment.
+func evalSource(t *testing.T, env *lisp.LEnv, source string) {
+	t.Helper()
+	s := token.NewScanner("test.lisp", strings.NewReader(source))
+	p := rdparser.New(s)
+	exprs, err := p.ParseProgram()
+	require.NoError(t, err)
+	for _, expr := range exprs {
+		result := env.Eval(expr)
+		require.NotEqual(t, lisp.LError, result.Type, "eval error: %v", result)
+	}
+}
+
+func TestEnvMacroExpander_SimpleExpansion(t *testing.T) {
+	env := newTestEnv(t)
+	evalSource(t, env, `
+(defmacro my-when (cond &rest body)
+  (quasiquote (if (unquote cond) (progn (unquote-splicing body)))))`)
+
+	expander := &EnvMacroExpander{Env: env}
+
+	// Build a form: (my-when true 42)
+	form := lisp.SExpr([]*lisp.LVal{
+		lisp.Symbol("my-when"),
+		lisp.Symbol("true"),
+		lisp.Int(42),
+	})
+
+	expanded := expander.ExpandMacro(form)
+	require.NotNil(t, expanded, "expansion should succeed")
+	// Expanded form should be (if true (progn 42))
+	assert.Equal(t, lisp.LSExpr, expanded.Type)
+}
+
+func TestEnvMacroExpander_NotAMacro(t *testing.T) {
+	env := newTestEnv(t)
+	expander := &EnvMacroExpander{Env: env}
+
+	// + is a builtin function, not a macro
+	form := lisp.SExpr([]*lisp.LVal{
+		lisp.Symbol("+"),
+		lisp.Int(1),
+		lisp.Int(2),
+	})
+	assert.Nil(t, expander.ExpandMacro(form))
+}
+
+func TestEnvMacroExpander_ExpansionError(t *testing.T) {
+	env := newTestEnv(t)
+	evalSource(t, env, `
+(defmacro needs-args (x y)
+  (quasiquote (+ (unquote x) (unquote y))))`)
+
+	expander := &EnvMacroExpander{Env: env}
+
+	// Wrong arity — should return nil (graceful failure)
+	form := lisp.SExpr([]*lisp.LVal{
+		lisp.Symbol("needs-args"),
+		lisp.Int(1),
+		// missing second arg
+	})
+	assert.Nil(t, expander.ExpandMacro(form))
+}
+
+func TestEnvMacroExpander_NilEnv(t *testing.T) {
+	expander := &EnvMacroExpander{Env: nil}
+	form := lisp.SExpr([]*lisp.LVal{lisp.Symbol("foo")})
+	assert.Nil(t, expander.ExpandMacro(form))
+}

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -173,7 +173,7 @@ func TestLoadWorkspaceMacros_Success(t *testing.T) {
 		`(defmacro my-when (cond &rest body) (quasiquote (if (unquote cond) (progn (unquote-splicing body)))))`,
 		lisp.DefaultUserPackage)
 
-	errs := LoadWorkspaceMacros(env, []MacroDef{def})
+	errs := LoadWorkspaceMacros(env, []MacroDef{def}, nil)
 	assert.Empty(t, errs, "loading a valid defmacro should produce no errors")
 
 	// Verify the macro is now callable in the env.
@@ -197,7 +197,7 @@ func TestLoadWorkspaceMacros_PackageContext(t *testing.T) {
 	// Switch to user package first to confirm LoadWorkspaceMacros switches back.
 	env.InPackage(lisp.String(lisp.DefaultUserPackage))
 
-	errs := LoadWorkspaceMacros(env, []MacroDef{def})
+	errs := LoadWorkspaceMacros(env, []MacroDef{def}, nil)
 	assert.Empty(t, errs)
 
 	// Verify the macro was registered in mypkg, not user.
@@ -223,7 +223,7 @@ func TestLoadWorkspaceMacros_PackageAutoCreated(t *testing.T) {
 		`(defmacro ws-macro () '99)`,
 		"newpkg")
 
-	errs := LoadWorkspaceMacros(env, []MacroDef{def})
+	errs := LoadWorkspaceMacros(env, []MacroDef{def}, nil)
 	assert.Empty(t, errs, "should auto-create the package, not error")
 
 	// Verify the macro was registered in the auto-created package.
@@ -239,7 +239,7 @@ func TestLoadWorkspaceMacros_ErrorReturned(t *testing.T) {
 	// A malformed defmacro — missing body.
 	def := parseMacroDef(t, `(defmacro)`, lisp.DefaultUserPackage)
 
-	errs := LoadWorkspaceMacros(env, []MacroDef{def})
+	errs := LoadWorkspaceMacros(env, []MacroDef{def}, nil)
 	require.NotEmpty(t, errs, "malformed defmacro should return an error")
 	assert.Contains(t, errs[0].Error(), "loading macro", "error should describe the failure")
 }
@@ -251,7 +251,7 @@ func TestLoadWorkspaceMacros_ErrorWithNonSymbolName(t *testing.T) {
 	// macroDefName returns "<unknown>" for non-symbol names.
 	def := parseMacroDef(t, `(defmacro 42 () '1)`, lisp.DefaultUserPackage)
 
-	errs := LoadWorkspaceMacros(env, []MacroDef{def})
+	errs := LoadWorkspaceMacros(env, []MacroDef{def}, nil)
 	require.NotEmpty(t, errs)
 	assert.Contains(t, errs[0].Error(), "<unknown>",
 		"error for non-symbol macro name should show <unknown>")
@@ -274,7 +274,7 @@ func TestLoadWorkspaceMacros_MultiplePackages(t *testing.T) {
 		parseMacroDef(t, `(defmacro mac-a () '1)`, "pkgA"),
 		parseMacroDef(t, `(defmacro mac-b () '2)`, "pkgB"),
 	}
-	errs := LoadWorkspaceMacros(env, defs)
+	errs := LoadWorkspaceMacros(env, defs, nil)
 	assert.Empty(t, errs)
 
 	// Each macro should be in its own package.

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -213,6 +213,26 @@ func TestLoadWorkspaceMacros_PackageContext(t *testing.T) {
 		"pkg-macro should NOT be defined in user package")
 }
 
+func TestLoadWorkspaceMacros_PackageAutoCreated(t *testing.T) {
+	// Workspace packages (e.g. "acre") don't exist in the boot env.
+	// LoadWorkspaceMacros should auto-create them via DefinePackage.
+	env := newTestEnv(t)
+
+	// "newpkg" is NOT pre-defined — simulates a workspace-only package.
+	def := parseMacroDef(t,
+		`(defmacro ws-macro () '99)`,
+		"newpkg")
+
+	errs := LoadWorkspaceMacros(env, []MacroDef{def})
+	assert.Empty(t, errs, "should auto-create the package, not error")
+
+	// Verify the macro was registered in the auto-created package.
+	env.InPackage(lisp.String("newpkg"))
+	mac := env.Get(lisp.Symbol("ws-macro"))
+	assert.Equal(t, lisp.LFun, mac.Type, "ws-macro should be defined in newpkg")
+	assert.True(t, mac.IsMacro())
+}
+
 func TestLoadWorkspaceMacros_ErrorReturned(t *testing.T) {
 	env := newTestEnv(t)
 

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -224,13 +224,78 @@ func TestLoadWorkspaceMacros_ErrorReturned(t *testing.T) {
 	assert.Contains(t, errs[0].Error(), "loading macro", "error should describe the failure")
 }
 
-func TestLoadWorkspaceMacros_ErrorIncludesMacroName(t *testing.T) {
+func TestLoadWorkspaceMacros_ErrorWithNonSymbolName(t *testing.T) {
 	env := newTestEnv(t)
 
 	// A defmacro where the name is not a symbol — will error during eval.
+	// macroDefName returns "<unknown>" for non-symbol names.
 	def := parseMacroDef(t, `(defmacro 42 () '1)`, lisp.DefaultUserPackage)
 
 	errs := LoadWorkspaceMacros(env, []MacroDef{def})
 	require.NotEmpty(t, errs)
-	assert.Contains(t, errs[0].Error(), "loading macro", "error should describe the failure")
+	assert.Contains(t, errs[0].Error(), "<unknown>",
+		"error for non-symbol macro name should show <unknown>")
+}
+
+func TestLoadWorkspaceMacros_MultiplePackages(t *testing.T) {
+	// Verify sequential loading of macros from different packages —
+	// each macro registers in its own package, not the previous one's.
+	env := newTestEnv(t)
+
+	env.Runtime.Registry.DefinePackage("pkgA")
+	env.InPackage(lisp.String("pkgA"))
+	env.UsePackage(lisp.Symbol(env.Runtime.Registry.Lang))
+
+	env.Runtime.Registry.DefinePackage("pkgB")
+	env.InPackage(lisp.String("pkgB"))
+	env.UsePackage(lisp.Symbol(env.Runtime.Registry.Lang))
+
+	defs := []MacroDef{
+		parseMacroDef(t, `(defmacro mac-a () '1)`, "pkgA"),
+		parseMacroDef(t, `(defmacro mac-b () '2)`, "pkgB"),
+	}
+	errs := LoadWorkspaceMacros(env, defs)
+	assert.Empty(t, errs)
+
+	// Each macro should be in its own package.
+	env.InPackage(lisp.String("pkgA"))
+	assert.Equal(t, lisp.LFun, env.Get(lisp.Symbol("mac-a")).Type,
+		"mac-a should be in pkgA")
+
+	env.InPackage(lisp.String("pkgB"))
+	assert.Equal(t, lisp.LFun, env.Get(lisp.Symbol("mac-b")).Type,
+		"mac-b should be in pkgB")
+
+	// Cross-check: mac-b should NOT be in pkgA.
+	env.InPackage(lisp.String("pkgA"))
+	assert.NotEqual(t, lisp.LFun, env.Get(lisp.Symbol("mac-b")).Type,
+		"mac-b should NOT leak into pkgA")
+}
+
+func TestEnvMacroExpander_Reset_ClearsCache(t *testing.T) {
+	env := newTestEnv(t)
+	expander := &EnvMacroExpander{Env: env}
+
+	// First: my-when is not defined → cached as not-a-macro.
+	form := lisp.SExpr([]*lisp.LVal{
+		lisp.Symbol("my-when"),
+		lisp.Symbol("true"),
+		lisp.Int(42),
+	})
+	assert.Nil(t, expander.ExpandMacro(form))
+	assert.True(t, expander.notMacro["my-when"], "should be cached as not-a-macro")
+
+	// Define the macro in the env.
+	evalSource(t, env, `(defmacro my-when (cond &rest body)
+	  (quasiquote (if (unquote cond) (progn (unquote-splicing body)))))`)
+
+	// Without Reset, stale cache prevents expansion.
+	assert.Nil(t, expander.ExpandMacro(form), "stale cache should prevent expansion")
+
+	// After Reset, expansion succeeds.
+	expander.Reset()
+	assert.Nil(t, expander.notMacro, "Reset should clear the cache")
+	expanded := expander.ExpandMacro(form)
+	require.NotNil(t, expanded, "after Reset, newly-defined macro should expand")
+	assert.Equal(t, "if", expanded.Cells[0].Str)
 }

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -260,6 +260,48 @@ func TestLoadWorkspaceMacros_UsePackageImports(t *testing.T) {
 	assert.Empty(t, errs, "macro using imported function should load without error")
 }
 
+func TestLoadWorkspaceMacros_DefunAvailableForMacroExpansion(t *testing.T) {
+	// Regression test: workspace-defined functions (defun) must be available
+	// during macro expansion. Without loading defuns into the env, macros
+	// that call workspace functions (like flatten) fail silently.
+	env := newTestEnv(t)
+
+	preamble := parsePreamble(t, `
+(in-package 'myapp)
+(defun my-flatten (seq)
+  (if (nil? seq) '()
+    (concat 'list (car seq) (my-flatten (cdr seq)))))
+(defmacro with-flat-defs (definitions &rest body)
+  (quasiquote
+    (lambda
+      (unquote (map 'list #^(first %) (my-flatten definitions)))
+      (progn (unquote-splicing body)))))`)
+
+	errs := LoadWorkspaceMacros(env, preamble)
+	assert.Empty(t, errs, "preamble with defun + defmacro should load without error")
+
+	// Verify the function is callable in the env.
+	env.InPackage(lisp.String("myapp"))
+	fn := env.Get(lisp.Symbol("my-flatten"))
+	assert.Equal(t, lisp.LFun, fn.Type, "my-flatten should be a function in the env")
+
+	// Verify the macro can expand (it calls my-flatten during expansion).
+	// Use the full analysis path to test end-to-end.
+	result := parseAndAnalyzeWithConfig(t,
+		`(in-package 'myapp)
+(defun test ()
+  (with-flat-defs (([x] [y]))
+    (list x y)))`,
+		&Config{
+			MacroExpander: &EnvMacroExpander{Env: env},
+		})
+
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "x", u.Name, "x should resolve as lambda param after macro expansion")
+		assert.NotEqual(t, "y", u.Name, "y should resolve as lambda param after macro expansion")
+	}
+}
+
 func TestLoadWorkspaceMacros_ErrorReturned(t *testing.T) {
 	env := newTestEnv(t)
 

--- a/analysis/scope.go
+++ b/analysis/scope.go
@@ -13,6 +13,7 @@ const (
 	ScopeLambda                    // lambda body
 	ScopeLet                       // let/let* body
 	ScopeFlet                      // flet/labels body
+	ScopeMacrolet                  // macrolet body
 	ScopeDotimes                   // dotimes body
 )
 
@@ -28,6 +29,8 @@ func (k ScopeKind) String() string {
 		return "let"
 	case ScopeFlet:
 		return "flet"
+	case ScopeMacrolet:
+		return "macrolet"
 	case ScopeDotimes:
 		return "dotimes"
 	default:

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -1032,10 +1032,27 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		}
 	}
 
-	// Remap user-package symbols from the load tree to their correct package.
-	// Two cases: (1) bare files — all defs remapped, (2) non-bare files —
-	// only defs before the first in-package are remapped (they inherit the
-	// load context at runtime but extractDefinitions assigns them to "user").
+	// Remap user-package symbols to their correct package.
+	//
+	// extractDefinitions assigns all symbols to "user" by default because
+	// it has no package context beyond in-package forms. At runtime, bare
+	// files (no in-package) inherit the caller's package from load-file,
+	// so their definitions belong in a different package.
+	//
+	// DefaultPackage (from main.lisp's in-package) is the workspace's
+	// "real" default package — the package most bare files will inherit
+	// at runtime, since main.lisp is typically the entry point that loads
+	// everything else.
+	//
+	// Three remapping rules:
+	// (1) Bare files in the load tree: remap to the load-tree's package
+	//     context (the package active at the load-file call site).
+	// (2) Bare files NOT in the load tree: remap to DefaultPackage.
+	//     These files may be loaded at runtime from inside function bodies
+	//     (e.g. template files loaded conditionally) — DefaultPackage is
+	//     the best static approximation of the runtime package.
+	// (3) Non-bare files: only remap user-package defs that appear before
+	//     the first in-package (they inherit the load context, not "user").
 	if defaultPkg != "" {
 		bareFiles := make(map[string]bool)
 		firstPkgLine := make(map[string]int) // file → line of first in-package

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -276,18 +276,22 @@ func scanFilePackage(exprs []*lisp.LVal) (string, int) {
 // a map from absolute file path to the package context inherited from the load
 // chain. This mirrors the runtime behavior where load-file executes in the
 // caller's current package context.
-func buildLoadTree(mainPath string) map[string]string {
-	result := make(map[string]string)
+//
+// Also returns loadOrder — the DFS traversal order of files, matching the
+// runtime's sequential load-file evaluation. Used to sort preamble forms
+// so workspace macros see definitions in the same order as the runtime.
+func buildLoadTree(mainPath string) (pkgMap map[string]string, loadOrder []string) {
+	pkgMap = make(map[string]string)
 	visited := make(map[string]bool)
-	walkLoadFile(mainPath, lisp.DefaultUserPackage, result, visited)
-	return result
+	walkLoadFile(mainPath, lisp.DefaultUserPackage, pkgMap, visited, &loadOrder)
+	return pkgMap, loadOrder
 }
 
 // walkLoadFile recursively parses a file and tracks package context through
 // in-package and load-file calls. It only tracks package *context* (which
 // package is active), not use-package imports — those are handled separately
 // by scanUsePackages and PackageImports.
-func walkLoadFile(filePath, currentPkg string, result map[string]string, visited map[string]bool) {
+func walkLoadFile(filePath, currentPkg string, result map[string]string, visited map[string]bool, order *[]string) {
 	absPath, err := filepath.Abs(filePath)
 	if err != nil {
 		return
@@ -296,6 +300,7 @@ func walkLoadFile(filePath, currentPkg string, result map[string]string, visited
 		return
 	}
 	visited[absPath] = true
+	*order = append(*order, absPath)
 
 	src, err := os.ReadFile(absPath) //nolint:gosec // workspace file
 	if err != nil {
@@ -327,7 +332,7 @@ func walkLoadFile(filePath, currentPkg string, result map[string]string, visited
 					continue
 				}
 				result[absLoad] = currentPkg
-				walkLoadFile(absLoad, currentPkg, result, visited)
+				walkLoadFile(absLoad, currentPkg, result, visited, order)
 			}
 		}
 	}
@@ -940,6 +945,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 	// Build load tree from main.lisp to infer packages for bare files.
 	var mainPath string
 	loadTree := make(map[string]string)
+	var loadOrder []string
 	var defaultPkg string
 	for _, p := range paths {
 		if filepath.Base(p) == "main.lisp" {
@@ -948,7 +954,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		}
 	}
 	if mainPath != "" {
-		loadTree = buildLoadTree(mainPath)
+		loadTree, loadOrder = buildLoadTree(mainPath)
 		// Find main.lisp's package from its fileResult.
 		for i, r := range results {
 			if paths[i] == mainPath && r.filePkg != "" {
@@ -966,20 +972,22 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		PackageImports: make(map[string][]string),
 		DefaultPackage: defaultPkg,
 	}
-	for i, r := range results {
-		prescan.ExportedGlobals = append(prescan.ExportedGlobals, r.globals...)
-		prescan.AllDefs = append(prescan.AllDefs, r.allDefs...)
-		prescan.DefForms = append(prescan.DefForms, r.defForms...)
-		// For bare files (no in-package), prepend a synthetic in-package
-		// using the load-tree's package context. This mirrors runtime
-		// behavior: (load-file "bare.lisp") inherits the caller's package,
-		// which may differ from DefaultPackage if in-package was called
-		// between load-file calls in main.lisp.
+	// Build a path→index map for ordering preambles by load tree.
+	pathIndex := make(map[string]int, len(paths))
+	for i, p := range paths {
+		absP, _ := filepath.Abs(p)
+		pathIndex[absP] = i
+	}
+
+	// appendFilePreamble adds a file's preamble forms with synthetic
+	// in-package for bare files inheriting the load context's package.
+	appendFilePreamble := func(idx int) {
+		r := results[idx]
 		if r.filePkg == "" && len(r.preamble) > 0 {
-			absPath, _ := filepath.Abs(paths[i])
+			absPath, _ := filepath.Abs(paths[idx])
 			inheritedPkg := loadTree[absPath]
 			if inheritedPkg == "" {
-				inheritedPkg = defaultPkg // fallback for files not in load tree
+				inheritedPkg = defaultPkg
 			}
 			if inheritedPkg != "" {
 				syntheticInPkg := lisp.SExpr([]*lisp.LVal{
@@ -990,6 +998,29 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 			}
 		}
 		prescan.Preamble = append(prescan.Preamble, r.preamble...)
+	}
+
+	// Aggregate preamble forms in load-tree DFS order (matching runtime's
+	// sequential load-file evaluation), then append files not in the load
+	// tree. This ensures macros see definitions in the same order as runtime.
+	loadedFiles := make(map[int]bool)
+	for _, absPath := range loadOrder {
+		if idx, ok := pathIndex[absPath]; ok {
+			appendFilePreamble(idx)
+			loadedFiles[idx] = true
+		}
+	}
+	// Files not in the load tree (not loaded via load-file from main.lisp).
+	for i := range results {
+		if !loadedFiles[i] {
+			appendFilePreamble(i)
+		}
+	}
+
+	for _, r := range results {
+		prescan.ExportedGlobals = append(prescan.ExportedGlobals, r.globals...)
+		prescan.AllDefs = append(prescan.AllDefs, r.allDefs...)
+		prescan.DefForms = append(prescan.DefForms, r.defForms...)
 		for pkg, syms := range r.pkgs {
 			prescan.PkgExports[pkg] = append(prescan.PkgExports[pkg], syms...)
 		}

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -970,6 +970,17 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		prescan.ExportedGlobals = append(prescan.ExportedGlobals, r.globals...)
 		prescan.AllDefs = append(prescan.AllDefs, r.allDefs...)
 		prescan.DefForms = append(prescan.DefForms, r.defForms...)
+		// For bare files (no in-package), prepend a synthetic in-package
+		// form so LoadWorkspaceMacros places their definitions in the
+		// workspace's DefaultPackage — matching runtime load behavior
+		// where (load-file) inherits the caller's package.
+		if r.filePkg == "" && defaultPkg != "" && len(r.preamble) > 0 {
+			syntheticInPkg := lisp.SExpr([]*lisp.LVal{
+				lisp.Symbol("in-package"),
+				lisp.Quote(lisp.Symbol(defaultPkg)),
+			})
+			prescan.Preamble = append(prescan.Preamble, syntheticInPkg)
+		}
 		prescan.Preamble = append(prescan.Preamble, r.preamble...)
 		for pkg, syms := range r.pkgs {
 			prescan.PkgExports[pkg] = append(prescan.PkgExports[pkg], syms...)

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -336,7 +336,7 @@ func walkLoadFile(filePath, currentPkg string, result map[string]string, visited
 // scanFileFull parses a file once and extracts exported globals, package-grouped
 // exports, all definitions, use-package declarations, raw defmacro AST nodes,
 // and the file's primary package ("" for bare files without in-package).
-func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, pkgAll map[string][]ExternalSymbol, usePackages map[string][]string, macroDefs []MacroDef, filePkg string, firstInPkgLine int) {
+func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, pkgAll map[string][]ExternalSymbol, usePackages map[string][]string, preamble []*lisp.LVal, filePkg string, firstInPkgLine int) {
 	s := token.NewScanner(filename, bytes.NewReader(source))
 	p := rdparser.New(s)
 
@@ -360,23 +360,20 @@ func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkg
 	}
 	usePackages = scanUsePackages(exprs)
 
-	// Collect raw defmacro AST nodes with package context for LoadWorkspaceMacros.
-	currentPkg := lisp.DefaultUserPackage
+	// Collect preamble forms (package management + macro definitions) in
+	// source order. LoadWorkspaceMacros evals these to replay the package
+	// setup and register macros, mirroring the runtime's (load) behavior.
 	for _, expr := range exprs {
 		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
 			continue
 		}
 		switch astutil.HeadSymbol(expr) {
-		case "in-package":
-			if name := scanPackageName(expr); name != "" {
-				currentPkg = name
-			}
-		case "defmacro":
-			macroDefs = append(macroDefs, MacroDef{Package: currentPkg, Node: expr})
+		case "in-package", "use-package", "export", "defmacro":
+			preamble = append(preamble, expr)
 		}
 	}
 
-	return globals, pkgs, defs, pkgAll, usePackages, macroDefs, filePkg, firstInPkgLine
+	return globals, pkgs, defs, pkgAll, usePackages, preamble, filePkg, firstInPkgLine
 }
 
 // extractDefinitions collects top-level definitions from pre-parsed expressions.
@@ -846,14 +843,6 @@ func ScanWorkspaceRefs(root string, cfg *Config, scanCfg *ScanConfig) map[string
 	return refs
 }
 
-// MacroDef pairs a raw (defmacro ...) AST node with the package it was
-// defined in. LoadWorkspaceMacros uses this to set the correct package
-// context before evaluating each macro definition.
-type MacroDef struct {
-	Package string     // package from the most recent in-package before this defmacro
-	Node    *lisp.LVal // the raw (defmacro name formals body...) AST node
-}
-
 // WorkspacePrescan holds the results of a workspace prescan: file definitions,
 // package exports, and DefFormSpecs extracted from defmacro definitions.
 type WorkspacePrescan struct {
@@ -881,11 +870,11 @@ type WorkspacePrescan struct {
 	// via use-package across all workspace files. This enables per-file
 	// analysis to resolve symbols from cross-file use-package declarations.
 	PackageImports map[string][]string
-	// MacroDefs are the raw AST nodes of top-level (defmacro ...) forms
-	// found in workspace files, paired with the package they were defined
-	// in. Pass these to LoadWorkspaceMacros to register them in a runtime
-	// environment for macro expansion during analysis.
-	MacroDefs []MacroDef
+	// Preamble contains package-management and macro-definition forms
+	// (in-package, use-package, export, defmacro) from all workspace files,
+	// in source order per file. Pass these to LoadWorkspaceMacros to replay
+	// the package setup and register macros in a runtime environment.
+	Preamble []*lisp.LVal
 	// DefaultPackage is the package declared in main.lisp (if present).
 	// Used as the default for bare files (no in-package) so that cross-file
 	// resolution works in projects where files inherit the package from
@@ -909,7 +898,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		allDefs        []ExternalSymbol
 		pkgAll         map[string][]ExternalSymbol
 		defForms       []DefFormSpec
-		macroDefs      []MacroDef
+		preamble       []*lisp.LVal
 		usePackages    map[string][]string
 		filePkg        string // "" for bare files
 		firstInPkgLine int    // 1-based line of first in-package, 0 if none
@@ -942,7 +931,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 				}
 				g, p, d, pa, up, md, fp, fpl := scanFileFull(fileSrc, paths[i])
 				df := extractDefFormSpecs(d)
-				results[i] = fileResult{globals: g, pkgs: p, allDefs: d, pkgAll: pa, defForms: df, macroDefs: md, usePackages: up, filePkg: fp, firstInPkgLine: fpl}
+				results[i] = fileResult{globals: g, pkgs: p, allDefs: d, pkgAll: pa, defForms: df, preamble: md, usePackages: up, filePkg: fp, firstInPkgLine: fpl}
 			}
 		}()
 	}
@@ -981,7 +970,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		prescan.ExportedGlobals = append(prescan.ExportedGlobals, r.globals...)
 		prescan.AllDefs = append(prescan.AllDefs, r.allDefs...)
 		prescan.DefForms = append(prescan.DefForms, r.defForms...)
-		prescan.MacroDefs = append(prescan.MacroDefs, r.macroDefs...)
+		prescan.Preamble = append(prescan.Preamble, r.preamble...)
 		for pkg, syms := range r.pkgs {
 			prescan.PkgExports[pkg] = append(prescan.PkgExports[pkg], syms...)
 		}

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -365,15 +365,15 @@ func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkg
 	}
 	usePackages = scanUsePackages(exprs)
 
-	// Collect preamble forms (package management + macro definitions) in
-	// source order. LoadWorkspaceMacros evals these to replay the package
-	// setup and register macros, mirroring the runtime's (load) behavior.
+	// Collect preamble forms (package management + definitions) in source
+	// order. LoadWorkspaceMacros evals these to replay the package setup
+	// and register macros/functions/globals, mirroring (load) behavior.
 	for _, expr := range exprs {
 		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
 			continue
 		}
 		switch astutil.HeadSymbol(expr) {
-		case "in-package", "use-package", "export", "defmacro", "defun":
+		case "in-package", "use-package", "export", "defmacro", "defun", "set":
 			preamble = append(preamble, expr)
 		}
 	}

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -1036,7 +1036,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 	// Two cases: (1) bare files — all defs remapped, (2) non-bare files —
 	// only defs before the first in-package are remapped (they inherit the
 	// load context at runtime but extractDefinitions assigns them to "user").
-	if defaultPkg != "" && len(loadTree) > 0 {
+	if defaultPkg != "" {
 		bareFiles := make(map[string]bool)
 		firstPkgLine := make(map[string]int) // file → line of first in-package
 		for i, r := range results {
@@ -1058,12 +1058,18 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 				return "", false
 			}
 			pkg, inTree := loadTree[sym.Source.File]
+			// Bare file: remap to load-tree package, or defaultPkg if not
+			// in the load tree. At runtime, bare files always inherit their
+			// caller's package — defaultPkg is the best approximation when
+			// the file isn't explicitly loaded via load-file.
+			if bareFiles[sym.Source.File] {
+				if !inTree {
+					pkg = defaultPkg
+				}
+				return pkg, true
+			}
 			if !inTree {
 				return "", false
-			}
-			// Bare file: remap all user-package defs.
-			if bareFiles[sym.Source.File] {
-				return pkg, true
 			}
 			// Non-bare file: remap user-package defs before the first in-package.
 			if line, ok := firstPkgLine[sym.Source.File]; ok && sym.Source.Line < line {

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -368,7 +368,7 @@ func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkg
 			continue
 		}
 		switch astutil.HeadSymbol(expr) {
-		case "in-package", "use-package", "export", "defmacro":
+		case "in-package", "use-package", "export", "defmacro", "defun":
 			preamble = append(preamble, expr)
 		}
 	}

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -336,7 +336,7 @@ func walkLoadFile(filePath, currentPkg string, result map[string]string, visited
 // scanFileFull parses a file once and extracts exported globals, package-grouped
 // exports, all definitions, use-package declarations, raw defmacro AST nodes,
 // and the file's primary package ("" for bare files without in-package).
-func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, pkgAll map[string][]ExternalSymbol, usePackages map[string][]string, macroDefs []*lisp.LVal, filePkg string, firstInPkgLine int) {
+func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, pkgAll map[string][]ExternalSymbol, usePackages map[string][]string, macroDefs []MacroDef, filePkg string, firstInPkgLine int) {
 	s := token.NewScanner(filename, bytes.NewReader(source))
 	p := rdparser.New(s)
 
@@ -360,11 +360,19 @@ func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkg
 	}
 	usePackages = scanUsePackages(exprs)
 
-	// Collect raw defmacro AST nodes for LoadWorkspaceMacros.
+	// Collect raw defmacro AST nodes with package context for LoadWorkspaceMacros.
+	currentPkg := lisp.DefaultUserPackage
 	for _, expr := range exprs {
-		if expr.Type == lisp.LSExpr && !expr.Quoted && len(expr.Cells) > 0 &&
-			astutil.HeadSymbol(expr) == "defmacro" {
-			macroDefs = append(macroDefs, expr)
+		if expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
+			continue
+		}
+		switch astutil.HeadSymbol(expr) {
+		case "in-package":
+			if name := scanPackageName(expr); name != "" {
+				currentPkg = name
+			}
+		case "defmacro":
+			macroDefs = append(macroDefs, MacroDef{Package: currentPkg, Node: expr})
 		}
 	}
 
@@ -838,6 +846,14 @@ func ScanWorkspaceRefs(root string, cfg *Config, scanCfg *ScanConfig) map[string
 	return refs
 }
 
+// MacroDef pairs a raw (defmacro ...) AST node with the package it was
+// defined in. LoadWorkspaceMacros uses this to set the correct package
+// context before evaluating each macro definition.
+type MacroDef struct {
+	Package string     // package from the most recent in-package before this defmacro
+	Node    *lisp.LVal // the raw (defmacro name formals body...) AST node
+}
+
 // WorkspacePrescan holds the results of a workspace prescan: file definitions,
 // package exports, and DefFormSpecs extracted from defmacro definitions.
 type WorkspacePrescan struct {
@@ -866,10 +882,10 @@ type WorkspacePrescan struct {
 	// analysis to resolve symbols from cross-file use-package declarations.
 	PackageImports map[string][]string
 	// MacroDefs are the raw AST nodes of top-level (defmacro ...) forms
-	// found in workspace files. Pass these to LoadWorkspaceMacros to
-	// register them in a runtime environment for macro expansion during
-	// analysis.
-	MacroDefs []*lisp.LVal
+	// found in workspace files, paired with the package they were defined
+	// in. Pass these to LoadWorkspaceMacros to register them in a runtime
+	// environment for macro expansion during analysis.
+	MacroDefs []MacroDef
 	// DefaultPackage is the package declared in main.lisp (if present).
 	// Used as the default for bare files (no in-package) so that cross-file
 	// resolution works in projects where files inherit the package from
@@ -893,7 +909,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		allDefs        []ExternalSymbol
 		pkgAll         map[string][]ExternalSymbol
 		defForms       []DefFormSpec
-		macroDefs      []*lisp.LVal
+		macroDefs      []MacroDef
 		usePackages    map[string][]string
 		filePkg        string // "" for bare files
 		firstInPkgLine int    // 1-based line of first in-package, 0 if none

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -334,15 +334,15 @@ func walkLoadFile(filePath, currentPkg string, result map[string]string, visited
 }
 
 // scanFileFull parses a file once and extracts exported globals, package-grouped
-// exports, all definitions, use-package declarations, and the file's primary
-// package ("" for bare files without in-package).
-func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, pkgAll map[string][]ExternalSymbol, usePackages map[string][]string, filePkg string, firstInPkgLine int) {
+// exports, all definitions, use-package declarations, raw defmacro AST nodes,
+// and the file's primary package ("" for bare files without in-package).
+func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkgs map[string][]ExternalSymbol, allDefs []ExternalSymbol, pkgAll map[string][]ExternalSymbol, usePackages map[string][]string, macroDefs []*lisp.LVal, filePkg string, firstInPkgLine int) {
 	s := token.NewScanner(filename, bytes.NewReader(source))
 	p := rdparser.New(s)
 
 	exprs, err := p.ParseProgram()
 	if err != nil {
-		return nil, nil, nil, nil, nil, "", 0
+		return nil, nil, nil, nil, nil, nil, "", 0
 	}
 
 	filePkg, firstInPkgLine = scanFilePackage(exprs)
@@ -359,7 +359,16 @@ func scanFileFull(source []byte, filename string) (globals []ExternalSymbol, pkg
 		}
 	}
 	usePackages = scanUsePackages(exprs)
-	return globals, pkgs, defs, pkgAll, usePackages, filePkg, firstInPkgLine
+
+	// Collect raw defmacro AST nodes for LoadWorkspaceMacros.
+	for _, expr := range exprs {
+		if expr.Type == lisp.LSExpr && !expr.Quoted && len(expr.Cells) > 0 &&
+			astutil.HeadSymbol(expr) == "defmacro" {
+			macroDefs = append(macroDefs, expr)
+		}
+	}
+
+	return globals, pkgs, defs, pkgAll, usePackages, macroDefs, filePkg, firstInPkgLine
 }
 
 // extractDefinitions collects top-level definitions from pre-parsed expressions.
@@ -856,6 +865,11 @@ type WorkspacePrescan struct {
 	// via use-package across all workspace files. This enables per-file
 	// analysis to resolve symbols from cross-file use-package declarations.
 	PackageImports map[string][]string
+	// MacroDefs are the raw AST nodes of top-level (defmacro ...) forms
+	// found in workspace files. Pass these to LoadWorkspaceMacros to
+	// register them in a runtime environment for macro expansion during
+	// analysis.
+	MacroDefs []*lisp.LVal
 	// DefaultPackage is the package declared in main.lisp (if present).
 	// Used as the default for bare files (no in-package) so that cross-file
 	// resolution works in projects where files inherit the package from
@@ -879,6 +893,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		allDefs        []ExternalSymbol
 		pkgAll         map[string][]ExternalSymbol
 		defForms       []DefFormSpec
+		macroDefs      []*lisp.LVal
 		usePackages    map[string][]string
 		filePkg        string // "" for bare files
 		firstInPkgLine int    // 1-based line of first in-package, 0 if none
@@ -909,9 +924,9 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 				if readErr != nil {
 					continue
 				}
-				g, p, d, pa, up, fp, fpl := scanFileFull(fileSrc, paths[i])
+				g, p, d, pa, up, md, fp, fpl := scanFileFull(fileSrc, paths[i])
 				df := extractDefFormSpecs(d)
-				results[i] = fileResult{globals: g, pkgs: p, allDefs: d, pkgAll: pa, defForms: df, usePackages: up, filePkg: fp, firstInPkgLine: fpl}
+				results[i] = fileResult{globals: g, pkgs: p, allDefs: d, pkgAll: pa, defForms: df, macroDefs: md, usePackages: up, filePkg: fp, firstInPkgLine: fpl}
 			}
 		}()
 	}
@@ -950,6 +965,7 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		prescan.ExportedGlobals = append(prescan.ExportedGlobals, r.globals...)
 		prescan.AllDefs = append(prescan.AllDefs, r.allDefs...)
 		prescan.DefForms = append(prescan.DefForms, r.defForms...)
+		prescan.MacroDefs = append(prescan.MacroDefs, r.macroDefs...)
 		for pkg, syms := range r.pkgs {
 			prescan.PkgExports[pkg] = append(prescan.PkgExports[pkg], syms...)
 		}

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -966,20 +966,28 @@ func PrescanWorkspace(root string, scanCfg *ScanConfig) (*WorkspacePrescan, erro
 		PackageImports: make(map[string][]string),
 		DefaultPackage: defaultPkg,
 	}
-	for _, r := range results {
+	for i, r := range results {
 		prescan.ExportedGlobals = append(prescan.ExportedGlobals, r.globals...)
 		prescan.AllDefs = append(prescan.AllDefs, r.allDefs...)
 		prescan.DefForms = append(prescan.DefForms, r.defForms...)
 		// For bare files (no in-package), prepend a synthetic in-package
-		// form so LoadWorkspaceMacros places their definitions in the
-		// workspace's DefaultPackage — matching runtime load behavior
-		// where (load-file) inherits the caller's package.
-		if r.filePkg == "" && defaultPkg != "" && len(r.preamble) > 0 {
-			syntheticInPkg := lisp.SExpr([]*lisp.LVal{
-				lisp.Symbol("in-package"),
-				lisp.Quote(lisp.Symbol(defaultPkg)),
-			})
-			prescan.Preamble = append(prescan.Preamble, syntheticInPkg)
+		// using the load-tree's package context. This mirrors runtime
+		// behavior: (load-file "bare.lisp") inherits the caller's package,
+		// which may differ from DefaultPackage if in-package was called
+		// between load-file calls in main.lisp.
+		if r.filePkg == "" && len(r.preamble) > 0 {
+			absPath, _ := filepath.Abs(paths[i])
+			inheritedPkg := loadTree[absPath]
+			if inheritedPkg == "" {
+				inheritedPkg = defaultPkg // fallback for files not in load tree
+			}
+			if inheritedPkg != "" {
+				syntheticInPkg := lisp.SExpr([]*lisp.LVal{
+					lisp.Symbol("in-package"),
+					lisp.Quote(lisp.Symbol(inheritedPkg)),
+				})
+				prescan.Preamble = append(prescan.Preamble, syntheticInPkg)
+			}
 		}
 		prescan.Preamble = append(prescan.Preamble, r.preamble...)
 		for pkg, syms := range r.pkgs {

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -1767,5 +1767,5 @@ func TestPrescanWorkspace_Preamble(t *testing.T) {
 	assert.Equal(t, 1, heads["use-package"], "should collect use-package")
 	assert.Equal(t, 1, heads["export"], "should collect export")
 	assert.Equal(t, 2, heads["defmacro"], "should collect both defmacro forms")
-	assert.Equal(t, 0, heads["defun"], "defun should NOT appear in Preamble")
+	assert.Equal(t, 1, heads["defun"], "should collect defun forms")
 }

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/luthersystems/elps/astutil"
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/parser/rdparser"
 	"github.com/luthersystems/elps/parser/token"
@@ -1736,38 +1737,35 @@ func TestScanConfig_EffectiveDefaults(t *testing.T) {
 	assert.Equal(t, int64(DefaultMaxFileBytes), negCfg.effectiveMaxFileBytes())
 }
 
-func TestPrescanWorkspace_MacroDefs(t *testing.T) {
+func TestPrescanWorkspace_Preamble(t *testing.T) {
 	dir := t.TempDir()
 
-	// File with in-package + defmacro — macro should have package "mypkg".
+	// File with in-package, use-package, export, defmacro, and defun.
+	// Only preamble forms should be collected.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "macros.lisp"), []byte(`
 (in-package 'mypkg)
+(use-package 'utils)
+(export 'my-macro)
 (defmacro my-macro (x) (quasiquote (+ (unquote x) 1)))
-(defun not-a-macro () 42)
+(defun not-a-preamble () 42)
 `), 0600))
 
-	// Bare file with defmacro — macro should have default package "user".
+	// Bare file with defmacro only.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "user.lisp"), []byte(`
 (defmacro user-macro () '1)
 `), 0600))
 
 	prescan, err := PrescanWorkspace(dir, nil)
 	require.NoError(t, err)
-	require.Len(t, prescan.MacroDefs, 2, "should collect both defmacro forms")
 
-	// Verify package context is correct.
-	pkgByName := make(map[string]string)
-	for _, md := range prescan.MacroDefs {
-		pkgByName[macroDefName(md.Node)] = md.Package
+	// Count preamble forms by type.
+	heads := make(map[string]int)
+	for _, form := range prescan.Preamble {
+		heads[astutil.HeadSymbol(form)]++
 	}
-	assert.Equal(t, "mypkg", pkgByName["my-macro"],
-		"my-macro should have package from in-package")
-	assert.Equal(t, "user", pkgByName["user-macro"],
-		"user-macro should have default user package")
-
-	// defun should NOT appear in MacroDefs.
-	for _, md := range prescan.MacroDefs {
-		assert.NotEqual(t, "not-a-macro", macroDefName(md.Node),
-			"defun should not appear in MacroDefs")
-	}
+	assert.Equal(t, 1, heads["in-package"], "should collect in-package")
+	assert.Equal(t, 1, heads["use-package"], "should collect use-package")
+	assert.Equal(t, 1, heads["export"], "should collect export")
+	assert.Equal(t, 2, heads["defmacro"], "should collect both defmacro forms")
+	assert.Equal(t, 0, heads["defun"], "defun should NOT appear in Preamble")
 }

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -1735,3 +1735,39 @@ func TestScanConfig_EffectiveDefaults(t *testing.T) {
 	assert.Equal(t, DefaultMaxWorkspaceFiles, negCfg.effectiveMaxFiles())
 	assert.Equal(t, int64(DefaultMaxFileBytes), negCfg.effectiveMaxFileBytes())
 }
+
+func TestPrescanWorkspace_MacroDefs(t *testing.T) {
+	dir := t.TempDir()
+
+	// File with in-package + defmacro — macro should have package "mypkg".
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "macros.lisp"), []byte(`
+(in-package 'mypkg)
+(defmacro my-macro (x) (quasiquote (+ (unquote x) 1)))
+(defun not-a-macro () 42)
+`), 0600))
+
+	// Bare file with defmacro — macro should have default package "user".
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "user.lisp"), []byte(`
+(defmacro user-macro () '1)
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+	require.Len(t, prescan.MacroDefs, 2, "should collect both defmacro forms")
+
+	// Verify package context is correct.
+	pkgByName := make(map[string]string)
+	for _, md := range prescan.MacroDefs {
+		pkgByName[macroDefName(md.Node)] = md.Package
+	}
+	assert.Equal(t, "mypkg", pkgByName["my-macro"],
+		"my-macro should have package from in-package")
+	assert.Equal(t, "user", pkgByName["user-macro"],
+		"user-macro should have default user package")
+
+	// defun should NOT appear in MacroDefs.
+	for _, md := range prescan.MacroDefs {
+		assert.NotEqual(t, "not-a-macro", macroDefName(md.Node),
+			"defun should not appear in MacroDefs")
+	}
+}

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -1349,7 +1349,7 @@ func TestBuildLoadTree_Basic(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.lisp"), []byte(`(defun a-fn () 1)`), 0600))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.lisp"), []byte(`(defun b-fn () 2)`), 0600))
 
-	tree := buildLoadTree(filepath.Join(dir, "main.lisp"))
+	tree, _ := buildLoadTree(filepath.Join(dir, "main.lisp"))
 
 	absA, _ := filepath.Abs(filepath.Join(dir, "a.lisp"))
 	absB, _ := filepath.Abs(filepath.Join(dir, "b.lisp"))
@@ -1369,7 +1369,7 @@ func TestBuildLoadTree_PackageSwitch(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.lisp"), []byte(`(defun a-fn () 1)`), 0600))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.lisp"), []byte(`(defun b-fn () 2)`), 0600))
 
-	tree := buildLoadTree(filepath.Join(dir, "main.lisp"))
+	tree, _ := buildLoadTree(filepath.Join(dir, "main.lisp"))
 
 	absA, _ := filepath.Abs(filepath.Join(dir, "a.lisp"))
 	absB, _ := filepath.Abs(filepath.Join(dir, "b.lisp"))
@@ -1389,7 +1389,7 @@ func TestBuildLoadTree_Nested(t *testing.T) {
 `), 0600))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.lisp"), []byte(`(defun b-fn () 2)`), 0600))
 
-	tree := buildLoadTree(filepath.Join(dir, "main.lisp"))
+	tree, _ := buildLoadTree(filepath.Join(dir, "main.lisp"))
 
 	absA, _ := filepath.Abs(filepath.Join(dir, "a.lisp"))
 	absB, _ := filepath.Abs(filepath.Join(dir, "b.lisp"))
@@ -1627,7 +1627,7 @@ func TestBuildLoadTree_CycleDetection(t *testing.T) {
 (load-file "a.lisp")
 `), 0600))
 
-	tree := buildLoadTree(filepath.Join(dir, "a.lisp"))
+	tree, _ := buildLoadTree(filepath.Join(dir, "a.lisp"))
 	assert.NotNil(t, tree, "should terminate without infinite loop")
 
 	absB, _ := filepath.Abs(filepath.Join(dir, "b.lisp"))

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -1434,6 +1434,52 @@ func TestPrescanWorkspace_DefaultPackage(t *testing.T) {
 	assert.True(t, found, "do-work should be in AllDefs")
 }
 
+func TestPrescanWorkspace_SetInBareFileRemapped(t *testing.T) {
+	// set definitions in bare template files should be remapped to the
+	// load-tree's package context, making them visible to other files.
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'myapp)
+(load-file "template.lisp")
+`), 0600))
+
+	// template.lisp — no in-package, uses set for a global.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "template.lisp"), []byte(`
+(set 'default-template "hello world")
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+
+	// default-template should be remapped to myapp (not user).
+	found := false
+	for _, d := range prescan.AllDefs {
+		if d.Name == "default-template" {
+			assert.Equal(t, "myapp", d.Package,
+				"set global in bare file should be remapped to load context package")
+			found = true
+		}
+	}
+	assert.True(t, found, "default-template should be in AllDefs")
+
+	// End-to-end: verify a file in myapp can resolve default-template.
+	cfg := &Config{
+		ExtraGlobals:   prescan.AllDefs,
+		PackageExports: prescan.PkgExports,
+		PackageSymbols: prescan.PkgAllSymbols,
+		PackageImports: prescan.PackageImports,
+		DefaultPackage: prescan.DefaultPackage,
+	}
+	result := parseAndAnalyzeWithConfig(t,
+		`(in-package 'myapp)
+(defun use-template () default-template)`, cfg)
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "default-template", u.Name,
+			"set global from bare template file should resolve cross-file")
+	}
+}
+
 // TestPrescanWorkspace_PhylumPattern replicates a typical phylum workspace:
 // - main.lisp sets in-package and imports packages via use-package
 // - main.lisp loads a utils file that switches packages then switches back

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -1747,7 +1747,8 @@ func TestPrescanWorkspace_Preamble(t *testing.T) {
 (use-package 'utils)
 (export 'my-macro)
 (defmacro my-macro (x) (quasiquote (+ (unquote x) 1)))
-(defun not-a-preamble () 42)
+(defun helper () 42)
+(set 'my-global "value")
 `), 0600))
 
 	// Bare file with defmacro only.
@@ -1768,4 +1769,5 @@ func TestPrescanWorkspace_Preamble(t *testing.T) {
 	assert.Equal(t, 1, heads["export"], "should collect export")
 	assert.Equal(t, 2, heads["defmacro"], "should collect both defmacro forms")
 	assert.Equal(t, 1, heads["defun"], "should collect defun forms")
+	assert.Equal(t, 1, heads["set"], "should collect set forms")
 }

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -1480,6 +1480,55 @@ func TestPrescanWorkspace_SetInBareFileRemapped(t *testing.T) {
 	}
 }
 
+func TestPrescanWorkspace_SetInBareFileNotInLoadTree(t *testing.T) {
+	// Bare files not explicitly loaded via load-file should still have
+	// their definitions remapped to DefaultPackage (not left in user).
+	// At runtime these files would inherit the caller's package; the
+	// best static approximation is DefaultPackage from main.lisp.
+	dir := t.TempDir()
+
+	// main.lisp does NOT load-file template.lisp.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lisp"), []byte(`
+(in-package 'myapp)
+(defun use-template () my-template)
+`), 0600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "template.lisp"), []byte(`
+(set 'my-template "hello world")
+`), 0600))
+
+	prescan, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "myapp", prescan.DefaultPackage)
+
+	// my-template should be remapped to myapp even without load-file.
+	found := false
+	for _, d := range prescan.AllDefs {
+		if d.Name == "my-template" {
+			assert.Equal(t, "myapp", d.Package,
+				"bare file set not in load tree should remap to DefaultPackage")
+			found = true
+		}
+	}
+	assert.True(t, found, "my-template should be in AllDefs")
+
+	// End-to-end: verify it resolves cross-file.
+	cfg := &Config{
+		ExtraGlobals:   prescan.AllDefs,
+		PackageExports: prescan.PkgExports,
+		PackageSymbols: prescan.PkgAllSymbols,
+		PackageImports: prescan.PackageImports,
+		DefaultPackage: prescan.DefaultPackage,
+	}
+	result := parseAndAnalyzeWithConfig(t,
+		`(in-package 'myapp)
+(defun use-template () my-template)`, cfg)
+	for _, u := range result.Unresolved {
+		assert.NotEqual(t, "my-template", u.Name,
+			"set global from bare file not in load tree should resolve via DefaultPackage")
+	}
+}
+
 // TestPrescanWorkspace_PhylumPattern replicates a typical phylum workspace:
 // - main.lisp sets in-package and imports packages via use-package
 // - main.lisp loads a utils file that switches packages then switches back

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -303,7 +303,20 @@ type LintConfig struct {
 	// Embedders that boot a full environment can pass
 	// &analysis.EnvMacroExpander{Env: env} to enable accurate symbol
 	// resolution inside macro bodies.
+	//
+	// For most embedders, setting Env is simpler — it automatically creates
+	// the expander and loads workspace macros. Use MacroExpander only when
+	// you need a custom implementation.
 	MacroExpander analysis.MacroExpander
+
+	// Env is an optional runtime environment for macro expansion. When set
+	// alongside a Workspace, workspace-defined macros are loaded into the
+	// env and a MacroExpander is created automatically. This is the
+	// recommended way for embedders to enable macro expansion — just pass
+	// the env and elps handles the rest.
+	//
+	// If MacroExpander is also set, it takes precedence over Env.
+	Env *lisp.LEnv
 }
 
 // LintFiles analyzes source files with full workspace + embedder context.
@@ -376,6 +389,14 @@ func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
 		pkgExports[pkg] = append(pkgExports[pkg], wsSyms...)
 	}
 
+	// Set up macro expansion. Explicit MacroExpander takes precedence;
+	// otherwise, if Env is provided, load workspace macros and create one.
+	expander := cfg.MacroExpander
+	if expander == nil && cfg.Env != nil {
+		analysis.LoadWorkspaceMacros(cfg.Env, prescan.MacroDefs)
+		expander = &analysis.EnvMacroExpander{Env: cfg.Env}
+	}
+
 	acfg := &analysis.Config{
 		ExtraGlobals:   prescan.AllDefs,
 		PackageExports: pkgExports,
@@ -383,7 +404,7 @@ func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
 		DefForms:       prescan.DefForms,
 		PackageImports: prescan.PackageImports,
 		DefaultPackage: prescan.DefaultPackage,
-		MacroExpander:  cfg.MacroExpander,
+		MacroExpander:  expander,
 	}
 
 	// Build workspace refs so lint analyzers (e.g. unused-function) can check

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -394,7 +394,7 @@ func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
 	// otherwise, if Env is provided, load workspace macros and create one.
 	expander := cfg.MacroExpander
 	if expander == nil && cfg.Env != nil {
-		if errs := analysis.LoadWorkspaceMacros(cfg.Env, prescan.MacroDefs); len(errs) > 0 {
+		if errs := analysis.LoadWorkspaceMacros(cfg.Env, prescan.MacroDefs, prescan.PackageImports); len(errs) > 0 {
 			for _, err := range errs {
 				slog.Warn("failed to load workspace macro", "error", err)
 			}

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -298,6 +298,12 @@ type LintConfig struct {
 	// analysis.ExtractPackageExports(env.Runtime.Registry) here to avoid
 	// the overhead of creating a temporary environment.
 	StdlibExports map[string][]analysis.ExternalSymbol
+
+	// MacroExpander optionally expands user-macro calls at analysis time.
+	// Embedders that boot a full environment can pass
+	// &analysis.EnvMacroExpander{Env: env} to enable accurate symbol
+	// resolution inside macro bodies.
+	MacroExpander analysis.MacroExpander
 }
 
 // LintFiles analyzes source files with full workspace + embedder context.
@@ -377,6 +383,7 @@ func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
 		DefForms:       prescan.DefForms,
 		PackageImports: prescan.PackageImports,
 		DefaultPackage: prescan.DefaultPackage,
+		MacroExpander:  cfg.MacroExpander,
 	}
 
 	// Build workspace refs so lint analyzers (e.g. unused-function) can check

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -394,7 +394,7 @@ func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
 	// otherwise, if Env is provided, load workspace macros and create one.
 	expander := cfg.MacroExpander
 	if expander == nil && cfg.Env != nil {
-		if errs := analysis.LoadWorkspaceMacros(cfg.Env, prescan.MacroDefs, prescan.PackageImports); len(errs) > 0 {
+		if errs := analysis.LoadWorkspaceMacros(cfg.Env, prescan.Preamble); len(errs) > 0 {
 			for _, err := range errs {
 				slog.Warn("failed to load workspace macro", "error", err)
 			}

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"sort"
 	"strings"
@@ -393,7 +394,11 @@ func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
 	// otherwise, if Env is provided, load workspace macros and create one.
 	expander := cfg.MacroExpander
 	if expander == nil && cfg.Env != nil {
-		analysis.LoadWorkspaceMacros(cfg.Env, prescan.MacroDefs)
+		if errs := analysis.LoadWorkspaceMacros(cfg.Env, prescan.MacroDefs); len(errs) > 0 {
+			for _, err := range errs {
+				slog.Warn("failed to load workspace macro", "error", err)
+			}
+		}
 		expander = &analysis.EnvMacroExpander{Env: cfg.Env}
 	}
 

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -380,7 +380,7 @@ func (s *Server) buildWorkspaceIndex() {
 	// Enable macro expansion at analysis time if an environment is available.
 	// Load workspace-defined macros into the env so the expander can find them.
 	if s.env != nil {
-		if errs := analysis.LoadWorkspaceMacros(s.env, macroDefs); len(errs) > 0 {
+		if errs := analysis.LoadWorkspaceMacros(s.env, macroDefs, packageImports); len(errs) > 0 {
 			for _, err := range errs {
 				s.sendNotification("window/logMessage", &protocol.LogMessageParams{
 					Type:    protocol.MessageTypeWarning,

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -321,7 +321,7 @@ func (s *Server) buildWorkspaceIndex() {
 
 	// Two-phase workspace scan: prescan extracts definitions AND
 	// macro-derived DefFormSpecs for cross-file def-like form recognition.
-	var macroDefs []analysis.MacroDef
+	var preamble []*lisp.LVal
 	if s.rootPath != "" {
 		if prescan, err := analysis.PrescanWorkspace(s.rootPath, scanCfg); err == nil {
 			extraGlobals = prescan.AllDefs
@@ -330,7 +330,7 @@ func (s *Server) buildWorkspaceIndex() {
 			defForms = prescan.DefForms
 			packageImports = prescan.PackageImports
 			defaultPackage = prescan.DefaultPackage
-			macroDefs = prescan.MacroDefs
+			preamble = prescan.Preamble
 			if prescan.Truncated {
 				s.sendNotification("window/showMessage", &protocol.ShowMessageParams{
 					Type:    protocol.MessageTypeWarning,
@@ -380,7 +380,7 @@ func (s *Server) buildWorkspaceIndex() {
 	// Enable macro expansion at analysis time if an environment is available.
 	// Load workspace-defined macros into the env so the expander can find them.
 	if s.env != nil {
-		if errs := analysis.LoadWorkspaceMacros(s.env, macroDefs, packageImports); len(errs) > 0 {
+		if errs := analysis.LoadWorkspaceMacros(s.env, preamble); len(errs) > 0 {
 			for _, err := range errs {
 				s.sendNotification("window/logMessage", &protocol.LogMessageParams{
 					Type:    protocol.MessageTypeWarning,

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -375,6 +375,11 @@ func (s *Server) buildWorkspaceIndex() {
 		DefaultPackage: defaultPackage,
 	}
 
+	// Enable macro expansion at analysis time if an environment is available.
+	if s.env != nil {
+		cfg.MacroExpander = &analysis.EnvMacroExpander{Env: s.env}
+	}
+
 	// Build workspace reference index using the populated config.
 	// Set it on the config so per-file analysis (and lint analyzers)
 	// can check cross-file references.
@@ -441,6 +446,7 @@ func (s *Server) getAnalysisConfig(uri string) *analysis.Config {
 		cfg.PackageImports = base.PackageImports
 		cfg.DefaultPackage = base.DefaultPackage
 		cfg.WorkspaceRefs = base.WorkspaceRefs
+		cfg.MacroExpander = base.MacroExpander
 	}
 	return cfg
 }

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -321,7 +321,7 @@ func (s *Server) buildWorkspaceIndex() {
 
 	// Two-phase workspace scan: prescan extracts definitions AND
 	// macro-derived DefFormSpecs for cross-file def-like form recognition.
-	var macroDefs []*lisp.LVal
+	var macroDefs []analysis.MacroDef
 	if s.rootPath != "" {
 		if prescan, err := analysis.PrescanWorkspace(s.rootPath, scanCfg); err == nil {
 			extraGlobals = prescan.AllDefs
@@ -380,7 +380,14 @@ func (s *Server) buildWorkspaceIndex() {
 	// Enable macro expansion at analysis time if an environment is available.
 	// Load workspace-defined macros into the env so the expander can find them.
 	if s.env != nil {
-		analysis.LoadWorkspaceMacros(s.env, macroDefs)
+		if errs := analysis.LoadWorkspaceMacros(s.env, macroDefs); len(errs) > 0 {
+			for _, err := range errs {
+				s.sendNotification("window/logMessage", &protocol.LogMessageParams{
+					Type:    protocol.MessageTypeWarning,
+					Message: err.Error(),
+				})
+			}
+		}
 		cfg.MacroExpander = &analysis.EnvMacroExpander{Env: s.env}
 	}
 

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -321,6 +321,7 @@ func (s *Server) buildWorkspaceIndex() {
 
 	// Two-phase workspace scan: prescan extracts definitions AND
 	// macro-derived DefFormSpecs for cross-file def-like form recognition.
+	var macroDefs []*lisp.LVal
 	if s.rootPath != "" {
 		if prescan, err := analysis.PrescanWorkspace(s.rootPath, scanCfg); err == nil {
 			extraGlobals = prescan.AllDefs
@@ -329,6 +330,7 @@ func (s *Server) buildWorkspaceIndex() {
 			defForms = prescan.DefForms
 			packageImports = prescan.PackageImports
 			defaultPackage = prescan.DefaultPackage
+			macroDefs = prescan.MacroDefs
 			if prescan.Truncated {
 				s.sendNotification("window/showMessage", &protocol.ShowMessageParams{
 					Type:    protocol.MessageTypeWarning,
@@ -376,7 +378,9 @@ func (s *Server) buildWorkspaceIndex() {
 	}
 
 	// Enable macro expansion at analysis time if an environment is available.
+	// Load workspace-defined macros into the env so the expander can find them.
 	if s.env != nil {
+		analysis.LoadWorkspaceMacros(s.env, macroDefs)
 		cfg.MacroExpander = &analysis.EnvMacroExpander{Env: s.env}
 	}
 

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -711,6 +711,7 @@ func TestDiagnostics_CrossFileSymbolResolution(t *testing.T) {
 	require.False(t, res.IsError)
 
 	diagnostics := decodeStructured[DiagnosticsResponse](t, res)
+	require.NotEmpty(t, diagnostics.Files, "should have diagnostics for at least one file")
 	// 'helper' should NOT be flagged as undefined — it's defined in a.lisp.
 	for _, fd := range diagnostics.Files {
 		for _, d := range fd.Diagnostics {
@@ -718,6 +719,42 @@ func TestDiagnostics_CrossFileSymbolResolution(t *testing.T) {
 				"cross-file symbol 'helper' should be resolved via workspace_root")
 		}
 	}
+}
+
+func TestDiagnostics_CrossFileSymbolResolution_WithoutWorkspace(t *testing.T) {
+	// Negative test: without workspace_root, cross-file symbols are NOT resolved.
+	// This proves the workspace_root fix is actually needed.
+	tmp := t.TempDir()
+	writeTestFile(t, filepath.Join(tmp, "a.lisp"), "(defun helper () 42)")
+	writeTestFile(t, filepath.Join(tmp, "b.lisp"), "(defun caller () (helper))")
+
+	// Create server WITHOUT workspace root — single-file analysis only.
+	session, serverSession := connectTestServer(t, New())
+	defer closeClientSession(t, session)
+	defer closeServerSession(t, serverSession)
+
+	// Analyze b.lisp alone, without workspace_root — single-file mode.
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "diagnostics",
+		Arguments: map[string]any{
+			"path": filepath.Join(tmp, "b.lisp"),
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	diagnostics := decodeStructured[DiagnosticsResponse](t, res)
+	// Without workspace context, 'helper' SHOULD be flagged as undefined.
+	var helperFlagged bool
+	for _, fd := range diagnostics.Files {
+		for _, d := range fd.Diagnostics {
+			if strings.Contains(d.Message, "helper") {
+				helperFlagged = true
+			}
+		}
+	}
+	assert.True(t, helperFlagged,
+		"without workspace_root, cross-file symbol 'helper' should be flagged as undefined")
 }
 
 func TestNullVsEmptySlice_References(t *testing.T) {

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -689,6 +689,37 @@ func TestDiagnosticsWorkspaceWide(t *testing.T) {
 	assert.True(t, hasErrors, "bad.lisp should produce diagnostics")
 }
 
+func TestDiagnostics_CrossFileSymbolResolution(t *testing.T) {
+	// Regression test for #259: MCP diagnostics should resolve symbols
+	// defined in other workspace files when workspace_root is set.
+	tmp := t.TempDir()
+	writeTestFile(t, filepath.Join(tmp, "a.lisp"), "(defun helper () 42)")
+	writeTestFile(t, filepath.Join(tmp, "b.lisp"), "(defun caller () (helper))")
+
+	session, serverSession := connectTestServer(t, New(WithWorkspaceRoot(tmp)))
+	defer closeClientSession(t, session)
+	defer closeServerSession(t, serverSession)
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "diagnostics",
+		Arguments: map[string]any{
+			"path":           filepath.Join(tmp, "b.lisp"),
+			"workspace_root": tmp,
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	diagnostics := decodeStructured[DiagnosticsResponse](t, res)
+	// 'helper' should NOT be flagged as undefined — it's defined in a.lisp.
+	for _, fd := range diagnostics.Files {
+		for _, d := range fd.Diagnostics {
+			assert.NotContains(t, d.Message, "helper",
+				"cross-file symbol 'helper' should be resolved via workspace_root")
+		}
+	}
+}
+
 func TestNullVsEmptySlice_References(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "empty.lisp")

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -651,6 +651,7 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 	scanCfg := &analysis.ScanConfig{
 		Excludes: s.excludePatterns,
 	}
+	var macroDefs []*lisp.LVal
 	if root != "" {
 		prescan, err := analysis.PrescanWorkspace(root, scanCfg)
 		if err != nil {
@@ -663,6 +664,7 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 		state.cfg.PackageImports = prescan.PackageImports
 		state.cfg.DefaultPackage = prescan.DefaultPackage
 		state.symbols = prescan.AllDefs
+		macroDefs = prescan.MacroDefs
 	}
 
 	reg := s.registry
@@ -687,6 +689,7 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 		state.cfg.WorkspaceRefs = state.refs
 	}
 	if s.env != nil {
+		analysis.LoadWorkspaceMacros(s.env, macroDefs)
 		state.cfg.MacroExpander = &analysis.EnvMacroExpander{Env: s.env}
 	}
 	return state, nil

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -584,6 +584,7 @@ func (s *service) loadDocument(path string, content *string, workspaceRoot *stri
 		PackageImports: state.cfg.PackageImports,
 		DefaultPackage: state.cfg.DefaultPackage,
 		WorkspaceRefs:  state.cfg.WorkspaceRefs,
+		MacroExpander:  state.cfg.MacroExpander,
 	}
 	var result *analysis.Result
 	if parsed.Exprs != nil {
@@ -684,6 +685,9 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 	if root != "" {
 		state.refs = analysis.ScanWorkspaceRefs(root, state.cfg, scanCfg)
 		state.cfg.WorkspaceRefs = state.refs
+	}
+	if s.env != nil {
+		state.cfg.MacroExpander = &analysis.EnvMacroExpander{Env: s.env}
 	}
 	return state, nil
 }

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -651,7 +651,7 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 	scanCfg := &analysis.ScanConfig{
 		Excludes: s.excludePatterns,
 	}
-	var macroDefs []*lisp.LVal
+	var macroDefs []analysis.MacroDef
 	if root != "" {
 		prescan, err := analysis.PrescanWorkspace(root, scanCfg)
 		if err != nil {
@@ -689,7 +689,11 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 		state.cfg.WorkspaceRefs = state.refs
 	}
 	if s.env != nil {
-		analysis.LoadWorkspaceMacros(s.env, macroDefs)
+		if errs := analysis.LoadWorkspaceMacros(s.env, macroDefs); len(errs) > 0 {
+			for _, err := range errs {
+				slog.Warn("failed to load workspace macro", "error", err)
+			}
+		}
 		state.cfg.MacroExpander = &analysis.EnvMacroExpander{Env: s.env}
 	}
 	return state, nil

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -579,7 +579,11 @@ func (s *service) loadDocument(path string, content *string, workspaceRoot *stri
 		Filename:       resolvedPath,
 		ExtraGlobals:   state.cfg.ExtraGlobals,
 		PackageExports: state.cfg.PackageExports,
+		PackageSymbols: state.cfg.PackageSymbols,
 		DefForms:       state.cfg.DefForms,
+		PackageImports: state.cfg.PackageImports,
+		DefaultPackage: state.cfg.DefaultPackage,
+		WorkspaceRefs:  state.cfg.WorkspaceRefs,
 	}
 	var result *analysis.Result
 	if parsed.Exprs != nil {
@@ -647,13 +651,17 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 		Excludes: s.excludePatterns,
 	}
 	if root != "" {
-		globals, pkgs, symbols, _, err := analysis.ScanWorkspaceAllWithConfig(root, scanCfg)
+		prescan, err := analysis.PrescanWorkspace(root, scanCfg)
 		if err != nil {
 			return nil, err
 		}
-		state.cfg.ExtraGlobals = globals
-		state.cfg.PackageExports = pkgs
-		state.symbols = symbols
+		state.cfg.ExtraGlobals = prescan.AllDefs
+		state.cfg.PackageExports = prescan.PkgExports
+		state.cfg.PackageSymbols = prescan.PkgAllSymbols
+		state.cfg.DefForms = prescan.DefForms
+		state.cfg.PackageImports = prescan.PackageImports
+		state.cfg.DefaultPackage = prescan.DefaultPackage
+		state.symbols = prescan.AllDefs
 	}
 
 	reg := s.registry
@@ -675,6 +683,7 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 	}
 	if root != "" {
 		state.refs = analysis.ScanWorkspaceRefs(root, state.cfg, scanCfg)
+		state.cfg.WorkspaceRefs = state.refs
 	}
 	return state, nil
 }

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -651,7 +651,7 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 	scanCfg := &analysis.ScanConfig{
 		Excludes: s.excludePatterns,
 	}
-	var macroDefs []analysis.MacroDef
+	var preamble []*lisp.LVal
 	if root != "" {
 		prescan, err := analysis.PrescanWorkspace(root, scanCfg)
 		if err != nil {
@@ -664,7 +664,7 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 		state.cfg.PackageImports = prescan.PackageImports
 		state.cfg.DefaultPackage = prescan.DefaultPackage
 		state.symbols = prescan.AllDefs
-		macroDefs = prescan.MacroDefs
+		preamble = prescan.Preamble
 	}
 
 	reg := s.registry
@@ -689,7 +689,7 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 		state.cfg.WorkspaceRefs = state.refs
 	}
 	if s.env != nil {
-		if errs := analysis.LoadWorkspaceMacros(s.env, macroDefs, state.cfg.PackageImports); len(errs) > 0 {
+		if errs := analysis.LoadWorkspaceMacros(s.env, preamble); len(errs) > 0 {
 			for _, err := range errs {
 				slog.Warn("failed to load workspace macro", "error", err)
 			}

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -689,7 +689,7 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 		state.cfg.WorkspaceRefs = state.refs
 	}
 	if s.env != nil {
-		if errs := analysis.LoadWorkspaceMacros(s.env, macroDefs); len(errs) > 0 {
+		if errs := analysis.LoadWorkspaceMacros(s.env, macroDefs, state.cfg.PackageImports); len(errs) > 0 {
 			for _, err := range errs {
 				slog.Warn("failed to load workspace macro", "error", err)
 			}


### PR DESCRIPTION
## Summary

Fixes 4 issues + semantic audit gaps + workspace macro loading for embedders.

### Issue fixes
- **#258**: `undefined-symbol` false positive for bare `else`/`true` in `cond` test position — added `analyzeCond`
- **#259**: MCP diagnostics ignores `workspace_root` — aligned `buildWorkspaceState` with LSP's `buildWorkspaceIndex`
- **#260**: `set 'x` inside lambda produces false `unused-variable` — `analyzeSet` now models `PutGlobal` semantics
- **#261**: Macro expansion at analysis time — `MacroExpander` interface, `EnvMacroExpander`, preamble-based workspace loading

### Semantic audit
- `macrolet` scope handling (new `ScopeMacrolet`)
- `qualified-symbol` argument skipped (data, not code)
- `thread-first`/`thread-last` explicit dispatch

### Workspace macro loading
- Preamble forms (`in-package`, `use-package`, `export`, `defmacro`, `defun`, `set`) collected per file in source order
- `LoadWorkspaceMacros` replays preamble into env, mirroring runtime's `(load)` behavior
- DFS load-order from `buildLoadTree` ensures definitions precede macros that use them
- Package resolution: bare files inherit load-tree context or fall back to `DefaultPackage`
- Auto-creates workspace packages + imports lang builtins
- `ExpandMacro(form, pkg)` resolves macros in the file's package context
- Thread-safe via `sync.Mutex` + `notMacro` cache with package-qualified keys

### Embedder API
```go
lintCfg := &lint.LintConfig{
    Workspace: root,
    Registry:  env.Runtime.Registry,
    Env:       env,  // just add this line — elps handles the rest
}
```

## Test plan

- [x] 40+ new test functions across analysis, expander, workspace, and MCP packages
- [x] `go test ./...` — all pass
- [x] `make static-checks` — 0 issues
- [x] CI: Lint & Test — pass
- [x] CI: Benchmark Comparison — pass (no regressions)
- [x] 4 QA professor passes + 3 code reviews — all findings addressed

Fixes #258, Fixes #259, Fixes #260, Fixes #261