### PR TITLE
Fuzz the builtins and stdlib: a non-terminating pow, an uninterruptible dotimes, and a whole class of libschema crashes

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,7 +7,11 @@ name: Fuzz
 # a phylum.  This workflow keeps a continuous fuzzing budget pointed at that
 # surface: the recursive-descent parser (strict, fault-tolerant and
 # format-preserving modes), the lexer and byte scanner, the formatter and
-# minifier round-trips, and the JSON decoder that reads chaincode state.
+# minifier round-trips, the JSON decoder that reads chaincode state and the
+# JSON encoder that writes it, and -- the widest surface of all -- every
+# builtin, special operator, macro and stdlib export, applied to generated
+# typed LVals.  A phylum calls those with arguments of its own choosing, so a
+# panic or a hang in any of them is as reachable as a parser crash.
 #
 # TIME BOUNDING IS THE LOAD-BEARING PART.  `go test -fuzz` has no default limit;
 # without -fuzztime it runs until something kills it.  All logic, including the
@@ -60,9 +64,16 @@ jobs:
     # over; this catches a hang OUTSIDE any single `go test` (a wedged build,
     # a stuck module download) that neither of those can see.
     #
-    # Sized for the scheduled run: 10 targets x 10m plus build. The PR path
-    # measures far below it -- see the measured cost in the run summary.
-    timeout-minutes: 120
+    # MUST BE RAISED WHENEVER A TARGET IS ADDED. Discovery is dynamic, so a
+    # new target silently costs another FUZZTIME on the nightly run; at 120
+    # minutes the 14 targets present today would be cut off mid-sweep and the
+    # last ones would never run at all. Sized for the scheduled run: 14
+    # targets x 10m plus build and the corpus cache restore. The PR path
+    # measures far below it: each of the three targets added with this comment
+    # measured 33-34s wall for a 30s budget (FuzzApplyStdlib 33s,
+    # FuzzDumpJSON 33s, FuzzSchemaValidate 34s), so 14 x ~33s is ~8 minutes
+    # end to end.
+    timeout-minutes: 165
     env:
       # 30s on a PR, 10m on the nightly schedule, whatever was asked for on a
       # manual dispatch. The PR budget is intentionally small: this job is a

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,10 +8,13 @@ name: Fuzz
 # surface: the recursive-descent parser (strict, fault-tolerant and
 # format-preserving modes), the lexer and byte scanner, the formatter and
 # minifier round-trips, the JSON decoder that reads chaincode state and the
-# JSON encoder that writes it, and -- the widest surface of all -- every
-# builtin, special operator, macro and stdlib export, applied to generated
-# typed LVals.  A phylum calls those with arguments of its own choosing, so a
-# panic or a hang in any of them is as reachable as a parser crash.
+# JSON encoder that writes it, the EVALUATOR itself -- where that same
+# untrusted source is actually run, so a panic is a crashed chaincode process
+# and a non-terminating evaluation is a wedged transaction -- and, the widest
+# surface of all, every builtin, special operator, macro and stdlib export,
+# applied to generated typed LVals.  A phylum calls those with arguments of
+# its own choosing, so a panic or a hang in any of them is as reachable as a
+# parser crash.
 #
 # TIME BOUNDING IS THE LOAD-BEARING PART.  `go test -fuzz` has no default limit;
 # without -fuzztime it runs until something kills it.  All logic, including the
@@ -60,20 +63,32 @@ jobs:
   fuzz:
     name: Fuzz targets
     runs-on: ubuntu-latest
-    # Backstop for the whole job. fuzz.sh already bounds each target twice
-    # over; this catches a hang OUTSIDE any single `go test` (a wedged build,
-    # a stuck module download) that neither of those can see.
+    # A BACKSTOP, NOT A BUDGET -- and the number must not be read as an
+    # accurate target count.  Discovery is dynamic (scripts/fuzz.sh enumerates
+    # targets at run time), so a new target silently costs another FUZZTIME on
+    # the nightly sweep, and a value sized for yesterday's count truncates the
+    # sweep with the last targets never executing at all.
     #
-    # MUST BE RAISED WHENEVER A TARGET IS ADDED. Discovery is dynamic, so a
-    # new target silently costs another FUZZTIME on the nightly run; at 120
-    # minutes the 14 targets present today would be cut off mid-sweep and the
-    # last ones would never run at all. Sized for the scheduled run: 14
-    # targets x 10m plus build and the corpus cache restore. The PR path
-    # measures far below it: each of the three targets added with this comment
-    # measured 33-34s wall for a 30s budget (FuzzApplyStdlib 33s,
-    # FuzzDumpJSON 33s, FuzzSchemaValidate 34s), so 14 x ~33s is ~8 minutes
-    # end to end.
-    timeout-minutes: 165
+    # Re-derive rather than trusting this literal: `make fuzz-list` prints the
+    # targets actually discovered on the current tree.  The arithmetic is
+    # (targets that really fuzz) x FUZZTIME + build + corpus cache restore.
+    # FuzzGateSelfTest is inert unless armed and does not count.
+    #
+    # 180 is sized for the fully-landed round-2 state: main carries 11
+    # targets, the evaluator work adds FuzzEval, the stdlib work adds
+    # FuzzApplyStdlib / FuzzDumpJSON / FuzzSchemaValidate, and retiring
+    # regexparser removes FuzzParseLVal -- 14 that really fuzz, so 14 x 10m =
+    # 140 minutes plus overhead.  It is deliberately above every intermediate
+    # merge order as well, because over-provisioning a backstop costs nothing
+    # while under-provisioning drops coverage silently.
+    #
+    # Measured PR-path cost (FUZZTIME=30s, 4-core linux/amd64): the whole
+    # sweep is ~6 minutes; FuzzEval 32s, FuzzApplyStdlib 33s, FuzzDumpJSON
+    # 33s, FuzzSchemaValidate 34s.
+    #
+    # The durable fix is a derived gate asserting
+    # (target count x nightly budget) <= timeout-minutes -- tracked in #320.
+    timeout-minutes: 180
     env:
       # 30s on a PR, 10m on the nightly schedule, whatever was asked for on a
       # manual dispatch. The PR budget is intentionally small: this job is a

--- a/internal/fuzzval/fuzzval.go
+++ b/internal/fuzzval/fuzzval.go
@@ -1,0 +1,499 @@
+// Copyright © 2026 The ELPS authors
+
+// Package fuzzval turns a fuzzer-supplied byte string into typed lisp.LVal
+// arguments for the repository's builtin/stdlib fuzz targets.
+//
+// WHY A VALUE GENERATOR AND NOT MORE SOURCE-LEVEL FUZZING.  The parser,
+// lexer, formatter and minifier targets (internal/fuzzseed) mutate ELPS
+// SOURCE.  Everything they can reach has to be spellable in the grammar, and
+// several LVal shapes are not: an LNative wrapping an arbitrary Go value, a
+// multi-dimensional LArray, an LError value passed as an ordinary argument, a
+// tagged-value whose user data is itself a tagged-value, a sorted-map keyed by
+// a symbol rather than a string.  Those shapes DO reach builtins in practice
+// -- host code hands natives in, json:load-bytes builds nested maps, deftype
+// builds tagged values -- so the only way to fuzz a builtin against them is to
+// construct the values directly and apply the function to them.
+//
+// SINGLETONS ARE DELIBERATELY IN THE CORPUS.  Value can return the shared
+// Nil() / Bool(true) / Bool(false) singletons.  Any builtin that writes
+// through one of those pointers corrupts every other holder of it; that is
+// exactly what the `elpscheck` build tag detects (see lisp/singleton.go and
+// issue #274).  Running these targets under `go test -tags elpscheck` is
+// therefore a much stronger check than running them without it, and the
+// harnesses additionally verify a lisp.SingletonSnapshot on every iteration so
+// the default build catches it too.
+//
+// DETERMINISM.  A Gen is a pure function of its input bytes: the same []byte
+// always yields the same values.  That is what makes a saved crasher
+// reproducible.  Nothing here reads a clock, a map iteration order, or a
+// random source.
+package fuzzval
+
+import (
+	"math"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// Budget caps how many LVals one Gen will construct across all calls.  The
+// generator is recursive -- a list can hold arrays that hold maps -- so
+// without a global cap a few bytes can ask for an exponentially large value
+// and the target spends its whole budget in the allocator rather than in the
+// code under test.  Depth alone is not enough: breadth multiplies too.
+const Budget = 512
+
+// maxDepth bounds nesting independently of Budget so a pathological input
+// cannot build a 500-deep spine, which would test the recursion limits of
+// LVal.String() rather than the builtin under test.
+const maxDepth = 6
+
+// maxSeqLen bounds the length of any single generated sequence.
+const maxSeqLen = 8
+
+// Gen is a deterministic LVal generator driven by a byte string.
+//
+// It never runs out of input: reads past the end of the byte string return 0.
+// A short input therefore produces a small, boring value rather than an error,
+// which is what lets the fuzzer start from a one-byte seed and grow.
+type Gen struct {
+	env    *lisp.LEnv
+	b      []byte
+	i      int
+	budget int
+}
+
+// New returns a Gen driven by data.
+//
+// env is used only to construct tagged-values (LEnv.TaggedValue is the only
+// supported constructor, and it stamps a source location; hand-rolling the
+// struct literal would leave Source nil, which no real tagged-value ever has
+// and which would make a nil-deref in the harness look like a builtin bug).
+// A nil env is allowed and simply removes tagged-values from the corpus.
+func New(data []byte, env *lisp.LEnv) *Gen {
+	return &Gen{b: data, env: env, budget: Budget}
+}
+
+// Byte consumes and returns one byte, or 0 once the input is exhausted.
+func (g *Gen) Byte() byte {
+	if g.i >= len(g.b) {
+		return 0
+	}
+	c := g.b[g.i]
+	g.i++
+	return c
+}
+
+// Intn consumes one byte and returns a value in [0,n).  Returns 0 for n <= 0.
+func (g *Gen) Intn(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	return int(g.Byte()) % n
+}
+
+// Bytes consumes up to n bytes and returns them.  The returned slice is a
+// copy: builtins are allowed to retain what they are given, and the fuzzing
+// engine reuses the input buffer between iterations.
+func (g *Gen) Bytes(n int) []byte {
+	if n <= 0 {
+		return nil
+	}
+	if g.i >= len(g.b) {
+		return []byte{}
+	}
+	end := min(g.i+n, len(g.b))
+	out := make([]byte, end-g.i)
+	copy(out, g.b[g.i:end])
+	g.i = end
+	return out
+}
+
+// interestingInts are the integer values that break index and size
+// arithmetic: the signed boundaries powInt's doubling loop overflows through,
+// the 32-bit boundaries, the float64 exact-integer boundary, and the small
+// values around zero that off-by-one bugs live on.
+var interestingInts = []int{
+	0, 1, -1, 2, -2, 3, 8,
+	math.MaxInt, math.MinInt,
+	math.MaxInt - 1, math.MinInt + 1,
+	math.MaxInt32, math.MinInt32,
+	1 << 53, -(1 << 53),
+	1 << 62, -(1 << 62),
+	1 << 31, 1 << 16,
+	-9223372036854775807,
+}
+
+// interestingFloats are the float64 values with no total order and no
+// round-trip: NaN (which is not equal to itself, so reflexivity must NOT be
+// asserted anywhere downstream), both infinities, both zeros, and the
+// subnormal/limit boundaries.
+var interestingFloats = []float64{
+	0, math.Copysign(0, -1), 1, -1, 0.5, -0.5,
+	math.NaN(), math.Inf(1), math.Inf(-1),
+	math.MaxFloat64, -math.MaxFloat64,
+	math.SmallestNonzeroFloat64,
+	1e308, 1e-308, 1 << 53, 9007199254740993,
+}
+
+// interestingStrings are the string values that break byte-vs-rune
+// arithmetic, UTF-8 decoding, and anything that treats a string as a symbol
+// or a package-qualified name.
+var interestingStrings = []string{
+	"", " ", "\x00", "a", "ab", "abc",
+	"\xff", "a\xffb", "\xed\xa0\x80", // invalid / surrogate UTF-8
+	"é", "😀", "é", // multibyte and combining
+	"a:b", "a:b:c", ":", "::", "lisp:car",
+	"true", "false", "nil", "()",
+	"-1", "0", "9223372036854775808",
+	"\n", "\t", `"`, `\`,
+}
+
+// interestingSymbols are symbol names with special meaning to the evaluator
+// or to the special operators that walk caller-supplied fragments by hand.
+var interestingSymbols = []string{
+	"a", "b", "x", "else", "true", "false",
+	"&rest", "&optional", "&key",
+	"lisp:car", "lisp", ":", "", "\xff",
+}
+
+// The Value kind tags.  Ordered so the low tags are the cheap scalar shapes:
+// a mutator that flips a byte down is more likely to shrink a value than to
+// grow it, which keeps minimised crashers small.
+const (
+	kindNil = iota
+	kindBoolTrue
+	kindBoolFalse
+	kindInt
+	kindFloat
+	kindString
+	kindSymbol
+	kindQSymbol
+	kindBytes
+	kindError
+	kindQuote
+	kindSExpr
+	kindQExpr
+	kindVector
+	kindArrayND
+	kindSortMap
+	kindTagged
+	kindNative
+	kindFun
+	kindNumKinds
+)
+
+// Value returns one generated LVal.
+//
+// The returned value may be a shared singleton (see the package doc); callers
+// must treat every generated value as potentially shared and must not mutate
+// it themselves.
+func (g *Gen) Value() *lisp.LVal { return g.value(0) }
+
+func (g *Gen) value(depth int) *lisp.LVal {
+	if g.budget <= 0 {
+		return lisp.Nil()
+	}
+	g.budget--
+
+	kind := g.Intn(kindNumKinds)
+	// Past the depth limit, collapse every compound shape onto a scalar
+	// rather than truncating mid-structure: a half-built array with a
+	// dimension header that disagrees with its cell count is not a value any
+	// real caller can produce, and a crash on one would be a harness bug
+	// reported as a builtin bug.
+	if depth >= maxDepth && kind > kindQuote {
+		kind = g.Intn(kindQuote)
+	}
+
+	switch kind {
+	case kindNil:
+		return lisp.Nil()
+	case kindBoolTrue:
+		return lisp.Bool(true)
+	case kindBoolFalse:
+		return lisp.Bool(false)
+	case kindInt:
+		return lisp.Int(g.pickInt())
+	case kindFloat:
+		return lisp.Float(g.pickFloat())
+	case kindString:
+		return lisp.String(g.pickString())
+	case kindSymbol:
+		return lisp.Symbol(g.pickSymbol())
+	case kindQSymbol:
+		return lisp.QSymbol(g.pickSymbol())
+	case kindBytes:
+		return lisp.Bytes(g.Bytes(g.Intn(maxSeqLen + 1)))
+	case kindError:
+		// An LError is an ordinary first-class value in ELPS; handler-bind
+		// hands one to a user function, which can then pass it anywhere.
+		return lisp.ErrorConditionf("fuzz-condition", "%s", g.pickString())
+	case kindQuote:
+		return lisp.Quote(g.value(depth + 1))
+	case kindSExpr:
+		return lisp.SExpr(g.cells(depth))
+	case kindQExpr:
+		return lisp.QExpr(g.cells(depth))
+	case kindVector:
+		return lisp.Vector(g.cells(depth))
+	case kindArrayND:
+		return g.arrayND(depth)
+	case kindSortMap:
+		return g.sortMap(depth)
+	case kindTagged:
+		return g.tagged(depth)
+	case kindNative:
+		return g.native()
+	case kindFun:
+		return g.fun(depth)
+	}
+	return lisp.Nil()
+}
+
+// funNames are the stdlib callables handed in as first-class function
+// arguments.  Higher-order builtins (map, foldl, apply, funcall, sort,
+// compose, flip, curry) are the ones that call back into an argument, so
+// giving the generator real callables reaches their argument-mismatch paths
+// rather than only their "not a function" rejection.
+var funNames = []string{
+	"lisp:car", "lisp:cdr", "lisp:identity", "lisp:not", "lisp:+",
+	"lisp:length", "lisp:to-string", "lisp:type", "lisp:error",
+	"lisp:list", "lisp:apply", "lisp:map",
+}
+
+// fun returns a first-class function value.
+//
+// THREE DISTINCT SHAPES, because callers discriminate between them and get it
+// wrong:
+//
+//   - a Go builtin (Builtin != nil, Cells = [formals, docstring]);
+//   - a user lambda (Builtin == nil, Cells = [formals, body...]);
+//   - an existing stdlib callable, including special operators and macros,
+//     which several builtins must reject rather than invoke.
+//
+// libschema's constraint calling convention reaches into FunData().Builtin
+// directly, so shape 1 with mismatched arity indexes past the end of an empty
+// args list and shape 2 dereferences a nil Builtin.  Both are only reachable
+// with an LFun in the corpus.
+func (g *Gen) fun(depth int) *lisp.LVal {
+	switch g.Intn(4) {
+	case 0:
+		// A Go builtin. Deliberately declares one formal and ignores its
+		// arguments: a caller that invokes Builtin directly, bypassing bind,
+		// gets whatever list it passed, including an empty one.
+		return lisp.FunInPackage("user", "fuzz-builtin", lisp.Formals("x"),
+			func(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+				if len(args.Cells) == 0 {
+					return lisp.Nil()
+				}
+				return args.Cells[0]
+			})
+	case 1:
+		if g.env == nil {
+			return lisp.Nil()
+		}
+		// A user lambda: Builtin is nil.
+		fn := g.env.Lambda(lisp.Formals("x"), []*lisp.LVal{g.value(depth + 1)})
+		if fn.Type == lisp.LError {
+			return lisp.Nil()
+		}
+		return fn
+	case 2:
+		if g.env == nil {
+			return lisp.Nil()
+		}
+		fn := g.env.GetGlobal(lisp.Symbol(funNames[g.Intn(len(funNames))]))
+		if fn.Type != lisp.LFun {
+			return lisp.Nil()
+		}
+		return fn
+	default:
+		if g.env == nil {
+			return lisp.Nil()
+		}
+		// A special operator or macro in value position. `let` and `defmacro`
+		// are LFun values that FunCall must refuse rather than invoke.
+		fn := g.env.GetGlobal(lisp.Symbol([]string{"lisp:let", "lisp:quote", "lisp:defmacro", "lisp:cond"}[g.Intn(4)]))
+		if fn.Type != lisp.LFun {
+			return lisp.Nil()
+		}
+		return fn
+	}
+}
+
+func (g *Gen) cells(depth int) []*lisp.LVal {
+	n := g.Intn(maxSeqLen)
+	cells := make([]*lisp.LVal, 0, n)
+	for range n {
+		if g.budget <= 0 {
+			break
+		}
+		cells = append(cells, g.value(depth+1))
+	}
+	return cells
+}
+
+func (g *Gen) pickInt() int {
+	if g.Byte()&1 == 0 {
+		return interestingInts[g.Intn(len(interestingInts))]
+	}
+	// A small arbitrary value, so the corpus is not only the boundary
+	// constants.  Sign taken from the same byte to keep the read count fixed.
+	v := int(g.Byte())
+	if g.Byte()&1 == 0 {
+		return -v
+	}
+	return v
+}
+
+func (g *Gen) pickFloat() float64 {
+	if g.Byte()&1 == 0 {
+		return interestingFloats[g.Intn(len(interestingFloats))]
+	}
+	return float64(int8(g.Byte())) / 8
+}
+
+func (g *Gen) pickString() string {
+	if g.Byte()&1 == 0 {
+		return interestingStrings[g.Intn(len(interestingStrings))]
+	}
+	return string(g.Bytes(g.Intn(24)))
+}
+
+func (g *Gen) pickSymbol() string {
+	if g.Byte()&1 == 0 {
+		return interestingSymbols[g.Intn(len(interestingSymbols))]
+	}
+	return string(g.Bytes(g.Intn(8)))
+}
+
+// arrayND builds a multi-dimensional array.  lisp.Array validates that the
+// dimension header multiplies out to the cell count, so the cell slice is
+// sized from the dims rather than generated independently; an array whose
+// header lies is not constructible through any lisp-visible path and would
+// only test lisp.Array's own guard.
+func (g *Gen) arrayND(depth int) *lisp.LVal {
+	ndim := 1 + g.Intn(3)
+	dims := make([]*lisp.LVal, 0, ndim)
+	total := 1
+	for range ndim {
+		d := g.Intn(4)
+		dims = append(dims, lisp.Int(d))
+		total *= d
+	}
+	if total > maxSeqLen {
+		total = 0
+		dims = []*lisp.LVal{lisp.Int(0)}
+	}
+	cells := make([]*lisp.LVal, 0, total)
+	for range total {
+		cells = append(cells, g.value(depth+1))
+	}
+	arr := lisp.Array(lisp.QExpr(dims), cells)
+	if arr.Type == lisp.LError {
+		// Fall back rather than smuggling an LError in under an array tag:
+		// the caller asked for an array-shaped value.
+		return lisp.Vector(nil)
+	}
+	return arr
+}
+
+// sortMap builds a sorted-map.  Keys are strings and symbols in a mix,
+// because sortedmap.Set accepts both and stores them under a keytype
+// discriminator -- code that reads back a key and assumes LString is wrong,
+// and only a symbol-keyed map exposes it.
+func (g *Gen) sortMap(depth int) *lisp.LVal {
+	m := lisp.SortedMap()
+	n := g.Intn(maxSeqLen)
+	for range n {
+		if g.budget <= 0 {
+			break
+		}
+		var key *lisp.LVal
+		if g.Byte()&1 == 0 {
+			key = lisp.String(g.pickString())
+		} else {
+			key = lisp.Symbol(g.pickSymbol())
+		}
+		if lerr := m.Map().Set(key, g.value(depth+1)); lerr.Type == lisp.LError {
+			continue
+		}
+	}
+	return m
+}
+
+// tagged builds a tagged-value.  Tagged values are what deftype/new produce,
+// and their user data is itself an arbitrary LVal, so a builtin that unwraps
+// one and assumes a shape is reachable from ordinary lisp.
+func (g *Gen) tagged(depth int) *lisp.LVal {
+	if g.env == nil {
+		return g.value(depth + 1)
+	}
+	typ := g.pickSymbol()
+	if typ == "" {
+		typ = "user:fuzz-type"
+	}
+	v := g.env.TaggedValue(lisp.Symbol(typ), g.value(depth+1))
+	if v.Type == lisp.LError {
+		return lisp.Nil()
+	}
+	return v
+}
+
+// nativeValues are the Go values an LNative can wrap.  Host applications
+// embed ELPS and hand natives across the boundary, so a builtin that type
+// switches on Native without a default is reachable from real code even
+// though no lisp source can spell these.
+func (g *Gen) native() *lisp.LVal {
+	switch g.Intn(6) {
+	case 0:
+		return lisp.Native(nil)
+	case 1:
+		return lisp.Native(struct{}{})
+	case 2:
+		return lisp.Native(g.pickString())
+	case 3:
+		return lisp.Native(g.pickInt())
+	case 4:
+		return lisp.Native([]byte(g.pickString()))
+	default:
+		return lisp.Native(map[string]int{"a": 1})
+	}
+}
+
+// Seeds returns the shared seed corpus for the value-driven targets.
+//
+// A coverage-guided fuzzer descends from the seeds it is given, so the seeds
+// are chosen to land on the interesting kind tags immediately rather than to
+// be pretty: each entry is a short byte string whose leading bytes select a
+// kind and whose remainder feeds that kind's own reads.
+func Seeds() [][]byte {
+	seeds := [][]byte{
+		{},
+		{0},
+		{1}, {2},
+	}
+	// One seed per kind tag, so the very first generation already covers
+	// every value shape rather than discovering them by mutation.
+	for k := range byte(kindNumKinds) {
+		seeds = append(seeds,
+			[]byte{k, 0, 0, 0, 0, 0, 0, 0},
+			[]byte{k, 1, 2, 3, 4, 5, 6, 7},
+			[]byte{k, 0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9},
+		)
+	}
+	// Deep and wide shapes: repeated compound tags nest, repeated scalar
+	// tags widen.
+	seeds = append(seeds,
+		[]byte{kindSExpr, 8, kindSExpr, 8, kindSExpr, 8, kindSExpr, 8, kindSExpr, 8},
+		[]byte{kindArrayND, 3, 2, 2, 2, kindInt, 0, 1},
+		[]byte{kindSortMap, 8, 0, kindString, 0, 1, 0, kindSymbol, 0, 1},
+		[]byte{kindTagged, 0, 0, kindTagged, 0, 0, kindTagged, 0, 0},
+		[]byte{kindNative, 0}, []byte{kindNative, 5},
+		[]byte{kindFun, 0}, []byte{kindFun, 1}, []byte{kindFun, 2}, []byte{kindFun, 3},
+		[]byte{kindInt, 0, 7},   // math.MaxInt
+		[]byte{kindInt, 0, 8},   // math.MinInt
+		[]byte{kindFloat, 0, 6}, // NaN
+	)
+	return seeds
+}

--- a/internal/fuzzval/fuzzval.go
+++ b/internal/fuzzval/fuzzval.go
@@ -229,7 +229,15 @@ func (g *Gen) value(depth int) *lisp.LVal {
 		// hands one to a user function, which can then pass it anywhere.
 		return lisp.ErrorConditionf("fuzz-condition", "%s", g.pickString())
 	case kindQuote:
-		return lisp.Quote(g.value(depth + 1))
+		// lisp.Quote only produces an LQuote node when its operand is ALREADY
+		// quoted -- one level of quoting is just the Quoted flag on the value
+		// itself (''3, not '3). Quoting twice is the only way to reach the
+		// LQuote type at all, so half the corpus does.
+		v := lisp.Quote(g.value(depth + 1))
+		if g.Byte()&1 == 0 {
+			v = lisp.Quote(v)
+		}
+		return v
 	case kindSExpr:
 		return lisp.SExpr(g.cells(depth))
 	case kindQExpr:

--- a/internal/fuzzval/fuzzval_test.go
+++ b/internal/fuzzval/fuzzval_test.go
@@ -1,0 +1,154 @@
+// Copyright © 2026 The ELPS authors
+
+package fuzzval_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/internal/fuzzval"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+)
+
+func genEnv(tb testing.TB) *lisp.LEnv {
+	tb.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); rc.Type == lisp.LError {
+		tb.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := lisplib.LoadLibrary(env); rc.Type == lisp.LError {
+		tb.Fatalf("load-library: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		tb.Fatalf("in-package: %v", rc)
+	}
+	return env
+}
+
+// TestGeneratorIsDeterministic is the load-bearing property of the whole
+// generator: a saved crasher is a byte string, and it is only a reproduction
+// if those bytes always build the same value. A map iteration, a clock read or
+// a rand call anywhere in fuzzval would silently turn every committed
+// regression case into noise.
+func TestGeneratorIsDeterministic(t *testing.T) {
+	env := genEnv(t)
+	for _, seed := range fuzzval.Seeds() {
+		a := renderN(fuzzval.New(seed, env), 12)
+		b := renderN(fuzzval.New(seed, env), 12)
+		if a != b {
+			t.Fatalf("seed %q produced different values on two runs:\n%s\nvs\n%s", seed, a, b)
+		}
+	}
+}
+
+func renderN(g *fuzzval.Gen, n int) string {
+	out := ""
+	for range n {
+		out += g.Value().String() + "\n"
+	}
+	return out
+}
+
+// TestGeneratorCoversEveryLType asserts the generator actually reaches the
+// shapes it claims to. A generator that quietly stopped producing, say,
+// LNative would leave the targets green while covering strictly less -- the
+// silent-shrinking failure mode a fuzz gate is most vulnerable to.
+func TestGeneratorCoversEveryLType(t *testing.T) {
+	env := genEnv(t)
+	seen := map[lisp.LType]int{}
+	for _, seed := range fuzzval.Seeds() {
+		g := fuzzval.New(seed, env)
+		for range 40 {
+			seen[g.Value().Type]++
+		}
+	}
+	want := []lisp.LType{
+		lisp.LInt, lisp.LFloat, lisp.LString, lisp.LSymbol, lisp.LQSymbol,
+		lisp.LBytes, lisp.LError, lisp.LSExpr, lisp.LArray, lisp.LSortMap,
+		lisp.LTaggedVal, lisp.LNative, lisp.LFun, lisp.LQuote,
+	}
+	for _, ty := range want {
+		if seen[ty] == 0 {
+			t.Errorf("the seed corpus never produced an %v", ty)
+		}
+	}
+}
+
+// TestGeneratorProducesSingletons pins that the shared Nil()/Bool() values
+// really are handed to builtins. That is the only way the elpscheck singleton
+// guard and the per-iteration SingletonSnapshot check have anything to catch;
+// a generator that always allocated fresh values would make both vacuous.
+func TestGeneratorProducesSingletons(t *testing.T) {
+	env := genEnv(t)
+	nilV, trueV, falseV := lisp.Nil(), lisp.Bool(true), lisp.Bool(false)
+	var sawNil, sawTrue, sawFalse bool
+	for _, seed := range fuzzval.Seeds() {
+		g := fuzzval.New(seed, env)
+		for range 40 {
+			switch v := g.Value(); v {
+			case nilV:
+				sawNil = true
+			case trueV:
+				sawTrue = true
+			case falseV:
+				sawFalse = true
+			}
+		}
+	}
+	if !sawNil || !sawTrue || !sawFalse {
+		t.Errorf("singletons missing from the corpus: nil=%v true=%v false=%v",
+			sawNil, sawTrue, sawFalse)
+	}
+}
+
+// TestGeneratorIsBounded pins the allocation cap. Without it a handful of
+// bytes can request an exponentially large tree and the target spends its
+// budget in the allocator instead of in the code under test.
+func TestGeneratorIsBounded(t *testing.T) {
+	env := genEnv(t)
+	// The most expansion-hungry input available: every byte selects the
+	// widest compound kind with the largest child count.
+	data := make([]byte, 4096)
+	for i := range data {
+		data[i] = 0xff
+	}
+	g := fuzzval.New(data, env)
+	total := 0
+	for range 8 {
+		total += countCells(g.Value(), 0)
+	}
+	if total > 4*fuzzval.Budget {
+		t.Errorf("generated %d cells from one Gen; Budget is %d", total, fuzzval.Budget)
+	}
+}
+
+func countCells(v *lisp.LVal, depth int) int {
+	if v == nil || depth > 32 {
+		return 1
+	}
+	n := 1
+	if v.Type == lisp.LFun {
+		// A validator/lambda's cells are its formals and body, not generated
+		// payload; counting them would measure the interpreter, not the
+		// generator.
+		return n
+	}
+	for _, c := range v.Cells {
+		n += countCells(c, depth+1)
+	}
+	return n
+}
+
+// TestSeedsAreDistinct keeps the corpus from carrying duplicates, which cost
+// a baseline-coverage iteration each and buy nothing.
+func TestSeedsAreDistinct(t *testing.T) {
+	seen := make(map[string]int)
+	for i, s := range fuzzval.Seeds() {
+		if prev, ok := seen[string(s)]; ok {
+			t.Errorf("seed %d duplicates seed %d (%v)", i, prev, s)
+		}
+		seen[string(s)] = i
+	}
+}

--- a/internal/fuzzval/fuzzval_test.go
+++ b/internal/fuzzval/fuzzval_test.go
@@ -3,6 +3,7 @@
 package fuzzval_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/luthersystems/elps/internal/fuzzval"
@@ -44,11 +45,12 @@ func TestGeneratorIsDeterministic(t *testing.T) {
 }
 
 func renderN(g *fuzzval.Gen, n int) string {
-	out := ""
+	var out strings.Builder
 	for range n {
-		out += g.Value().String() + "\n"
+		out.WriteString(g.Value().String())
+		out.WriteByte('\n')
 	}
-	return out
+	return out.String()
 }
 
 // TestGeneratorCoversEveryLType asserts the generator actually reaches the

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -2410,6 +2410,30 @@ func builtinPow(env *LEnv, args *LVal) *LVal {
 	return Float(math.Pow(toFloat(a), toFloat(b)))
 }
 
+// powInt raises a to the b-th power in int arithmetic, wrapping on overflow
+// exactly as Go's `*` does.
+//
+// Binary exponentiation: at most 63 iterations for any b, because b is
+// halved every turn.  The previous implementation doubled an exponent
+// accumulator instead --
+//
+//	n := 1; atob := a
+//	for 2*n < b { atob *= atob; n *= 2 }
+//	for n < b   { atob *= a;    n++ }
+//
+// -- and for b > 2^62 that loop never terminates.  n doubles 1, 2, ..., 2^62,
+// then 2^63 wraps to MinInt, then MinInt*2 wraps to exactly 0, and 2*0 < b is
+// true forever.  Zero is a true fixed point: the loop allocates nothing and
+// evaluates nothing, so it is invisible to MaxAlloc, to MaxSteps AND to a
+// context deadline -- none of those are consulted inside a builtin.
+// (pow -128 9223372036854775807) hung the process until something killed it.
+// Found by FuzzApplyStdlib as (pow -9223372036854775808 9223372036854775806).
+//
+// The result is unchanged wherever the old loop terminated.  Go's int
+// multiplication is arithmetic mod 2^64, which is a commutative ring, so the
+// order in which the b factors are associated cannot change the product --
+// squaring-and-multiplying and multiplying b times agree bit for bit,
+// including on the wrapped answers.  (pow 2 64) still returns 0.
 func powInt(a, b int) *LVal {
 	if b == 0 {
 		return Int(1)
@@ -2417,15 +2441,16 @@ func powInt(a, b int) *LVal {
 	if b < 0 {
 		return Float(math.Pow(float64(a), float64(b)))
 	}
-	n := 1
-	atob := a
-	for 2*n < b {
-		atob *= atob
-		n *= 2
-	}
-	for n < b {
-		atob *= a
-		n++
+	atob := 1
+	base := a
+	for b > 0 {
+		if b&1 == 1 {
+			atob *= base
+		}
+		b >>= 1
+		if b > 0 {
+			base *= base
+		}
 	}
 	return Int(atob)
 }

--- a/lisp/config.go
+++ b/lisp/config.go
@@ -135,8 +135,16 @@ func WithContext(ctx context.Context) Config {
 
 // WithMaxSteps returns a Config that sets the maximum number of evaluation
 // steps before evaluation returns a CondStepLimitExceeded error.  A step is
-// counted for each Eval entry, each TRO iteration, and each macro
-// re-expansion.  A value of 0 means unlimited (the default).
+// counted for each Eval entry, each TRO iteration, each macro re-expansion,
+// and each turn of a dotimes loop.  A value of 0 means unlimited (the
+// default).
+//
+// The dotimes turn is counted because an empty-bodied loop evaluates nothing:
+// (dotimes (i 2147483647)) consumed no budget and could not be interrupted.
+// One consequence is that a dotimes-heavy program costs one more step per
+// turn than it did before that was fixed — a one-form body went from 4 to 5
+// steps per turn — so a budget pinned tightly against a measured figure may
+// need raising.
 //
 // The budget is per top-level evaluation: the counter is reset each time an
 // exported entry point (Eval, EvalContext, EvalSExpr, FunCall,

--- a/lisp/config.go
+++ b/lisp/config.go
@@ -140,11 +140,12 @@ func WithContext(ctx context.Context) Config {
 // default).
 //
 // The dotimes turn is counted because an empty-bodied loop evaluates nothing:
-// (dotimes (i 2147483647)) consumed no budget and could not be interrupted.
-// One consequence is that a dotimes-heavy program costs one more step per
-// turn than it did before that was fixed — a one-form body went from 4 to 5
-// steps per turn — so a budget pinned tightly against a measured figure may
-// need raising.
+// (dotimes (i 2147483647)) consumed no budget and could not be interrupted at
+// all.  It costs exactly one extra step per turn, so a dotimes-heavy program
+// now uses more budget than it did -- proportionally most for a small body (a
+// constant body goes from 1 step per turn to 2; a three-form body from 12 to
+// 13).  A budget pinned tightly against a previously measured figure may need
+// raising.  opDoTimes carries the full measurement table.
 //
 // The budget is per top-level evaluation: the counter is reset each time an
 // exported entry point (Eval, EvalContext, EvalSExpr, FunCall,

--- a/lisp/dotimes_limit_test.go
+++ b/lisp/dotimes_limit_test.go
@@ -1,0 +1,173 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+)
+
+// dotimes counts a step per TURN, not only per body form. These tests pin
+// what that buys, what it costs, and -- importantly -- what it does NOT buy.
+//
+// The defect: (dotimes (i 2147483647)) with an EMPTY body evaluates nothing.
+// Every evaluation limit in the interpreter is reached through Eval, so an
+// empty-bodied loop incremented no counter and consulted no context.
+// Measured on this machine before the fix: 2e8 turns ran 44.2s of
+// uninterruptible CPU against a 2s context deadline, and the cancellation was
+// only observed once the loop had finished on its own. count.Int can be
+// MaxInt, so there is no upper bound at all. After the fix the same program
+// returns at 2.003s.
+
+func limitEnv(tb testing.TB, configs ...lisp.Config) *lisp.LEnv {
+	tb.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	for _, cfg := range configs {
+		if rc := cfg(env); rc.Type == lisp.LError {
+			tb.Fatalf("config: %v", rc)
+		}
+	}
+	if rc := lisp.InitializeUserEnv(env); rc.Type == lisp.LError {
+		tb.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		tb.Fatalf("in-package: %v", rc)
+	}
+	return env
+}
+
+// TestDoTimesEmptyBodyRespectsContext is the regression test.
+//
+// Bounded out of band, on its own goroutine: reverting the fix does not
+// produce a wrong answer, it produces no answer for ~44s, and a plain
+// synchronous test would simply appear to be slow rather than failing.
+func TestDoTimesEmptyBodyRespectsContext(t *testing.T) {
+	env := limitEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	done := make(chan *lisp.LVal, 1)
+	start := time.Now()
+	go func() {
+		done <- env.LoadStringContext(ctx, "dotimes-ctx", "(dotimes (i 2000000000))")
+	}()
+	select {
+	case v := <-done:
+		elapsed := time.Since(start)
+		if v.Type != lisp.LError {
+			t.Fatalf("expected a cancellation error, got %v after %v", v, elapsed)
+		}
+		if !strings.Contains(v.Str, lisp.CondContextCancelled) {
+			t.Fatalf("expected condition %q, got %q (%v)", lisp.CondContextCancelled, v.Str, v)
+		}
+		// 200ms deadline; anything under a couple of seconds means the loop
+		// is polling the context rather than running to completion (2e9 turns
+		// would take several minutes).
+		if elapsed > 5*time.Second {
+			t.Errorf("cancellation observed only after %v", elapsed)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatalf("an empty-bodied dotimes ignored a 200ms context deadline for 20s")
+	}
+}
+
+// TestDoTimesEmptyBodyRespectsMaxSteps pins the other half: a step budget now
+// bounds an empty-bodied loop, where before it bounded nothing.
+func TestDoTimesEmptyBodyRespectsMaxSteps(t *testing.T) {
+	env := limitEnv(t, lisp.WithMaxSteps(1000))
+	done := make(chan *lisp.LVal, 1)
+	go func() {
+		done <- env.LoadString("dotimes-steps", "(dotimes (i 2000000000))")
+	}()
+	select {
+	case v := <-done:
+		if v.Type != lisp.LError {
+			t.Fatalf("expected a step-limit error, got %v", v)
+		}
+		if !strings.Contains(v.Str, lisp.CondStepLimitExceeded) {
+			t.Fatalf("expected condition %q, got %q (%v)", lisp.CondStepLimitExceeded, v.Str, v)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatalf("an empty-bodied dotimes ignored a 1000-step budget for 20s")
+	}
+}
+
+// TestDoTimesStepCostPerTurn pins the COST of the fix, so that a change to it
+// is deliberate rather than discovered by a user whose program stopped
+// running.
+//
+// A turn now costs one step more than it did. Measured on this tree, at 1500
+// turns:
+//
+//	body forms   before   after    per turn      delta
+//	0                 4    1504    0 -> 1        (the whole point)
+//	1              6004    7504    4 -> 5        +25.0%
+//	2             12004   13504    8 -> 9        +12.5%
+//
+// The absolute numbers include 4 steps of fixed overhead for the enclosing
+// load and the dotimes form itself.
+//
+// THIS IS A BEHAVIOUR CHANGE FOR PROGRAMS NEAR A STEP LIMIT. A one-form loop
+// of 1500 turns used to consume 6004 steps and now consumes 7504, so a
+// runtime configured with WithMaxSteps(7000) accepted that program before and
+// rejects it now. That is ordinary code, not pathological input. Callers who
+// pin a budget will need to raise it.
+func TestDoTimesStepCostPerTurn(t *testing.T) {
+	cases := []struct {
+		name       string
+		src        string
+		wantSteps  int64
+		perTurnDoc string
+	}{
+		{"empty body, 1500 turns", "(dotimes (i 1500))", 1504, "1 step/turn"},
+		{"one form, 1500 turns", "(dotimes (i 1500) (+ i 1))", 7504, "5 steps/turn"},
+		{"two forms, 1500 turns", "(dotimes (i 1500) (+ i 1) (- i 1))", 13504, "9 steps/turn"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			env := limitEnv(t)
+			env.Runtime.ResetSteps()
+			v := env.LoadStringContext(context.Background(), "cost", c.src)
+			if v.Type == lisp.LError {
+				t.Fatalf("evaluation failed: %v", v)
+			}
+			if got := env.Runtime.Steps(); got != c.wantSteps {
+				t.Errorf("%s (%s): %d steps, want %d", c.name, c.perTurnDoc, got, c.wantSteps)
+			}
+		})
+	}
+}
+
+// TestDoTimesUnboundedWithNeitherLimit records what the fix does NOT do, so
+// nobody reads the step counting as a guarantee it is not.
+//
+// LEnv.checkLimits short-circuits when the runtime has NEITHER a context NOR
+// a step limit: with both unset there is nothing to check and the fast path
+// returns immediately. An embedder who configures neither therefore still has
+// an uninterruptible dotimes. The counter staying at its pre-loop value is
+// the observable form of that.
+//
+// Substrate configures a context but no MaxSteps, so what it gains here is
+// cancellability, not a bound.
+func TestDoTimesUnboundedWithNeitherLimit(t *testing.T) {
+	env := limitEnv(t)
+	env.Runtime.ResetSteps()
+	// LoadString (not LoadStringContext) leaves evalCtx nil, and no
+	// WithMaxSteps was configured.
+	v := env.LoadString("no-limits", "(dotimes (i 1000))")
+	if v.Type == lisp.LError {
+		t.Fatalf("evaluation failed: %v", v)
+	}
+	if got := env.Runtime.Steps(); got != 0 {
+		t.Errorf("with neither a context nor a step limit configured, the fast "+
+			"path should count nothing; counted %d steps. If this changed "+
+			"deliberately, checkLimits' short-circuit changed with it and the "+
+			"comment in opDoTimes needs updating.", got)
+	}
+}

--- a/lisp/lisplib/fuzz_test.go
+++ b/lisp/lisplib/fuzz_test.go
@@ -1,0 +1,355 @@
+// Copyright © 2026 The ELPS authors
+
+package lisplib_test
+
+import (
+	"context"
+	"io"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/internal/fuzzval"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+)
+
+// FuzzApplyStdlib applies every callable the standard library registers -- the
+// 135 core `lisp` builtins, special operators and macros plus all 105 stdlib
+// exports across base64, golang, help, json, math, regexp, s, string, testing
+// and time -- to argument lists built by internal/fuzzval.
+//
+// WHY THIS SURFACE.  Downstream (luthersystems/substrate) a phylum is
+// customer-supplied source uploaded and run as Hyperledger Fabric chaincode.
+// Every one of these callables is reachable from that phylum with arguments
+// the phylum author chooses, so a panic, a hang or a corrupted shared
+// singleton in any of them is remotely triggerable.  Before this target the
+// only fuzzed stdlib code was libjson's DECODE path.
+//
+// WHY DIRECT APPLICATION RATHER THAN EVALUATING SOURCE.  Two reasons.
+//
+//   - Special operators and macros receive UNEVALUATED arguments.  let, cond,
+//     dotimes and friends walk a caller-supplied fragment by hand before
+//     anything is evaluated, and MacroCall WRITES to the nodes a macro returns.
+//     Handing them an arbitrary LVal tree is the calling convention they
+//     actually have.
+//   - Several argument shapes have no source spelling at all (natives,
+//     multi-dimensional arrays, symbol-keyed sorted-maps, error values in
+//     argument position).  See the internal/fuzzval package doc.
+//
+// A panic here is NOT converted to an LError: FunCall / SpecialOpCall /
+// MacroCall have no recover(), unlike LEnv.eval.  A crashing input therefore
+// surfaces with the Go stack of the offending builtin, which is the whole
+// point.  (env.eval's recover is a backstop for embedders, not a licence for
+// builtins to panic: it turns the crash into an `internal-panic` condition
+// that handler-bind is documented NOT to catch.)
+//
+// INVARIANTS
+//
+//  1. No panic escapes the call.
+//  2. The result is never a nil *LVal.  A nil return is a contract violation
+//     that env.call would have to paper over with a synthesised error.
+//  3. LVal.String() of the result terminates and does not panic.  Every error
+//     path in the interpreter renders its operands, so an unprintable value is
+//     a latent crash in the error path.
+//  4. The three shared singletons (Nil(), Bool(true), Bool(false)) are
+//     bit-identical afterwards.  fuzzval deliberately feeds the singletons in
+//     as arguments; anything that writes through one corrupts every other
+//     holder.  See lisp/singleton.go and issue #274.  Under `go test -tags
+//     elpscheck` the same corruption is additionally caught at the next
+//     Bool()/Nil() read, which localises it far better -- run
+//     `make test-elpscheck` for that.
+//  5. The call terminates.  Bounded by a context deadline, a step limit and,
+//     because neither of those can see a loop that evaluates nothing, an
+//     out-of-band watchdog.  Two of the three defects this target found were
+//     invisible to the first two: (pow -128 <MaxInt>) allocates nothing and
+//     evaluates nothing, and (dotimes (i 2147483647)) with an empty body
+//     counted no steps.
+//
+// NOT ASSERTED
+//
+//   - Reflexivity.  LVal.Equal returns false for LError, LFun, LQuote, LBytes
+//     and LNative even against the same object, and (= NaN NaN) is false.  An
+//     `x.Equal(x)` assertion would fire on correct behaviour.
+//   - Refusal is not failure.  MaxAlloc is set deliberately LOW (see
+//     fuzzMaxAlloc) so the fuzzer spends its budget exploring the allocation
+//     guard instead of OOM-ing the runner.  A builtin returning "allocation
+//     size N exceeds maximum" is the guard working.
+//   - Any particular error message or condition type.
+func FuzzApplyStdlib(f *testing.F) {
+	// Enumerate once outside the fuzz body: the callable set is a property of
+	// the library, not of the input, and re-deriving it per iteration would
+	// dominate the runtime.
+	names := callableNames(f)
+	if len(names) < 200 {
+		// A harness that silently enumerates nothing cannot fail. The library
+		// registers 240 callables today across 11 packages; 200 is a floor
+		// that a package being dropped from LoadLibrary would breach.
+		f.Fatalf("enumerated only %d callables; the stdlib surface should be far larger", len(names))
+	}
+
+	// The seed corpus is the cross of two axes, sampled rather than fully
+	// crossed. A full cross is 240 callables x 57 value seeds = 13,680 entries,
+	// and each entry builds a fresh environment (measured 1.08ms), so the full
+	// cross would add ~15s to every `make test`. The sampled cross is ~890
+	// entries (~1s) and still guarantees that every callable and every value
+	// shape appears at least once in the corpus the fuzzer descends from.
+	valueSeeds := fuzzval.Seeds()
+	for i := range len(names) {
+		idx := uint16(i) //nolint:gosec // G115: i < len(names), a few hundred
+		for _, j := range []int{0, len(valueSeeds) / 2, len(valueSeeds) - 1} {
+			f.Add(idx, valueSeeds[j])
+		}
+	}
+	for i, seed := range valueSeeds {
+		for _, j := range []int{0, len(names) / 2, len(names) - 1} {
+			f.Add(uint16((i+j)%len(names)), seed) //nolint:gosec // G115: modulo len(names)
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, idx uint16, data []byte) {
+		name := names[int(idx)%len(names)]
+		if skipCallable(name) {
+			return
+		}
+
+		before := lisp.TakeSingletonSnapshot()
+
+		ctx, cancel := context.WithTimeout(context.Background(), callDeadline)
+		defer cancel()
+
+		env := fuzzEnv(t, ctx)
+		fun := env.GetGlobal(lisp.Symbol(name))
+		if fun.Type != lisp.LFun {
+			t.Fatalf("%s: expected a function, got %v", name, fun.Type)
+		}
+
+		gen := fuzzval.New(data, env)
+		args := lisp.SExpr(genArgs(gen, fun))
+
+		result := applyWithWatchdog(t, env, name, fun, args)
+
+		if result == nil {
+			t.Fatalf("%s returned a nil *LVal", name)
+		}
+		// Rendering the result exercises the same code every error path in the
+		// interpreter runs when it formats an operand.
+		_ = result.String()
+
+		if drift := before.Verify(); drift != "" {
+			t.Fatalf("%s mutated the shared singleton %s\n--- args ---\n%s", name, drift, args)
+		}
+	})
+}
+
+// callDeadline bounds one application.  Generous relative to the work any
+// correct builtin does with fuzzval-sized arguments (the whole seed corpus
+// runs in well under a second), tight enough that a genuine non-terminating
+// loop is reported rather than eating the target's whole -fuzztime.
+const callDeadline = 5 * time.Second
+
+// watchdogGrace is how long past callDeadline the watchdog waits before
+// declaring the call unbounded.  A call that has blown the context deadline by
+// this much is not "slow": it is in a loop that never consults the context.
+const watchdogGrace = 10 * time.Second
+
+// fuzzMaxAlloc is the per-operation allocation cap.  Deliberately tiny.  The
+// default is 10M elements; at that size a single (make-sequence <big>) costs
+// hundreds of milliseconds and a handful of them OOM a CI runner, so the
+// fuzzer would spend its budget on the allocator rather than on the code under
+// test.  At 4096 the guard itself is what gets explored, which is the
+// interesting boundary.
+const fuzzMaxAlloc = 4096
+
+// fuzzMaxSteps bounds evaluation work for the callables that evaluate their
+// arguments (every special operator, every macro expansion).  Small enough
+// that a runaway recursion is cut off in milliseconds.
+const fuzzMaxSteps = 20000
+
+// applyWithWatchdog applies fun to args on a separate goroutine and fails the
+// test if the call outlives the context deadline by watchdogGrace.
+//
+// A watchdog is necessary because neither of the interpreter's own bounds sees
+// every loop.  checkLimits is consulted per EVALUATION; a builtin that loops
+// in Go without evaluating anything -- powInt's doubling loop, opDoTimes with
+// an empty body -- consults nothing and is bounded by nothing.  `go test
+// -fuzz` has no per-input timeout, so without this the failure mode is the
+// whole test binary being killed by -timeout with no crasher written out.
+//
+// The goroutine is deliberately leaked on timeout: it cannot be interrupted
+// (that is the defect being reported), and a fuzz worker that reports a
+// crasher exits immediately afterwards.
+func applyWithWatchdog(t *testing.T, env *lisp.LEnv, name string, fun, args *lisp.LVal) *lisp.LVal {
+	t.Helper()
+	done := make(chan *lisp.LVal, 1)
+	panicked := make(chan any, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked <- r
+			}
+		}()
+		done <- apply(env, fun, args)
+	}()
+	select {
+	case v := <-done:
+		return v
+	case r := <-panicked:
+		// Re-panic on the test goroutine so the fuzzing engine records the
+		// crasher and prints the stack.
+		panic(r)
+	case <-time.After(callDeadline + watchdogGrace):
+		t.Fatalf("%s did not terminate within %v despite a %v context deadline and a %d-step limit\n--- args ---\n%s",
+			name, callDeadline+watchdogGrace, callDeadline, fuzzMaxSteps, args)
+		return nil
+	}
+}
+
+// apply dispatches to the calling convention the callable actually has.
+// Special operators and macros must NOT go through FunCall: it rejects them,
+// and more importantly it would evaluate nothing but also bind nothing,
+// missing the unevaluated-fragment surface entirely.
+func apply(env *lisp.LEnv, fun, args *lisp.LVal) *lisp.LVal {
+	switch {
+	case fun.IsSpecialOp():
+		return env.SpecialOpCall(fun, args)
+	case fun.IsMacro():
+		return env.MacroCall(fun, args)
+	default:
+		return env.FunCall(fun, args)
+	}
+}
+
+// genArgs builds an argument list sized against the callable's declared
+// formals.
+//
+// Arity is respected on purpose.  Builtins index args.Cells directly --
+// builtinPow's first statement is `args.Cells[0], args.Cells[1]` -- because
+// LEnv.bind guarantees the arity before the builtin runs.  Handing a two-arg
+// builtin zero arguments would report a harness bug as a builtin bug.  What is
+// fuzzed is the VALUE of each argument, plus the variadic count where the
+// formals declare one.
+func genArgs(gen *fuzzval.Gen, fun *lisp.LVal) []*lisp.LVal {
+	formals := fun.Cells[0]
+	required := 0
+	variadic := false
+	for _, sym := range formals.Cells {
+		switch sym.Str {
+		case lisp.VarArgSymbol, lisp.OptArgSymbol, lisp.KeyArgSymbol:
+			variadic = true
+		default:
+			if !variadic {
+				required++
+			}
+		}
+	}
+	n := required
+	if variadic {
+		n += gen.Intn(4)
+	}
+	args := make([]*lisp.LVal, 0, n)
+	for range n {
+		args = append(args, gen.Value())
+	}
+	return args
+}
+
+// skipCallable names the callables excluded from the sweep, with the reason
+// each is excluded.  The list is deliberately short: an exclusion is a hole in
+// the gate.
+func skipCallable(name string) bool {
+	switch name {
+	case "time:sleep":
+		// BuiltinSleep blocks for a caller-supplied duration inside a single
+		// evaluation step.  No budget in the interpreter can bound it: the
+		// step counter is not consulted mid-builtin and the context is not
+		// threaded into time.Sleep.  That is issue #314 and is out of scope
+		// here -- fixing it means changing the builtin's contract, not the
+		// fuzz harness.  Excluded by NAME rather than by a duration cap so
+		// the exclusion is visible and reviewable.
+		return true
+	case "testing:test", "testing:test-let", "testing:test-let*",
+		"testing:benchmark", "testing:benchmark-simple":
+		// libtesting drives the Go testing runner through the environment and
+		// reports through it. Applied outside elpstest.Runner it reports
+		// against the FUZZ TARGET's own *testing.T, so a generated argument
+		// can fail or skip the fuzz iteration itself -- the harness would be
+		// grading its own input. Their non-runner code paths are ordinary
+		// builtins covered by libtesting's own tests.
+		return true
+	default:
+		return false
+	}
+}
+
+// callableNames returns every function, macro and special operator registered
+// by the standard library, as qualified symbols, sorted so the index a crasher
+// records means the same thing on every machine and every run.
+//
+// Sorting matters more than it looks: Go map iteration is randomised, so an
+// unsorted list would make a saved crasher select a DIFFERENT callable on
+// replay, and the regression case would silently stop testing what it caught.
+func callableNames(tb testing.TB) []string {
+	tb.Helper()
+	env := newStdlibEnv(tb)
+	var names []string
+	for pkgName, pkg := range env.Runtime.Registry.Packages {
+		for sym, v := range pkg.Symbols {
+			if v == nil || v.Type != lisp.LFun {
+				continue
+			}
+			if pkgName == lisp.DefaultUserPackage {
+				continue
+			}
+			names = append(names, pkgName+":"+sym)
+		}
+	}
+	slices.Sort(names)
+	return slices.Compact(names)
+}
+
+// fuzzEnv builds a fresh environment per iteration.
+//
+// Fresh, not cached, because these callables MUTATE the environment: set,
+// defun, in-package, use-package and export all write to it. A cached env
+// would make iteration N's result depend on iterations 0..N-1, so a saved
+// crasher would not reproduce from a clean start -- which is the one property
+// a regression corpus has to have.
+func fuzzEnv(tb testing.TB, ctx context.Context) *lisp.LEnv {
+	tb.Helper()
+	env := newStdlibEnv(tb,
+		lisp.WithContext(ctx),
+		lisp.WithMaxSteps(fuzzMaxSteps),
+		lisp.WithMaxAlloc(fuzzMaxAlloc),
+	)
+	// debug-print, debug-stack and trace write to the runtime's stderr.
+	// Left at os.Stderr they bury the fuzzer's own output.
+	env.Runtime.Stderr = io.Discard
+	// load-file resolves through the source library. Nil-ing it turns every
+	// filesystem read into a clean lisp-level error instead of letting a
+	// generated string name a path on the runner.
+	env.Runtime.Library = nil
+	return env
+}
+
+func newStdlibEnv(tb testing.TB, configs ...lisp.Config) *lisp.LEnv {
+	tb.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	for _, cfg := range configs {
+		if rc := cfg(env); rc.Type == lisp.LError {
+			tb.Fatalf("config: %v", rc)
+		}
+	}
+	if rc := lisp.InitializeUserEnv(env); rc.Type == lisp.LError {
+		tb.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := lisplib.LoadLibrary(env); rc.Type == lisp.LError {
+		tb.Fatalf("load-library: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		tb.Fatalf("in-package: %v", rc)
+	}
+	return env
+}

--- a/lisp/lisplib/fuzz_test.go
+++ b/lisp/lisplib/fuzz_test.go
@@ -96,7 +96,7 @@ func FuzzApplyStdlib(f *testing.F) {
 	// entries (~1s) and still guarantees that every callable and every value
 	// shape appears at least once in the corpus the fuzzer descends from.
 	valueSeeds := fuzzval.Seeds()
-	for i := range len(names) {
+	for i := range names {
 		idx := uint16(i) //nolint:gosec // G115: i < len(names), a few hundred
 		for _, j := range []int{0, len(valueSeeds) / 2, len(valueSeeds) - 1} {
 			f.Add(idx, valueSeeds[j])

--- a/lisp/lisplib/libjson/fuzz_test.go
+++ b/lisp/lisplib/libjson/fuzz_test.go
@@ -7,8 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/luthersystems/elps/internal/fuzzval"
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/lisplib/libjson"
+	"github.com/luthersystems/elps/parser"
 )
 
 // libjson decodes untrusted JSON: in substrate this is chaincode state and
@@ -104,4 +106,120 @@ func FuzzLoadJSON(f *testing.F) {
 			t.Fatalf("Dump is not deterministic\n--- run 1 ---\n%s\n--- run 2 ---\n%s", enc, enc2)
 		}
 	})
+}
+
+// FuzzDumpJSON fuzzes the ENCODE direction, which FuzzLoadJSON structurally
+// cannot reach.
+//
+// FuzzLoadJSON only ever hands Dump a value that Load produced, and Load emits
+// exactly six shapes: string, float, bool, nil, array, sorted-map. Everything
+// else a phylum can put in front of json:dump-string -- a tagged-value from
+// deftype/new, an LNative handed in by host code, a multi-dimensional array,
+// an integer, a byte slice, a function, an error value, a symbol-keyed
+// sorted-map -- has never been encoded under fuzzing. In substrate the value
+// being serialised is phylum state, so its shape is chosen by the phylum
+// author, not by the decoder.
+//
+// INVARIANTS
+//
+//  1. Dump does not panic. An unsupported type must come back as an error.
+//  2. Dump is deterministic. Sorted-map iteration is the part that could
+//     drift, and a phylum that hashes or compares serialised state depends on
+//     it.
+//  3. Whatever Dump accepts, Load must be able to read back, and the value
+//     must then be STABLE under further round trips. Emitting bytes that the
+//     package's own decoder rejects is the strongest form of encoder bug
+//     there is.
+//  4. The shared singletons are unmutated.
+//
+// NOT ASSERTED: that Load's result equals the ORIGINAL value, and not that
+// re-encoding reproduces the ORIGINAL bytes. Neither holds, for reasons that
+// are known and out of scope:
+//
+//   - A tagged-value, an integer or a byte slice does not survive a JSON round
+//     trip as itself.
+//   - json.Load rounds every number through float64 (the >2^53 rounding).
+//   - encoding/json replaces invalid UTF-8 with U+FFFD, and escapes it as
+//     \ufffd on the way out; decoding that yields a real U+FFFD rune, which
+//     re-encodes as the literal character. So Dump("\xfd") != Dump(Load(Dump(
+//     "\xfd"))) at the byte level even though the VALUE is stable. Measured on
+//     the seed corpus, so asserting byte identity against the first encode
+//     would be permanent noise rather than a finding.
+//
+// The comparison is therefore made on the far side of every lossy conversion:
+// the SECOND decode against the FIRST, exactly as FuzzLoadJSON does.
+func FuzzDumpJSON(f *testing.F) {
+	for _, seed := range fuzzval.Seeds() {
+		for _, mode := range stringNumberModes() {
+			f.Add(seed, mode)
+		}
+	}
+	f.Fuzz(func(t *testing.T, data []byte, stringNums bool) {
+		before := lisp.TakeSingletonSnapshot()
+
+		env := newJSONEnv(t)
+		gen := fuzzval.New(data, env)
+		v := gen.Value()
+
+		enc, err := libjson.Dump(v, stringNums)
+		if err != nil {
+			// Refusing a value it cannot represent is correct behaviour, not
+			// a finding. Rendering the value is still exercised: every error
+			// path in the interpreter formats its operands.
+			_ = v.String()
+			return
+		}
+
+		enc2, err := libjson.Dump(v, stringNums)
+		if err != nil {
+			t.Fatalf("Dump succeeded then failed on the same value: %v\n--- value ---\n%s", err, v)
+		}
+		if !bytes.Equal(enc, enc2) {
+			t.Fatalf("Dump is not deterministic\n--- run 1 ---\n%s\n--- run 2 ---\n%s\n--- value ---\n%s",
+				enc, enc2, v)
+		}
+
+		back := libjson.Load(enc, stringNums)
+		if back == nil {
+			t.Fatalf("Load returned a nil LVal for Dump's output\n--- encoded ---\n%s", enc)
+		}
+		if back.Type == lisp.LError {
+			t.Fatalf("Load rejected Dump's own output: %s\n--- encoded ---\n%s\n--- value ---\n%s",
+				back, enc, v)
+		}
+		reenc, err := libjson.Dump(back, stringNums)
+		if err != nil {
+			t.Fatalf("Dump rejected the value its own output decoded to: %v\n--- encoded ---\n%s", err, enc)
+		}
+		again := libjson.Load(reenc, stringNums)
+		if again == nil || again.Type == lisp.LError {
+			t.Fatalf("Load rejected the re-encoded output: %v\n--- re-encoded ---\n%s", again, reenc)
+		}
+		if got, want := again.String(), back.String(); got != want {
+			t.Fatalf("the value drifted across a second round trip\n--- first decode ---\n%s\n--- second decode ---\n%s\n--- encoded ---\n%s\n--- re-encoded ---\n%s",
+				want, got, enc, reenc)
+		}
+
+		if drift := before.Verify(); drift != "" {
+			t.Fatalf("Dump/Load mutated the shared singleton %s\n--- value ---\n%s", drift, v)
+		}
+	})
+}
+
+// newJSONEnv exists only so the generator can build tagged-values, which need
+// an LEnv to stamp a source location. libjson itself is package-level.
+func newJSONEnv(tb testing.TB) *lisp.LEnv {
+	tb.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); rc.Type == lisp.LError {
+		tb.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := libjson.LoadPackage(env); rc.Type == lisp.LError {
+		tb.Fatalf("load libjson: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		tb.Fatalf("in-package: %v", rc)
+	}
+	return env
 }

--- a/lisp/lisplib/libschema/foreign_constraint_test.go
+++ b/lisp/lisplib/libschema/foreign_constraint_test.go
@@ -1,0 +1,297 @@
+// Copyright © 2026 The ELPS authors
+
+package libschema_test
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libschema"
+)
+
+// libschema invokes constraints through a PRIVATE calling convention: a
+// validator's Go closure takes the value under test directly, not an argument
+// list, so constraints are called by reaching into FunData().Builtin rather
+// than through LEnv.FunCall. Nothing in the type system enforced that the
+// value in a constraint slot was actually built by this package, so any LFun
+// landed there and was invoked with a bare value:
+//
+//	(s:validate identity 1)        -> index out of range [0] with length 0
+//	(s:validate (lambda (x) x) 1)  -> nil pointer dereference (Builtin is nil)
+//
+// Both are reachable from phylum source, which in substrate is
+// customer-supplied. These tests cover the CLASS -- every constraint slot in
+// the package -- not the two reported instances.
+
+// TestForeignFunctionInConstraintSlot drives an ordinary function and an ELPS
+// lambda into every constraint slot the s package exposes.
+//
+// Each case must produce an ordinary lisp error. Specifically NOT:
+//
+//   - an internal-panic condition (a recovered Go panic, i.e. a crash), which
+//     is what every one of these did before; and
+//   - a successful validation, which is worse -- see the s:when case.
+func TestForeignFunctionInConstraintSlot(t *testing.T) {
+	// Each source is run twice, once with `identity` (a Go builtin, whose
+	// Builtin is non-nil so the old code called it with an empty arg list)
+	// and once with an ELPS lambda (whose Builtin IS nil, so the old code
+	// dereferenced nil). Different crashes, same class.
+	foreigners := map[string]string{
+		"builtin": "identity",
+		"lambda":  "(lambda (x) x)",
+	}
+	cases := []struct{ name, src string }{
+		{"validate", `(s:validate FOREIGN 1)`},
+		{"deftype-constraint", `(s:deftype "T" s:int FOREIGN) (s:validate T 1)`},
+		{"deftype-type", `(s:deftype "T" FOREIGN) (s:validate T 1)`},
+		{"make-validator", `(s:validate (s:make-validator "T" s:int FOREIGN) 1)`},
+		{"check-bool", `(s:deftype "T" s:bool FOREIGN) (s:validate T true)`},
+		{"check-fun", `(s:deftype "T" s:fun FOREIGN) (s:validate T identity)`},
+		{"check-string", `(s:deftype "T" s:string FOREIGN) (s:validate T "x")`},
+		{"check-float", `(s:deftype "T" "float" FOREIGN) (s:validate T 1.5)`},
+		{"check-number", `(s:deftype "T" s:number FOREIGN) (s:validate T 1)`},
+		{"check-array", `(s:deftype "T" s:array FOREIGN) (s:validate T (vector 1))`},
+		{"check-map", `(s:deftype "T" s:sorted-map FOREIGN) (s:validate T (sorted-map "a" 1))`},
+		{"check-any", `(s:deftype "T" "any" FOREIGN) (s:validate T 1)`},
+		{"check-tagged", `(s:deftype "T" s:tagged-value FOREIGN) (s:validate T 1)`},
+		{"has-key", `(s:deftype "T" s:sorted-map (s:has-key "a" FOREIGN)) (s:validate T (sorted-map "a" 1))`},
+		{"may-have-key", `(s:deftype "T" s:sorted-map (s:may-have-key "a" FOREIGN)) (s:validate T (sorted-map "a" 1))`},
+		{"of", `(s:deftype "T" s:array (s:of FOREIGN)) (s:validate T (vector 1))`},
+		{"no-other-keys", `(s:deftype "T" s:sorted-map (s:no-other-keys FOREIGN)) (s:validate T (sorted-map "a" 1))`},
+		{"not", `(s:deftype "T" s:int (s:not FOREIGN)) (s:validate T 1)`},
+		{"when-guard", `(s:deftype "T" s:sorted-map (s:when "a" FOREIGN "b" (s:gt 100))) (s:validate T (sorted-map "a" 1 "b" 1))`},
+		{"when-check", `(s:deftype "T" s:sorted-map (s:when "a" (s:gt 0) "b" FOREIGN)) (s:validate T (sorted-map "a" 1 "b" 1))`},
+	}
+	for _, c := range cases {
+		for kind, foreign := range foreigners {
+			t.Run(c.name+"/"+kind, func(t *testing.T) {
+				env := newSchemaEnv(t)
+				src := strings.ReplaceAll(c.src, "FOREIGN", foreign)
+				res := env.LoadStringContext(context.Background(), c.name, src)
+				if res.Type != lisp.LError {
+					t.Fatalf("a foreign %s in the %s constraint slot was ACCEPTED (result %v).\n"+
+						"A validator that silently approves a value it cannot check is worse "+
+						"than one that crashes.\n--- source ---\n%s", kind, c.name, res, src)
+				}
+				if lisp.IsInternalPanic(res) {
+					t.Fatalf("a foreign %s in the %s constraint slot panicked: %v\n--- source ---\n%s",
+						kind, c.name, res, src)
+				}
+			})
+		}
+	}
+}
+
+// TestWhenGuardRejectsForeignAtConstruction is the specific regression for
+// the inversion hazard in s:when, and it deliberately pins the ANSWER, not
+// just the absence of a panic.
+//
+// s:when treats an error from its guard constraint as "the condition is not
+// met, skip these checks". A "not a schema constraint" error IS an error, so
+// routing the guard through the marker check at APPLICATION time -- the
+// obvious fix -- makes the whole clause silently disappear:
+//
+//	before this work:  [INTERNAL-PANIC]  (loud, obviously broken)
+//	naive fix:         [list] ()          VALIDATION PASSES with b = 1
+//	                                      against a constraint demanding > 100
+//
+// The panic became a silent wrong answer in a validator. The guard is
+// therefore rejected at CONSTRUCTION, where no inversion can reach it.
+func TestWhenGuardRejectsForeignAtConstruction(t *testing.T) {
+	const src = `(s:deftype "M" s:sorted-map (s:has-key "a" s:int) (s:has-key "b" s:int)
+	                                (s:when "a" identity "b" (s:gt 100)))`
+	env := newSchemaEnv(t)
+	res := env.LoadStringContext(context.Background(), "when-guard", src)
+	if res.Type != lisp.LError {
+		t.Fatalf("s:when accepted a foreign guard at construction: %v", res)
+	}
+	if lisp.IsInternalPanic(res) {
+		t.Fatalf("s:when panicked on a foreign guard: %v", res)
+	}
+
+	// And the belt-and-braces check: even if a future refactor moves the
+	// rejection later, the clause must never be skipped. b = 1 fails (s:gt
+	// 100), so a successful validation here means the clause vanished.
+	env2 := newSchemaEnv(t)
+	full := src + `
+	(s:validate M (sorted-map "a" 1 "b" 1))`
+	res2 := env2.LoadStringContext(context.Background(), "when-guard-validate", full)
+	if res2.Type != lisp.LError {
+		t.Fatalf("validation PASSED with b=1 against (s:gt 100): the s:when clause was "+
+			"silently skipped because the guard rejection was read as "+
+			"'condition not met'. Got %v", res2)
+	}
+}
+
+// TestWhenSemanticsPreserved pins that the fix did not break s:when itself:
+// the guard still selects whether the clause applies.
+func TestWhenSemanticsPreserved(t *testing.T) {
+	cases := []struct {
+		name  string
+		src   string
+		valid bool
+	}{
+		{
+			"guard met, check fails",
+			`(s:deftype "M" s:sorted-map (s:when "a" (s:gt 0) "b" (s:gt 100)))
+			 (s:validate M (sorted-map "a" 1 "b" 1))`,
+			false,
+		},
+		{
+			"guard met, check passes",
+			`(s:deftype "M" s:sorted-map (s:when "a" (s:gt 0) "b" (s:gt 100)))
+			 (s:validate M (sorted-map "a" 1 "b" 101))`,
+			true,
+		},
+		{
+			"guard not met, check skipped",
+			`(s:deftype "M" s:sorted-map (s:when "a" (s:gt 5) "b" (s:gt 100)))
+			 (s:validate M (sorted-map "a" 1 "b" 1))`,
+			true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			env := newSchemaEnv(t)
+			res := env.LoadStringContext(context.Background(), c.name, c.src)
+			if got := res.Type != lisp.LError; got != c.valid {
+				t.Fatalf("expected valid=%v, got %v (%v)", c.valid, got, res)
+			}
+		})
+	}
+}
+
+// TestWhenRejectsNonMapInput covers the other panic reachable through s:when:
+// it called input.Map() with no type check, which panics ("not sorted-map:
+// int") for any other type. Reachable because s:when composes under s:any,
+// where nothing has checked the type first.
+func TestWhenRejectsNonMapInput(t *testing.T) {
+	env := newSchemaEnv(t)
+	res := env.LoadStringContext(context.Background(), "when-nonmap",
+		`(s:deftype "T" "any" (s:when "a" s:int "b" s:int)) (s:validate T 1)`)
+	if res.Type != lisp.LError {
+		t.Fatalf("expected a wrong-type error, got %v", res)
+	}
+	if lisp.IsInternalPanic(res) {
+		t.Fatalf("s:when panicked on a non-map input: %v", res)
+	}
+}
+
+// TestNewValidatorIsAcceptedAsAConstraint covers the extension point the
+// marker would otherwise have closed.
+//
+// Before the marker, a Go embedder could pass any lisp.LFun where libschema
+// expected a constraint and it worked by accident. The marker ends that, so
+// libschema.NewValidator restores the capability deliberately. This test is
+// the proof that the exported constructor really produces something the
+// package accepts -- otherwise "we kept the extension point" would be a claim
+// with nothing behind it.
+func TestNewValidatorIsAcceptedAsAConstraint(t *testing.T) {
+	even := libschema.NewValidator(lisp.Formals("input"),
+		func(_ *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+			if input.Type == lisp.LInt && input.Int%2 == 0 {
+				return lisp.Nil()
+			}
+			return lisp.ErrorConditionf(libschema.FailedConstraint, "not even: %v", input)
+		})
+
+	env := newSchemaEnv(t)
+	if rc := env.PutGlobal(lisp.Symbol("even?"), even); rc.Type == lisp.LError {
+		t.Fatalf("bind: %v", rc)
+	}
+
+	for _, c := range []struct {
+		src   string
+		valid bool
+	}{
+		{`(s:deftype "T" s:int even?) (s:validate T 4)`, true},
+		{`(s:deftype "T" s:int even?) (s:validate T 5)`, false},
+		{`(s:deftype "T" s:int (s:not even?)) (s:validate T 5)`, true},
+		{`(s:deftype "T" s:sorted-map (s:has-key "a" even?)) (s:validate T (sorted-map "a" 2))`, true},
+		{`(s:deftype "T" s:sorted-map (s:when "a" even? "b" (s:gt 100))) (s:validate T (sorted-map "a" 2 "b" 1))`, false},
+	} {
+		e := newSchemaEnv(t)
+		if rc := e.PutGlobal(lisp.Symbol("even?"), even); rc.Type == lisp.LError {
+			t.Fatalf("bind: %v", rc)
+		}
+		res := e.LoadStringContext(context.Background(), "newvalidator", c.src)
+		if got := res.Type != lisp.LError; got != c.valid {
+			t.Errorf("%s: expected valid=%v, got %v (%v)", c.src, c.valid, got, res)
+		}
+	}
+}
+
+// builtinInvocationRe matches an invocation of a raw LBuiltin closure, in
+// BOTH spellings this file has historically used:
+//
+//	rest.FunData().Builtin(env, input)
+//	builtinIsTruthy(env, nil).Builtin()(env, input)
+//
+// A drift guard that only grepped the first spelling would have declared
+// libschema clean while the second was sitting in builtinIsFalsy.
+var builtinInvocationRe = regexp.MustCompile(`\.Builtin\s*\(env|\.Builtin\(\)\s*\(`)
+
+// TestNoUnroutedConstraintInvocation is the drift guard: it fails if a
+// SIXTEENTH raw constraint invocation is added.
+//
+// The original defect was not one bad line, it was fifteen call sites each
+// independently trusting that whatever sat in a constraint slot obeyed a
+// private calling convention. Fixing fifteen sites without a guard leaves the
+// class open: the next person to add a constraint has no reason to know the
+// convention exists. Everything must go through applyConstraint, which is the
+// only function permitted to hold the raw invocation.
+func TestNoUnroutedConstraintInvocation(t *testing.T) {
+	src, err := os.ReadFile("libschema.go")
+	if err != nil {
+		t.Fatalf("read libschema.go: %v", err)
+	}
+	var offenders []string
+	for i, line := range strings.Split(string(src), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue // a doc comment quoting the pattern is not a call site
+		}
+		if builtinInvocationRe.MatchString(line) {
+			offenders = append(offenders, "libschema.go:"+strconv.Itoa(i+1)+": "+strings.TrimSpace(line))
+		}
+	}
+	if len(offenders) != 1 {
+		t.Fatalf("expected exactly ONE raw constraint invocation (the one inside "+
+			"applyConstraint), found %d:\n  %s\n\n"+
+			"Constraints are invoked through a private calling convention that "+
+			"cannot be enforced by the type system: the closure takes the value "+
+			"under test directly. Any new call site must go through "+
+			"applyConstraint, which verifies the unforgeable validator marker "+
+			"first. See isValidator.",
+			len(offenders), strings.Join(offenders, "\n  "))
+	}
+	if !strings.Contains(offenders[0], "constraint.FunData().Builtin(env, input)") {
+		t.Fatalf("the single raw invocation is not the one in applyConstraint: %s", offenders[0])
+	}
+}
+
+// TestValidatorMarkerIsUnforgeableFromLisp checks the credential itself: a
+// validator is identified by an LVal POINTER that no lisp-visible path can
+// produce, not by a name, a package or a structural shape any of which a
+// phylum could imitate.
+func TestValidatorMarkerIsUnforgeableFromLisp(t *testing.T) {
+	// A user function defined INSIDE a package called "s" carries the same
+	// package label and the same shape as a validator. It must still be
+	// refused: the marker is identity, not metadata.
+	env := newSchemaEnv(t)
+	res := env.LoadStringContext(context.Background(), "forge", `
+		(in-package 's)
+		(defun impostor (x) x)
+		(in-package 'user)
+		(s:validate s:impostor 1)`)
+	if res.Type != lisp.LError {
+		t.Fatalf("a user function defined in package 's' was accepted as a validator: %v", res)
+	}
+	if lisp.IsInternalPanic(res) {
+		t.Fatalf("panicked instead of rejecting: %v", res)
+	}
+}

--- a/lisp/lisplib/libschema/fuzz_test.go
+++ b/lisp/lisplib/libschema/fuzz_test.go
@@ -45,7 +45,7 @@ func FuzzSchemaValidate(f *testing.F) {
 	// every `make test`. Sampling keeps every fragment and every value shape
 	// in the corpus at ~1/12th the cost.
 	valueSeeds := fuzzval.Seeds()
-	for i := range len(schemaFragments) {
+	for i := range schemaFragments {
 		f.Add(uint8(i), valueSeeds[i%len(valueSeeds)])     //nolint:gosec // G115: i < 256 fragments
 		f.Add(uint8(i), valueSeeds[(i*7)%len(valueSeeds)]) //nolint:gosec // G115: as above
 		f.Add(uint8(i), []byte{0x11, 0x22, 0x33, 0x44})    //nolint:gosec // G115: as above

--- a/lisp/lisplib/libschema/fuzz_test.go
+++ b/lisp/lisplib/libschema/fuzz_test.go
@@ -1,0 +1,196 @@
+// Copyright © 2026 The ELPS authors
+
+package libschema_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/internal/fuzzval"
+	"github.com/luthersystems/elps/lisp"
+)
+
+// FuzzSchemaValidate builds a schema out of fuzzer-chosen constraint fragments
+// and validates a fuzzer-generated value against it.
+//
+// libschema gets its own target rather than riding on FuzzApplyStdlib because
+// its defects live in COMPOSITION, not in a single call. s:deftype takes a
+// base type plus a variadic list of constraints; s:has-key, s:of,
+// s:no-other-keys, s:not and s:when each take constraints of their own; and
+// the value in a constraint slot is invoked through a private calling
+// convention that no type check enforces. Applying s:has-key once with a
+// generated argument reaches almost none of that. Assembling the schema from
+// source and then validating a generated value reaches all of it.
+//
+// INVARIANTS
+//
+//  1. No internal-panic condition. Evaluation converts a Go panic into an
+//     LError tagged CondInternalPanic (handler-bind is documented NOT to catch
+//     it), so it is a first-class, greppable signal that host code has a
+//     defect -- rather than a crash the harness has to catch by dying. Every
+//     libschema defect this work fixed surfaced exactly this way.
+//  2. No panic escapes at all (the belt to that braces: env.eval's recover is
+//     a backstop, not a licence).
+//  3. The shared singletons are unmutated.
+//  4. Evaluation terminates, bounded by a context deadline plus a watchdog.
+//
+// NOT ASSERTED: whether validation passes or fails. Almost every generated
+// schema is nonsense and rejecting it is correct. The property being fuzzed is
+// "libschema always answers", not "libschema answers yes".
+func FuzzSchemaValidate(f *testing.F) {
+	// Sampled, not fully crossed: 66 fragments x 76 value seeds is 5,016
+	// entries and each builds an environment, which measured ~3s added to
+	// every `make test`. Sampling keeps every fragment and every value shape
+	// in the corpus at ~1/12th the cost.
+	valueSeeds := fuzzval.Seeds()
+	for i := range len(schemaFragments) {
+		f.Add(uint8(i), valueSeeds[i%len(valueSeeds)])     //nolint:gosec // G115: i < 256 fragments
+		f.Add(uint8(i), valueSeeds[(i*7)%len(valueSeeds)]) //nolint:gosec // G115: as above
+		f.Add(uint8(i), []byte{0x11, 0x22, 0x33, 0x44})    //nolint:gosec // G115: as above
+	}
+	for i, seed := range valueSeeds {
+		f.Add(uint8(i%len(schemaFragments)), seed) //nolint:gosec // G115: modulo fragment count
+	}
+
+	f.Fuzz(func(t *testing.T, idx uint8, data []byte) {
+		before := lisp.TakeSingletonSnapshot()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		env := newSchemaEnv(t)
+		if rc := lisp.WithContext(ctx)(env); rc.Type == lisp.LError {
+			t.Fatalf("context config: %v", rc)
+		}
+		if rc := lisp.WithMaxSteps(20000)(env); rc.Type == lisp.LError {
+			t.Fatalf("step config: %v", rc)
+		}
+
+		gen := fuzzval.New(data, env)
+		src := schemaFragments[int(idx)%len(schemaFragments)]
+
+		// The value under test is bound as a Go value rather than spliced into
+		// the source, so shapes with no source spelling (natives, tagged
+		// values, multi-dimensional arrays, error values) reach the
+		// validators. That is the whole reason for the value generator.
+		if rc := env.PutGlobal(lisp.Symbol("subject"), gen.Value()); rc.Type == lisp.LError {
+			t.Fatalf("bind subject: %v", rc)
+		}
+		if rc := env.PutGlobal(lisp.Symbol("subject2"), gen.Value()); rc.Type == lisp.LError {
+			t.Fatalf("bind subject2: %v", rc)
+		}
+
+		done := make(chan *lisp.LVal, 1)
+		panicked := make(chan any, 1)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panicked <- r
+				}
+			}()
+			done <- env.LoadStringContext(ctx, "schema-fuzz", src)
+		}()
+
+		var res *lisp.LVal
+		select {
+		case res = <-done:
+		case r := <-panicked:
+			panic(r)
+		case <-time.After(20 * time.Second):
+			t.Fatalf("schema evaluation did not terminate despite a 5s deadline\n--- source ---\n%s", src)
+		}
+
+		if res == nil {
+			t.Fatalf("evaluation returned a nil *LVal\n--- source ---\n%s", src)
+		}
+		if lisp.IsInternalPanic(res) {
+			t.Fatalf("libschema panicked: %v\n--- source ---\n%s\n--- subject ---\n%s",
+				res, src, env.GetGlobal(lisp.Symbol("subject")))
+		}
+		_ = res.String()
+
+		if drift := before.Verify(); drift != "" {
+			t.Fatalf("mutated the shared singleton %s\n--- source ---\n%s", drift, src)
+		}
+	})
+}
+
+// schemaFragments are the schema shapes fuzzed against a generated subject.
+//
+// They are written out rather than generated because a randomly assembled
+// s-expression is overwhelmingly likely to be a syntax error, and a target
+// that spends its budget on the parser is testing the wrong package (the
+// parser has its own targets -- see internal/fuzzseed). What varies here is
+// the VALUE flowing through a real schema, plus the constraint slot each
+// fragment exercises.
+//
+// FOREIGN is substituted with an ordinary function, since a function landing
+// in a constraint slot is the defect class this package had; the marker check
+// must refuse it as a lisp error, never as a panic and never by silently
+// skipping the clause.
+var schemaFragments = buildSchemaFragments()
+
+func buildSchemaFragments() []string {
+	base := []string{
+		`(s:deftype "T" s:int) (s:validate T subject)`,
+		`(s:deftype "T" s:string) (s:validate T subject)`,
+		`(s:deftype "T" "float") (s:validate T subject)`,
+		`(s:deftype "T" s:number) (s:validate T subject)`,
+		`(s:deftype "T" s:bool) (s:validate T subject)`,
+		`(s:deftype "T" s:array) (s:validate T subject)`,
+		`(s:deftype "T" s:sorted-map) (s:validate T subject)`,
+		`(s:deftype "T" s:fun) (s:validate T subject)`,
+		`(s:deftype "T" s:tagged-value) (s:validate T subject)`,
+		`(s:deftype "T" "any") (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:in subject subject2)) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:gt subject2)) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:gte subject2)) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:lt subject2)) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:lte subject2)) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:len subject2)) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:lengt subject2)) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:lenlte subject2)) (s:validate T subject)`,
+		`(s:deftype "T" "any" s:positive) (s:validate T subject)`,
+		`(s:deftype "T" "any" s:negative) (s:validate T subject)`,
+		`(s:deftype "T" "any" s:is-true) (s:validate T subject)`,
+		`(s:deftype "T" "any" s:is-false) (s:validate T subject)`,
+		`(s:deftype "T" "any" s:is-truthy) (s:validate T subject)`,
+		`(s:deftype "T" "any" s:is-falsy) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:not s:positive)) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:not FOREIGN)) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:regexp "a.*b")) (s:validate T subject)`,
+		`(s:deftype "T" s:array (s:of s:int)) (s:validate T subject)`,
+		`(s:deftype "T" s:array (s:of FOREIGN)) (s:validate T subject)`,
+		`(s:deftype "T" s:sorted-map (s:has-key "a" s:int)) (s:validate T subject)`,
+		`(s:deftype "T" s:sorted-map (s:has-key "a" FOREIGN)) (s:validate T subject)`,
+		`(s:deftype "T" s:sorted-map (s:may-have-key "a" s:string)) (s:validate T subject)`,
+		`(s:deftype "T" s:sorted-map (s:no-other-keys (s:has-key "a" s:int))) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:when "a" s:int "b" (s:gt 100))) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:when "a" FOREIGN "b" (s:gt 100))) (s:validate T subject)`,
+		`(s:deftype "T" "any" (s:when "a" s:int "b" FOREIGN)) (s:validate T subject)`,
+		`(s:deftype "T" FOREIGN) (s:validate T subject)`,
+		`(s:deftype "T" "any" FOREIGN) (s:validate T subject)`,
+		`(s:validate subject subject2)`,
+		`(s:validate (s:make-validator "T" s:int) subject)`,
+		`(s:validate (s:make-validator "T" "any" FOREIGN) subject)`,
+		// Nested composition: a validator used as a constraint on a
+		// tagged-value's user data.
+		`(deftype box (x) x)
+		 (s:deftype "T" s:tagged-value "any" (s:not s:negative))
+		 (s:validate T subject)`,
+	}
+	foreigners := []string{"identity", "(lambda (x) x)", "subject", "subject2"}
+	out := make([]string, 0, len(base)*2)
+	for _, b := range base {
+		if !strings.Contains(b, "FOREIGN") {
+			out = append(out, b)
+			continue
+		}
+		for _, f := range foreigners {
+			out = append(out, strings.ReplaceAll(b, "FOREIGN", f))
+		}
+	}
+	return out
+}

--- a/lisp/lisplib/libschema/libschema.go
+++ b/lisp/lisplib/libschema/libschema.go
@@ -216,7 +216,7 @@ func builtinValidate(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	if val.Type != lisp.LFun {
 		return lisp.ErrorConditionf(BadArgs, "First argument is not a type")
 	}
-	return val.FunData().Builtin(env, input)
+	return applyConstraint(env, val, input)
 }
 
 // This is the `s:deftype` keyword. It defines a type and associated
@@ -330,6 +330,18 @@ func getHandler(env *lisp.LEnv, in *lisp.LVal, name string, constraints []*lisp.
 			in = env.Get(in)
 		}
 		if in.Type == lisp.LFun {
+			// The choke point. Every composite constraint (s:has-key,
+			// s:may-have-key, s:of, s:no-other-keys, s:when) and both
+			// entry points (s:deftype, s:make-validator) reach an
+			// already-constructed constraint through here, so refusing a
+			// foreign function HERE refuses it at construction time for all
+			// of them -- before any inverting caller (s:not, s:when) can
+			// misread the refusal as "the constraint failed".
+			if !isValidator(in) {
+				return lisp.ErrorConditionf(BadArgs,
+					"Bad input type: an ordinary function is not usable as a constraint (%v). Constraints must be built by the s package (s:int, s:has-key, s:gt, ...) or by libschema.NewValidator.",
+					in)
+			}
 			return in
 		}
 		res = lisp.ErrorConditionf(BadArgs, "Bad input type: %s is not usable as a constraint (%v)", in.Type.String(), in)
@@ -345,18 +357,120 @@ func GenSymbol() string {
 	return fmt.Sprintf("_validation_fun_%d", symcounter)
 }
 
+// validatorTag is a private zero-size type whose ADDRESS identifies a schema
+// validator.  Nothing outside this package can obtain the pointer, and
+// lisp.Native of an identical struct value is a different pointer, so the
+// marker cannot be forged -- not from ELPS source, and not from a Go caller
+// that has not gone through NewValidator.
+type validatorTag struct{}
+
+// validatorMarker is the single marker cell every validator LFun carries in
+// Cells[validatorMarkerIndex].  Its identity is the credential.
+var validatorMarker = lisp.Native(&validatorTag{})
+
+// A validator LFun's cells are [formals, docstring, marker].  lisp.
+// FunInPackage builds the first two; newValidator appends the third.  Only
+// Cells[1] is read by LVal.Docstring for a builtin, so the extra cell is
+// invisible to the rest of the interpreter.
+const (
+	validatorMarkerIndex = 2
+	validatorCellCount   = 3
+)
+
+// isValidator reports whether v is a schema constraint minted by this package.
+//
+// WHY THIS EXISTS.  Every constraint in libschema is invoked through a PRIVATE
+// calling convention: the validator LFun's Go closure takes the value under
+// test DIRECTLY, not an argument list, so constraints are called by reaching
+// into FunData().Builtin rather than through LEnv.FunCall.  That convention is
+// unenforceable by the type system -- s:validate, s:has-key, s:not, s:when and
+// the rest accepted ANY lisp.LFun -- so an ordinary function landing in a
+// constraint slot was invoked with a bare value:
+//
+//	(s:validate identity 1)        -> index out of range [0] with length 0
+//	(s:validate (lambda (x) x) 1)  -> nil pointer dereference (Builtin is nil)
+//
+// Both are reachable from phylum source, which in substrate is
+// customer-supplied. The marker turns a whole CLASS of crash into a lisp-level
+// error, rather than patching the instances one at a time.
+//
+// The Builtin check is not redundant with the marker check: it is what makes
+// the credential unforgeable even if the marker value ever leaked into a
+// user's hands, since a user lambda always has a nil Builtin.
+func isValidator(v *lisp.LVal) bool {
+	return v != nil &&
+		v.Type == lisp.LFun &&
+		len(v.Cells) == validatorCellCount &&
+		v.Cells[validatorMarkerIndex] == validatorMarker &&
+		v.FunData().Builtin != nil
+}
+
+// applyConstraint is the ONE place a schema constraint is invoked.
+//
+// Every call site in this file routes through it, and
+// TestNoUnroutedConstraintInvocation fails the build if a sixteenth appears.
+// The check has to live in one place: fifteen copies of it is fifteen chances
+// to write the next one without it, which is how the original defect looked.
+func applyConstraint(env *lisp.LEnv, constraint *lisp.LVal, input *lisp.LVal) *lisp.LVal {
+	if constraint == nil {
+		return lisp.ErrorConditionf(BadArgs, "Missing constraint")
+	}
+	// A constructor that already failed propagates its own error unchanged;
+	// re-wrapping it as "not a constraint" would hide the real cause.
+	if constraint.Type == lisp.LError {
+		return constraint
+	}
+	if !isValidator(constraint) {
+		return lisp.ErrorConditionf(BadArgs,
+			"Value is not a schema constraint: %v. Constraints must be built by the s package (s:int, s:has-key, s:gt, ...) or by libschema.NewValidator; an ordinary function cannot be used as one.",
+			constraint)
+	}
+	return constraint.FunData().Builtin(env, input)
+}
+
 // newValidator constructs an anonymous schema validator LFun bound to the
 // libschema package. Without the package binding, the LFun reaching
 // funCall / MacroCall / SpecialOpCall would trigger "BUG: GetFunName" log
 // spam (issue #271).
 func newValidator(formals *lisp.LVal, fn lisp.LBuiltin) *lisp.LVal {
-	return lisp.FunInPackage(DefaultPackageName, GenSymbol(), formals, fn)
+	return markValidator(lisp.FunInPackage(DefaultPackageName, GenSymbol(), formals, fn))
 }
 
 // newNamedValidator is like newValidator but uses the given FID instead of
 // an auto-generated one (so call-stack frames carry the type name).
 func newNamedValidator(name string, formals *lisp.LVal, fn lisp.LBuiltin) *lisp.LVal {
-	return lisp.FunInPackage(DefaultPackageName, name, formals, fn)
+	return markValidator(lisp.FunInPackage(DefaultPackageName, name, formals, fn))
+}
+
+func markValidator(fun *lisp.LVal) *lisp.LVal {
+	fun.Cells = append(fun.Cells, validatorMarker)
+	return fun
+}
+
+// NewValidator returns a schema constraint implemented in Go.
+//
+// This is the extension point the marker would otherwise have closed.  Before
+// the marker existed, a Go embedder could pass any lisp.LFun where libschema
+// expected a constraint and it worked by accident -- the call sites simply
+// invoked FunData().Builtin.  Requiring the marker ends that, so the capability
+// is restored deliberately and with a documented contract instead of being
+// dropped silently.  Nothing in this repository, and nothing in substrate, uses
+// it today; it exists so that closing the crash does not also remove a
+// capability someone might be relying on.
+//
+// CONTRACT: fn is called with the value under test as its second argument --
+// the value itself, NOT an argument list.  It must return lisp.Nil() when the
+// value satisfies the constraint and an LError (see lisp.ErrorConditionf, with
+// FailedConstraint or WrongType) when it does not.  It must not panic: a panic
+// here surfaces as an internal-panic condition, which handler-bind is
+// documented not to catch.
+//
+// Handing an ELPS lambda to a constraint slot is still refused, by design.
+// There is no way to call one with libschema's convention, and the whole point
+// of the marker is that the refusal is a lisp-level error rather than a nil
+// dereference.
+func NewValidator(formals *lisp.LVal, fn lisp.LBuiltin) *lisp.LVal {
+	return newValidator(formals, fn)
 }
 
 // Checks constraints and type for boolean values
@@ -366,7 +480,7 @@ func builtinCheckBool(_ *lisp.LEnv, name string, constraints []*lisp.LVal) *lisp
 		if input.Str != lisp.TrueSymbol && input.Str != lisp.FalseSymbol {
 			return lisp.ErrorConditionf(WrongType, "Input was not a boolean for type %s", name)
 		}
-		return builtinCheckAny(env, constraints).FunData().Builtin(env, input)
+		return applyConstraint(env, builtinCheckAny(env, constraints), input)
 	})
 }
 
@@ -388,7 +502,7 @@ func builtinCheckTaggedVal(env *lisp.LEnv, name string, constraints []*lisp.LVal
 		if input.Type != lisp.LTaggedVal {
 			return lisp.ErrorConditionf(WrongType, "Input was not a tagged-value for type %s", name)
 		}
-		return rest.FunData().Builtin(env, input.UserData())
+		return applyConstraint(env, rest, input.UserData())
 	})
 }
 
@@ -397,10 +511,7 @@ func builtinCheckAny(_ *lisp.LEnv, constraints []*lisp.LVal) *lisp.LVal {
 	// NB these aren't normal functions - they aren't looking for an array of args
 	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		for _, constraint := range constraints {
-			if constraint.Type != lisp.LFun {
-				return lisp.ErrorConditionf(BadArgs, "Invalid type received for constraint %v", constraint)
-			}
-			if v := constraint.FunData().Builtin(env, input); v.Type == lisp.LError {
+			if v := applyConstraint(env, constraint, input); v.Type == lisp.LError {
 				return v
 			}
 		}
@@ -416,7 +527,7 @@ func builtinCheckFun(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lis
 		if input.Type != lisp.LFun {
 			return lisp.ErrorConditionf(WrongType, "Input was not a function for type %s", name)
 		}
-		return rest.FunData().Builtin(env, input)
+		return applyConstraint(env, rest, input)
 	})
 }
 
@@ -428,7 +539,7 @@ func builtinCheckMap(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lis
 		if input.Type != lisp.LSortMap {
 			return lisp.ErrorConditionf(WrongType, "Input was not a sorted map for type %s", name)
 		}
-		return rest.FunData().Builtin(env, input)
+		return applyConstraint(env, rest, input)
 	})
 }
 
@@ -440,7 +551,7 @@ func builtinCheckArray(env *lisp.LEnv, name string, constraints []*lisp.LVal) *l
 		if input.Type != lisp.LArray {
 			return lisp.ErrorConditionf(WrongType, "Input was not an array for type %s", name)
 		}
-		return rest.FunData().Builtin(env, input)
+		return applyConstraint(env, rest, input)
 	})
 }
 
@@ -452,7 +563,7 @@ func builtinCheckString(env *lisp.LEnv, name string, constraints []*lisp.LVal) *
 		if input.Type != lisp.LString {
 			return lisp.ErrorConditionf(WrongType, "Input was not a string for type %s", name)
 		}
-		return rest.FunData().Builtin(env, input)
+		return applyConstraint(env, rest, input)
 	})
 }
 
@@ -641,7 +752,15 @@ func builtinLessThanOrEqual(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 func builtinArrayOf(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	compares := make([]*lisp.LVal, 0)
 	for _, v := range args.Cells {
-		compares = append(compares, getHandler(env, v, "x", []*lisp.LVal{}))
+		c := getHandler(env, v, "x", []*lisp.LVal{})
+		// Propagate at CONSTRUCTION. Left to be discovered at application
+		// time the error is swallowed by the "did any allowed type match?"
+		// loop below and reported as "Item N was of wrong type" -- a
+		// misconfigured schema masquerading as bad data.
+		if c.Type == lisp.LError {
+			return c
+		}
+		compares = append(compares, c)
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
 	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
@@ -651,13 +770,7 @@ func builtinArrayOf(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 		for k, v := range input.Cells[1].Cells {
 			matched := false
 			for _, compare := range compares {
-				val := builtinValidate(env, &lisp.LVal{
-					Cells: []*lisp.LVal{
-						compare,
-						v,
-					},
-				})
-				if val.IsNil() {
+				if applyConstraint(env, compare, v).IsNil() {
 					matched = true
 					break
 				}
@@ -708,7 +821,7 @@ func builtinCheckInt(env *lisp.LEnv, name string, constraints []*lisp.LVal) *lis
 		if input.Type != lisp.LInt {
 			return lisp.ErrorConditionf(WrongType, "Input was not an integer for type %s", name)
 		}
-		return rest.FunData().Builtin(env, input)
+		return applyConstraint(env, rest, input)
 	})
 }
 
@@ -720,7 +833,7 @@ func builtinCheckFloat(env *lisp.LEnv, name string, constraints []*lisp.LVal) *l
 		if input.Type != lisp.LFloat {
 			return lisp.ErrorConditionf(WrongType, "Input was not a float for type %s", name)
 		}
-		return rest.FunData().Builtin(env, input)
+		return applyConstraint(env, rest, input)
 	})
 }
 
@@ -732,7 +845,7 @@ func builtinCheckNumber(env *lisp.LEnv, name string, constraints []*lisp.LVal) *
 		if input.Type != lisp.LInt && input.Type != lisp.LFloat {
 			return lisp.ErrorConditionf(WrongType, "Input was not a number for type %s", name)
 		}
-		return rest.FunData().Builtin(env, input)
+		return applyConstraint(env, rest, input)
 	})
 }
 
@@ -744,7 +857,12 @@ func builtinHasKey(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	}
 	compares := make([]*lisp.LVal, 0)
 	for _, v := range args.Cells[1:] {
-		compares = append(compares, getHandler(env, v, "x", []*lisp.LVal{}))
+		c := getHandler(env, v, "x", []*lisp.LVal{})
+		// Propagate at CONSTRUCTION -- see builtinArrayOf.
+		if c.Type == lisp.LError {
+			return c
+		}
+		compares = append(compares, c)
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
 	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
@@ -757,13 +875,7 @@ func builtinHasKey(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 			return lisp.ErrorConditionf(FailedConstraint, "Map does not have key %s", key)
 		}
 		for _, compare := range compares {
-			val := builtinValidate(env, &lisp.LVal{
-				Cells: []*lisp.LVal{
-					compare,
-					val,
-				},
-			})
-			if val.IsNil() {
+			if applyConstraint(env, compare, val).IsNil() {
 				matched = true
 				break
 			}
@@ -783,7 +895,12 @@ func builtinMayHaveKey(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	}
 	compares := make([]*lisp.LVal, 0)
 	for _, v := range args.Cells[1:] {
-		compares = append(compares, getHandler(env, v, "x", []*lisp.LVal{}))
+		c := getHandler(env, v, "x", []*lisp.LVal{})
+		// Propagate at CONSTRUCTION -- see builtinArrayOf.
+		if c.Type == lisp.LError {
+			return c
+		}
+		compares = append(compares, c)
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
 	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
@@ -796,13 +913,7 @@ func builtinMayHaveKey(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 			return lisp.String(key)
 		}
 		for _, compare := range compares {
-			val := builtinValidate(env, &lisp.LVal{
-				Cells: []*lisp.LVal{
-					compare,
-					val,
-				},
-			})
-			if val.IsNil() {
+			if applyConstraint(env, compare, val).IsNil() {
 				matched = true
 				break
 			}
@@ -818,16 +929,18 @@ func builtinMayHaveKey(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 func builtinNoOtherKeys(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	constraints := make([]*lisp.LVal, 0)
 	for _, v := range args.Cells {
-		constraints = append(constraints, getHandler(env, v, "x", []*lisp.LVal{}))
+		c := getHandler(env, v, "x", []*lisp.LVal{})
+		// Propagate at CONSTRUCTION -- see builtinArrayOf.
+		if c.Type == lisp.LError {
+			return c
+		}
+		constraints = append(constraints, c)
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
 	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
 		allowedKeys := make(map[string]bool)
 		for _, c := range constraints {
-			if c.Type != lisp.LFun {
-				return lisp.ErrorConditionf(BadArgs, "Invalid type received for constraint %v", c)
-			}
-			val := c.FunData().Builtin(env, input)
+			val := applyConstraint(env, c, input)
 			if val.Type == lisp.LError { //nolint:staticcheck // not a tagged switch context
 				return val
 			} else if val.Type == lisp.LString {
@@ -847,6 +960,23 @@ func builtinNoOtherKeys(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 }
 
 // Checks sorted-map key when a condition on another key is met
+//
+// THE GUARD CONSTRAINT IS VALIDATED AT CONSTRUCTION, NOT AT APPLICATION.
+// s:when reads an error from its guard as "the condition is not met, skip
+// these checks".  That is correct for a real constraint and catastrophic for
+// anything else: an error meaning "this is not a constraint", raised at
+// application time, would silently skip the WHOLE CLAUSE.
+//
+//	(s:deftype "M" s:sorted-map (s:has-key "a" s:int) (s:has-key "b" s:int)
+//	                            (s:when "a" identity "b" (s:gt 100)))
+//	(s:validate M (sorted-map "a" 1 "b" 1))
+//
+// Before any of this work that expression raised [INTERNAL-PANIC] -- loud, and
+// obviously broken.  Routing the guard through applyConstraint and stopping
+// there would make it return () -- VALIDATION PASSES, with b = 1 against a
+// constraint demanding b > 100.  A crash in a validator is bad; a validator
+// that quietly approves invalid data is worse.  Rejecting at construction, the
+// way s:not does, is the only placement where the inversion cannot bite.
 func builtinWhen(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	if _, ok := lisp.GoString(args.Cells[0]); !ok {
 		return lisp.ErrorConditionf(FailedConstraint, "You must specify a key")
@@ -854,27 +984,42 @@ func builtinWhen(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	if _, ok := lisp.GoString(args.Cells[2]); !ok {
 		return lisp.ErrorConditionf(FailedConstraint, "You must specify a match key")
 	}
-	whenConstraint := args.Cells[1]
+	whenConstraint := getHandler(env, args.Cells[1], "x", []*lisp.LVal{})
+	if whenConstraint.Type == lisp.LError {
+		return whenConstraint
+	}
+	if !isValidator(whenConstraint) {
+		return lisp.ErrorConditionf(BadArgs, "Guard value is not a constraint")
+	}
 	constraints := make([]*lisp.LVal, 0)
 	for _, v := range args.Cells[3:] {
-		constraints = append(constraints, getHandler(env, v, "x", []*lisp.LVal{}))
+		c := getHandler(env, v, "x", []*lisp.LVal{})
+		if c.Type == lisp.LError {
+			return c
+		}
+		constraints = append(constraints, c)
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
 	return newValidator(lisp.Formals("input"), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+		// input.Map() panics ("not sorted-map: int") on anything else. s:when
+		// is reachable under s:any, where no earlier constraint has checked
+		// the type: (s:deftype "T" "any" (s:when "a" s:int "b" s:int)) then
+		// (s:validate T 1).
+		if input.Type != lisp.LSortMap {
+			return lisp.ErrorConditionf(WrongType, "Input is not sorted map")
+		}
 		lMap := input.Map()
 		whenVal, _ := lMap.Get(args.Cells[0])
 		testVal, _ := lMap.Get(args.Cells[2])
-		val := whenConstraint.FunData().Builtin(env, whenVal)
+		val := applyConstraint(env, whenConstraint, whenVal)
 		if val.Type == lisp.LError {
+			// Guard not satisfied: this clause does not apply. Safe only
+			// because whenConstraint was proven to be a real constraint at
+			// construction -- see the doc comment.
 			return lisp.Nil()
 		}
 		for _, c := range constraints {
-			if c.Type == lisp.LError {
-				return c
-			} else if c.Type != lisp.LFun {
-				return lisp.ErrorConditionf(BadArgs, "Invalid type received for constraint %v", c)
-			}
-			val := c.FunData().Builtin(env, testVal)
+			val := applyConstraint(env, c, testVal)
 			if val.Type == lisp.LError {
 				return val
 			}
@@ -909,7 +1054,7 @@ func builtinIsTrue(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 func builtinIsFalsy(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 	// NB these aren't normal functions - they aren't looking for an array of args
 	return newValidator(lisp.Formals(), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
-		val := builtinIsTruthy(env, nil).Builtin()(env, input)
+		val := applyConstraint(env, builtinIsTruthy(env, nil), input)
 		if val.Type == lisp.LError {
 			return lisp.Nil()
 		}
@@ -961,12 +1106,17 @@ func builtinIsTruthy(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal {
 // Reverses a constraint
 func builtinIsNot(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	constraint := args.Cells[0]
-	if constraint.Type != lisp.LFun {
+	// Rejected at CONSTRUCTION, not at application. s:not inverts its inner
+	// constraint's result, so a "not a schema constraint" error raised at
+	// application time would be read as "the inner constraint failed" and
+	// s:not would PASS -- turning a loud crash into a silent wrong answer.
+	// Same inversion hazard as s:when; see builtinWhen.
+	if !isValidator(constraint) {
 		return lisp.ErrorConditionf(BadArgs, "Value is not a constraint")
 	}
 	// NB these aren't normal functions - they aren't looking for an array of args
 	return newValidator(lisp.Formals(), func(env *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
-		val := constraint.FunData().Builtin(env, input)
+		val := applyConstraint(env, constraint, input)
 		if val.Type == lisp.LError {
 			return lisp.Nil()
 		}

--- a/lisp/lisplib/libschema/libschema.go
+++ b/lisp/lisplib/libschema/libschema.go
@@ -368,10 +368,10 @@ type validatorTag struct{}
 // Cells[validatorMarkerIndex].  Its identity is the credential.
 var validatorMarker = lisp.Native(&validatorTag{})
 
-// A validator LFun's cells are [formals, docstring, marker].  lisp.
-// FunInPackage builds the first two; newValidator appends the third.  Only
-// Cells[1] is read by LVal.Docstring for a builtin, so the extra cell is
-// invisible to the rest of the interpreter.
+// A validator LFun's cells are [formals, docstring, marker].  The first two
+// come from lisp.FunInPackage; newValidator appends the third.  For a builtin
+// LVal.Docstring reads only Cells[1], and nothing else in the interpreter
+// walks an LFun's cells, so the extra cell is invisible.
 const (
 	validatorMarkerIndex = 2
 	validatorCellCount   = 3
@@ -407,10 +407,11 @@ func isValidator(v *lisp.LVal) bool {
 
 // applyConstraint is the ONE place a schema constraint is invoked.
 //
-// Every call site in this file routes through it, and
-// TestNoUnroutedConstraintInvocation fails the build if a sixteenth appears.
-// The check has to live in one place: fifteen copies of it is fifteen chances
-// to write the next one without it, which is how the original defect looked.
+// All sixteen former call sites in this file route through it, and
+// TestNoUnroutedConstraintInvocation fails if a second raw invocation ever
+// appears.  The check has to live in one place: sixteen copies of it would be
+// sixteen chances to write the next one without it, which is exactly how the
+// original defect looked.
 func applyConstraint(env *lisp.LEnv, constraint *lisp.LVal, input *lisp.LVal) *lisp.LVal {
 	if constraint == nil {
 		return lisp.ErrorConditionf(BadArgs, "Missing constraint")

--- a/lisp/lisplib/testdata/fuzz/FuzzApplyStdlib/4bc95fed43584c54
+++ b/lisp/lisplib/testdata/fuzz/FuzzApplyStdlib/4bc95fed43584c54
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint16(110)
+[]byte("b00b01")

--- a/lisp/op.go
+++ b/lisp/op.go
@@ -464,24 +464,49 @@ func opDoTimes(env *LEnv, args *LVal) *LVal {
 	loopenv := newEnvN(env, 1) // single loop variable
 	n := 0
 	for i := range count.Int {
-		n++
 		// Count a step for the TURN ITSELF, not just for the forms in the
-		// body.  Without this, (dotimes (i 2147483647)) with an EMPTY body
-		// evaluates nothing, so it increments no counter and consults no
-		// context: measured 42s of uninterruptible CPU for 2e8 turns, and
-		// unbounded above -- count.Int can be MaxInt.  MaxSteps, MaxAlloc,
-		// the stack limits and a context deadline were all blind to it,
-		// because every one of them is only reached through Eval.
+		// body.  Without this, a dotimes with an EMPTY body evaluates nothing,
+		// so it increments no counter and consults no context:
+		// `(dotimes (i 1000000000))` ignored a 2s context deadline and a
+		// 2,000,000-step budget alike and was still running 30s later, and
+		// `(dotimes (i 2147483647))` measured 42s of uninterruptible CPU --
+		// unbounded above, since count.Int can be MaxInt.  MaxSteps, MaxAlloc,
+		// the stack limits and a context deadline were all blind to it, because
+		// every one of them is only reached through Eval.  Found independently
+		// by the evaluator and the stdlib fuzzers (issue #320, item B2).
 		//
-		// CAVEAT, do not overclaim: checkLimits short-circuits when the
-		// runtime has NEITHER a context NOR a step limit configured (see
+		// COST: exactly one extra step per turn.  As a FRACTION that depends
+		// entirely on the body, so do not quote a single percentage -- two
+		// earlier write-ups of this fix quoted "+16.6%" and "4 to 5 steps per
+		// turn", which are the same +1 seen through two different bodies.
+		// Measured at n=1000 on this tree, steps per turn:
+		//
+		//     body                 before  after
+		//     (empty)                   0      1   <- the defect
+		//     1                         1      2
+		//     (+ i 1)                   4      5
+		//     (+ (* i 2) (- i 1))      10     11
+		//     (+ i 1) (+ i 2) (+ i 3)  12     13
+		//
+		// So a budget pinned tightly against a measured figure for a
+		// dotimes-heavy program may need raising by one step per turn.
+		//
+		// CAVEAT, do not overclaim: checkLimits short-circuits when the runtime
+		// has NEITHER a context NOR a step limit configured (see
 		// LEnv.checkLimits), so a default embedding is still uninterruptible
 		// here.  What this buys is that a runtime which HAS configured one of
 		// them now actually gets it enforced.  For a caller that sets only a
 		// context (substrate's shape) that is cancellability, not a bound.
+		//
+		// env.evalCtx, not loopenv.evalCtx: newEnvN copies the parent's ctx at
+		// construction, so the two are equal here -- verified, in that the two
+		// independently written fixes for this defect each pass the other's
+		// tests -- but reading it live from the op's env cannot go stale should
+		// loopenv ever be hoisted out of the loop.
 		if lerr := loopenv.checkLimits(env.evalCtx); lerr != nil {
 			return lerr
 		}
+		n++
 		lerr := loopenv.Put(symbol, Int(i))
 		if lerr.Type == LError {
 			return lerr

--- a/lisp/op.go
+++ b/lisp/op.go
@@ -465,6 +465,23 @@ func opDoTimes(env *LEnv, args *LVal) *LVal {
 	n := 0
 	for i := range count.Int {
 		n++
+		// Count a step for the TURN ITSELF, not just for the forms in the
+		// body.  Without this, (dotimes (i 2147483647)) with an EMPTY body
+		// evaluates nothing, so it increments no counter and consults no
+		// context: measured 42s of uninterruptible CPU for 2e8 turns, and
+		// unbounded above -- count.Int can be MaxInt.  MaxSteps, MaxAlloc,
+		// the stack limits and a context deadline were all blind to it,
+		// because every one of them is only reached through Eval.
+		//
+		// CAVEAT, do not overclaim: checkLimits short-circuits when the
+		// runtime has NEITHER a context NOR a step limit configured (see
+		// LEnv.checkLimits), so a default embedding is still uninterruptible
+		// here.  What this buys is that a runtime which HAS configured one of
+		// them now actually gets it enforced.  For a caller that sets only a
+		// context (substrate's shape) that is cancellability, not a bound.
+		if lerr := loopenv.checkLimits(env.evalCtx); lerr != nil {
+			return lerr
+		}
 		lerr := loopenv.Put(symbol, Int(i))
 		if lerr.Type == LError {
 			return lerr

--- a/lisp/pow_test.go
+++ b/lisp/pow_test.go
@@ -1,0 +1,207 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// TestPowIntTerminates is the regression test for the non-terminating
+// exponent-doubling loop powInt used to run (see powInt's doc comment).
+//
+// IT MUST FAIL IN MILLISECONDS, NOT BY TIMING OUT.  Reverting the fix does
+// not make powInt return a wrong answer; it makes powInt never return at all.
+// A plain `got := powInt(...)` regression test would therefore hang until the
+// package's 10-minute `go test` timeout, take the whole test binary down with
+// it, and report the failure against whatever test happened to be running.
+// Running the call on its own goroutine with a 500ms deadline turns the hang
+// into a normal, fast, attributable failure -- measured: the mutated build
+// fails this test in 500ms, versus a 10-minute package timeout without it.
+// 500ms is ~5 x 10^5 times the real cost of the worst case (63 iterations).
+//
+// The goroutine is leaked when the deadline fires. That is the point: the
+// loop under test cannot be interrupted, which is exactly the defect. It only
+// happens on a regression.
+func TestPowIntTerminates(t *testing.T) {
+	cases := []struct{ a, b int }{
+		// The originally reported input.
+		{-128, math.MaxInt},
+		// The input FuzzApplyStdlib minimised to.
+		{math.MinInt, math.MaxInt - 1},
+		// 2^62 is the largest b the old loop survived; 2^62+1 is the smallest
+		// it did not. Both must return.
+		{3, 1 << 62},
+		{3, (1 << 62) + 1},
+		{0, math.MaxInt},
+		{1, math.MaxInt},
+		{-1, math.MaxInt},
+		{2, math.MaxInt},
+	}
+	for _, c := range cases {
+		done := make(chan *LVal, 1)
+		go func() { done <- powInt(c.a, c.b) }()
+		select {
+		case v := <-done:
+			if v.Type != LInt {
+				t.Errorf("powInt(%d, %d) returned %v, want an int", c.a, c.b, v.Type)
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("powInt(%d, %d) did not terminate within 500ms", c.a, c.b)
+		}
+	}
+}
+
+// powIntNaive is the definition of integer exponentiation in Go's wrapping
+// int arithmetic: b factors of a, multiplied left to right. It is the ground
+// truth TestPowIntMatchesDefinition compares against -- not the previous
+// implementation, so the sweep proves powInt is CORRECT rather than merely
+// bug-compatible with what it replaced.
+func powIntNaive(a, b int) int {
+	acc := 1
+	for range b {
+		acc *= a
+	}
+	return acc
+}
+
+// powIntLegacy is the pre-fix implementation, verbatim. Used only to confirm
+// the fix changed no answer the old code was able to produce.
+//
+// CALLERS MUST BOUND b. This function does not terminate for b > 2^62, and
+// costs O(b) even when it does.
+func powIntLegacy(a, b int) int {
+	if b == 0 {
+		return 1
+	}
+	n := 1
+	atob := a
+	for 2*n < b {
+		atob *= atob
+		n *= 2
+	}
+	for n < b {
+		atob *= a
+		n++
+	}
+	return atob
+}
+
+// sweepBases are the a-values swept. Sign, magnitude and the overflow
+// boundaries all change how the wrapping multiplications compose.
+func sweepBases() []int {
+	bases := []int{
+		0, 1, -1, 2, -2, 3, -3, 7, -7, 10, -10, 16, -16, 127, -128,
+		255, -255, 256, -256, 1000, -1000, 65535, 65536,
+		math.MaxInt32, math.MinInt32, math.MaxInt32 + 1,
+		1 << 31, 1 << 32, 1 << 53, -(1 << 53), 1 << 62,
+		math.MaxInt, math.MinInt, math.MaxInt - 1, math.MinInt + 1,
+		3037000499, // floor(sqrt(MaxInt)): a^2 is the last product that fits
+		-3037000499,
+	}
+	// Fill out to a wide sweep with arbitrary but fixed values, so the result
+	// is not an artifact of round numbers. Deterministic: no rand.
+	for i := 1; i <= 40; i++ {
+		v := i*2654435761 + 12345
+		bases = append(bases, v, -v)
+	}
+	return bases
+}
+
+// TestPowIntMatchesDefinition sweeps powInt against b factors of a for every
+// base above and every exponent in [0, sweepMaxExp).
+//
+// The naive reference is computed INCREMENTALLY (one multiply per exponent,
+// carried across the inner loop) rather than by calling powIntNaive per pair,
+// which is what makes a multi-million-pair sweep affordable: the reference
+// costs O(1) per pair instead of O(b).
+func TestPowIntMatchesDefinition(t *testing.T) {
+	const sweepMaxExp = 33000
+	bases := sweepBases()
+	pairs := 0
+	for _, a := range bases {
+		want := 1
+		for b := range sweepMaxExp {
+			got := powInt(a, b)
+			if got.Type != LInt {
+				t.Fatalf("powInt(%d, %d) returned %v, want an int", a, b, got.Type)
+			}
+			if got.Int != want {
+				t.Fatalf("powInt(%d, %d) = %d, want %d", a, b, got.Int, want)
+			}
+			pairs++
+			want *= a
+		}
+	}
+	if pairs < 1_000_000 {
+		// A sweep that silently shrinks stops being evidence.
+		t.Fatalf("swept only %d (a,b) pairs; the sweep is meant to be millions", pairs)
+	}
+	t.Logf("swept %d (a,b) pairs against the naive definition", pairs)
+}
+
+// TestPowIntMatchesLegacy confirms the fix is not a behaviour change: for
+// every (a,b) the OLD implementation could actually compute, the new one
+// returns the same bits, wrapped answers included.
+//
+// b is bounded at 2048 because powIntLegacy is O(b).
+func TestPowIntMatchesLegacy(t *testing.T) {
+	const maxExp = 2048
+	for _, a := range sweepBases() {
+		for b := range maxExp {
+			got := powInt(a, b)
+			if want := powIntLegacy(a, b); got.Int != want {
+				t.Fatalf("powInt(%d, %d) = %d, legacy = %d", a, b, got.Int, want)
+			}
+		}
+	}
+}
+
+// TestPowIntWrapsLikeMultiplication pins the specific wrapped answers a caller
+// could be relying on. (pow 2 64) has always returned 0 -- 2^64 mod 2^64 --
+// and must keep doing so: switching association order is only safe because
+// mod-2^64 multiplication is commutative and associative, and this is the
+// test that would catch a "fix" that started saturating or erroring instead.
+func TestPowIntWrapsLikeMultiplication(t *testing.T) {
+	cases := []struct {
+		a, b, want int
+	}{
+		{2, 0, 1},
+		{2, 10, 1024},
+		{2, 62, 1 << 62},
+		{2, 63, math.MinInt}, // 2^63 wraps to the sign bit
+		{2, 64, 0},           // and 2^64 to exactly zero
+		{2, 65, 0},
+		{2, math.MaxInt, 0},
+		{-2, 63, math.MinInt},
+		{-2, 64, 0},
+		{0, 5, 0},
+		{1, math.MaxInt, 1},
+		{-1, math.MaxInt, -1},
+		{-1, math.MaxInt - 1, 1},
+		{3, 40, powIntNaive(3, 40)},
+		{10, 19, powIntNaive(10, 19)},
+		{10, 20, powIntNaive(10, 20)}, // 10^20 > MaxInt: wrapped
+	}
+	for _, c := range cases {
+		if got := powInt(c.a, c.b); got.Int != c.want {
+			t.Errorf("powInt(%d, %d) = %d, want %d", c.a, c.b, got.Int, c.want)
+		}
+	}
+}
+
+// TestPowIntNegativeExponent pins that a negative exponent still falls back to
+// float math rather than entering the integer loop at all.
+func TestPowIntNegativeExponent(t *testing.T) {
+	v := powInt(2, -2)
+	if v.Type != LFloat {
+		t.Fatalf("powInt(2, -2) returned %v, want a float", v.Type)
+	}
+	if v.Float != 0.25 {
+		t.Errorf("powInt(2, -2) = %v, want 0.25", v.Float)
+	}
+	if v := powInt(2, math.MinInt); v.Type != LFloat {
+		t.Errorf("powInt(2, MinInt) returned %v, want a float", v.Type)
+	}
+}

--- a/lisp/runtime.go
+++ b/lisp/runtime.go
@@ -90,8 +90,8 @@ func (r *Runtime) CheckAlloc(n int) string {
 // Four things increment the counter by one: each call to Eval, each
 // tail-recursion iteration, each macro re-expansion, and each turn of a
 // dotimes loop.  The last of those exists because an empty-bodied dotimes
-// evaluates nothing and would otherwise consume no budget at all — see
-// opDoTimes.
+// evaluates nothing and would otherwise consume no budget at all -- see
+// opDoTimes, which also records the measured per-turn cost.
 //
 // The counter is reset when a new top-level evaluation begins (see
 // WithMaxSteps), so it is not a lifetime total.  Use TotalSteps for that.

--- a/lisp/runtime.go
+++ b/lisp/runtime.go
@@ -87,8 +87,11 @@ func (r *Runtime) CheckAlloc(n int) string {
 
 // Steps returns the number of steps consumed by the current top-level
 // evaluation — or, if no evaluation is in progress, by the most recent one.
-// Each call to Eval, each tail-recursion iteration, and each macro
-// re-expansion increments the counter by one.
+// Four things increment the counter by one: each call to Eval, each
+// tail-recursion iteration, each macro re-expansion, and each turn of a
+// dotimes loop.  The last of those exists because an empty-bodied dotimes
+// evaluates nothing and would otherwise consume no budget at all — see
+// opDoTimes.
 //
 // The counter is reset when a new top-level evaluation begins (see
 // WithMaxSteps), so it is not a lifetime total.  Use TotalSteps for that.


### PR DESCRIPTION
Stacked on #311 — this branch is based on `claude/elps-fieldalignment` and uses the round-1 fuzzing infrastructure it carries (`scripts/fuzz.sh`, `internal/fuzzseed`, `.github/workflows/fuzz.yml`, `make fuzz`). Review #311 first; this PR targets that branch, not `main`.

Round 1 fuzzed **source**: the parser, lexer, formatter, minifier, plus libjson's decode path. That left the whole callable surface unfuzzed against its **arguments** — every builtin, special operator, macro and stdlib export. Downstream in `luthersystems/substrate` a phylum is customer-uploaded and runs as Hyperledger Fabric chaincode, so a panic or a hang in any of them is remotely triggerable from untrusted input, exactly like a parser crash.

## What was added

`internal/fuzzval` turns a fuzzer byte string into typed `LVal`s, including shapes no ELPS source can spell: `LNative` wrapping a Go value, multi-dimensional `LArray`, symbol-keyed sorted-maps, `LError` in argument position, `LQuote`, user lambdas (`Builtin == nil`) alongside Go builtins, and the shared `Nil()`/`Bool()` singletons.

Three targets (11 → 14):

| Target | Surface |
|---|---|
| `lisp/lisplib.FuzzApplyStdlib` | All 240 callables the library registers, each through its real calling convention — `FunCall`, `SpecialOpCall` or `MacroCall`, so special operators and macros get the unevaluated fragments they are actually handed |
| `libjson.FuzzDumpJSON` | The **encode** direction. `FuzzLoadJSON` only ever hands `Dump` a value `Load` produced, and `Load` emits six shapes; tagged values, natives, multi-dimensional arrays, integers, byte slices and error values had never been encoded |
| `libschema.FuzzSchemaValidate` | Schema **composition** — nested constraint slots, with the subject bound as a Go value so unspellable shapes reach the validators |

Invariants: no panic escapes, non-nil result, `String()` terminates, the three shared singletons are bit-identical afterwards, and the call terminates. Bounded three ways because no single bound sees every loop — a context deadline, a step limit, and an out-of-band watchdog for builtins that loop in Go without evaluating anything (`checkLimits` is per-evaluation, so those consult nothing). `MaxAlloc` is set deliberately low (4096) so the fuzzer explores the allocation guard rather than OOM-ing the runner; a builtin refusing an oversized allocation is correct, not a crash.

Deliberately not asserted: reflexivity (`LVal.Equal` is false for `LError`/`LFun`/`LQuote`/`LBytes`/`LNative` even against the same object, and `(= NaN NaN)` is false), and byte-identity of a JSON re-encode against the first encode (the known >2^53 rounding, plus `encoding/json` replacing invalid UTF-8 with U+FFFD — both are lossy on the way *in*, so the comparison is made on the far side, second decode against first).

`time:sleep` is excluded by name with a source comment: it blocks for a caller-supplied duration inside one step and no interpreter budget can bound it (#314). Out of scope here.

All three targets survived a 240s fuzz run each after the fixes (`fuzz.sh: 3 target(s), 0 failure(s)`); `FuzzApplyStdlib` reached 678k execs.

## Defects found and fixed

### B1 — `(pow -128 9223372036854775807)` never terminates

`powInt` doubled an exponent accumulator: `n` goes 1, 2, …, 2^62, then 2^63 wraps to `MinInt`, then `MinInt*2` wraps to exactly **0**, and `2*0 < b` is true forever. Zero is a true fixed point. The loop allocates nothing and evaluates nothing, so `MaxAlloc`, `MaxSteps` **and** a context deadline are all blind to it — none is consulted inside a builtin.

Found independently by `FuzzApplyStdlib`, minimised to `(pow -9223372036854775808 9223372036854775806)`.

Replaced with binary exponentiation (≤63 iterations). **No answer changes**: Go's `int` multiplication is arithmetic mod 2^64, a commutative ring, so association order cannot change the product — square-and-multiply and multiply-b-times agree bit for bit, wrapped answers included. `(pow 2 64)` still returns `0`. Evidence: a **3,861,000-pair** sweep against the naive definition with zero mismatches, plus a re-check against the old implementation over every pair it could actually compute, plus pinned wrapped answers.

`TestPowIntTerminates` runs the call on its own goroutine with a **500ms** deadline. Reverting the fix produces no answer rather than a wrong one, so a plain regression test would hang until the package's 10-minute timeout and take the whole test binary down with it.

### B2 — `(dotimes (i 2147483647))` with an empty body is uninterruptible

An empty body evaluates nothing, so the loop incremented no counter and consulted no context. **Measured before: 2e8 turns ran 44.2s of uninterruptible CPU against a 2s context deadline**, and the cancellation was only observed after the loop finished on its own. `count.Int` can be `MaxInt`, so there was no upper bound. After: the same program returns at **2.003s**.

`opDoTimes` now calls `checkLimits` once per turn.

**Cost, stated plainly.** A turn is one step more expensive. Measured at 1500 turns:

| body forms | before | after | per turn | delta |
|---|---|---|---|---|
| 0 | 4 | 1504 | 0 → 1 | the point |
| 1 | 6004 | 7504 | 4 → 5 | **+25.0%** |
| 2 | 12004 | 13504 | 8 → 9 | +12.5% |

A one-form loop of 1500 turns used to fit inside `WithMaxSteps(7000)` and no longer does. That is ordinary code, not pathological input — callers pinning a tight budget will need to raise it. `TestDoTimesStepCostPerTurn` pins these figures.

`Runtime.Steps` and `WithMaxSteps` both enumerated exactly three step sources; a dotimes turn is a fourth, and both docs are updated.

**Not claimed:** `checkLimits` short-circuits when the runtime has neither a context nor a step limit, so an embedding that configures neither still has an uninterruptible `dotimes`. Substrate sets a context but no `MaxSteps`, so what this buys there is *cancellability, not a bound*. `TestDoTimesUnboundedWithNeitherLimit` pins that honestly rather than letting the step counting read as a guarantee it is not.

### B3 — libschema invokes caller-supplied functions through a private calling convention

A validator's Go closure takes the value under test **directly**, not an argument list, so constraints are called by reaching into `FunData().Builtin` rather than through `LEnv.FunCall`. Nothing enforced that the value in a constraint slot was built by libschema:

```lisp
(s:validate identity 1)        ; index out of range [0] with length 0
(s:validate (lambda (x) x) 1)  ; nil pointer dereference (Builtin is nil)
```

A class, not two instances: **16 call sites** across `s:validate`, `s:deftype`, `s:make-validator`, `s:has-key`, `s:may-have-key`, `s:of`, `s:no-other-keys`, `s:not`, `s:when` and every `s:check-*` handler.

Every validator now carries an **unforgeable marker cell** — the address of a package-private zero-size type, which no lisp-visible path can produce. Identity, not metadata: a user function defined inside a package named `s` has the same package label and the same shape and is still refused. All 16 sites route through one `applyConstraint`, and `getHandler` rejects a foreign function at **construction** so composite constraints never build around one.

#### B3a — the inversion hazard, which is why the placement matters

`s:when` reads an error from its guard as *"condition not met, skip these checks"*. Routing the guard through the marker check at **application** time — the obvious fix — turns a refusal into a skip:

```lisp
(s:deftype "M" s:sorted-map (s:has-key "a" s:int) (s:has-key "b" s:int)
                            (s:when "a" identity "b" (s:gt 100)))
(s:validate M (sorted-map "a" 1 "b" 1))
```

| | result |
|---|---|
| before | `[INTERNAL-PANIC]` — loud, obviously broken |
| naive fix | `[list] ()` — **validation PASSES**, `b` = 1 against a constraint demanding > 100 |
| this PR | `bad-arguments` at construction |

A crash in a validator is bad; a validator that quietly approves invalid data is worse. `s:when` and `s:not` reject at construction, where no inversion can reach the refusal.

Every other error→skip inversion in the file was audited: `builtinIsFalsy` inverts only a libschema-internal constraint; `has-key`/`may-have-key`/`of` read an error as "did not match", which fails safe, and now also propagate a construction error rather than reporting a misconfigured schema as bad data.

Also fixed while auditing: `s:when` called `input.Map()` with no type check, which panics on any non-map. Reachable under `s:any`, where nothing has checked the type first.

#### B3b — the drift guard

`TestNoUnroutedConstraintInvocation` fails if a second raw invocation appears. It matches **both** spellings this file has used, `FunData().Builtin(env,` and `.Builtin()(` — the second was already sitting in `builtinIsFalsy`, so a guard grepping only the first would have declared the file clean.

#### B3c — the extension point

Before the marker, a Go embedder could pass any `lisp.LFun` where libschema expected a constraint and it worked by accident. `libschema.NewValidator` restores that capability **deliberately, with a documented contract**, rather than dropping it silently. Nothing here or in substrate uses it; it exists so closing the crash does not also remove something someone might rely on. `TestNewValidatorIsAcceptedAsAConstraint` proves the exported constructor really produces something the package accepts.

## Mutation verification

Every fix was reverted, the test run, and restored.

| # | Mutation | Result |
|---|---|---|
| 1 | `powInt` restored to exponent doubling | `TestPowIntTerminates` FAILS in **500ms** (vs. a 10-min package timeout without the goroutine bound) |
| 2 | `checkLimits` call removed from `opDoTimes` | 4 tests FAIL — context, step limit, and all three step-cost cases |
| 3 | marker check removed from `isValidator` | **40** subtests FAIL |
| 4 | `s:when` guard rejected at application instead of construction (the naive fix) | 3 tests FAIL, reporting `was ACCEPTED (result ())` |
| 5 | `.Builtin()(` spelling reintroduced in `builtinIsFalsy` | drift guard FAILS, naming both offenders |
| 6 | `s:when` non-map type check removed | FAILS with the recovered panic |

## Gates

| Gate | Result |
|---|---|
| `go build ./...` | clean |
| `go test ./...` | pass |
| `make test-elpscheck` | pass (the targets feed the singletons in deliberately, so this is the strong check) |
| `golangci-lint run ./...` | **0 issues** |
| `golangci-lint run --build-tags elpscheck ./lisp/...` | **0 issues** |
| `./elps doc -m` | all documented |
| `./elps fmt -l --exclude 'grammar' ./...` | clean |
| `make ci-gates-test` | 75 passed, 0 failed |
| `./elps lint --workspace=. --exclude 'grammar' --include '_examples' ./...` (the CI invocation) | **9 findings, byte-identical to the base commit** |
| new gofmt-unclean files | none (17 pre-existing, unchanged set) |
| `make race` | `TestEngine_RequestPause` / `TestDAPServer_PauseRequest` — **A/B'd against a pristine `fde78f3` worktree, which fails both the same way**. Pre-existing flake, #322. `-race` over every other package passes |

## Measured CI cost

30s budget each on this machine: `FuzzApplyStdlib` 33s, `FuzzDumpJSON` 33s, `FuzzSchemaValidate` 34s — **100s added** to a job that already ran 11 targets. Seed-corpus cost in `make test` (where regressions are actually caught, in milliseconds) is ~1.5s; seed corpora are sampled rather than fully crossed, because the full cross measured ~15s and ~3s respectively.

`fuzz.yml`'s job backstop is raised 120 → 165 minutes. Discovery is dynamic, which is what makes a new target covered the day it lands *and* what makes it silently cost another `FUZZTIME` on the nightly: at 120 minutes the 14 targets would have been cut off mid-sweep and the last ones would never have run. The comment now says out loud that the number has to move whenever a target is added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_