### PR TITLE
fix(debugger): make the pause tests actually assert, and ack the DAP pause after arming

### DIFF
--- a/lisp/x/debugger/dapserver/handler.go
+++ b/lisp/x/debugger/dapserver/handler.go
@@ -1039,10 +1039,16 @@ func (h *handler) applyLaunchConfig(cfg launchConfig) {
 }
 
 func (h *handler) onPause(req *dap.PauseRequest) {
+	// Arm the engine BEFORE acknowledging. A client that receives a
+	// successful pause response is entitled to assume the request has taken
+	// effect; replying first leaves a window in which a short-lived program
+	// can run to completion and terminate without ever stopping, even though
+	// the client was told the pause succeeded.
+	h.engine.RequestPause()
+
 	resp := &dap.PauseResponse{}
 	resp.Response = h.newResponse(req.Seq, req.Command)
 	h.send(resp)
-	h.engine.RequestPause()
 }
 
 func (h *handler) onSource(req *dap.SourceRequest) {

--- a/lisp/x/debugger/dapserver/handler_test.go
+++ b/lisp/x/debugger/dapserver/handler_test.go
@@ -9,11 +9,13 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"testing/fstest"
 	"time"
 
 	"github.com/google/go-dap"
+	"github.com/luthersystems/elps/elpsutil"
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/lisplib"
 	"github.com/luthersystems/elps/lisp/x/debugger"
@@ -452,6 +454,54 @@ func newDAPTestEnv(t *testing.T, dbg *debugger.Engine) *lisp.LEnv {
 	rc = env.InPackage(lisp.String(lisp.DefaultUserPackage))
 	require.True(t, rc.IsNil(), "InPackage failed: %v", rc)
 	return env
+}
+
+// pauseGate is a rendezvous between the test goroutine and the eval
+// goroutine. newPauseGate installs a `(debug-test-gate)` builtin in env; the
+// program under test calls it, which parks the eval goroutine until the test
+// calls Release. That lets a test drive a DAP pause while the program is
+// provably mid-flight, instead of racing a short program with a sleep or a
+// poll on EvalCount. (Mirrors the helper in the debugger package — test
+// helpers do not cross package boundaries.)
+type pauseGate struct {
+	entered     chan struct{}
+	release     chan struct{}
+	enteredOnce sync.Once
+	releaseOnce sync.Once
+}
+
+// newPauseGate installs the gate builtin into env's current package.
+func newPauseGate(t *testing.T, env *lisp.LEnv) *pauseGate {
+	t.Helper()
+	g := &pauseGate{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	// Never leave the eval goroutine parked if the test fails before it
+	// reaches its own Release call.
+	t.Cleanup(g.Release)
+	env.AddBuiltins(true, elpsutil.Function("debug-test-gate", lisp.Formals(),
+		func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+			g.enteredOnce.Do(func() { close(g.entered) })
+			<-g.release
+			return lisp.Nil()
+		}))
+	return g
+}
+
+// Release unparks the eval goroutine. Safe to call more than once.
+func (g *pauseGate) Release() {
+	g.releaseOnce.Do(func() { close(g.release) })
+}
+
+// WaitEntered blocks until the program reaches the gate.
+func (g *pauseGate) WaitEntered(t *testing.T) {
+	t.Helper()
+	select {
+	case <-g.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("program never reached debug-test-gate")
+	}
 }
 
 func sendDAPRequest(t *testing.T, w io.Writer, msg dap.Message) {
@@ -1669,15 +1719,27 @@ func TestDAPServer_PauseRequest(t *testing.T) {
 	s.configDone()
 
 	env := newDAPTestEnv(t, s.engine)
+	gate := newPauseGate(t, env)
 
-	// Use a long-running recursive program so we can pause mid-execution.
-	// Large countdown ensures the program is still running when the pause
-	// request takes effect — even on slow CI machines.
+	// The program must actually run to completion, otherwise the assertions
+	// below say nothing about pausing a live program.
+	//
+	// Keep the countdown small. Attaching a debugger disables tail-call
+	// optimisation globally (see lisp/env.go), so every turn of this loop
+	// costs a physical stack frame and anything past ~25k aborts with
+	// "physical stack height exceeded maximum". The historical (countdown
+	// 100000) never counted down at all: it burned ~2s hitting the frame cap
+	// and returned an error the test discarded.
+	//
+	// Correctness does not rest on the program being slow. debug-test-gate
+	// parks the eval goroutine until this test releases it, so the pause is
+	// armed while the program is provably mid-flight.
 	program := "(defun countdown (n)\n" +
 		"  (if (<= n 0)\n" +
 		"    0\n" +
 		"    (countdown (- n 1))))\n" +
-		"(countdown 100000)"
+		"(debug-test-gate)\n" +
+		"(countdown 200)"
 
 	resultCh := make(chan *lisp.LVal, 1)
 	go func() {
@@ -1685,12 +1747,11 @@ func TestDAPServer_PauseRequest(t *testing.T) {
 		resultCh <- res
 	}()
 
-	// Wait for eval goroutine to be well into execution before pausing.
-	require.Eventually(t, func() bool {
-		return s.engine.EvalCount() > 10
-	}, 2*time.Second, time.Millisecond, "eval goroutine did not start")
+	// Park the program at the gate before pausing.
+	gate.WaitEntered(t)
 
-	// Send Pause request.
+	// Send Pause request. The handler arms the engine before replying, so a
+	// successful response means the pause is already in effect.
 	s.send(&dap.PauseRequest{
 		Request: dap.Request{
 			ProtocolMessage: dap.ProtocolMessage{Seq: s.nextSeq(), Type: "request"},
@@ -1702,6 +1763,9 @@ func TestDAPServer_PauseRequest(t *testing.T) {
 	pauseResp, ok := msg.(*dap.PauseResponse)
 	require.True(t, ok, "expected PauseResponse, got %T", msg)
 	assert.True(t, pauseResp.Success)
+
+	// Let the program run on into the armed pause.
+	gate.Release()
 
 	// Wait for the engine to actually pause.
 	require.Eventually(t, func() bool {
@@ -1718,7 +1782,13 @@ func TestDAPServer_PauseRequest(t *testing.T) {
 	s.continueExec()
 
 	select {
-	case <-resultCh:
+	case res := <-resultCh:
+		// Assert the program ran to completion. Without this the test passes
+		// just as happily when the program dies at the physical frame cap,
+		// which is exactly how (countdown 100000) went unnoticed for the
+		// life of this test.
+		require.Equal(t, lisp.LInt, res.Type, "program did not run to completion: %v", res)
+		assert.Equal(t, 0, res.Int, "countdown should reach zero")
 	case <-time.After(5 * time.Second):
 		if s.engine.IsPaused() {
 			s.engine.Resume()

--- a/lisp/x/debugger/engine_test.go
+++ b/lisp/x/debugger/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luthersystems/elps/elpsutil"
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/lisplib"
 	"github.com/luthersystems/elps/parser"
@@ -34,6 +35,62 @@ func newTestEnv(t *testing.T, dbg *Engine) *lisp.LEnv {
 	rc = env.InPackage(lisp.String(lisp.DefaultUserPackage))
 	require.True(t, rc.IsNil(), "InPackage failed: %v", rc)
 	return env
+}
+
+// pauseGate is a rendezvous between the test goroutine and the eval
+// goroutine. Calling newPauseGate installs a `(debug-test-gate)` builtin in
+// env; the program under test calls it, which parks the eval goroutine until
+// the test calls release. That lets a test arm a pause while the program is
+// provably mid-flight, instead of racing a short program with a sleep or a
+// poll on EvalCount.
+type pauseGate struct {
+	entered     chan struct{}
+	release     chan struct{}
+	enteredOnce sync.Once
+	releaseOnce sync.Once
+}
+
+// newPauseGate installs the gate builtin into env's current package.
+func newPauseGate(t *testing.T, env *lisp.LEnv) *pauseGate {
+	t.Helper()
+	g := &pauseGate{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	// Never leave the eval goroutine parked if the test fails before it
+	// reaches its own release call.
+	t.Cleanup(g.Release)
+	env.AddBuiltins(true, gateBuiltin(g))
+	return g
+}
+
+// Release unparks the eval goroutine. Safe to call more than once.
+func (g *pauseGate) Release() {
+	g.releaseOnce.Do(func() { close(g.release) })
+}
+
+// WaitEntered blocks until the program reaches the gate.
+func (g *pauseGate) WaitEntered(t *testing.T) {
+	t.Helper()
+	select {
+	case <-g.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("program never reached debug-test-gate")
+	}
+}
+
+func (g *pauseGate) enter() {
+	g.enteredOnce.Do(func() { close(g.entered) })
+	<-g.release
+}
+
+// gateBuiltin exposes g to lisp as `(debug-test-gate)`.
+func gateBuiltin(g *pauseGate) lisp.LBuiltinDef {
+	return elpsutil.Function("debug-test-gate", lisp.Formals(),
+		func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+			g.enter()
+			return lisp.Nil()
+		})
 }
 
 func snapshotPause(evt Event) pauseSnapshot {
@@ -989,15 +1046,27 @@ func TestEngine_RequestPause(t *testing.T) {
 	e.Enable()
 
 	env := newTestEnv(t, e)
+	gate := newPauseGate(t, env)
 
-	// Use a long-running program so we have time to request a pause.
-	// Large countdown ensures the program is still running when RequestPause
-	// takes effect — even on slow CI machines.
+	// The program must actually run to completion, otherwise the assertions
+	// below say nothing about pausing a live program.
+	//
+	// Keep the countdown small. Attaching a debugger disables tail-call
+	// optimisation globally (see lisp/env.go), so every turn of this loop
+	// costs a physical stack frame and anything past ~25k aborts with
+	// "physical stack height exceeded maximum". The historical (countdown
+	// 100000) never counted down at all: it burned ~1.5s hitting the frame
+	// cap and returned an error the test discarded.
+	//
+	// Correctness does not rest on the program being slow. debug-test-gate
+	// parks the eval goroutine until this test releases it, so the pause is
+	// armed while the program is provably mid-flight.
 	program := "(defun countdown (n)\n" +
 		"  (if (<= n 0)\n" +
 		"    0\n" +
 		"    (countdown (- n 1))))\n" +
-		"(countdown 100000)"
+		"(debug-test-gate)\n" +
+		"(countdown 200)"
 
 	resultCh := make(chan *lisp.LVal, 1)
 	go func() {
@@ -1005,13 +1074,10 @@ func TestEngine_RequestPause(t *testing.T) {
 		resultCh <- res
 	}()
 
-	// Wait for eval goroutine to be well into execution, then request pause.
-	// We wait for multiple evals (not just 1) so the program is solidly running
-	// and won't finish before RequestPause takes effect.
-	require.Eventually(t, func() bool {
-		return e.EvalCount() > 10
-	}, 2*time.Second, time.Millisecond, "eval goroutine did not start")
+	// Arm the pause while the program is parked at the gate, then let it run.
+	gate.WaitEntered(t)
 	e.RequestPause()
+	gate.Release()
 
 	// The engine should pause.
 	require.Eventually(t, func() bool {
@@ -1032,31 +1098,20 @@ func TestEngine_RequestPause(t *testing.T) {
 	assert.Equal(t, StopPause, stopReason, "expected pause stop reason")
 	mu.Unlock()
 
-	// Resume to let the program finish.
+	// Resume to let the program finish. A pause request is one-shot — it is
+	// consumed in WaitIfPaused and the stepper is reset on continue — so a
+	// single Resume is enough.
 	e.Resume()
 
-	// Keep resuming if needed (recursive calls may re-trigger).
-	resumeDone := make(chan struct{})
-	go func() {
-		ticker := time.NewTicker(10 * time.Millisecond)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-resumeDone:
-				return
-			case <-ticker.C:
-				if e.IsPaused() {
-					e.Resume()
-				}
-			}
-		}
-	}()
-
 	select {
-	case <-resultCh:
-		close(resumeDone)
+	case res := <-resultCh:
+		// Assert the program ran to completion. Without this the test
+		// passes just as happily when the program dies at the physical
+		// frame cap, which is exactly how (countdown 100000) went
+		// unnoticed for the life of this test.
+		require.Equal(t, lisp.LInt, res.Type, "program did not run to completion: %v", res)
+		assert.Equal(t, 0, res.Int, "countdown should reach zero")
 	case <-time.After(5 * time.Second):
-		close(resumeDone)
 		if e.IsPaused() {
 			e.Resume()
 		}


### PR DESCRIPTION
## The finding: these two tests have never asserted anything

`TestEngine_RequestPause` and `TestDAPServer_PauseRequest` fail intermittently under `make race`. Six agents have now burned effort proving it wasn't their change.

The headline is not the flake. It is that **both tests have been asserting nothing about a running program for their entire life.**

Both ran `(countdown 100000)`. With a debugger attached, tail-call optimisation is disabled globally (`lisp/env.go:1307`: `if env.Runtime.Debugger == nil { npop = env.Runtime.Stack.TerminalFID(...) }`), so every turn of the loop costs a *physical* stack frame and the program aborts at the 25,001-frame cap instead of counting down. Measured on this branch (`go test -race`, `lisp/x/debugger`):

| n | elapsed | result |
|---|---|---|
| 100000 | 1.78s | `physical stack height exceeded maximum: 25001` |
| 25000 | 0.93s | `physical stack height exceeded maximum: 25001` |
| 2000 | 0.21s | `0` (completes) |
| 200 | 0.01s | `0` (completes) |

`n=100000` and `n=25000` are indistinguishable — both just hit the cap. **Both tests discarded the result**, so this passed silently. The "flake" was a 5-second deadline racing a program that was never going to finish.

The failure mode is unanimous with that reading. Across **214 reproduced failures** in two independent stress runs under deliberate CPU load, every single one landed on the final `select` deadline:

```
  84  engine_test.go:1049: timeout waiting for eval result
 130  handler_test.go:1724: timeout waiting for program to finish
```

**Zero** landed on any pause assertion or stop-reason assertion. `DATA RACE` / `panic:` count across ~1600 race-instrumented runs: **0**. It is a wall-clock problem, not a synchronisation defect.

## The fix

1. **Bound the work, don't widen the wait.** ~200 turns that actually complete. The deadlines are untouched at 5s.
2. **Add a blocking gate.** Shrinking alone trades one flake for a rarer one — a short program can finish before a starved test goroutine reaches `RequestPause`. A `(debug-test-gate)` builtin (test-only, installed via `env.AddBuiltins`) parks the eval goroutine until the test releases it, so the pause is armed while the program is *provably* mid-flight rather than probably mid-flight. `EvalCount()` polling and the `time`-based resume loop are gone.
3. **Assert the result.** `require.Equal(t, lisp.LInt, res.Type)` + `assert.Equal(t, 0, res.Int)`, so a future bump back over the frame cap fails loudly instead of silently.

## Separate, user-visible: `onPause` acknowledged before arming

`handler.onPause` sent the DAP success response **before** calling `engine.RequestPause()`:

```go
h.send(resp)
h.engine.RequestPause()
```

This is a real product bug independent of the tests. A DAP client (VS Code) that receives a successful `pause` response is entitled to assume the request has taken effect. With the old ordering, a short-lived program can run to completion and terminate in the window between the reply and the arming — the client is told the pause succeeded and then watches the program finish without ever stopping. Arm first, acknowledge second.

It also restores the happens-before the DAP test now relies on: the test releases the gate only after reading a successful `PauseResponse`. Outbound writes are already serialised by `Server.send`'s mutex, so reordering is safe.

## Stress numbers

Interleaved A/B — old and new binaries alternating inside **one** load window, arm order swapped on alternate iterations, so neither arm gets a quieter machine. 200 iterations per arm, `-race`, busy-spin load on a 4-core box (raised from 8 to 16 loaders early in the run; because the arms interleave, both saw it equally). Peak load average 22. Total wall 2910s.

| arm | failures | mean wall per invocation |
|---|---|---|
| `TestEngine_RequestPause` — **before** | **84 / 200 (42%)** | 5312 ms |
| `TestEngine_RequestPause` — **after** | **0 / 200** | 1554 ms |
| `TestDAPServer_PauseRequest` — **before** | **130 / 200 (65%)** | 5849 ms |
| `TestDAPServer_PauseRequest` — **after** | **0 / 200** | 1531 ms |

(The "after" means are dominated by race-binary process startup under saturation, not by the tests.) In-test time, same binaries, three consecutive runs each:

| test | before | after |
|---|---|---|
| `TestEngine_RequestPause` | 1.24s / 1.18s / 1.28s | 0.02s / 0.03s / 0.03s |
| `TestDAPServer_PauseRequest` | 1.26s / 1.17s / 1.24s | 0.05s / 0.05s / 0.03s |

Margin against the untouched 5s deadline goes from ~4× to ~150×.

A prior non-interleaved run at 10-way load gave the same picture: 40 iterations → 9/40 engine and 11/40 DAP failures, again all at the final deadline.

## Sibling tests with the same shape

Reported, not fixed here (keeping this PR small):

- `TestEngine_ExceptionBreakpoint` (`engine_test.go` ~L373) and `TestEngine_FunctionBreakpoint` (`engine_test.go` ~L1137) both wait on `e.IsPaused()` and then **immediately sample `stopReason`**, which is written by the event callback. `WaitIfPaused` publishes `pausedEnv` (what `IsPaused` reads) *before* invoking the callback, so the reason can lag the paused flag by a scheduling quantum. `TestEngine_RequestPause` already carried a comment describing exactly this and worked around it with `require.Eventually`; these two did not get the workaround. Same class: waiting on one signal while asserting on another.
- No other test in `lisp/x/**` pairs a hard wall-clock deadline with a heavy program — every other `countdown` in these suites is 3–5 turns. The two `time.Sleep` sites (`engine_test.go` ReadyCh delay, `handler_test.go` `dialWithRetry`) are benign.
- `Engine.EvalCount()` now has no callers. It is exported API on an experimental package, so it is left in place; worth a look if `lisp/x/debugger` ever gets an API sweep.

## Verification

`go build ./...` · `go test ./...` · `make race` · `make test-elpscheck` · `golangci-lint run ./...` **0 issues** · `./elps doc -m` · `./elps fmt -l --exclude 'grammar' ./...` · `make ci-gates-test` (53 passed) · `./elps lint --workspace=. --exclude 'grammar' --include '_examples' ./...` byte-identical to `919ef2d` · no new gofmt-unclean files (34 pre-existing on main, unchanged). No struct fields reordered in `lisp/x/` (`fieldalignment` is exempt there by `.golangci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi