### PR TITLE
chore: SHA-pin Actions and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -122,7 +122,7 @@ jobs:
 
       - name: Post PR comment
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         env:
           BENCH_RESULT: ${{ steps.benchstat.outputs.result }}
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Restore cached baseline
         if: github.event_name == 'pull_request'
         id: cache-baseline
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: bench-baseline.txt
           key: benchmark-baseline-${{ github.event.pull_request.base.sha }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload baseline cache
         if: github.event_name == 'push'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: bench-baseline.txt
           key: benchmark-baseline-${{ github.sha }}

--- a/.github/workflows/elps.yml
+++ b/.github/workflows/elps.yml
@@ -16,10 +16,10 @@ jobs:
     name: Lint & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version: "1.25"
           cache: true
@@ -28,7 +28,7 @@ jobs:
         run: go mod download
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9
         with:
           version: v2.6
           args: --timeout=5m ./...
@@ -57,10 +57,10 @@ jobs:
     name: Build (Windows)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version: "1.25"
           cache: true

--- a/.github/workflows/tree-sitter.yml
+++ b/.github/workflows/tree-sitter.yml
@@ -20,10 +20,10 @@ jobs:
     name: Tree-sitter Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version: "1.25"
           cache: true

--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -28,10 +28,10 @@ jobs:
           # Windows cross-compilation (EnableWindowsANSIConsole).
           # Windows users get the universal (no-binary) package.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version: "1.25"
           cache: true
@@ -44,7 +44,7 @@ jobs:
             -o editors/vscode/bin/elps${{ matrix.ext }} .
           chmod +x editors/vscode/bin/elps${{ matrix.ext }}
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: binary-${{ matrix.target }}
           path: editors/vscode/bin/
@@ -61,10 +61,10 @@ jobs:
           - target: darwin-x64
           - target: darwin-arm64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "20"
 
@@ -72,7 +72,7 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: binary-${{ matrix.target }}
           path: editors/vscode/bin/
@@ -103,10 +103,10 @@ jobs:
     needs: build-binaries
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "20"
 


### PR DESCRIPTION
## Summary

Part of the org hardening initiative (luthersystems/infosec#1).

### 1. Pin every external Action to a commit SHA

Replaces `uses: foo/bar@v4` with `uses: foo/bar@<sha>  # v4`. Defends against the tj-actions/changed-files class of attack, where a compromised maintainer can retroactively repoint a version tag to a malicious commit. SHA pins are immutable; tag pins are not.

Pinned in this PR:
- `actions/checkout@v6` → `de0fac2` (# `v6`)
- `actions/download-artifact@v8` → `3e5f45b` (# `v8`)
- `actions/github-script@v9` → `3a2844b` (# `v9`)
- `actions/setup-go@v6` → `4a36011` (# `v6`)
- `actions/setup-node@v6` → `48b55a0` (# `v6`)
- `actions/upload-artifact@v7` → `043fb46` (# `v7`)
- `golangci/golangci-lint-action@v9` → `1e7e51e` (# `v9`)

**Could not resolve (skipped):**
- `actions/cache/restore@v5`
- `actions/cache/save@v5`

### 2. Add `.github/dependabot.yml`

Enables the `github-actions` ecosystem updater with grouped weekly updates. Dependabot auto-bumps SHAs (and updates the trailing version comments) every Monday, so pins stay current without manual maintenance.

Phase 1 only — the `github-actions` ecosystem. Runtime ecosystem (npm/pip/gomod) will be added per repo in Phase 2, once CI is confirmed green.

## Test plan

- [ ] CI passes (Actions resolve correctly with the SHA pins).
- [ ] After merge, confirm Dependabot picks up the new config.
