### PR TITLE
fix(lisp): identity-guard singleton mutation in stampMacroExpansion

### DIFF
--- a/.github/workflows/elps.yml
+++ b/.github/workflows/elps.yml
@@ -36,8 +36,11 @@ jobs:
       - name: Tests
         run: make test
 
-      - name: Race detection (debugger)
-        run: go test -race -count=1 ./lisp/x/debugger/...
+      - name: Race detection (full)
+        run: make race
+
+      - name: Singleton integrity (elpscheck)
+        run: make test-elpscheck
 
       - name: Check formatting
         run: |

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,21 @@ test: go-test
 go-test:
 	go test -cover ./...
 
+# Run the full test suite with the race detector. CI runs this to catch
+# concurrent mutations of shared state — see issue #274. Kept separate
+# from `make test` because race-instrumented runs are ~3x slower.
+.PHONY: race
+race:
+	go test -race -count=1 ./...
+
+# Run the test suite with the `elpscheck` build tag, which enables
+# per-call integrity checks on the Bool()/Nil() singletons. Detects
+# inadvertent singleton mutation at the next read after the offending
+# write. See lisp/singleton_check_elpscheck.go and issue #274.
+.PHONY: test-elpscheck
+test-elpscheck:
+	go test -tags elpscheck ./...
+
 .PHONY: examples
 examples:
 	$(MAKE) -C _examples

--- a/elpstest/lisptest.go
+++ b/elpstest/lisptest.go
@@ -152,6 +152,17 @@ func (r *Runner) LoadBenchmarks(t *testing.B, path string, source io.Reader) []s
 // determine a file basename to use in LEnv.Load().  RunTest returns true if
 // the test, and any teardown function given, completed successfully.
 func (r *Runner) RunTest(t *testing.T, i int, path string, source io.Reader) {
+	// Snapshot the shared singleton LVals before running the test; if a
+	// macro expansion or other tree-walker accidentally mutates a
+	// singleton (issue #274), the per-test guard surfaces the regression
+	// at the offending lisp test, not at end-of-suite.
+	snap := lisp.TakeSingletonSnapshot()
+	defer func() {
+		if drift := snap.Verify(); drift != "" {
+			t.Errorf("singleton %s was mutated during test", drift)
+		}
+	}()
+
 	env, err := r.NewEnv(t)
 	if err != nil {
 		t.Error(err.Error())
@@ -319,6 +330,15 @@ type TestSuite []struct {
 
 // RunTestSuite runs each TestSequence in tests on isolated lisp.LEnvs.
 func RunTestSuite(t *testing.T, tests TestSuite) {
+	// Snapshot the singleton LVals before running the suite; if any
+	// sequence mutates one (issue #274), report it before returning.
+	snap := lisp.TakeSingletonSnapshot()
+	defer func() {
+		if drift := snap.Verify(); drift != "" {
+			t.Errorf("singleton %s was mutated during test suite", drift)
+		}
+	}()
+
 	for i, test := range tests {
 		log.Printf("test %d -- %s", i, test.Name)
 		env := lisp.NewEnv(nil)

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -289,39 +289,19 @@ func Value(v interface{}) *LVal {
 	}
 }
 
-// Singleton LVals for Nil, true, and false.
-//
-// These are pre-allocated, shared, immutable values returned by Nil(),
-// Bool(true), and Bool(false). They exist because these three values are
-// constructed on nearly every evaluation cycle — Nil() is returned by
-// ~130 call sites (every builtin/op that "returns nothing"), and Bool()
-// is returned by every comparison, predicate, and type check.
-//
-// SAFETY: A full audit of all 127 Nil() and 63 Bool() call sites
-// confirmed that no call site mutates the returned *LVal. The only
-// mutation vector was stampMacroExpansion in macro.go, which has been
-// guarded to skip empty SExprs (nil singletons). The ELPS language has
-// no destructive list operations (no nconc, rplaca, etc.) — append!
-// only works on vectors (LArray), not lists (LSExpr), and cons/append
-// create new lists without mutating their inputs.
-//
-// INVARIANT: Code that receives a Nil(), Bool(true), or Bool(false)
-// return value MUST NOT mutate any field on the returned *LVal. If you
-// need a mutable nil value (e.g., to build up a list), use SExpr(nil)
-// directly instead of Nil().
-var (
-	singletonNil   = &LVal{Source: nativeSource(), Type: LSExpr}
-	singletonTrue  = &LVal{Source: nativeSource(), Type: LSymbol, Str: TrueSymbol}
-	singletonFalse = &LVal{Source: nativeSource(), Type: LSymbol, Str: FalseSymbol}
-)
+// Singleton LVals (singletonNil, singletonTrue, singletonFalse) and
+// their helpers (isSingleton, assertNotSingleton, SingletonSnapshot)
+// live in singleton.go.
 
 // Bool returns an LVal with truthiness identical to b.
 //
 // The returned value is a shared singleton — callers MUST NOT mutate it.
 func Bool(b bool) *LVal {
 	if b {
+		checkSingleton(singletonTrue)
 		return singletonTrue
 	}
+	checkSingleton(singletonFalse)
 	return singletonFalse
 }
 
@@ -400,6 +380,7 @@ func QSymbol(s string) *LVal {
 // If you need a mutable empty list (e.g., to append children), use
 // SExpr(nil) directly.
 func Nil() *LVal {
+	checkSingleton(singletonNil)
 	return singletonNil
 }
 

--- a/lisp/macro.go
+++ b/lisp/macro.go
@@ -230,20 +230,18 @@ func macroDeftype(env *LEnv, args *LVal) *LVal {
 // MacroExpansionInfo with a unique, monotonically-increasing ID. The
 // runtime's sequence counter is used to generate IDs.
 //
-// Singleton values (Nil, Bool) are skipped because they are shared,
-// immutable, pre-allocated values. Stamping a source location onto a
-// singleton would corrupt it for all other users. See the singleton
-// comments in lisp.go for details.
+// Singleton values (Nil(), Bool(true), Bool(false)) are skipped via
+// identity check — they are shared, immutable, pre-allocated values
+// and mutating one corrupts every reader of that singleton for the
+// remainder of the process lifetime. See issue #274.
 func stampMacroExpansion(v *LVal, callSite *token.Location, ctx *MacroExpansionContext, rt *Runtime) {
 	if v == nil || callSite == nil {
 		return
 	}
-	// Do not mutate singleton nil values. Nil is a shared immutable
-	// value, and stamping a source location onto it would affect every
-	// place that holds a reference to the singleton. Nil nodes at the
-	// end of macro expansion bodies (e.g., the trailing () in progn)
-	// have no diagnostic value anyway.
-	if v.Type == LSExpr && len(v.Cells) == 0 {
+	// Identity-based guard: a type-based check would catch only the empty-
+	// LSExpr singletonNil and miss singletonTrue/singletonFalse (which are
+	// LSymbol with Source.Pos == -1). See issue #274.
+	if isSingleton(v) {
 		return
 	}
 	if v.Source == nil || v.Source.Pos < 0 {
@@ -251,7 +249,7 @@ func stampMacroExpansion(v *LVal, callSite *token.Location, ctx *MacroExpansionC
 		if ctx != nil {
 			v.MacroExpansion = &MacroExpansionInfo{
 				MacroExpansionContext: ctx,
-				ID:                   rt.nextMacroExpID(),
+				ID:                    rt.nextMacroExpID(),
 			}
 		}
 	}

--- a/lisp/macro_expansion_test.go
+++ b/lisp/macro_expansion_test.go
@@ -124,6 +124,45 @@ func TestStampMacroExpansion_SkipsSingletonNil(t *testing.T) {
 	assert.Nil(t, nilVal.MacroExpansion)
 }
 
+// TestStampMacroExpansion_SkipsSingletonTrue verifies that Bool(true)
+// — an LSymbol singleton with Source.Pos == -1 — is not mutated by
+// macro expansion stamping. A type-based guard catches only singletonNil
+// (the empty LSExpr); identity-based guarding is required for the two
+// Bool singletons. See issue #274.
+func TestStampMacroExpansion_SkipsSingletonTrue(t *testing.T) {
+	callSite := &token.Location{File: "test.lisp", Line: 5, Col: 1, Pos: 0}
+	rt := StandardRuntime()
+	ctx := &MacroExpansionContext{CallSite: callSite, Name: "lisp:defun"}
+
+	origSource := Bool(true).Source
+
+	trueVal := Bool(true) // singleton
+	stampMacroExpansion(trueVal, callSite, ctx, rt)
+
+	assert.Nil(t, trueVal.MacroExpansion, "Bool(true) singleton was mutated (MacroExpansion)")
+	assert.Equal(t, origSource, trueVal.Source, "Bool(true) singleton was mutated (Source)")
+	assert.Nil(t, Bool(true).MacroExpansion, "Bool(true) singleton corruption is shared")
+	assert.Equal(t, origSource, Bool(true).Source, "Bool(true) singleton corruption is shared (Source)")
+}
+
+// TestStampMacroExpansion_SkipsSingletonFalse mirrors the Bool(true)
+// case. See TestStampMacroExpansion_SkipsSingletonTrue.
+func TestStampMacroExpansion_SkipsSingletonFalse(t *testing.T) {
+	callSite := &token.Location{File: "test.lisp", Line: 5, Col: 1, Pos: 0}
+	rt := StandardRuntime()
+	ctx := &MacroExpansionContext{CallSite: callSite, Name: "lisp:defun"}
+
+	origSource := Bool(false).Source
+
+	falseVal := Bool(false) // singleton
+	stampMacroExpansion(falseVal, callSite, ctx, rt)
+
+	assert.Nil(t, falseVal.MacroExpansion, "Bool(false) singleton was mutated (MacroExpansion)")
+	assert.Equal(t, origSource, falseVal.Source, "Bool(false) singleton was mutated (Source)")
+	assert.Nil(t, Bool(false).MacroExpansion, "Bool(false) singleton corruption is shared")
+	assert.Equal(t, origSource, Bool(false).Source, "Bool(false) singleton corruption is shared (Source)")
+}
+
 func TestRuntimeMacroExpSeq(t *testing.T) {
 	rt := StandardRuntime()
 	id1 := rt.nextMacroExpID()

--- a/lisp/main_test.go
+++ b/lisp/main_test.go
@@ -1,0 +1,28 @@
+// Copyright © 2025 The ELPS authors
+
+package lisp
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// TestMain wraps the package test suite to detect inadvertent mutations
+// of the shared singleton LVals (singletonNil, singletonTrue,
+// singletonFalse). Any test that corrupts a singleton — directly or via
+// a tree-walker that fails to guard against them — will fail the suite
+// even if the offending test itself passed. See issue #274.
+func TestMain(m *testing.M) {
+	snap := TakeSingletonSnapshot()
+	code := m.Run()
+	if drift := snap.Verify(); drift != "" {
+		fmt.Fprintf(os.Stderr,
+			"FATAL: singleton %s was mutated during test run\n  Nil=%+v\n  True=%+v\n  False=%+v\n",
+			drift, singletonNil, singletonTrue, singletonFalse)
+		if code == 0 {
+			code = 1
+		}
+	}
+	os.Exit(code)
+}

--- a/lisp/singleton.go
+++ b/lisp/singleton.go
@@ -1,0 +1,111 @@
+// Copyright © 2025 The ELPS authors
+
+package lisp
+
+import (
+	"fmt"
+)
+
+// Singleton LVals for Nil, true, and false.
+//
+// These are pre-allocated, shared, immutable values returned by Nil(),
+// Bool(true), and Bool(false). They exist because these three values are
+// constructed on nearly every evaluation cycle — Nil() is returned by
+// ~130 call sites (every builtin/op that "returns nothing"), and Bool()
+// is returned by every comparison, predicate, and type check.
+//
+// SAFETY: A full audit of all 127 Nil() and 63 Bool() call sites
+// confirmed that no call site mutates the returned *LVal. The only
+// historical mutation vector was stampMacroExpansion in macro.go (see
+// issue #274); it is now guarded by isSingleton/assertNotSingleton.
+// The ELPS language has no destructive list operations (no nconc,
+// rplaca, etc.) — append! only works on vectors (LArray), not lists
+// (LSExpr), and cons/append create new lists without mutating their
+// inputs.
+//
+// INVARIANT: Code that receives a Nil(), Bool(true), or Bool(false)
+// return value MUST NOT mutate any field on the returned *LVal. If you
+// need a mutable nil value (e.g., to build up a list), use SExpr(nil)
+// directly instead of Nil(). Tree walkers that mutate LVal fields MUST
+// guard with isSingleton(v) / assertNotSingleton(v) before writing.
+var (
+	singletonNil   = &LVal{Source: nativeSource(), Type: LSExpr}
+	singletonTrue  = &LVal{Source: nativeSource(), Type: LSymbol, Str: TrueSymbol}
+	singletonFalse = &LVal{Source: nativeSource(), Type: LSymbol, Str: FalseSymbol}
+)
+
+// isSingleton reports whether v is one of the three shared, immutable
+// singleton LVal values (Nil(), Bool(true), Bool(false)).
+//
+// Identity-based — not type-based — because singletonTrue/singletonFalse
+// are LSymbol values that would otherwise pass type-based "synthetic
+// node" checks. See issue #274.
+func isSingleton(v *LVal) bool {
+	return v == singletonNil || v == singletonTrue || v == singletonFalse
+}
+
+// assertNotSingleton panics if v is a shared singleton LVal. Intended as
+// a guard at the entry of any function that walks an LVal tree and
+// writes to LVal fields. Cheap (one pointer compare against each of
+// three constants), documents intent, and surfaces regressions loudly.
+func assertNotSingleton(v *LVal) {
+	if isSingleton(v) {
+		panic(fmt.Sprintf("internal error: attempt to mutate singleton LVal (%s)", v.Type))
+	}
+}
+
+// SingletonSnapshot captures the current bit pattern of the three
+// singleton LVals. It is used by test infrastructure to detect
+// inadvertent mutations to shared singletons — see TestMain in lisp_
+// and the per-test guard in elpstest.Runner.
+type SingletonSnapshot struct {
+	nilV   LVal
+	trueV  LVal
+	falseV LVal
+}
+
+// TakeSingletonSnapshot captures the current state of the three
+// singleton LVals so callers can later verify they were not mutated.
+func TakeSingletonSnapshot() SingletonSnapshot {
+	return SingletonSnapshot{
+		nilV:   *singletonNil,
+		trueV:  *singletonTrue,
+		falseV: *singletonFalse,
+	}
+}
+
+// Verify compares the current singleton state to the snapshot. If any
+// singleton has drifted it returns the name of the offender; otherwise
+// it returns the empty string.
+func (s SingletonSnapshot) Verify() string {
+	if !singletonLValEqual(&s.nilV, singletonNil) {
+		return "Nil()"
+	}
+	if !singletonLValEqual(&s.trueV, singletonTrue) {
+		return "Bool(true)"
+	}
+	if !singletonLValEqual(&s.falseV, singletonFalse) {
+		return "Bool(false)"
+	}
+	return ""
+}
+
+// singletonLValEqual reports whether two LVal struct values are
+// equivalent for singleton-corruption detection. It compares all
+// scalar/pointer fields exactly; slice fields are compared by length
+// (singletons should always have len == 0). The Native interface field
+// is compared with == (singletons should always be nil).
+func singletonLValEqual(a, b *LVal) bool {
+	return a.Source == b.Source &&
+		a.Type == b.Type &&
+		a.Str == b.Str &&
+		a.Int == b.Int &&
+		a.Float == b.Float &&
+		a.FunType == b.FunType &&
+		a.Quoted == b.Quoted &&
+		a.Spliced == b.Spliced &&
+		a.Meta == b.Meta &&
+		a.MacroExpansion == b.MacroExpansion &&
+		a.Native == b.Native &&
+		len(a.Cells) == len(b.Cells)
+}

--- a/lisp/singleton_check_default.go
+++ b/lisp/singleton_check_default.go
@@ -1,0 +1,13 @@
+// Copyright © 2025 The ELPS authors
+
+//go:build !elpscheck
+
+package lisp
+
+// checkSingleton is a zero-cost no-op in production builds. In the
+// elpscheck build (//go:build elpscheck) it verifies that the three
+// singleton LVals are bit-identical to their init-time snapshot and
+// panics if any has drifted. See singleton_check_elpscheck.go.
+//
+//nolint:unused // build-tag variant
+func checkSingleton(_ *LVal) {}

--- a/lisp/singleton_check_elpscheck.go
+++ b/lisp/singleton_check_elpscheck.go
@@ -1,0 +1,32 @@
+// Copyright © 2025 The ELPS authors
+
+//go:build elpscheck
+
+package lisp
+
+import (
+	"fmt"
+)
+
+// initSnapshot is the bit-pattern of all three singleton LVals captured
+// at package init time, before any user code can mutate them.
+var initSnapshot SingletonSnapshot
+
+func init() {
+	initSnapshot = TakeSingletonSnapshot()
+}
+
+// checkSingleton verifies that all three singleton LVals are
+// bit-identical to their init-time snapshot. Called from Bool() and
+// Nil() on every invocation — so any mutation is detected at the next
+// read of any singleton, localizing the corruption to within a handful
+// of evaluations of the offending write.
+//
+// Cost: three struct-field compares per call. Only enabled under the
+// `elpscheck` build tag.
+func checkSingleton(_ *LVal) {
+	if drift := initSnapshot.Verify(); drift != "" {
+		panic(fmt.Sprintf("singleton corruption detected: %s mutated\n  current Nil=%+v\n  current True=%+v\n  current False=%+v",
+			drift, singletonNil, singletonTrue, singletonFalse))
+	}
+}

--- a/lisp/singleton_check_elpscheck_test.go
+++ b/lisp/singleton_check_elpscheck_test.go
@@ -1,0 +1,44 @@
+// Copyright © 2025 The ELPS authors
+
+//go:build elpscheck
+
+package lisp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCheckSingleton_DetectsCorruption verifies that the elpscheck
+// build tag actually catches singleton mutation. Run with:
+//
+//	go test -tags elpscheck -run TestCheckSingleton_DetectsCorruption ./lisp/
+//
+// We mutate Bool(true).Source, then call checkSingleton — it should
+// panic. The test restores the singleton before returning so it does
+// not poison the rest of the suite (TestMain would otherwise fail).
+func TestCheckSingleton_DetectsCorruption(t *testing.T) {
+	orig := singletonTrue.Source
+	defer func() {
+		singletonTrue.Source = orig
+	}()
+
+	singletonTrue.Source = nil
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected checkSingleton to panic, got nil")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected panic to be a string, got %T: %v", r, r)
+		}
+		assert.True(t, strings.Contains(msg, "Bool(true)"),
+			"panic message should name the offending singleton; got: %s", msg)
+	}()
+
+	checkSingleton(singletonTrue)
+}

--- a/lisp/singleton_race_loadstring_test.go
+++ b/lisp/singleton_race_loadstring_test.go
@@ -1,0 +1,72 @@
+// Copyright © 2025 The ELPS authors
+
+// Realistic singleton-mutation regression test via LoadString.
+//
+// Demonstrates that the fix holds along the natural production code
+// path (parser -> reader -> macroexpand -> stampMacroExpansion) rather
+// than only when stampMacroExpansion is invoked directly. Each
+// goroutine has its own Runtime/Env, but pre-fix, stampMacroExpansion
+// mutated the *process-wide* singletonTrue / singletonFalse LVals, so
+// the race fires across runtimes. With the fix, the singletons are
+// never written and `-race` stays clean. See issue #274.
+
+package lisp_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+)
+
+// A small macro whose expansion body contains literal `true` and
+// `false` symbols. stampMacroExpansion recurses through every cell, so
+// any literal Bool() in the body would have tripped the pre-fix
+// mutation. Multiple literals make the race likelier under stress.
+const racyProgram = `
+(defmacro racy-mac (x)
+  (quasiquote
+    (progn
+      (if (unquote x) true false)
+      (if (unquote x) false true)
+      true
+      false)))
+
+(defun call-me (z)
+  "@trace{ call-me }"
+  (racy-mac z))
+`
+
+func TestSingletonRaceFromLoadString(t *testing.T) {
+	const goroutines = 8
+	const iters = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := range goroutines {
+		go func(g int) {
+			defer wg.Done()
+			for range iters {
+				env := lisp.NewEnv(nil)
+				if rc := lisp.InitializeUserEnv(env, lisp.WithReader(parser.NewReader())); rc.Type == lisp.LError {
+					t.Errorf("goroutine %d: InitializeUserEnv failed: %v", g, rc)
+					return
+				}
+				env.InPackage(lisp.String(lisp.DefaultUserPackage))
+				// Loading parses + macroexpands `racy-mac`, whose body
+				// contains literal `true`/`false`. Stamping recurses
+				// through them; with the fix, singletons are skipped.
+				if rc := env.LoadString("racy.lisp", racyProgram); rc.Type == lisp.LError {
+					t.Errorf("goroutine %d: LoadString failed: %v", g, rc)
+					return
+				}
+				if rc := env.LoadString("invoke.lisp", `(call-me true)`); rc.Type == lisp.LError {
+					t.Errorf("goroutine %d: call-me failed: %v", g, rc)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/lisp/singleton_race_test.go
+++ b/lisp/singleton_race_test.go
@@ -1,0 +1,78 @@
+// Copyright © 2025 The ELPS authors
+
+// Singleton mutation regression test for issue #274.
+//
+// Pre-fix: stampMacroExpansion (macro.go) mutated LVal.Source and
+// .MacroExpansion on every recursive node, and its singleton guard
+// checked only for empty LSExpr (Nil), missing singletonTrue /
+// singletonFalse (LSymbol values with Source.Pos == -1). Every macro
+// expansion that recursed into a Bool() result therefore overwrote the
+// shared global singleton, racing with every concurrent
+// macro-expanding goroutine.
+//
+// With the fix in place, stampMacroExpansion uses an identity-based
+// guard (isSingleton) and never mutates any of the three singletons.
+// This test hammers it concurrently and asserts the singletons are
+// untouched. Run with `go test -race` to confirm no data race.
+
+package lisp
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/luthersystems/elps/parser/token"
+)
+
+func TestSingletonRaceRegression(t *testing.T) {
+	const (
+		goroutines = 8
+		iterations = 2000
+	)
+
+	origTrueSource := Bool(true).Source
+	origFalseSource := Bool(false).Source
+
+	rt := &Runtime{}
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for g := range goroutines {
+		go func(g int) {
+			defer wg.Done()
+			callSite := &token.Location{
+				File: "racer.lisp",
+				Pos:  100 + g,
+				Line: g + 1,
+				Col:  g + 1,
+			}
+			ctx := &MacroExpansionContext{CallSite: callSite, Name: "lisp:test"}
+			for range iterations {
+				// Each goroutine repeatedly attempts to stamp the global
+				// singletonTrue and singletonFalse. With the fix the calls
+				// are no-ops on the singletons.
+				stampMacroExpansion(Bool(true), callSite, ctx, rt)
+				stampMacroExpansion(Bool(false), callSite, ctx, rt)
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	if Bool(true).Source != origTrueSource {
+		t.Errorf("Bool(true).Source mutated by concurrent macro stamping: got %+v want %+v",
+			Bool(true).Source, origTrueSource)
+	}
+	if Bool(true).MacroExpansion != nil {
+		t.Errorf("Bool(true).MacroExpansion mutated by concurrent macro stamping: got %+v",
+			Bool(true).MacroExpansion)
+	}
+	if Bool(false).Source != origFalseSource {
+		t.Errorf("Bool(false).Source mutated by concurrent macro stamping: got %+v want %+v",
+			Bool(false).Source, origFalseSource)
+	}
+	if Bool(false).MacroExpansion != nil {
+		t.Errorf("Bool(false).MacroExpansion mutated by concurrent macro stamping: got %+v",
+			Bool(false).MacroExpansion)
+	}
+}

--- a/lisp/singleton_test.go
+++ b/lisp/singleton_test.go
@@ -1,0 +1,56 @@
+// Copyright © 2025 The ELPS authors
+
+package lisp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSingleton(t *testing.T) {
+	assert.True(t, isSingleton(Nil()))
+	assert.True(t, isSingleton(Bool(true)))
+	assert.True(t, isSingleton(Bool(false)))
+
+	// Fresh allocations are not singletons.
+	assert.False(t, isSingleton(SExpr(nil)))
+	assert.False(t, isSingleton(Symbol("x")))
+	assert.False(t, isSingleton(Int(0)))
+	assert.False(t, isSingleton(String("")))
+
+	// Nil pointer is not a singleton.
+	assert.False(t, isSingleton(nil))
+}
+
+func TestAssertNotSingleton_Panics(t *testing.T) {
+	assert.Panics(t, func() { assertNotSingleton(Nil()) })
+	assert.Panics(t, func() { assertNotSingleton(Bool(true)) })
+	assert.Panics(t, func() { assertNotSingleton(Bool(false)) })
+}
+
+func TestAssertNotSingleton_AllowsNonSingleton(t *testing.T) {
+	assert.NotPanics(t, func() { assertNotSingleton(SExpr(nil)) })
+	assert.NotPanics(t, func() { assertNotSingleton(Symbol("x")) })
+	assert.NotPanics(t, func() { assertNotSingleton(Int(0)) })
+}
+
+func TestSingletonSnapshot_DetectsMutation(t *testing.T) {
+	// Save originals so we can restore after the test — TestMain
+	// snapshot will verify singletons are intact at suite end.
+	origSource := singletonTrue.Source
+	defer func() { singletonTrue.Source = origSource }()
+
+	snap := TakeSingletonSnapshot()
+	require.Empty(t, snap.Verify(), "fresh snapshot should match current state")
+
+	// Mutate a singleton (test only — restored in defer).
+	singletonTrue.Source = nil
+	drift := snap.Verify()
+	assert.Equal(t, "Bool(true)", drift, "Verify should report which singleton drifted")
+
+	// Restore.
+	singletonTrue.Source = origSource
+	assert.Empty(t, snap.Verify(), "after restore Verify should pass")
+}


### PR DESCRIPTION
## Summary

Closes #274.

`stampMacroExpansion` used a type-based singleton guard (`v.Type == LSExpr && len(v.Cells) == 0`) that caught only `singletonNil`. `singletonTrue` and `singletonFalse` are `LSymbol` values with `Source.Pos == -1`, so they bypassed the type-check and tripped the `Pos < 0` branch — directly mutating the shared, process-wide singletons on every macro expansion that recursed into a Bool() literal. The mutation was a 16-byte write to the singleton's `Source` field (and, when a debugger was attached, `MacroExpansion`); it persisted for the remainder of the process lifetime and was visible to every subsequent reader of `Bool(true)` / `Bool(false)`.

## Changes

### Direct fix
- `lisp/macro.go` — replace the type-based guard in `stampMacroExpansion` with an identity-based `isSingleton(v)` check.
- `lisp/singleton.go` (new) — move singleton vars here; add `isSingleton(v)` and `assertNotSingleton(v)` helpers, plus a `SingletonSnapshot` type for use by test infrastructure.
- `lisp/lisp.go` — `Bool()` and `Nil()` now call `checkSingleton(...)`, which is a no-op in production builds and a per-call integrity check under the `elpscheck` build tag.
- `lisp/macro_expansion_test.go` — add `TestStampMacroExpansion_SkipsSingletonTrue` / `SkipsSingletonFalse` alongside the existing Nil test.
- `lisp/singleton_test.go` — unit tests for `isSingleton`, `assertNotSingleton`, and `SingletonSnapshot.Verify`.

### Safeguards (so this can't silently regress)

1. **`TestMain` snapshot in `lisp/`** (`main_test.go`) — snapshots all three singletons at suite start; fails the suite if any drifted by `m.Run()` completion. Catches any test (or transitive code path) that mutates a singleton.
2. **Per-test snapshot in `elpstest.Runner`** (`elpstest/lisptest.go`) — wraps `RunTest` and `RunTestSuite` so lisp-level corruption surfaces at the offending subtest, not at end-of-suite.
3. **`elpscheck` build tag** (`singleton_check_default.go`, `singleton_check_elpscheck.go`) — under `-tags elpscheck`, every `Bool()` / `Nil()` call verifies the three singletons match their init-time snapshot and panics with a clear message if any drifted. Zero-cost in production builds; CI runs `make test-elpscheck`.
4. **Race detector across full suite** — `make race` runs `go test -race ./...`; CI now runs it instead of just the debugger subtree. Catches concurrent singleton mutations from any parallel test.
5. **Regression tests under `-race`**:
   - `TestSingletonRaceRegression` — 8 goroutines × 2000 iterations directly call `stampMacroExpansion(Bool(true), ...)` / `Bool(false)`; verifies singletons are bit-identical afterwards.
   - `TestSingletonRaceFromLoadString` — 8 goroutines × 200 iterations exercise the natural production path (parse → macroexpand → stamp) via a macro whose body contains literal `true`/`false`; verifies no race fires.
6. **`elpscheck` self-test** — `TestCheckSingleton_DetectsCorruption` (under build tag) intentionally mutates a singleton and verifies the integrity check panics with a useful message, then restores state.

### Audit findings

I walked every `*LVal` field-write site in `lisp/` (`grep -nE '\.(Source|MacroExpansion|Quoted|Spliced|Native|Cells|Bytes|Str|Type|FunType|Meta)\s*='`). All other writes are on freshly-allocated `*LVal`s (`Copy()`/`Quote()`/`Splice()`/`shallowUnquote()` always do `*cp = *v` first; `SExpr`/`QExpr`/`Symbol`/`Int`/etc. always return fresh allocations; `SetCallStack` only fires on LError, which singletons cannot be).

Concrete positives:
- ` + "`lisp/lisp.go:262`" + ` ` + "`t.Quoted = true`" + ` — ` + "`t`" + ` is ` + "`Symbol(v.Str)`" + `, fresh.
- ` + "`lisp/lisp.go:502`" + ` ` + "`cp.Str = symbol.Str`" + ` — ` + "`cp`" + ` is a fresh ` + "`*fun`" + ` copy.
- ` + "`lisp/lisp.go:657`" + ` / ` + "`:674`" + ` / ` + "`:683`" + ` — ` + "`Quote`" + `/` + "`Splice`" + `/` + "`shallowUnquote`" + ` all copy first.
- ` + "`lisp/lisp.go:752`" + ` ` + "`v.Native = stack.Copy()`" + ` — guarded ` + "`if v.Type != LError { panic }`" + `; singletons are LSExpr/LSymbol.
- ` + "`lisp/lisp.go:1240`" + ` ` + "`s.Quoted = false`" + ` — ` + "`s`" + ` returned by ` + "`builtinConcat`" + ` (fresh list).
- ` + "`lisp/lisp.go:1260`" + ` ` + "`bound.Cells = append(...)`" + ` — ` + "`bound`" + ` is ` + "`SExpr(nil)`" + `, fresh.
- ` + "`lisp/env.go:883`" + ` ` + "`lerr.Source = env.Loc`" + ` — LError.
- ` + "`lisp/package.go:89`" + ` ` + "`lerr.Source = k.Source`" + ` — LError.
- ` + "`lisp/loader.go:51`" + ` ` + "`lerr.Source = expr.Source`" + ` — LError.
- ` + "`lisp/op.go:403/491/529/558/587`" + ` ` + "`args.Cells = args.Cells[1:]`" + ` — ` + "`args`" + ` is the call-site argument list (fresh SExpr from caller); not a singleton.
- ` + "`lisp/builtins.go:1015/1038/1041/1043/1193/1602/1651/1742`" + ` — all mutate freshly-allocated SExprs/QExprs (` + "`gcall`" + `, ` + "`list`" + `, ` + "`v`" + ` from copy/new array).
- ` + "`lisp/macro.go:199/389`" + ` — ` + "`lambda`" + ` / ` + "`expr`" + ` both fresh ` + "`SExpr(...)`" + ` allocations.

**Conclusion:** ` + "`stampMacroExpansion`" + ` was the only singleton-mutating code path. All other writes are safe by construction.

## Test plan

- [x] ` + "`make test`" + ` — Go tests + lisp examples pass
- [x] ` + "`make race`" + ` — full suite under ` + "`-race`" + ` (8 packages with parallel tests including the two singleton race regressions)
- [x] ` + "`make test-elpscheck`" + ` — full suite under ` + "`-tags elpscheck`" + ` (per-call integrity verification on every ` + "`Bool()/Nil()`" + ` call)
- [x] ` + "`./elps doc -m`" + ` — all docstrings present
- [x] Pre-fix reproducer from issue #274 (`TestStampMacroExpansion_SkipsSingletonTrue`/`SkipsSingletonFalse`) now passes
- [x] ` + "`TestCheckSingleton_DetectsCorruption`" + ` confirms the ` + "`elpscheck`" + ` tag catches a synthetic mutation