### PR TITLE
fix(lisp): defensive nil-guards in error rendering chain

### DIFF
--- a/lisp/error.go
+++ b/lisp/error.go
@@ -14,11 +14,32 @@ import (
 // information (e.g. call stack) can be stored in the Cells slice.
 type ErrorVal LVal
 
+// nilErrorMessage is the sentinel returned by the rendering chain when a nil
+// *ErrorVal receiver is observed. It exists so that diagnostic paths that
+// reach DumpErrorStack with a corrupted value never crash the process — the
+// caller still gets a non-empty string describing what went wrong. See
+// substrate#288.
+const nilErrorMessage = "<nil error>"
+
+// corruptedNativeMessage is the sentinel returned by ErrorMessage when the
+// type switch over Cells[0].Native panics (e.g. due to a stale itab from a
+// concurrent mutation or an unsafe pointer cast). The intent is to surface
+// the corruption to the operator without taking down the process.
+const corruptedNativeMessage = "<corrupted error: cell native deref panicked>"
+
 // Error implements the error interface.  When the error condition is not
 // “error” it wil be printed preceding the error message.  Otherwise, the
 // name of the function that generated the error will be printed preceding the
 // error, if the function can be determined.
+//
+// Defensive: a nil receiver returns the nilErrorMessage sentinel rather than
+// dereferencing. This matters because diagnostic code (e.g. substrate's
+// DumpErrorStack) may be invoked from a deferred recover handler where the
+// LVal pointer can be stale or zeroed.
 func (e *ErrorVal) Error() string {
+	if e == nil {
+		return nilErrorMessage
+	}
 	if e.Source != nil {
 		return fmt.Sprintf("%s: %s", e.Source, e.baseMessage())
 	}
@@ -26,6 +47,9 @@ func (e *ErrorVal) Error() string {
 }
 
 func (e *ErrorVal) baseMessage() string {
+	if e == nil {
+		return nilErrorMessage
+	}
 	msg := e.ErrorMessage()
 	if e.Str != "error" {
 		return fmt.Sprintf("%s: %s", e.Str, msg)
@@ -41,36 +65,71 @@ func (e *ErrorVal) baseMessage() string {
 // "unmatched-syntax"). This is the programmatic error classification
 // stored in the LVal.Str field for LError values.
 func (e *ErrorVal) Condition() string {
+	if e == nil {
+		return ""
+	}
 	return e.Str
 }
 
 // FunName returns the qualified name of function on the top of the call stack
 // when the error occurred.
 func (e *ErrorVal) FunName() string {
+	if e == nil {
+		return ""
+	}
 	stack := (*LVal)(e).CallStack()
 	if stack == nil {
 		return ""
 	}
-	if stack.Top() == nil {
+	top := stack.Top()
+	if top == nil {
 		return ""
 	}
-	return stack.Top().QualifiedFunName(DefaultUserPackage)
+	return top.QualifiedFunName(DefaultUserPackage)
 }
 
 // ErrorMessage returns the underlying message in the error.
-func (e *ErrorVal) ErrorMessage() string {
-	if len(e.Cells) > 0 {
+//
+// Defensive: the original implementation crashed at substrate#288 when
+// Cells[0].Native held a corrupted interface (stale itab → invalid pointer
+// deref during the type switch). The deferred recover ensures the diagnostic
+// pipeline always produces a renderable string even when the underlying LVal
+// is malformed; well-formed errors are unaffected.
+func (e *ErrorVal) ErrorMessage() (msg string) {
+	if e == nil {
+		return nilErrorMessage
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			msg = corruptedNativeMessage
+		}
+	}()
+	if len(e.Cells) > 0 && e.Cells[0] != nil {
 		switch v := e.Cells[0].Native.(type) {
 		case error:
-			return v.Error()
+			if v != nil {
+				return v.Error()
+			}
 		}
 	}
 
 	return errorCellMessage(e.Cells)
 }
 
-// WriteTrace writes the error and a stack trace to w
+// WriteTrace writes the error and a stack trace to w.
+//
+// Defensive: a nil receiver writes the nilErrorMessage sentinel rather than
+// panicking. This keeps DumpErrorStack-style callers safe even when fed a
+// corrupted LError pointer.
 func (e *ErrorVal) WriteTrace(w io.Writer) (int, error) {
+	if e == nil {
+		bw := bufio.NewWriter(w)
+		n, err := bw.WriteString(nilErrorMessage + "\n")
+		if err != nil {
+			return n, err
+		}
+		return n, bw.Flush()
+	}
 	bw := bufio.NewWriter(w)
 	var n int
 	var err error
@@ -102,11 +161,18 @@ func (e *ErrorVal) WriteTrace(w io.Writer) (int, error) {
 	return n, bw.Flush()
 }
 
+// errorCellMessage renders the cells of an LError as a human-readable
+// message. Nil cells are skipped (rendered as "<nil>") rather than
+// dereferenced; see substrate#288.
 func errorCellMessage(ecells []*LVal) string {
 	var buf bytes.Buffer
 	for i, cell := range ecells {
 		if i > 0 {
 			buf.WriteString(" ")
+		}
+		if cell == nil {
+			buf.WriteString("<nil>")
+			continue
 		}
 		if cell.Type == LString {
 			buf.WriteString(cell.Str)

--- a/lisp/error.go
+++ b/lisp/error.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
 )
 
 // ErrorVal implements the error interface so that errors can be first class lisp
@@ -16,9 +17,8 @@ type ErrorVal LVal
 
 // nilErrorMessage is the sentinel returned by the rendering chain when a nil
 // *ErrorVal receiver is observed. It exists so that diagnostic paths that
-// reach DumpErrorStack with a corrupted value never crash the process — the
-// caller still gets a non-empty string describing what went wrong. See
-// substrate#288.
+// reach the rendering chain with a corrupted value never crash the caller —
+// the caller still gets a non-empty string describing what went wrong.
 const nilErrorMessage = "<nil error>"
 
 // corruptedNativeMessage is the sentinel returned by ErrorMessage when the
@@ -33,11 +33,12 @@ const corruptedNativeMessage = "<corrupted error: cell native deref panicked>"
 // error, if the function can be determined.
 //
 // Defensive: a nil receiver returns the nilErrorMessage sentinel rather than
-// dereferencing. This matters because diagnostic code (e.g. substrate's
-// DumpErrorStack) may be invoked from a deferred recover handler where the
-// LVal pointer can be stale or zeroed.
+// dereferencing. This matters because diagnostic code that renders errors may
+// be invoked from a deferred recover handler where the LVal pointer can be
+// stale or zeroed.
 func (e *ErrorVal) Error() string {
 	if e == nil {
+		log.Printf("elps: ErrorVal.Error called on nil receiver; returning sentinel")
 		return nilErrorMessage
 	}
 	if e.Source != nil {
@@ -48,6 +49,7 @@ func (e *ErrorVal) Error() string {
 
 func (e *ErrorVal) baseMessage() string {
 	if e == nil {
+		log.Printf("elps: ErrorVal.baseMessage called on nil receiver; returning sentinel")
 		return nilErrorMessage
 	}
 	msg := e.ErrorMessage()
@@ -90,17 +92,22 @@ func (e *ErrorVal) FunName() string {
 
 // ErrorMessage returns the underlying message in the error.
 //
-// Defensive: the original implementation crashed at substrate#288 when
-// Cells[0].Native held a corrupted interface (stale itab → invalid pointer
-// deref during the type switch). The deferred recover ensures the diagnostic
-// pipeline always produces a renderable string even when the underlying LVal
-// is malformed; well-formed errors are unaffected.
+// Defensive: a downstream consumer reported a SIGSEGV inside the type switch
+// over Cells[0].Native when the interface header was corrupted (stale itab
+// → invalid pointer deref during the type assertion). The deferred recover
+// ensures the diagnostic pipeline always produces a renderable string even
+// when the underlying LVal is malformed; well-formed errors are unaffected.
+// The recovered panic is logged so the operator sees that something is
+// corrupting the error's Cells[0].Native — silently swallowing would hide a
+// real bug.
 func (e *ErrorVal) ErrorMessage() (msg string) {
 	if e == nil {
+		log.Printf("elps: ErrorVal.ErrorMessage called on nil receiver; returning sentinel")
 		return nilErrorMessage
 	}
 	defer func() {
 		if r := recover(); r != nil {
+			log.Printf("elps: ErrorVal.ErrorMessage recovered panic during Cells[0].Native type switch: %v; returning sentinel %q", r, corruptedNativeMessage)
 			msg = corruptedNativeMessage
 		}
 	}()
@@ -119,10 +126,10 @@ func (e *ErrorVal) ErrorMessage() (msg string) {
 // WriteTrace writes the error and a stack trace to w.
 //
 // Defensive: a nil receiver writes the nilErrorMessage sentinel rather than
-// panicking. This keeps DumpErrorStack-style callers safe even when fed a
-// corrupted LError pointer.
+// panicking. This keeps callers safe even when fed a corrupted LError pointer.
 func (e *ErrorVal) WriteTrace(w io.Writer) (int, error) {
 	if e == nil {
+		log.Printf("elps: ErrorVal.WriteTrace called on nil receiver; emitting sentinel")
 		bw := bufio.NewWriter(w)
 		n, err := bw.WriteString(nilErrorMessage + "\n")
 		if err != nil {
@@ -162,8 +169,7 @@ func (e *ErrorVal) WriteTrace(w io.Writer) (int, error) {
 }
 
 // errorCellMessage renders the cells of an LError as a human-readable
-// message. Nil cells are skipped (rendered as "<nil>") rather than
-// dereferenced; see substrate#288.
+// message. Nil cells are rendered as "<nil>" rather than dereferenced.
 func errorCellMessage(ecells []*LVal) string {
 	var buf bytes.Buffer
 	for i, cell := range ecells {
@@ -171,6 +177,7 @@ func errorCellMessage(ecells []*LVal) string {
 			buf.WriteString(" ")
 		}
 		if cell == nil {
+			log.Printf("elps: errorCellMessage skipping nil cell at index %d (LError has malformed Cells slice)", i)
 			buf.WriteString("<nil>")
 			continue
 		}

--- a/lisp/error_test.go
+++ b/lisp/error_test.go
@@ -16,10 +16,9 @@ import (
 )
 
 // panickingNative is a value that lives in an LVal.Native interface and
-// panics on any method call. It mimics the corruption-via-stale-itab
-// scenario described in substrate#288, where ErrorVal.ErrorMessage crashed
-// at the type-switch on Cells[0].Native because dereferencing the
-// underlying pointer was invalid.
+// panics on any method call. It mimics a corruption-via-stale-itab scenario
+// where ErrorVal.ErrorMessage crashes at the type-switch on Cells[0].Native
+// because dereferencing the underlying pointer is invalid.
 type panickingNative struct{}
 
 // Error satisfies the error interface so that the value matches the
@@ -34,8 +33,8 @@ func (panickingNative) Error() string {
 
 // TestErrorVal_NilReceiver verifies that every renderer on *ErrorVal
 // tolerates a nil receiver and returns a sentinel rather than panicking.
-// This is the foundation of substrate#288's defense: DumpErrorStack may
-// be invoked from a deferred-recover path where the LVal pointer is stale.
+// Diagnostic callers may invoke these methods from a deferred-recover path
+// where the LVal pointer is stale.
 func TestErrorVal_NilReceiver(t *testing.T) {
 	var e *lisp.ErrorVal
 
@@ -68,8 +67,8 @@ func TestErrorVal_NilReceiver(t *testing.T) {
 }
 
 // TestErrorVal_NilCells verifies that an ErrorVal with no cells does not
-// panic when rendered. This is the simplest variant of the substrate#288
-// corruption surface: an LError that lost its message-bearing cells.
+// panic when rendered. This is the simplest variant of the corruption
+// surface: an LError that lost its message-bearing cells.
 func TestErrorVal_NilCells(t *testing.T) {
 	e := (*lisp.ErrorVal)(&lisp.LVal{Type: lisp.LError, Str: "test-error"})
 
@@ -110,12 +109,12 @@ func TestErrorVal_NilCellPointer(t *testing.T) {
 	})
 }
 
-// TestErrorVal_CorruptedNative is the direct regression test for
-// substrate#288: ErrorMessage took a type-switch over Cells[0].Native and
-// crashed when that interface, while satisfying the error type, panicked
-// on the actual Error() call (the closest reproducible analogue of a
-// stale-itab deref without unsafe trickery). The deferred recover in
-// ErrorMessage must convert the panic into a sentinel string.
+// TestErrorVal_CorruptedNative is the direct regression test for the
+// corruption-during-rendering crash: ErrorMessage took a type-switch over
+// Cells[0].Native and crashed when that interface, while satisfying the
+// error type, panicked on the actual Error() call (the closest reproducible
+// analogue of a stale-itab deref without unsafe trickery). The deferred
+// recover in ErrorMessage must convert the panic into a sentinel string.
 func TestErrorVal_CorruptedNative(t *testing.T) {
 	nativeCell := &lisp.LVal{Native: panickingNative{}}
 	e := (*lisp.ErrorVal)(&lisp.LVal{

--- a/lisp/error_test.go
+++ b/lisp/error_test.go
@@ -15,6 +15,152 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// panickingNative is a value that lives in an LVal.Native interface and
+// panics on any method call. It mimics the corruption-via-stale-itab
+// scenario described in substrate#288, where ErrorVal.ErrorMessage crashed
+// at the type-switch on Cells[0].Native because dereferencing the
+// underlying pointer was invalid.
+type panickingNative struct{}
+
+// Error satisfies the error interface so that the value matches the
+// "case error" arm of ErrorMessage's type switch. The panic then fires
+// when the renderer calls v.Error() — which models the failure mode of
+// a corrupted error-bearing Native more faithfully than panicking from
+// the type switch itself (Go's type switch on interfaces does not panic
+// for valid itabs; the original crash was inside the error method call).
+func (panickingNative) Error() string {
+	panic("simulated corruption in Native interface")
+}
+
+// TestErrorVal_NilReceiver verifies that every renderer on *ErrorVal
+// tolerates a nil receiver and returns a sentinel rather than panicking.
+// This is the foundation of substrate#288's defense: DumpErrorStack may
+// be invoked from a deferred-recover path where the LVal pointer is stale.
+func TestErrorVal_NilReceiver(t *testing.T) {
+	var e *lisp.ErrorVal
+
+	require.NotPanics(t, func() {
+		s := e.Error()
+		assert.Equal(t, "<nil error>", s)
+	}, "Error() on nil receiver must not panic")
+
+	require.NotPanics(t, func() {
+		s := e.ErrorMessage()
+		assert.Equal(t, "<nil error>", s)
+	}, "ErrorMessage() on nil receiver must not panic")
+
+	require.NotPanics(t, func() {
+		s := e.Condition()
+		assert.Equal(t, "", s)
+	}, "Condition() on nil receiver must not panic")
+
+	require.NotPanics(t, func() {
+		s := e.FunName()
+		assert.Equal(t, "", s)
+	}, "FunName() on nil receiver must not panic")
+
+	require.NotPanics(t, func() {
+		var buf bytes.Buffer
+		_, err := e.WriteTrace(&buf)
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "<nil error>")
+	}, "WriteTrace() on nil receiver must not panic")
+}
+
+// TestErrorVal_NilCells verifies that an ErrorVal with no cells does not
+// panic when rendered. This is the simplest variant of the substrate#288
+// corruption surface: an LError that lost its message-bearing cells.
+func TestErrorVal_NilCells(t *testing.T) {
+	e := (*lisp.ErrorVal)(&lisp.LVal{Type: lisp.LError, Str: "test-error"})
+
+	require.NotPanics(t, func() {
+		s := e.Error()
+		// Bare condition with no cells: the renderer prints
+		// "<condition>: <empty>" or similar — the contract is just
+		// "no panic, useful string".
+		assert.Contains(t, s, "test-error")
+	})
+}
+
+// TestErrorVal_NilCellPointer verifies that an ErrorVal whose Cells slice
+// contains a nil *LVal does not panic. The original errorCellMessage
+// dereferenced cell.Type / cell.Str / cell.String() unconditionally.
+func TestErrorVal_NilCellPointer(t *testing.T) {
+	e := (*lisp.ErrorVal)(&lisp.LVal{
+		Type:  lisp.LError,
+		Str:   "test-error",
+		Cells: []*lisp.LVal{nil, nil},
+	})
+
+	require.NotPanics(t, func() {
+		s := e.Error()
+		assert.Contains(t, s, "<nil>")
+	})
+
+	require.NotPanics(t, func() {
+		s := e.ErrorMessage()
+		assert.Contains(t, s, "<nil>")
+	})
+
+	require.NotPanics(t, func() {
+		var buf bytes.Buffer
+		_, err := e.WriteTrace(&buf)
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "<nil>")
+	})
+}
+
+// TestErrorVal_CorruptedNative is the direct regression test for
+// substrate#288: ErrorMessage took a type-switch over Cells[0].Native and
+// crashed when that interface, while satisfying the error type, panicked
+// on the actual Error() call (the closest reproducible analogue of a
+// stale-itab deref without unsafe trickery). The deferred recover in
+// ErrorMessage must convert the panic into a sentinel string.
+func TestErrorVal_CorruptedNative(t *testing.T) {
+	nativeCell := &lisp.LVal{Native: panickingNative{}}
+	e := (*lisp.ErrorVal)(&lisp.LVal{
+		Type:  lisp.LError,
+		Str:   "test-error",
+		Cells: []*lisp.LVal{nativeCell},
+	})
+
+	require.NotPanics(t, func() {
+		s := e.ErrorMessage()
+		assert.Equal(t, "<corrupted error: cell native deref panicked>", s)
+	}, "ErrorMessage() must convert a panic in the Native deref into a sentinel")
+
+	require.NotPanics(t, func() {
+		s := e.Error()
+		// Error() wraps ErrorMessage() via baseMessage(); the sentinel
+		// must propagate through that chain.
+		assert.Contains(t, s, "<corrupted error")
+	}, "Error() must not propagate the panic from a corrupted Native")
+
+	require.NotPanics(t, func() {
+		var buf bytes.Buffer
+		_, err := e.WriteTrace(&buf)
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "<corrupted error")
+	}, "WriteTrace() must not propagate the panic from a corrupted Native")
+}
+
+// TestErrorVal_NilNativeError verifies that a Cells[0].Native holding a
+// typed-nil error does not crash. The original code matched the error
+// arm and called v.Error() on a nil interface-backed pointer.
+func TestErrorVal_NilNativeError(t *testing.T) {
+	var nilErr error
+	nativeCell := &lisp.LVal{Native: nilErr}
+	e := (*lisp.ErrorVal)(&lisp.LVal{
+		Type:  lisp.LError,
+		Str:   "test-error",
+		Cells: []*lisp.LVal{nativeCell},
+	})
+
+	require.NotPanics(t, func() {
+		_ = e.ErrorMessage()
+	})
+}
+
 func TestErrors(t *testing.T) {
 	tests := elpstest.TestSuite{
 		{"ignore-errors", elpstest.TestSequence{


### PR DESCRIPTION
## Summary

The error rendering chain on `*ErrorVal` (`Error` / `baseMessage` / `ErrorMessage` / `errorCellMessage` / `FunName` / `Condition` / `WriteTrace`) crashed the process when fed a malformed value. The diagnostic itself shouldn't crash — that's the point.

A downstream consumer caught this in production (post-v1.48.0):

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x14 pc=...]
github.com/luthersystems/elps/lisp.(*ErrorVal).ErrorMessage(...)
   .../lisp/error.go:63
github.com/luthersystems/elps/lisp.(*ErrorVal).baseMessage(...) error.go:29
github.com/luthersystems/elps/lisp.(*ErrorVal).Error(...) error.go:23
github.com/luthersystems/elps/lisp.(*ErrorVal).WriteTrace(...) error.go:82
```

The crash site is the type switch in `ErrorMessage` over `Cells[0].Native`. The `addr=0x14` indicates a small-offset deref on a non-nil-but-corrupted pointer (stale itab / heap reuse / etc.). The panic then re-fires inside a downstream defer (OTel span End in our case) and kills the container — defeating the whole point of the v1.48.0 Go-stack diagnostic.

## What changed

All confined to `lisp/error.go`:

- **Nil receiver guard** on `Error`, `baseMessage`, `ErrorMessage`, `Condition`, `FunName`, `WriteTrace` — returns `"<nil error>"` / `""` instead of dereferencing.
- **Nil-cell guard** in `errorCellMessage` — nil entries render as `"<nil>"` instead of panicking on `cell.Type` / `cell.String()`.
- **Cells[0] nil-pointer guard** in `ErrorMessage` before the type switch.
- **`defer recover`** wrapping the `Cells[0].Native` type switch in `ErrorMessage`. Converts any panic (stale itab, corrupted Native deref) into the sentinel `"<corrupted error: cell native deref panicked>"` so the operator sees the failure mode without crashing the process.
- **Typed-nil error guard** in the `case error` arm — avoids `v.Error()` on a nil interface-backed pointer.
- **`log.Printf` on every defensive branch** — silently swallowing a recovered panic in `ErrorMessage` would hide the upstream bug the guard was meant to expose. Operators get a log line whenever a guard fires.

This is purely defensive. Well-formed `LError` values render identically. The change does NOT fix the upstream Native corruption (still unknown) — it just ensures the diagnostic path always emits something useful and the process never dies from rendering a malformed error.

## Tests

New tests in `lisp/error_test.go`:

- `TestErrorVal_NilReceiver` — `var e *ErrorVal; e.Error()` style, all six methods.
- `TestErrorVal_NilCells` — `LError` with no cells.
- `TestErrorVal_NilCellPointer` — `Cells: []*LVal{nil, nil}`.
- `TestErrorVal_CorruptedNative` — direct regression using a `panickingNative` whose `Error()` panics, modelling the stale-itab deref.
- `TestErrorVal_NilNativeError` — typed-nil `error` in `Native`.

## Test plan

- [x] `go test -race ./lisp/...` — all tests pass
- [x] `go vet ./...` — clean

## Out of scope

Other places in the codebase that touch `Cells[i]` without nil checks remain unguarded — this PR is scoped to the rendering chain reachable from external `WriteTrace` callers. The upstream cause of the Native-pointer corruption is unknown and tracked separately.