### PR TITLE
fix: silence GetFunName BUG: log spam from libschema validators (#271)

### DIFF
--- a/lisp/constructors_test.go
+++ b/lisp/constructors_test.go
@@ -1,0 +1,68 @@
+// Copyright © 2018 The ELPS authors
+
+package lisp
+
+import "testing"
+
+// noopBuiltin is an LBuiltin used as a stand-in body for constructor
+// tests — none of the cases below invoke it.
+func noopBuiltin(_ *LEnv, _ *LVal) *LVal { return Nil() }
+
+// TestFunInPackage_SetsPackage guards the FunInPackage / MacroInPackage
+// / SpecialOpInPackage constructor invariant for issue #271: each must
+// produce an LFun whose FunData.Package equals the pkg argument. A
+// regression in this layer would re-enable the BUG: GetFunName log
+// spam that the libschema fix and surrounding API safeguards
+// eliminated.
+func TestFunInPackage_SetsPackage(t *testing.T) {
+	formals := QExpr([]*LVal{Symbol("x")})
+
+	t.Run("FunInPackage", func(t *testing.T) {
+		v := FunInPackage("my-pkg", "fid-1", formals, noopBuiltin)
+		if v.Type != LFun {
+			t.Fatalf("Type = %v, want LFun", v.Type)
+		}
+		if got := v.Package(); got != "my-pkg" {
+			t.Errorf("Package() = %q, want %q", got, "my-pkg")
+		}
+		if got := v.FID(); got != "fid-1" {
+			t.Errorf("FID() = %q, want %q", got, "fid-1")
+		}
+	})
+
+	t.Run("MacroInPackage", func(t *testing.T) {
+		v := MacroInPackage("my-pkg", "fid-2", formals, noopBuiltin)
+		if v.Type != LFun {
+			t.Fatalf("Type = %v, want LFun", v.Type)
+		}
+		if v.FunType != LFunMacro {
+			t.Errorf("FunType = %v, want LFunMacro", v.FunType)
+		}
+		if got := v.Package(); got != "my-pkg" {
+			t.Errorf("Package() = %q, want %q", got, "my-pkg")
+		}
+	})
+
+	t.Run("SpecialOpInPackage", func(t *testing.T) {
+		v := SpecialOpInPackage("my-pkg", "fid-3", formals, noopBuiltin)
+		if v.Type != LFun {
+			t.Fatalf("Type = %v, want LFun", v.Type)
+		}
+		if v.FunType != LFunSpecialOp {
+			t.Errorf("FunType = %v, want LFunSpecialOp", v.FunType)
+		}
+		if got := v.Package(); got != "my-pkg" {
+			t.Errorf("Package() = %q, want %q", got, "my-pkg")
+		}
+	})
+
+	// Empty pkg is a valid input — it documents the (deprecated)
+	// "caller will set Package later" path. Verify the constructor
+	// doesn't reject or rewrite it.
+	t.Run("FunInPackage empty pkg", func(t *testing.T) {
+		v := FunInPackage("", "fid-4", formals, noopBuiltin)
+		if got := v.Package(); got != "" {
+			t.Errorf("Package() = %q, want empty", got)
+		}
+	})
+}

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -680,9 +680,7 @@ func (env *LEnv) Lambda(formals *LVal, body []*LVal) *LVal {
 // method doesn't produce the expected behavior and can't be exported publicly
 // because of that.
 func (env *LEnv) builtin(f LBuiltinDef) *LVal {
-	v := Fun(NewEnv(env).getFID(), f.Formals(), f.Eval)
-	v.FunData().Package = env.Runtime.Package.Name
-	return v
+	return FunInPackage(env.Runtime.Package.Name, NewEnv(env).getFID(), f.Formals(), f.Eval)
 }
 
 func (env *LEnv) Terminal(expr *LVal) *LVal {
@@ -714,9 +712,8 @@ func (env *LEnv) AddMacros(external bool, macs ...LBuiltinDef) {
 			panic(fmt.Sprintf("macro already defined: %v (= %v)", k, exist))
 		}
 		id := fmt.Sprintf("<builtin-macro ``%s''>", mac.Name())
-		fn := Macro(id, mac.Formals(), mac.Eval)
+		fn := MacroInPackage(pkg.Name, id, mac.Formals(), mac.Eval)
 		fn.Cells[1] = String(builtinDocstring(mac))
-		fn.FunData().Package = pkg.Name
 		pkg.Put(k, fn)
 		if external {
 			pkg.Externals = append(pkg.Externals, k.Str)
@@ -738,9 +735,8 @@ func (env *LEnv) AddSpecialOps(external bool, ops ...LBuiltinDef) {
 			panic(fmt.Sprintf("macro already defined: %v (= %v)", k, exist))
 		}
 		id := fmt.Sprintf("<special-op ``%s''>", op.Name())
-		fn := SpecialOp(id, op.Formals(), op.Eval)
+		fn := SpecialOpInPackage(pkg.Name, id, op.Formals(), op.Eval)
 		fn.Cells[1] = String(builtinDocstring(op))
-		fn.FunData().Package = pkg.Name
 		pkg.Put(k, fn)
 		if external {
 			pkg.Externals = append(pkg.Externals, k.Str)
@@ -762,9 +758,8 @@ func (env *LEnv) AddBuiltins(external bool, funs ...LBuiltinDef) {
 			panic("symbol already defined: " + f.Name())
 		}
 		id := fmt.Sprintf("<builtin-function ``%s''>", f.Name())
-		v := Fun(id, f.Formals(), f.Eval)
+		v := FunInPackage(pkg.Name, id, f.Formals(), f.Eval)
 		v.Cells[1] = String(builtinDocstring(f))
-		v.FunData().Package = pkg.Name
 		pkg.Put(k, v)
 		if external {
 			pkg.Externals = append(pkg.Externals, k.Str)

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -522,21 +522,38 @@ func FunRef(symbol, fun *LVal) *LVal {
 	return cp
 }
 
-// Fun returns an LVal representing a function
-func Fun(fid string, formals *LVal, fn LBuiltin) *LVal {
+// FunInPackage returns an LFun bound to the named package. Prefer this
+// over Fun for code embedding ELPS: Fun leaves Package empty, and a
+// package-less LFun reaching funCall / MacroCall / SpecialOpCall
+// produces "BUG: GetFunName" log spam (issue #271).
+func FunInPackage(pkg, fid string, formals *LVal, fn LBuiltin) *LVal {
 	return &LVal{
 		Source: nativeSource(),
 		Type:   LFun,
 		Native: &LFunData{
 			FID:     fid,
 			Builtin: fn,
+			Package: pkg,
 		},
 		Cells: []*LVal{formals, String("")},
 	}
 }
 
-// Macro returns an LVal representing a macro
-func Macro(fid string, formals *LVal, fn LBuiltin) *LVal {
+// Fun returns an LVal representing a function. Package is left empty;
+// callers MUST set v.FunData().Package before the value is invoked, or
+// GetFunName will log "BUG: ..." at every call site that observes a
+// package-less LFun.
+//
+// Deprecated: use FunInPackage, which sets Package atomically. See
+// issue #271.
+func Fun(fid string, formals *LVal, fn LBuiltin) *LVal {
+	return FunInPackage("", fid, formals, fn)
+}
+
+// MacroInPackage returns a macro LFun bound to the named package.
+// Prefer this over Macro for the same reasons FunInPackage is preferred
+// over Fun. See issue #271.
+func MacroInPackage(pkg, fid string, formals *LVal, fn LBuiltin) *LVal {
 	return &LVal{
 		Source:  nativeSource(),
 		Type:    LFun,
@@ -544,6 +561,35 @@ func Macro(fid string, formals *LVal, fn LBuiltin) *LVal {
 		Native: &LFunData{
 			FID:     fid,
 			Builtin: fn,
+			Package: pkg,
+		},
+		Cells: []*LVal{formals, String("")},
+	}
+}
+
+// Macro returns an LVal representing a macro. Package is left empty;
+// callers MUST set v.FunData().Package before the value is invoked, or
+// GetFunName will log "BUG: ..." at every call site that observes a
+// package-less LFun.
+//
+// Deprecated: use MacroInPackage, which sets Package atomically. See
+// issue #271.
+func Macro(fid string, formals *LVal, fn LBuiltin) *LVal {
+	return MacroInPackage("", fid, formals, fn)
+}
+
+// SpecialOpInPackage returns a special-operator LFun bound to the named
+// package. Prefer this over SpecialOp for the same reasons FunInPackage
+// is preferred over Fun. See issue #271.
+func SpecialOpInPackage(pkg, fid string, formals *LVal, fn LBuiltin) *LVal {
+	return &LVal{
+		Source:  nativeSource(),
+		Type:    LFun,
+		FunType: LFunSpecialOp,
+		Native: &LFunData{
+			FID:     fid,
+			Builtin: fn,
+			Package: pkg,
 		},
 		Cells: []*LVal{formals, String("")},
 	}
@@ -553,17 +599,15 @@ func Macro(fid string, formals *LVal, fn LBuiltin) *LVal {
 // operators are function which receive unevaluated results, like macros.
 // However values returned by special operations do not require further
 // evaluation, unlike macros.
+//
+// Package is left empty; callers MUST set v.FunData().Package before the
+// value is invoked, or GetFunName will log "BUG: ..." at every call site
+// that observes a package-less LFun.
+//
+// Deprecated: use SpecialOpInPackage, which sets Package atomically.
+// See issue #271.
 func SpecialOp(fid string, formals *LVal, fn LBuiltin) *LVal {
-	return &LVal{
-		Source:  nativeSource(),
-		Type:    LFun,
-		FunType: LFunSpecialOp,
-		Native: &LFunData{
-			FID:     fid,
-			Builtin: fn,
-		},
-		Cells: []*LVal{formals, String("")},
-	}
+	return SpecialOpInPackage("", fid, formals, fn)
 }
 
 // Error returns an LError representing err.  Errors store their message in

--- a/lisp/lisplib/libschema/libschema.go
+++ b/lisp/lisplib/libschema/libschema.go
@@ -53,7 +53,14 @@ const (
 	WrongType        = "wrong-type"
 )
 
-// LoadPackage adds the schema package to env
+// LoadPackage adds the schema package to env.
+//
+// The package name is hardcoded to DefaultPackageName. If a future
+// caller wants to load libschema under a different name, also update
+// newValidator/newNamedValidator (below) to thread the chosen name
+// through instead of using DefaultPackageName directly — otherwise
+// validator LFuns will carry stale "s" labels in stack frames and
+// profiler attributes.
 func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 	prevPkg := env.Runtime.Package.Name
 	defer env.InPackage(lisp.Symbol(prevPkg))
@@ -338,10 +345,24 @@ func GenSymbol() string {
 	return fmt.Sprintf("_validation_fun_%d", symcounter)
 }
 
+// newValidator constructs an anonymous schema validator LFun bound to the
+// libschema package. Without the package binding, the LFun reaching
+// funCall / MacroCall / SpecialOpCall would trigger "BUG: GetFunName" log
+// spam (issue #271).
+func newValidator(formals *lisp.LVal, fn lisp.LBuiltin) *lisp.LVal {
+	return lisp.FunInPackage(DefaultPackageName, GenSymbol(), formals, fn)
+}
+
+// newNamedValidator is like newValidator but uses the given FID instead of
+// an auto-generated one (so call-stack frames carry the type name).
+func newNamedValidator(name string, formals *lisp.LVal, fn lisp.LBuiltin) *lisp.LVal {
+	return lisp.FunInPackage(DefaultPackageName, name, formals, fn)
+}
+
 // Checks constraints and type for boolean values
 func builtinCheckBool(_ *lisp.LEnv, name string, constraints []*lisp.LVal) *lisp.LVal {
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Str != lisp.TrueSymbol && input.Str != lisp.FalseSymbol {
 			return lisp.ErrorConditionf(WrongType, "Input was not a boolean for type %s", name)
 		}
@@ -363,7 +384,7 @@ func builtinCheckTaggedVal(env *lisp.LEnv, name string, constraints []*lisp.LVal
 		}
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Type != lisp.LTaggedVal {
 			return lisp.ErrorConditionf(WrongType, "Input was not a tagged-value for type %s", name)
 		}
@@ -374,7 +395,7 @@ func builtinCheckTaggedVal(env *lisp.LEnv, name string, constraints []*lisp.LVal
 // Checks constraints and type for untyped values
 func builtinCheckAny(_ *lisp.LEnv, constraints []*lisp.LVal) *lisp.LVal {
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		for _, constraint := range constraints {
 			if constraint.Type != lisp.LFun {
 				return lisp.ErrorConditionf(BadArgs, "Invalid type received for constraint %v", constraint)
@@ -391,7 +412,7 @@ func builtinCheckAny(_ *lisp.LEnv, constraints []*lisp.LVal) *lisp.LVal {
 func builtinCheckFun(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lisp.LVal {
 	rest := builtinCheckAny(env, constraints)
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Type != lisp.LFun {
 			return lisp.ErrorConditionf(WrongType, "Input was not a function for type %s", name)
 		}
@@ -403,7 +424,7 @@ func builtinCheckFun(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lis
 func builtinCheckMap(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lisp.LVal {
 	rest := builtinCheckAny(env, constraints)
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Type != lisp.LSortMap {
 			return lisp.ErrorConditionf(WrongType, "Input was not a sorted map for type %s", name)
 		}
@@ -415,7 +436,7 @@ func builtinCheckMap(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lis
 func builtinCheckArray(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lisp.LVal {
 	rest := builtinCheckAny(env, constraints)
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Type != lisp.LArray {
 			return lisp.ErrorConditionf(WrongType, "Input was not an array for type %s", name)
 		}
@@ -427,7 +448,7 @@ func builtinCheckArray(env *lisp.LEnv, name string, constraints []*lisp.LVal) *l
 func builtinCheckString(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lisp.LVal {
 	rest := builtinCheckAny(env, constraints)
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Type != lisp.LString {
 			return lisp.ErrorConditionf(WrongType, "Input was not a string for type %s", name)
 		}
@@ -438,7 +459,7 @@ func builtinCheckString(env *lisp.LEnv, name string, constraints []*lisp.LVal) *
 // Checks values are within the allowed set. Good for making enums.
 func builtinAllowedValues(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		for _, v := range args.Cells {
 			if eq := input.Equal(v); lisp.True(eq) {
 				return lisp.Nil()
@@ -458,7 +479,7 @@ func builtinRegexp(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		return lisp.ErrorConditionf(BadArgs, "You must specify a valid pattern: %s", err.Error())
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		match, readable := lisp.GoString(input)
 		if readable && compiled.MatchString(match) {
 			return lisp.Nil()
@@ -474,7 +495,7 @@ func builtinLen(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		return lisp.ErrorConditionf(FailedConstraint, "You cannot compare %v to a number", args.Cells[0])
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		switch input.Type {
 		case lisp.LString:
 			if len(input.Str) != comparison {
@@ -500,7 +521,7 @@ func builtinLenGreaterThan(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		return lisp.ErrorConditionf(FailedConstraint, "You cannot compare %v to a number", args.Cells[0])
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		switch input.Type {
 		case lisp.LString:
 			if len(input.Str) <= comparison {
@@ -526,7 +547,7 @@ func builtinLenGreaterThanOrEqual(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		return lisp.ErrorConditionf(FailedConstraint, "You cannot compare %v to a number", args.Cells[0])
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		switch input.Type {
 		case lisp.LString:
 			if len(input.Str) < comparison {
@@ -552,7 +573,7 @@ func builtinLenLessThan(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		return lisp.ErrorConditionf(FailedConstraint, "You cannot compare %v to a number", args.Cells[0])
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		switch input.Type {
 		case lisp.LString:
 			if len(input.Str) >= comparison {
@@ -578,7 +599,7 @@ func builtinLenLessThanOrEqual(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		return lisp.ErrorConditionf(FailedConstraint, "You cannot compare %v to a number", args.Cells[0])
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		switch input.Type {
 		case lisp.LString:
 			if len(input.Str) > comparison {
@@ -604,7 +625,7 @@ func builtinGreaterThan(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		return lisp.ErrorConditionf(FailedConstraint, "You cannot compare %v to a number", args.Cells[0])
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		compareTo, ok := lisp.GoFloat64(input)
 		if !ok {
 			return lisp.ErrorConditionf(FailedConstraint, "Value cannot be compared")
@@ -623,7 +644,7 @@ func builtinGreaterThanOrEqual(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		return lisp.ErrorConditionf(FailedConstraint, "You cannot compare %v to a number", args.Cells[0])
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		compareTo, ok := lisp.GoFloat64(input)
 		if !ok {
 			return lisp.ErrorConditionf(FailedConstraint, "Value cannot be compared")
@@ -642,7 +663,7 @@ func builtinLessThan(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		return lisp.ErrorConditionf(FailedConstraint, "You cannot compare %v to a number", args.Cells[0])
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		compareTo, ok := lisp.GoFloat64(input)
 		if !ok {
 			return lisp.ErrorConditionf(FailedConstraint, "Value cannot be compared")
@@ -661,7 +682,7 @@ func builtinLessThanOrEqual(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		return lisp.ErrorConditionf(FailedConstraint, "You cannot compare %v to a number", args.Cells[0])
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		compareTo, ok := lisp.GoFloat64(input)
 		if !ok {
 			return lisp.ErrorConditionf(FailedConstraint, "Value cannot be compared")
@@ -680,7 +701,7 @@ func builtinArrayOf(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		compares = append(compares, getHandler(env, v, "x", []*lisp.LVal{}))
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Type != lisp.LArray {
 			return lisp.ErrorConditionf(WrongType, "Invalid input for 'of' - need an array")
 		}
@@ -709,7 +730,7 @@ func builtinArrayOf(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 // Checks value is greater than 0
 func builtinPositive(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		compareTo, ok := lisp.GoFloat64(input)
 		if !ok {
 			return lisp.ErrorConditionf(FailedConstraint, "Value cannot be compared")
@@ -724,7 +745,7 @@ func builtinPositive(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 // Checks value is less than zero
 func builtinNegative(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		compareTo, ok := lisp.GoFloat64(input)
 		if !ok {
 			return lisp.ErrorConditionf(FailedConstraint, "Value cannot be compared")
@@ -740,7 +761,7 @@ func builtinNegative(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 func builtinCheckInt(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lisp.LVal {
 	rest := builtinCheckAny(env, constraints)
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(name, lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newNamedValidator(name, lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Type != lisp.LInt {
 			return lisp.ErrorConditionf(WrongType, "Input was not an integer for type %s", name)
 		}
@@ -752,7 +773,7 @@ func builtinCheckInt(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lis
 func builtinCheckFloat(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lisp.LVal {
 	rest := builtinCheckAny(env, constraints)
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(name, lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newNamedValidator(name, lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Type != lisp.LFloat {
 			return lisp.ErrorConditionf(WrongType, "Input was not a float for type %s", name)
 		}
@@ -764,7 +785,7 @@ func builtinCheckFloat(env *lisp.LEnv, name string, constraints []*lisp.LVal) *l
 func builtinCheckNumber(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lisp.LVal {
 	rest := builtinCheckAny(env, constraints)
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(name, lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newNamedValidator(name, lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Type != lisp.LInt && input.Type != lisp.LFloat {
 			return lisp.ErrorConditionf(WrongType, "Input was not a number for type %s", name)
 		}
@@ -783,7 +804,7 @@ func builtinHasKey(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		compares = append(compares, getHandler(env, v, "x", []*lisp.LVal{}))
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Type != lisp.LSortMap {
 			return lisp.ErrorConditionf(WrongType, "Input is not sorted map")
 		}
@@ -822,7 +843,7 @@ func builtinMayHaveKey(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		compares = append(compares, getHandler(env, v, "x", []*lisp.LVal{}))
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Type != lisp.LSortMap {
 			return lisp.ErrorConditionf(WrongType, "Input is not sorted map")
 		}
@@ -857,7 +878,7 @@ func builtinNoOtherKeys(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		constraints = append(constraints, getHandler(env, v, "x", []*lisp.LVal{}))
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		allowedKeys := make(map[string]bool)
 		for _, c := range constraints {
 			if c.Type != lisp.LFun {
@@ -896,7 +917,7 @@ func builtinWhen(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		constraints = append(constraints, getHandler(env, v, "x", []*lisp.LVal{}))
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		lMap := input.Map()
 		whenVal, _ := lMap.Get(args.Cells[0])
 		testVal, _ := lMap.Get(args.Cells[2])
@@ -922,7 +943,7 @@ func builtinWhen(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 // Checks if value is false
 func builtinIsFalse(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals(), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals(), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Str != lisp.FalseSymbol {
 			return lisp.ErrorConditionf(FailedConstraint, "Value %v is not false", input)
 		}
@@ -933,7 +954,7 @@ func builtinIsFalse(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 // Checks if value is true
 func builtinIsTrue(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals(), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals(), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Str != lisp.TrueSymbol {
 			return lisp.ErrorConditionf(FailedConstraint, "Value %v is not true", input)
 		}
@@ -944,7 +965,7 @@ func builtinIsTrue(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 // Checks if value can reasonably be considered to be false
 func builtinIsFalsy(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals(), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals(), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		val := builtinIsTruthy(env, nil).Builtin()(env, input)
 		if val.Type == lisp.LError {
 			return lisp.Nil()
@@ -956,7 +977,7 @@ func builtinIsFalsy(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 // Checks if value can reasonably be considered to be true
 func builtinIsTruthy(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals(), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals(), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		if input.Str == lisp.TrueSymbol {
 			return lisp.Nil()
 		}
@@ -993,7 +1014,7 @@ func builtinIsNot(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		return lisp.ErrorConditionf(BadArgs, "Value is not a constraint")
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
-	return lisp.Fun(GenSymbol(), lisp.Formals(), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+	return newValidator(lisp.Formals(), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		val := constraint.FunData().Builtin(env, input)
 		if val.Type == lisp.LError {
 			return lisp.Nil()

--- a/lisp/lisplib/libschema/libschema_test.go
+++ b/lisp/lisplib/libschema/libschema_test.go
@@ -1,12 +1,157 @@
 package libschema_test
 
 import (
-	"github.com/luthersystems/elps/elpstest"
+	"bytes"
+	"context"
+	"log"
+	"regexp"
 	"testing"
+
+	"github.com/luthersystems/elps/elpstest"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
 )
 
 func TestPackage(t *testing.T) {
 	r := &elpstest.Runner{}
 	defer r.Close()
 	r.RunTestFile(t, "libschema_test.lisp")
+}
+
+// newSchemaEnv bootstraps a complete env with the standard library
+// (including libschema) loaded and the current package set to "user".
+func newSchemaEnv(t *testing.T) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); !rc.IsNil() {
+		t.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := lisplib.LoadLibrary(env); !rc.IsNil() {
+		t.Fatalf("load-library: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); !rc.IsNil() {
+		t.Fatalf("in-package: %v", rc)
+	}
+	return env
+}
+
+// captureLog redirects log.Default()'s output to a buffer for the
+// duration of the test, restoring it on cleanup.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOutput := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevOutput)
+		log.SetFlags(prevFlags)
+	})
+	return &buf
+}
+
+// bugGetFunNameRe matches the specific BUG: log emitted by
+// (*LEnv).GetFunName when it observes a package-less LFun. Anchored on
+// the GetFunName prefix so unrelated future "BUG:" log messages in
+// other code paths can't accidentally trip these regression checks.
+var bugGetFunNameRe = regexp.MustCompile(`BUG: GetFunName:`)
+
+// TestValidatorFunCallNoBugLog is the headline regression test for
+// issue #271. libschema's s:deftype binds the constructed validator
+// LFun as a global symbol (see builtinDefType). Resolving that symbol
+// and invoking it goes through env.funCall, which calls
+// env.GetFunName(fun) before dispatch. Pre-fix the validator had an
+// empty Package field, so GetFunName logged "BUG: ..." on every
+// invocation. This test asserts the invariant directly (Package set on
+// the validator LFun) and additionally asserts no BUG: GetFunName line
+// appears on the default logger when the validator is funCall'd.
+//
+// We invoke the validator via env.FunCallContext directly (rather than
+// via a Lisp `(Score ...)` expression) so the assertion is isolated to
+// the funCall -> GetFunName path under test — it does not depend on
+// libschema's internal argument-shape semantics.
+func TestValidatorFunCallNoBugLog(t *testing.T) {
+	t.Run("deftype path", func(t *testing.T) {
+		env := newSchemaEnv(t)
+
+		if rc := env.LoadStringContext(context.Background(), "regression-271-deftype",
+			`(s:deftype "Score" "int" (s:gte 0))`); rc.Type == lisp.LError {
+			t.Fatalf("s:deftype: %v", rc)
+		}
+
+		// env.Get returns the bound LFun without going through funCall.
+		fun := env.Get(lisp.Symbol("Score"))
+		if fun.Type != lisp.LFun {
+			t.Fatalf("Score did not resolve to an LFun: %v", fun.Type)
+		}
+		// Direct invariant check: the validator's Package must be
+		// non-empty regardless of any downstream funCall behavior.
+		if pkg := fun.Package(); pkg == "" {
+			t.Fatalf("validator LFun has empty Package — issue #271 regression")
+		}
+
+		buf := captureLog(t)
+		_ = env.FunCallContext(context.Background(), fun, lisp.QExpr([]*lisp.LVal{lisp.Int(5)}))
+		if got := buf.String(); bugGetFunNameRe.MatchString(got) {
+			t.Fatalf("unexpected BUG: GetFunName line during validator funCall:\n%s", got)
+		}
+	})
+
+	t.Run("make-validator path", func(t *testing.T) {
+		env := newSchemaEnv(t)
+
+		// s:make-validator returns the validator instead of binding it.
+		// Bind it ourselves so we can resolve and funCall via env.Get.
+		if rc := env.LoadStringContext(context.Background(), "regression-271-mkv",
+			`(set 'positive-int (s:make-validator "PositiveInt" "int" (s:gt 0)))`); rc.Type == lisp.LError {
+			t.Fatalf("s:make-validator: %v", rc)
+		}
+
+		fun := env.Get(lisp.Symbol("positive-int"))
+		if fun.Type != lisp.LFun {
+			t.Fatalf("positive-int did not resolve to an LFun: %v", fun.Type)
+		}
+		if pkg := fun.Package(); pkg == "" {
+			t.Fatalf("make-validator LFun has empty Package — issue #271 regression")
+		}
+
+		buf := captureLog(t)
+		_ = env.FunCallContext(context.Background(), fun, lisp.QExpr([]*lisp.LVal{lisp.Int(1)}))
+		if got := buf.String(); bugGetFunNameRe.MatchString(got) {
+			t.Fatalf("unexpected BUG: GetFunName line during make-validator funCall:\n%s", got)
+		}
+	})
+}
+
+// TestGetFunNameBugLogStillFires is the positive control for
+// TestValidatorFunCallNoBugLog. It constructs an LFun via the
+// deprecated lisp.Fun (which intentionally leaves Package empty),
+// binds it, invokes it, and asserts the BUG: GetFunName line *does*
+// appear. This proves the safety-net log in (*LEnv).GetFunName is
+// still armed — if a future refactor silently neutered the log (or
+// the empty-Package error path in pkgFunName), this test would catch
+// it and TestValidatorFunCallNoBugLog wouldn't go vacuously green.
+func TestGetFunNameBugLogStillFires(t *testing.T) {
+	env := newSchemaEnv(t)
+
+	// Construct a package-less LFun via the deprecated constructor.
+	// We intentionally use lisp.Fun (not FunInPackage) here — that's
+	// the path whose detector we are verifying still fires.
+	pkgless := lisp.Fun("regression-271-positive-control", lisp.Formals("x"), //nolint:staticcheck // SA1019: intentional use of deprecated constructor — we are testing the detector for its empty-Package path
+		func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal { return lisp.Nil() })
+	if pkgless.Package() != "" {
+		t.Fatalf("test setup: expected package-less LFun, got Package=%q", pkgless.Package())
+	}
+	if rc := env.PutGlobal(lisp.Symbol("pkgless-victim"), pkgless); rc.Type == lisp.LError {
+		t.Fatalf("put-global: %v", rc)
+	}
+
+	buf := captureLog(t)
+	_ = env.FunCallContext(context.Background(), pkgless, lisp.QExpr([]*lisp.LVal{lisp.Int(0)}))
+	if got := buf.String(); !bugGetFunNameRe.MatchString(got) {
+		t.Fatalf("expected BUG: GetFunName line for package-less LFun but got none — safety net disarmed?\ncaptured output:\n%s", got)
+	}
 }


### PR DESCRIPTION
## Summary

- libschema constructed all of its validator LFuns via `lisp.Fun(GenSymbol(), ...)` and never set `FunData.Package`. Two paths (`builtinDefType` via `env.PutGlobal`, `builtinMakeValidator` via its return value) then expose those LFuns as callable Lisp symbols. Invoking them goes through `funCall`, which calls `env.GetFunName(fun)` before dispatch and logs `BUG: GetFunName: unknown package for function ...` because `Package()` is empty. Under validator-heavy workloads this floods stderr.
- Three layers of fix:
  1. **Root cause**: route every libschema validator construction through new helpers (`newValidator`, `newNamedValidator`) that set `Package = DefaultPackageName`.
  2. **API safeguard**: add `FunInPackage` / `MacroInPackage` / `SpecialOpInPackage` and mark the existing `Fun` / `Macro` / `SpecialOp` with Go `// Deprecated:` directives. Surfaced by `gopls`, `godoc`, and downstream `golangci-lint` configs that don't silence `SA1019`. **Caveat**: this repo's `.golangci.yml` disables `SA1019` globally to permit an ongoing migration to `*Context` methods, so our own CI will not flag new uses — the IDE and downstream signals remain. Reintroducing a project-narrow check is a possible follow-up.
  3. **In-tree consistency**: switch `env.builtin`, `AddBuiltins`, `AddMacros`, `AddSpecialOps` to the new constructors so the two-step `construct + assign Package` idiom collapses to one call.
- The `BUG:` log in `GetFunName` stays. After this PR it only fires for genuine invariant violations — and a positive-control test verifies it still fires for the deprecated `lisp.Fun(...)` path so a future refactor can't silently neuter it.

## Why this is safe (no evaluation change)

`f.Package()` is consulted in three places: stack/profiler labels (diagnostic), debugger qualified-name display (diagnostic), and runtime namespace switching during function bodies (`env.go:1459-1468`). The namespace-swap path is reached only for Lisp-defined functions — Go builtins (LBuiltins) take an earlier branch in `env.call` and return before the swap. libschema's validators are all Go LBuiltins and do no `env.Get` symbol lookups in their bodies, so binding them to package `s` changes only their stack-frame and profiler labels.

## Test plan

- [x] `make go-test` — full Go test suite green.
- [x] `make test-examples` — all sicp / oop / user-defined-types examples pass.
- [x] New regression tests:
  - `TestValidatorFunCallNoBugLog/deftype_path` — `s:deftype`-bound validator funCall, no `BUG: GetFunName:` line.
  - `TestValidatorFunCallNoBugLog/make-validator_path` — second exposure path, same assertion.
  - `TestGetFunNameBugLogStillFires` — positive control: package-less LFun via deprecated `lisp.Fun(...)` still trips the BUG log.
  - `TestFunInPackage_SetsPackage` (lisp pkg) — unit-level invariant guard for the new constructors.
- [x] Verified mutation resistance: reverting `libschema.go` to its pre-fix state causes both no-BUG subtests to fail with `"validator LFun has empty Package — issue #271 regression"`. The positive-control test passes regardless of fix state.
- [x] `golangci-lint run ./...` — same 5 pre-existing issues as `main`, zero new findings.
- [x] `./elps doc -m` — clean.
- [x] Manual sanity in REPL: `(s:deftype "Score" "int")` + `(Score 5)` no longer produces `BUG:` on stderr.

Closes #271.