### PR TITLE
fix(mcpserver): disable tools/list_changed; bundle dependabot bumps

### DIFF
--- a/.github/workflows/elps.yml
+++ b/.github/workflows/elps.yml
@@ -28,7 +28,7 @@ jobs:
         run: go mod download
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee  # v9
         with:
           version: v2.6
           args: --timeout=5m ./...

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -3740,9 +3740,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -129,6 +129,14 @@ func New(opts ...Option) *Server {
 	s.server = mcp.NewServer(s.impl, &mcp.ServerOptions{
 		Instructions: s.instructions,
 		Logger:       s.logger,
+		// Tools are registered once at construction and never change at
+		// runtime, so we disable the "tools/list_changed" notification.
+		// Leaving it on (the default) causes AddTool calls during
+		// registration to schedule a debounced notification that races
+		// the stdio session's shutdown — the notification fires after
+		// the client closes stdin and the resulting "server is closing:
+		// EOF" write error propagates up to a non-zero subprocess exit.
+		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
 	})
 	s.registerCoreTools()
 	for _, register := range s.registrars {


### PR DESCRIPTION
## Summary
Bundles three changes:

1. **`mcpserver`: disable `tools/list_changed` capability** — fixes flaky CI race in `TestMCPCommand_*` integration tests (`session.Close()` returning `exit status 1`).
   - Root cause: the MCP go-sdk's `AddTool` schedules a debounced (10 ms) `notifications/tools/list_changed`. When the stdio client finishes in well under 10 ms, the timer fires after stdin is closed and the write hits `server is closing: EOF`, propagating to a non-zero subprocess exit.
   - ELPS tools are registered once at `mcpserver.New()` and never mutate, so we opt out of the capability — the SDK then never schedules the timer.
2. **deps:** bump `golangci/golangci-lint-action` 9.2.0 → 9.2.1 (supersedes #282).
3. **deps-dev:** bump `qs` 6.15.0 → 6.15.2 in `editors/vscode` (supersedes #281).

## Test plan
- [x] `go test -race -count=1 ./mcpserver/... ./cmd/...` — green
- [x] 50× stress of `-run TestMCPCommand_` under `-race` — 0/50 failed
- [x] Concurrent stress harness (16 workers × 200 spawns): 8/800 (~1%) before, **0/3200** after
- [ ] CI green on full bundle

## Review notes
- `/review` findings on the mcpserver change: none at any severity
- qa-professor: no test files changed → skipped
- Dependabot bumps cherry-picked unmodified (one commit per work item)

Closes #281
Closes #282