### PR TITLE
ci: bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -43,7 +43,7 @@ jobs:
       - name: Restore cached baseline
         if: github.event_name == 'pull_request'
         id: cache-baseline
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: bench-baseline.txt
           key: benchmark-baseline-${{ github.event.pull_request.base.sha }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload baseline cache
         if: github.event_name == 'push'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: bench-baseline.txt
           key: benchmark-baseline-${{ github.sha }}
@@ -122,7 +122,7 @@ jobs:
 
       - name: Post PR comment
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           BENCH_RESULT: ${{ steps.benchstat.outputs.result }}
         with:

--- a/.github/workflows/elps.yml
+++ b/.github/workflows/elps.yml
@@ -16,10 +16,10 @@ jobs:
     name: Lint & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
           cache: true
@@ -57,10 +57,10 @@ jobs:
     name: Build (Windows)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
           cache: true

--- a/.github/workflows/tree-sitter.yml
+++ b/.github/workflows/tree-sitter.yml
@@ -20,10 +20,10 @@ jobs:
     name: Tree-sitter Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
           cache: true

--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -28,10 +28,10 @@ jobs:
           # Windows cross-compilation (EnableWindowsANSIConsole).
           # Windows users get the universal (no-binary) package.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
           cache: true
@@ -44,7 +44,7 @@ jobs:
             -o editors/vscode/bin/elps${{ matrix.ext }} .
           chmod +x editors/vscode/bin/elps${{ matrix.ext }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: binary-${{ matrix.target }}
           path: editors/vscode/bin/
@@ -61,10 +61,10 @@ jobs:
           - target: darwin-x64
           - target: darwin-arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -72,7 +72,7 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: binary-${{ matrix.target }}
           path: editors/vscode/bin/
@@ -103,10 +103,10 @@ jobs:
     needs: build-binaries
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 


### PR DESCRIPTION
## Summary

GitHub's runner deprecation notice ([2025-09-19 changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)) warns that Node.js 20 actions will be forced to Node 24 on **2026-06-02** and removed entirely on **2026-09-16**. The v1.48.0 release workflow run flagged `actions/checkout@v4`, `actions/setup-go@v5`, and `actions/upload-artifact@v4` against this deprecation.

This PR bumps every workflow action to the latest major that ships on Node 24.

## Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-go` | v5 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/cache/{restore,save}` | v4 | v5 |
| `actions/github-script` | v7 | v9 |

`golangci/golangci-lint-action` was already at v9.

## Files touched

- `.github/workflows/elps.yml` — CI Tests
- `.github/workflows/benchmark.yml` — Benchmark Regression Check (also bumps cache and github-script)
- `.github/workflows/tree-sitter.yml` — Tree-sitter Grammar Tests
- `.github/workflows/vscode-publish.yml` — Publish VS Code Extension (also bumps upload/download-artifact and setup-node)

## Notes

`actions/upload-artifact` v4 → v7 spans a real breaking change in v5 (removed implicit merge of artifacts with the same name across jobs). This workflow uses unique per-matrix names (`binary-${{ matrix.target }}`) so it's not affected; each `download-artifact` step pulls by the same unique name.

## Test plan

- [ ] CI Tests workflow passes on this PR
- [ ] Benchmark workflow runs (PR comment posts via `github-script@v9`)
- [ ] Tree-sitter tests pass (when grammar paths touched — not in this PR)
- [ ] On next tag, `Publish VS Code Extension` workflow runs cleanly with no Node 20 deprecation warnings