### PR TITLE
Grammar-aware fuzzing of the parse -> format -> minify pipeline, and the 9 defects it found

### DIFF
--- a/formatter/comment_preservation_test.go
+++ b/formatter/comment_preservation_test.go
@@ -156,6 +156,49 @@ func TestCommentBetweenPrefixAndOperand(t *testing.T) {
 	}
 }
 
+// TestLonghandPrefixFormKeepsComments covers the other direction: longhand a
+// human wrote out, with a comment somewhere inside it.
+//
+// The printer re-sugars "(lisp:function f)" to "#'f", and the shorthand has
+// nowhere to put a comment that sat between the brackets -- so re-sugaring
+// DELETED it.  Those forms now stay longhand.  The comment-free rows are the
+// controls: re-sugaring is the normal, desirable outcome and must not regress.
+func TestLonghandPrefixFormKeepsComments(t *testing.T) {
+	tests := []formatTest{
+		{
+			name:     "funref/leading",
+			input:    "(lisp:function\n; c\nf)\n",
+			expected: "(lisp:function\n  ; c\n  f)\n",
+		},
+		{
+			name:     "funref/trailing-on-head",
+			input:    "(lisp:function ; c\nf)\n",
+			expected: "(lisp:function ; c\n  f)\n",
+		},
+		{
+			name:     "funref/inner-trailing",
+			input:    "(lisp:function f\n; c\n)\n",
+			expected: "(lisp:function f\n               ; c\n               )\n",
+		},
+		{
+			name:     "unbound/trailing-on-head",
+			input:    "(lisp:expr ; c\n%)\n",
+			expected: "(lisp:expr ; c\n  %)\n",
+		},
+		// Controls: no comment, so the shorthand is still written.
+		{name: "funref/plain", input: "(lisp:function f)\n", expected: "#'f\n"},
+		{name: "unbound/plain", input: "(lisp:expr %)\n", expected: "#^%\n"},
+		{name: "funref/already-short", input: "#'f\n", expected: "#'f\n"},
+		// A comment INSIDE the operand belongs to the operand's own printer
+		// and survives the shorthand, so it must not block re-sugaring.
+		{name: "unbound/operand-inner", input: "#^(\n; c\n)\n", expected: "#^(\n   ; c\n   )\n"},
+	}
+	runFormatTests(t, tests)
+	for _, tt := range tests {
+		requireCommentsPreserved(t, tt.input)
+	}
+}
+
 // TestCommentInEmptySExpr covers a comment between the brackets of a form with
 // no children.
 //

--- a/formatter/comment_preservation_test.go
+++ b/formatter/comment_preservation_test.go
@@ -38,6 +38,8 @@ func commentTokens(t *testing.T, src string) []string {
 				out = append(out, tok.Text)
 			case token.EOF, token.ERROR, token.INVALID:
 				return out
+			default:
+				// Every other token type is irrelevant here.
 			}
 		}
 	}

--- a/formatter/comment_preservation_test.go
+++ b/formatter/comment_preservation_test.go
@@ -1,0 +1,275 @@
+// Copyright © 2026 The ELPS authors
+
+package formatter
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/parser/lexer"
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/require"
+)
+
+// `elps fmt` deleting a comment is not visible to any AST-shaped check.
+// Comments are not part of the tree, so a dropped one leaves the parsed
+// program identical AND leaves Format idempotent -- the output is a perfectly
+// stable fixed point that is simply missing a line of the user's file.  Five
+// separate defects presented exactly that way, and every one of them was found
+// by comparing the COMMENT TOKENS on either side of a format rather than the
+// trees.
+//
+// The tests below pin each shape with its exact expected output (via
+// runFormatTests, which also asserts idempotency), and commentsPreserved
+// re-checks the whole set token-by-token so a future defect in one of these
+// paths cannot hide behind a plausible-looking expectation.
+
+// commentTokens returns the text of every comment in src, in order.  A
+// hash-bang lexes as HASH_BANG plus a COMMENT holding the rest of the line.
+func commentTokens(t *testing.T, src string) []string {
+	t.Helper()
+	lex := lexer.New(token.NewScanner("test", bytes.NewReader([]byte(src))))
+	out := []string{}
+	for range 1 << 12 {
+		for _, tok := range lex.ReadToken() {
+			switch tok.Type {
+			case token.COMMENT, token.HASH_BANG:
+				out = append(out, tok.Text)
+			case token.EOF, token.ERROR, token.INVALID:
+				return out
+			}
+		}
+	}
+	t.Fatalf("lexer did not terminate on %q", src)
+	return nil
+}
+
+// requireCommentsPreserved asserts that formatting src neither drops nor
+// rewrites a comment.
+func requireCommentsPreserved(t *testing.T, src string) {
+	t.Helper()
+	out, err := Format([]byte(src), nil)
+	require.NoError(t, err, "Format failed on %q", src)
+	require.Equal(t, commentTokens(t, src), commentTokens(t, string(out)),
+		"comments changed\n--- input ---\n%s\n--- output ---\n%s", src, out)
+}
+
+// TestCommentBeforePrefixForm covers a comment written on the line(s) before a
+// prefix form.
+//
+// tokenLVal drains the parser's pending comments onto the first LVal it
+// builds, and for a prefix form that is the OPERAND, not the node the comments
+// belong to.  ' survived by accident (lisp.Quote shallow-copies an unquoted
+// operand, Meta pointer included), but #' and #^ build a fresh two-cell
+// s-expression and the printer's shorthand path writes only the prefix and the
+// operand -- so "; c\n#'a" formatted to "#'a".
+//
+// The matrix is the whole point.  The original version of this test had no row
+// with a BLANK LINE between the comment and the form, and none with a
+// PRECEDING top-level form, and the fix for the deletion introduced a
+// regression visible only in that corner: #' inherits its prefix token's
+// PrecedingNewlines onto its operand (readFunRef emits FUN_REF and the symbol
+// from one readToken, with no skipWhitespace between them), so the node
+// reported a blank line before the comment that the source did not have and
+// `elps fmt` inserted one.  ' and #^ scan separately and report zero, which is
+// why they need to be here as controls: a fix broad enough to break them has
+// to fail.
+func TestCommentBeforePrefixForm(t *testing.T) {
+	var tests []formatTest
+	for _, form := range []struct{ name, text string }{
+		{"quote", "'f"},
+		{"funref", "#'f"},
+		{"unbound", "#^f"},
+		{"plain", "f"}, // control: no prefix at all
+	} {
+		for _, ctx := range []struct{ name, prefix string }{
+			{"first", ""},
+			{"after-form", "(a)\n"},
+		} {
+			for _, gap := range []struct{ name, text string }{
+				{"adjacent", ""},
+				{"blank-line", "\n"},
+			} {
+				src := ctx.prefix + "; c\n" + gap.text + form.text + "\n"
+				tests = append(tests, formatTest{
+					name:     form.name + "/" + ctx.name + "/" + gap.name,
+					input:    src,
+					expected: src, // every shape is already an exact fixed point
+				})
+			}
+		}
+	}
+	runFormatTests(t, tests)
+	for _, tt := range tests {
+		requireCommentsPreserved(t, tt.input)
+	}
+}
+
+// TestCommentBeforeNestedPrefixForm is the same defect one level in, where the
+// comment belongs to a child rather than a top-level form.
+func TestCommentBeforeNestedPrefixForm(t *testing.T) {
+	var tests []formatTest
+	for _, form := range []string{"'g", "#'g", "#^g", "g"} {
+		for _, gap := range []struct{ name, text string }{
+			{"adjacent", ""},
+			{"blank-line", "\n"},
+		} {
+			src := "(f\n  ; c\n" + gap.text + "  " + form + ")\n"
+			tests = append(tests, formatTest{
+				name:     form + "/" + gap.name,
+				input:    src,
+				expected: src,
+			})
+		}
+	}
+	runFormatTests(t, tests)
+	for _, tt := range tests {
+		requireCommentsPreserved(t, tt.input)
+	}
+}
+
+// TestCommentBetweenPrefixAndOperand covers a comment written AFTER the prefix
+// token, in the gap before the thing it applies to.
+//
+// Those comments are collected while the operand is parsed and land on the
+// operand, which the printer reaches through writeQuote or tryPrefixForm --
+// neither of which writes a child's leading comments.  Quoting an
+// already-quoted operand or a list builds an LQuote node with a Meta of its
+// own, so "'\n; c\n[a]" lost the comment entirely; quoting a plain symbol
+// shared the operand's Meta and only moved it.  Both now move it above the
+// prefix, which is where the comment can be written without changing what the
+// form means.
+func TestCommentBetweenPrefixAndOperand(t *testing.T) {
+	tests := []formatTest{
+		{name: "quote/symbol", input: "'\n; c\na\n", expected: "; c\n'a\n"},
+		{name: "quote/glued", input: "'; c\na\n", expected: "; c\n'a\n"},
+		{name: "quote/list", input: "'\n; c\n[a]\n", expected: "; c\n'[a]\n"},
+		{name: "quote/sexpr", input: "'\n; c\n(a)\n", expected: "; c\n'(a)\n"},
+		{name: "quote/quote", input: "'\n; c\n'a\n", expected: "; c\n''a\n"},
+		{name: "unbound", input: "#^; c\na\n", expected: "; c\n#^a\n"},
+		{name: "both-sides", input: "; a\n'; b\nX\n", expected: "; a\n; b\n'X\n"},
+	}
+	runFormatTests(t, tests)
+	for _, tt := range tests {
+		requireCommentsPreserved(t, tt.input)
+	}
+}
+
+// TestCommentInEmptySExpr covers a comment between the brackets of a form with
+// no children.
+//
+// writeSExpr took a shortcut for that case -- write "()", return -- which
+// skipped both writeInnerTrailingComments and the closing-bracket newline, so
+// "(\n; c\n)" formatted to "()".  Only the unquoted-paren path was affected:
+// "[...]", "'(...)" and every non-empty form reach writeListInner, which
+// handles both.  Those are the controls.
+func TestCommentInEmptySExpr(t *testing.T) {
+	tests := []formatTest{
+		{name: "paren", input: "(\n; c\n)\n", expected: "(\n ; c\n )\n"},
+		{name: "paren/two", input: "(\n; a\n; b\n)\n", expected: "(\n ; a\n ; b\n )\n"},
+		{name: "brace", input: "[\n; c\n]\n", expected: "[\n ; c\n ]\n"},
+		{name: "quoted-paren", input: "'(\n; c\n)\n", expected: "'(\n  ; c\n  )\n"},
+		{name: "unbound-paren", input: "#^(\n; c\n)\n", expected: "#^(\n   ; c\n   )\n"},
+		{name: "nested", input: "(f (\n; c\n))\n", expected: "(f (\n    ; c\n    ))\n"},
+		// Controls: no comment involved.
+		{name: "empty-paren", input: "()\n", expected: "()\n"},
+		{name: "empty-brace", input: "[]\n", expected: "[]\n"},
+		// The closing bracket on its own line is now honoured for an empty
+		// form too, matching what "[" has always done.
+		{name: "paren-newline", input: "(\n)\n", expected: "(\n )\n"},
+		{name: "brace-newline", input: "[\n]\n", expected: "[\n ]\n"},
+	}
+	runFormatTests(t, tests)
+	for _, tt := range tests {
+		requireCommentsPreserved(t, tt.input)
+	}
+}
+
+// TestCommentBeforeSExprHead covers a comment between an opening bracket and
+// the head of the form.
+//
+// writeSExpr wrote the head with no leading-comment handling at all -- it only
+// ever considered the head's NEWLINE, and only for a data list -- so "(\n; c\n
+// f x)" formatted to "(f x)".  writeListInner has always written a first
+// child's leading comments, which is why the bracketed forms are the controls.
+func TestCommentBeforeSExprHead(t *testing.T) {
+	tests := []formatTest{
+		{name: "call", input: "(\n; c\nf x)\n", expected: "(\n ; c\n f x)\n"},
+		{name: "call/two", input: "(\n; a\n; b\nf x)\n", expected: "(\n ; a\n ; b\n f x)\n"},
+		{name: "data-list", input: "(\n; c\n1 2)\n", expected: "(\n ; c\n 1 2)\n"},
+		{name: "brace", input: "[\n; c\nf x]\n", expected: "[\n ; c\n f x]\n"},
+		{name: "nested", input: "(g (\n; c\nf x))\n", expected: "(g (\n    ; c\n    f x))\n"},
+		// Controls: no comment, so the head keeps being pulled up next to the
+		// bracket for a call and left in place for a data list.
+		{name: "call-newline", input: "(\nf x)\n", expected: "(f x)\n"},
+		{name: "data-newline", input: "(\n1 2)\n", expected: "(\n 1 2)\n"},
+	}
+	runFormatTests(t, tests)
+	for _, tt := range tests {
+		requireCommentsPreserved(t, tt.input)
+	}
+}
+
+// TestNegativeLiteralAfterComment covers a signed literal that starts a line
+// following a comment.
+//
+// The sign and the digits are two tokens merged into one literal by
+// ParseNegative, which carried over the sign token's Source but not its
+// whitespace bookkeeping.  PrecedingNewlines collapsed to zero, the literal
+// was printed back on the previous line, and when that line ended in a comment
+// the comment SWALLOWED it: "(a ; c\n-1)" formatted to "(a ; c -1)", which
+// re-parses as "(a)".  `elps fmt` deleting a term from the program it was
+// asked to tidy.
+func TestNegativeLiteralAfterComment(t *testing.T) {
+	tests := []formatTest{
+		{name: "int", input: "(a ; c\n-1)\n", expected: "(a ; c\n  -1)\n"},
+		{name: "float", input: "(a ; c\n-1.5)\n", expected: "(a ; c\n  -1.5)\n"},
+		{name: "symbol", input: "(a ; c\n-x)\n", expected: "(a ; c\n  -x)\n"},
+		{name: "exponent", input: "(a ; c\n-1e5)\n", expected: "(a ; c\n  -1e5)\n"},
+		{name: "leading-comment", input: "(a\n; c\n-1)\n", expected: "(a\n  ; c\n  -1)\n"},
+		{name: "top-level", input: "; c\n-1\n", expected: "; c\n-1\n"},
+		// Controls: an unsigned literal in the same position, and a signed one
+		// with no comment in play.
+		{name: "unsigned", input: "(a ; c\n1)\n", expected: "(a ; c\n  1)\n"},
+		{name: "same-line", input: "(a -1)\n", expected: "(a -1)\n"},
+	}
+	runFormatTests(t, tests)
+	for _, tt := range tests {
+		requireCommentsPreserved(t, tt.input)
+		// The literal must still be there.  This is the assertion the AST
+		// checks make: a swallowed term changes the program.
+		out, err := Format([]byte(tt.input), nil)
+		require.NoError(t, err)
+		roundTripEqual(t, tt.input, string(out))
+	}
+}
+
+// TestFormatRejectsNothingItPrints pins the shape that made `elps fmt` produce
+// output it could not read back: a hash-bang followed by a #' whose operand
+// cannot be re-sugared.  The comment landed on the operand, the longhand
+// printer wrote it INSIDE the form, and a hash-bang is only legal at the start
+// of a program.
+func TestFormatRejectsNothingItPrints(t *testing.T) {
+	srcs := []string{
+		"#!/usr/bin/env elps\n#':%\n",
+		"#!/usr/bin/env elps\n#'f\n",
+		"#!/usr/bin/env elps\n; c\n#'f\n",
+		"#!\n#^a\n",
+	}
+	for _, src := range srcs {
+		t.Run(strings.ReplaceAll(src, "\n", "\\n"), func(t *testing.T) {
+			out, err := Format([]byte(src), nil)
+			require.NoError(t, err, "Format rejected %q", src)
+			again, err := Format(out, nil)
+			require.NoError(t, err, "Format rejected its own output %q", out)
+			require.Equal(t, string(out), string(again), "not idempotent")
+			require.Equal(t, commentTokens(t, src), commentTokens(t, string(out)),
+				"comments changed\n--- in ---\n%s\n--- out ---\n%s", src, out)
+			// roundTripEqual drives a bare Parse loop, which reports a
+			// hash-bang as an unexpected token -- only ParseProgram consumes
+			// one.  Format re-reading its own output above is the equivalent
+			// check for these inputs.
+		})
+	}
+}

--- a/formatter/printer.go
+++ b/formatter/printer.go
@@ -330,8 +330,22 @@ func (p *printer) blankLinesBefore(v *lisp.LVal) int {
 // writeSExpr writes an unquoted s-expression (function call, special form, etc).
 func (p *printer) writeSExpr(v *lisp.LVal, indent int) {
 	if len(v.Cells) == 0 {
+		// An s-expression with no children still has two pieces of metadata
+		// between its brackets: comments captured by captureInnerTrailingComments
+		// and a closing bracket that stood on its own line.  This branch used to
+		// write "()" and return, DELETING the comments -- "(\n; c\n)" formatted
+		// to "()".  Only the unquoted-paren path was affected; "[...]", "'(...)"
+		// and non-empty forms all reach writeListInner, which handles both.
+		// Found by FuzzGeneratedPipeline's comment-preservation check, the same
+		// invariant that catches the prefix-form comment loss.
 		bracket := bracketOpen(v)
 		p.writeString(string(bracket))
+		openCol := p.col
+		p.writeInnerTrailingComments(v, openCol)
+		if v.Meta != nil && (len(v.Meta.InnerTrailingComments) > 0 || v.Meta.ClosingBracketNewline) {
+			p.newline()
+			p.writeIndent(openCol)
+		}
 		p.writeString(string(bracketClose(bracket)))
 		return
 	}
@@ -348,7 +362,22 @@ func (p *printer) writeSExpr(v *lisp.LVal, indent int) {
 	// Write the first child (head).
 	// For data lists (non-symbol head), preserve first-child-on-new-line.
 	isCall := v.Cells[0].Type == lisp.LSymbol
-	if !isCall && hasNewlineBefore(v.Cells[0]) {
+	head := v.Cells[0]
+	if head.Meta != nil && len(head.Meta.LeadingComments) > 0 {
+		// A comment written between the opening bracket and the head is
+		// attached to the head, and neither branch below wrote it: "(\n; c\n f
+		// x)" formatted to "(f x)", DELETING it.  writeListInner has always
+		// written a first child's leading comments; the s-expression printer
+		// only ever considered the head's newline, and only for a data list.
+		// Found by FuzzGeneratedPipeline's comment-preservation check.
+		p.newline()
+		for range p.blankLinesBefore(head) {
+			p.newline()
+		}
+		p.writeLeadingComments(head, bracketCol+1)
+		p.writeBlankLinesAfterComments(head)
+		p.writeIndent(bracketCol + 1)
+	} else if !isCall && hasNewlineBefore(head) {
 		p.newline()
 		p.writeIndent(bracketCol + 1)
 	}
@@ -484,6 +513,13 @@ func (p *printer) writeListInner(v *lisp.LVal, indent int) {
 // Found by FuzzFormat.
 func (p *printer) tryPrefixForm(v *lisp.LVal, indent int) bool {
 	if len(v.Cells) != 2 || v.Cells[0].Type != lisp.LSymbol {
+		return false
+	}
+	// The shorthand has nowhere to put a comment attached to the operand: it
+	// writes the prefix and the operand and nothing else.  rdparser hoists
+	// such comments onto the prefix node itself, so this only fires for
+	// longhand a human wrote out, but re-sugaring it would delete the comment.
+	if inner := v.Cells[1]; inner.Meta != nil && len(inner.Meta.LeadingComments) > 0 {
 		return false
 	}
 	switch v.Cells[0].Str {

--- a/formatter/printer.go
+++ b/formatter/printer.go
@@ -515,11 +515,18 @@ func (p *printer) tryPrefixForm(v *lisp.LVal, indent int) bool {
 	if len(v.Cells) != 2 || v.Cells[0].Type != lisp.LSymbol {
 		return false
 	}
-	// The shorthand has nowhere to put a comment attached to the operand: it
-	// writes the prefix and the operand and nothing else.  rdparser hoists
-	// such comments onto the prefix node itself, so this only fires for
-	// longhand a human wrote out, but re-sugaring it would delete the comment.
-	if inner := v.Cells[1]; inner.Meta != nil && len(inner.Meta.LeadingComments) > 0 {
+	// The shorthand has nowhere to put a comment written inside the form: it
+	// writes the prefix and the operand and nothing else, so re-sugaring
+	// "(lisp:function ; c\n f)" to "#'f" DELETES the comment.  rdparser hoists
+	// comments in the gap after a #'/#^ onto the prefix node itself, so this
+	// only fires for longhand a human wrote out -- but that is exactly the
+	// input `elps fmt` is asked to tidy.  Falling through to the longhand
+	// printer keeps every comment.
+	//
+	// Skipped when comments are being stripped anyway (compact mode, which is
+	// what the minifier emits through): there is no comment left to lose, and
+	// refusing the shorthand there would only make the output bigger.
+	if !p.cfg.StripComments && hasComments(v) {
 		return false
 	}
 	switch v.Cells[0].Str {
@@ -537,6 +544,25 @@ func (p *printer) tryPrefixForm(v *lisp.LVal, indent int) bool {
 		p.writeString("#^")
 		p.writeExpr(v.Cells[1], indent)
 		return true
+	}
+	return false
+}
+
+// hasComments reports whether any comment is attached inside v: to one of its
+// children, or between the last child and the closing bracket.  v's OWN
+// leading and trailing comments are not included -- those are written by
+// whoever prints v, and survive the shorthand.
+func hasComments(v *lisp.LVal) bool {
+	if v.Meta != nil && len(v.Meta.InnerTrailingComments) > 0 {
+		return true
+	}
+	for _, c := range v.Cells {
+		// Only the comments the PARENT is responsible for writing.  A child's
+		// own inner comments are written by writeExpr when it prints the
+		// child, and survive the shorthand: "#^(\n; c\n)" keeps its comment.
+		if c.Meta != nil && (len(c.Meta.LeadingComments) > 0 || c.Meta.TrailingComment != nil) {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/fuzzgen/fuzzgen.go
+++ b/internal/fuzzgen/fuzzgen.go
@@ -235,6 +235,13 @@ var stringBodies = []string{
 // A raw-string body may neither contain three consecutive quotes nor end in
 // one: the scanner closes the literal at the first triple quote it finds, so
 // either shape terminates the token early and leaves a stray quote behind.
+// Radix-macro bodies.  Both must stay inside int64 and must not be followed by
+// a word rune, which readHexLiteral and readOctalLiteral both reject.
+var (
+	hexDigits   = []string{"0", "FF", "dead", "7fffffff", "1", "aA"}
+	octalDigits = []string{"0", "7", "777", "17777777777", "1"}
+)
+
 var rawStringBodies = []string{
 	``, `a`, "a\nb", `; comment`, `\`, `\n`, `(a b)`, "\n\n", `a"b`, `x'y`,
 }
@@ -305,7 +312,7 @@ func (g *generator) rawComment() {
 	case 4:
 		g.raw("; λ 日本語")
 	case 5:
-		g.raw(";" + strings.Repeat("x", 200))
+		g.raw(";" + strings.Repeat("x", g.longRun(200)))
 	case 6:
 		g.raw("; -1")
 	default:
@@ -368,9 +375,9 @@ func (g *generator) atom() {
 	case 7, 8:
 		g.token(g.floatLiteral())
 	case 9:
-		g.token("#x" + []string{"0", "FF", "dead", "7fffffff", "1", "aA"}[g.pick(6)])
+		g.token("#x" + hexDigits[g.pick(len(hexDigits))])
 	case 10:
-		g.token("#o" + []string{"0", "7", "777", "17777777777", "1"}[g.pick(5)])
+		g.token("#o" + octalDigits[g.pick(len(octalDigits))])
 	case 11, 12:
 		g.token(`"` + stringBodies[g.pick(len(stringBodies))] + `"`)
 	case 13:
@@ -380,6 +387,16 @@ func (g *generator) atom() {
 	default:
 		g.token(symbols[g.pick(len(symbols))])
 	}
+}
+
+// longRun caps the repeat count of an oversized token once the byte budget is
+// spent, so a single production cannot blow past MaxBytes by an unbounded
+// amount.  Overshoot stays bounded by one long token plus the closing brackets.
+func (g *generator) longRun(n int) int {
+	if g.buf.Len() >= g.lim.MaxBytes {
+		return 1
+	}
+	return n
 }
 
 // pick chooses an index into a table, defaulting to 0 on an exhausted script.
@@ -476,6 +493,16 @@ func (g *generator) sexpr(depth int, open byte) {
 	n := g.pick(4)
 	for i := 0; i < n && !g.spent(); i++ {
 		g.form(depth + 1)
+		// A comment on the SAME line as the child it follows is attached to
+		// that child as a TrailingComment, not to whatever comes next -- a
+		// different parser path from the whole-line comment g.comment writes,
+		// and the one the sign-merge defect lived behind: with a trailing
+		// comment above it, a "-1" on the next line has nothing but its own
+		// PrecedingNewlines to say it belongs on a new line.
+		if !g.spent() && g.choose(8) == 0 {
+			g.raw(" ")
+			g.rawComment()
+		}
 	}
 	// A comment between the last child and the closing bracket lands in
 	// InnerTrailingComments, and a closing bracket on its own line is
@@ -515,11 +542,15 @@ func (g *generator) quote(depth int) {
 // then re-parses it, rejecting any name that does not read back as the same
 // symbol, so the operand pool is restricted to names that do.
 func (g *generator) funRef() {
-	names := []string{
-		"f", "foo", "car", "+", "-", "a.b", "λ", "lisp:car", "pkg:foo",
-		"x!", "defun", "日本語",
-	}
-	g.token("#'" + names[g.pick(len(names))])
+	g.token("#'" + funRefNames[g.pick(len(funRefNames))])
+}
+
+// funRefNames are operands ParseFunRef accepts.  It reads the operand with
+// ParseSymbol and then RE-PARSES it, rejecting any name that does not read back
+// as the same symbol, and the printer's canWriteFunRef mirrors that check.
+var funRefNames = []string{
+	"f", "foo", "car", "+", "-", "a.b", "λ", "lisp:car", "pkg:foo",
+	"x!", "defun", "日本語",
 }
 
 // unbound writes #^expr.  ParseUnbound rejects an operand containing a nested
@@ -695,18 +726,18 @@ func (g *generator) nestBurst(depth int) {
 func (g *generator) huge() {
 	switch g.choose(6) {
 	case 0:
-		g.token(strings.Repeat("z", 300))
+		g.token(strings.Repeat("z", g.longRun(300)))
 	case 1:
-		g.token(`"` + strings.Repeat("s", 400) + `"`)
+		g.token(`"` + strings.Repeat("s", g.longRun(400)) + `"`)
 	case 2:
-		g.token(`"""` + strings.Repeat("r", 400) + `"""`)
+		g.token(`"""` + strings.Repeat("r", g.longRun(400)) + `"""`)
 	case 3:
-		g.token(strings.Repeat("λ", 100))
+		g.token(strings.Repeat("λ", g.longRun(100)))
 	case 4:
-		g.token("pkg:" + strings.Repeat("q", 200))
+		g.token("pkg:" + strings.Repeat("q", g.longRun(200)))
 	default:
 		// 100 escaped backslashes: the trailing-backslash parity path at a
 		// size no byte-at-a-time mutator is going to build by accident.
-		g.token(`"` + strings.Repeat(`\\`, 100) + `"`)
+		g.token(`"` + strings.Repeat(`\\`, g.longRun(100)) + `"`)
 	}
 }

--- a/internal/fuzzgen/fuzzgen.go
+++ b/internal/fuzzgen/fuzzgen.go
@@ -1,0 +1,712 @@
+// Copyright © 2026 The ELPS authors
+
+// Package fuzzgen turns a fuzzer-supplied byte script into syntactically valid
+// ELPS source.
+//
+// # Why
+//
+// Every other fuzz target in this repository takes raw bytes.  A
+// coverage-guided mutator starting from raw bytes spends most of its budget on
+// input that dies at the first token, so the states it reaches are the ones
+// near the entrance: the scanner, the lexer's dispatch switch, the parser's
+// error paths.  The states BEHIND a successful parse -- comment attachment,
+// blank-line bookkeeping, prefix-form re-sugaring, scope-aware renaming -- are
+// where `elps fmt` and `elps minify` silently rewrite a customer's program,
+// and raw bytes hardly ever get there.
+//
+// This package generates the other kind of input: programs that are
+// syntactically valid but semantically hostile.  Deep nesting, every bracket
+// kind, keyword and package-qualified symbols, unicode identifiers, reader
+// macros with awkward operands, oversized literals, and comments in every
+// position the grammar permits one.
+//
+// # Contract
+//
+// Generate's output ALWAYS parses.  That is the load-bearing property: it is
+// what lets a fuzz target treat "the parser rejected this" as a defect rather
+// than as the expected outcome, which is how the float-exponent and
+// trailing-backslash lexer bugs were found -- both of them rejected input the
+// language is supposed to accept, and no raw-byte target could tell that
+// rejection apart from the millions of legitimate ones.
+//
+// The contract cuts both ways.  A crasher reported by a target that asserts it
+// is either a parser defect or a generator defect, and triage has to consider
+// both.  TestGeneratedProgramsAlwaysParse sweeps a large deterministic sample
+// so that a generator defect is caught by `go test` rather than by a red fuzz
+// run.
+//
+// # Determinism
+//
+// Generation is a pure function of (script, limits).  The fuzzing engine
+// records the script, not the ELPS text, so a crasher reproduces from the
+// committed corpus entry with no generated source to store.  Corpus files
+// under testdata/fuzz are therefore scripts.
+//
+// Nothing consumes randomness, wall-clock time or the environment, and every
+// production consumes at least one script byte, so generation terminates on a
+// finite script.  Three independent bounds apply anyway -- byte budget,
+// nesting cap and script length -- because a generator that can emit an
+// unbounded program hands the mutator a seed that costs seconds per execution.
+//
+// # On dialects
+//
+// There is deliberately only ONE grammar here.  An earlier iteration carried a
+// second, narrower dialect defined as the intersection of the two parsers this
+// repository used to ship; parser/regexparser is being removed, so that
+// definition no longer names anything and a subset with no defining property
+// is just an untested code path.  If a future target needs a restricted
+// vocabulary it should say what restricts it.
+package fuzzgen
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Limits bounds a single generated program.  All three are enforced
+// independently: the byte budget stops a wide program, the depth cap stops a
+// deep one, and the script itself runs out.
+type Limits struct {
+	// MaxBytes is the size at which generation stops opening new constructs.
+	// The result may exceed it by the tail of the construct in flight plus
+	// the closing brackets, which is bounded by MaxDepth + one literal.
+	MaxBytes int
+	// MaxDepth is the maximum nesting depth of generated forms.  Kept far
+	// below rdparser.DefaultMaxParseDepth: the depth guard is already
+	// covered by fuzzseed.Pathological, and a deep seed is expensive to
+	// mutate.
+	MaxDepth int
+	// MaxForms is the maximum number of top-level forms.
+	MaxForms int
+}
+
+// DefaultLimits are the bounds the fuzz targets use.  Sized so that a
+// generated program stays in the range where a coverage-guided run manages
+// thousands of executions per second; the oversized shapes that must also keep
+// working live in fuzzseed.Pathological, which ordinary unit tests run once
+// each.
+func DefaultLimits() Limits {
+	return Limits{MaxBytes: 2048, MaxDepth: 10, MaxForms: 10}
+}
+
+// Generate renders script as ELPS source under DefaultLimits.
+func Generate(script []byte) []byte {
+	return GenerateLimited(script, DefaultLimits())
+}
+
+// GenerateLimited renders script as ELPS source under the given limits.  A nil
+// or empty script yields the empty program, which is valid.
+func GenerateLimited(script []byte, lim Limits) []byte {
+	if lim.MaxBytes <= 0 {
+		lim.MaxBytes = DefaultLimits().MaxBytes
+	}
+	if lim.MaxDepth <= 0 {
+		lim.MaxDepth = DefaultLimits().MaxDepth
+	}
+	if lim.MaxForms <= 0 {
+		lim.MaxForms = DefaultLimits().MaxForms
+	}
+	g := &generator{script: script, lim: lim}
+	g.program()
+	return []byte(g.buf.String())
+}
+
+type generator struct {
+	script  []byte
+	pos     int
+	buf     strings.Builder
+	lim     Limits
+	needSep bool // a token was written; the next one needs whitespace first
+}
+
+// next consumes one script byte.  It returns -1 once the script is exhausted,
+// at which point every choose() falls to its default arm and generation winds
+// down deterministically instead of looping.
+func (g *generator) next() int {
+	if g.pos >= len(g.script) {
+		return -1
+	}
+	b := g.script[g.pos]
+	g.pos++
+	return int(b)
+}
+
+// choose consumes one script byte and reduces it to [0,n), or returns -1 when
+// the script is exhausted.
+func (g *generator) choose(n int) int {
+	b := g.next()
+	if b < 0 {
+		return -1
+	}
+	return b % n
+}
+
+func (g *generator) spent() bool {
+	return g.pos >= len(g.script) || g.buf.Len() >= g.lim.MaxBytes
+}
+
+// raw writes text without any separator bookkeeping.
+func (g *generator) raw(s string) {
+	g.buf.WriteString(s)
+}
+
+// pad writes the whitespace that must precede the next token.  ELPS separates
+// tokens by whitespace everywhere except immediately inside a bracket or
+// immediately after a prefix macro, and those callers write through raw
+// instead.
+func (g *generator) pad() {
+	if !g.needSep {
+		return
+	}
+	g.needSep = false
+	switch g.choose(8) {
+	case 3:
+		g.raw("\n")
+	case 4:
+		g.raw("\n\n")
+	case 5:
+		g.raw("  ")
+	case 6:
+		g.raw("\t")
+	case 7:
+		g.raw(" \n ")
+	default: // 0,1,2 and the exhausted script
+		g.raw(" ")
+	}
+}
+
+// token writes one complete token, separated from whatever came before.
+func (g *generator) token(s string) {
+	g.pad()
+	g.raw(s)
+	g.needSep = true
+}
+
+// ---------------------------------------------------------------------------
+// vocabularies
+//
+// Every entry is a token the lexer and parser accept as written.  The rules
+// that constrain them are narrow enough to be worth stating:
+//
+//   - miscWordSymbols is "._+-*/=<>!&~%?$"; '_' is NOT in it, so an underscore
+//     is not a legal symbol rune.
+//   - a symbol holds at most one ':', and neither side may be empty except the
+//     package side of a keyword (":kw" is legal, "kw:" is not).
+//   - a leading digit routes to the number lexer, so no symbol may start with
+//     one.
+//   - '-' glued to a digit or a symbol lexes as NEGATIVE and is merged into
+//     the following token by ParseNegative, so "-x" is the symbol "-x".
+
+var symbols = []string{
+	"a", "b", "f", "x", "y", "foo", "bar", "baz", "list", "car", "cdr",
+	"+", "-", "*", "/", "=", "<", ">", "!", "&", "~", "%", "?", "$", ".",
+	"a.b", "x!", "y?", "n%", "->", "<=>", "f2", "v9x",
+	// unicode identifiers: isWordStart admits any unicode.IsLetter rune, so
+	// these are ordinary symbols and must survive the printer unchanged.
+	"λ", "Ω", "日本語", "café", "Ünïcödé", "мир", "ασδφ",
+}
+
+var keywords = []string{":a", ":key", ":opt", ":λ", ":x1", ":rest"}
+
+var qualified = []string{
+	"lisp:car", "pkg:foo", "a:b", "user:x", "λ:μ", "test:assert=",
+}
+
+// specials are real ELPS forms.  Generating them keeps the minifier's
+// scope-aware renaming and the formatter's per-form indentation rules on the
+// hot path instead of leaving them to be reached by accident.
+var specials = []string{
+	"defun", "defmacro", "lambda", "let", "let*", "labels", "flet",
+	"quasiquote", "unquote", "unquote-splicing", "quote", "if", "cond",
+	"handler-bind", "in-package", "use-package", "export", "set", "set!",
+	"progn", "and", "or", "not", "error", "ignore-errors",
+}
+
+// stringBodies are bodies that survive strconv.Unquote, which is what
+// ParseLiteralString uses.  A raw newline is rejected by the lexer and a raw
+// control character by Unquote, so escapes are the only way to reach them.
+var stringBodies = []string{
+	``, `a`, `hello world`, `a b`,
+	`\n`, `\t`, `\\`, `\"`, `\x41`, `é`, `\U0001F600`, `\000`,
+	`\\\\`, `a\\`, `\\n`, `;not a comment`, `(`, `)`, `[]`, `#'`,
+	`é`, `日本語`, `λ`, `  `, `-1`, `1e5`,
+}
+
+// A raw-string body may neither contain three consecutive quotes nor end in
+// one: the scanner closes the literal at the first triple quote it finds, so
+// either shape terminates the token early and leaves a stray quote behind.
+var rawStringBodies = []string{
+	``, `a`, "a\nb", `; comment`, `\`, `\n`, `(a b)`, "\n\n", `a"b`, `x'y`,
+}
+
+// ---------------------------------------------------------------------------
+// productions
+
+func (g *generator) program() {
+	// A hash-bang is only legal as the very first thing in a program, and it
+	// is the one token whose handling differs between Parse and ParseProgram.
+	if g.choose(6) == 0 {
+		g.raw("#!/usr/bin/env elps\n")
+	}
+	for i := 0; i < g.lim.MaxForms && !g.spent(); i++ {
+		g.topLevel()
+	}
+	// A file ending in a comment leaves it in PendingComments rather than
+	// attached to any node -- a distinct printer path.
+	if g.choose(10) == 0 {
+		g.comment()
+	}
+	if g.choose(4) != 0 {
+		g.raw("\n")
+	}
+}
+
+func (g *generator) topLevel() {
+	switch g.choose(10) {
+	case 0, 1:
+		g.comment()
+	case 2:
+		g.comment()
+		g.comment()
+	case 3:
+		g.comment()
+		g.raw("\n") // blank line between the comment and the form it precedes
+	}
+	g.form(0)
+	if g.choose(6) == 0 {
+		g.raw(" ")
+		g.rawComment() // trailing, on the same line as the form
+	}
+	g.raw("\n")
+	g.needSep = false
+}
+
+// comment writes a whole-line comment, separated from what precedes it.
+func (g *generator) comment() {
+	g.pad()
+	if !strings.HasSuffix(g.buf.String(), "\n") {
+		g.raw("\n")
+	}
+	g.rawComment()
+}
+
+// rawComment writes "; ..." plus the newline that terminates it.  A comment
+// runs to end of line, so the newline is part of the token, not separation.
+func (g *generator) rawComment() {
+	switch g.choose(8) {
+	case 0:
+		g.raw(";")
+	case 1:
+		g.raw(";;; section")
+	case 2:
+		g.raw("; (unbalanced")
+	case 3:
+		g.raw(`; "unterminated`)
+	case 4:
+		g.raw("; λ 日本語")
+	case 5:
+		g.raw(";" + strings.Repeat("x", 200))
+	case 6:
+		g.raw("; -1")
+	default:
+		g.raw("; c")
+	}
+	g.raw("\n")
+	g.needSep = false
+}
+
+func (g *generator) form(depth int) {
+	if depth >= g.lim.MaxDepth || g.spent() {
+		g.atom()
+		return
+	}
+	switch g.choose(24) {
+	case 0, 1, 2, 3:
+		g.atom()
+	case 4, 5, 6:
+		g.sexpr(depth, '(')
+	case 7, 8:
+		g.sexpr(depth, '[')
+	case 9:
+		g.quote(depth)
+	case 10:
+		g.funRef()
+	case 11:
+		g.unbound(depth)
+	case 12:
+		g.quasi(depth)
+	case 13:
+		g.nestBurst(depth)
+	case 14:
+		g.special(depth)
+	case 15:
+		g.huge()
+	case 16:
+		// A form whose leading comment sits inside the enclosing bracket.
+		g.comment()
+		g.form(depth + 1)
+	case 17:
+		// Negative literal glued to a sign token: two tokens, one literal.
+		g.negative()
+	default:
+		g.atom()
+	}
+}
+
+func (g *generator) atom() {
+	switch g.choose(16) {
+	case 0, 1:
+		g.token(symbols[g.pick(len(symbols))])
+	case 2:
+		g.token(keywords[g.pick(len(keywords))])
+	case 3:
+		g.token(qualified[g.pick(len(qualified))])
+	case 4:
+		g.token(specials[g.pick(len(specials))])
+	case 5, 6:
+		g.token(g.intLiteral())
+	case 7, 8:
+		g.token(g.floatLiteral())
+	case 9:
+		g.token("#x" + []string{"0", "FF", "dead", "7fffffff", "1", "aA"}[g.pick(6)])
+	case 10:
+		g.token("#o" + []string{"0", "7", "777", "17777777777", "1"}[g.pick(5)])
+	case 11, 12:
+		g.token(`"` + stringBodies[g.pick(len(stringBodies))] + `"`)
+	case 13:
+		g.token(`"""` + rawStringBodies[g.pick(len(rawStringBodies))] + `"""`)
+	case 14:
+		g.token("()")
+	default:
+		g.token(symbols[g.pick(len(symbols))])
+	}
+}
+
+// pick chooses an index into a table, defaulting to 0 on an exhausted script.
+func (g *generator) pick(n int) int {
+	i := g.choose(n)
+	if i < 0 {
+		return 0
+	}
+	return i
+}
+
+// intLiteral stays inside int64.  Overflowing literals are a parse error, and
+// they are already covered by fuzzseed.Adversarial; generating them here would
+// break the "always parses" contract for no new coverage.
+func (g *generator) intLiteral() string {
+	switch g.choose(8) {
+	case 0:
+		return "0"
+	case 1:
+		return "1"
+	case 2:
+		return "9223372036854775807" // math.MaxInt64
+	case 3:
+		return strings.Repeat("9", 18)
+	case 4:
+		return "007"
+	case 5:
+		return strconv.Itoa(g.pick(256))
+	case 6:
+		return "1000000"
+	default:
+		return "42"
+	}
+}
+
+// floatLiteral covers the exponent grammar, which is [+-]?digit+ after e/E.
+// The single-digit exponents here are the shapes the lexer used to reject.
+func (g *generator) floatLiteral() string {
+	switch g.choose(12) {
+	case 0:
+		return "1.5"
+	case 1:
+		return "0.0"
+	case 2:
+		return "1e5"
+	case 3:
+		return "1E5"
+	case 4:
+		return "1.5e2"
+	case 5:
+		return "1e+5"
+	case 6:
+		return "1.5e-2"
+	case 7:
+		return "1e55"
+	case 8:
+		return "0.1e0"
+	case 9:
+		return "123.456"
+	case 10:
+		return "1e308"
+	default:
+		return "2.0"
+	}
+}
+
+// negative emits a sign glued to what follows.  The lexer only produces a
+// NEGATIVE token when something CAN be glued to it, and ParseNegative merges
+// the two, so this is the one place where a single AST node spans two tokens.
+func (g *generator) negative() {
+	switch g.choose(4) {
+	case 0:
+		g.token("-" + g.intLiteral())
+	case 1:
+		g.token("-" + g.floatLiteral())
+	case 2:
+		g.token("-" + symbols[g.pick(len(symbols))])
+	default:
+		g.token("-1")
+	}
+}
+
+// sexpr writes a bracketed form.  Both bracket kinds are generated: '(' is a
+// cons expression and '[' a list, and the formatter tracks which one the
+// source used.
+func (g *generator) sexpr(depth int, open byte) {
+	closer := byte(')')
+	if open == '[' {
+		closer = ']'
+	}
+	g.pad()
+	g.raw(string(open))
+	g.needSep = false
+	n := g.pick(4)
+	for i := 0; i < n && !g.spent(); i++ {
+		g.form(depth + 1)
+	}
+	// A comment between the last child and the closing bracket lands in
+	// InnerTrailingComments, and a closing bracket on its own line is
+	// recorded separately again.
+	switch g.choose(10) {
+	case 0:
+		g.comment()
+	case 1:
+		g.raw("\n")
+		g.needSep = false
+	}
+	g.raw(string(closer))
+	g.needSep = true
+}
+
+// quote writes a ' prefix.  Whitespace and even a comment may sit between the
+// quote and its operand -- unlike #' and #^, which the lexer requires to be
+// glued to theirs -- so all three gaps are generated.
+func (g *generator) quote(depth int) {
+	g.pad()
+	g.raw("'")
+	g.needSep = false
+	switch g.choose(12) {
+	case 0:
+		g.raw("'") // quote chain
+	case 1:
+		g.raw("\n")
+	case 2:
+		g.raw("\n\n")
+	case 3:
+		g.rawComment()
+	}
+	g.form(depth + 1)
+}
+
+// funRef writes #'name.  ParseFunRef reads the operand with ParseSymbol and
+// then re-parses it, rejecting any name that does not read back as the same
+// symbol, so the operand pool is restricted to names that do.
+func (g *generator) funRef() {
+	names := []string{
+		"f", "foo", "car", "+", "-", "a.b", "λ", "lisp:car", "pkg:foo",
+		"x!", "defun", "日本語",
+	}
+	g.token("#'" + names[g.pick(len(names))])
+}
+
+// unbound writes #^expr.  ParseUnbound rejects an operand containing a nested
+// UNQUOTED s-expression, and the printer's re-sugaring check mirrors that
+// exactly, so the operand is drawn from the shapes that satisfy both.
+func (g *generator) unbound(depth int) {
+	g.pad()
+	g.raw("#^")
+	g.needSep = false
+	switch g.choose(8) {
+	case 0:
+		g.raw("%")
+	case 1:
+		g.raw("(+ % 1)")
+	case 2:
+		g.raw("[% 1]")
+	case 3:
+		g.raw("'a")
+	case 4:
+		g.raw("()")
+	case 5:
+		g.raw(`"s"`)
+	case 6:
+		g.raw("(list % %)")
+	default:
+		g.atomNoPad(depth)
+	}
+	g.needSep = true
+}
+
+// atomNoPad writes an atom with no leading whitespace, for the operand slot of
+// a prefix macro that forbids one.
+func (g *generator) atomNoPad(depth int) {
+	_ = depth
+	switch g.choose(6) {
+	case 0:
+		g.raw(symbols[g.pick(len(symbols))])
+	case 1:
+		g.raw(keywords[g.pick(len(keywords))])
+	case 2:
+		g.raw(g.intLiteral())
+	case 3:
+		g.raw(g.floatLiteral())
+	case 4:
+		g.raw(`"` + stringBodies[g.pick(len(stringBodies))] + `"`)
+	default:
+		g.raw("a")
+	}
+}
+
+// quasi writes a quasiquote template.  ELPS has no backquote reader syntax --
+// quasiquote, unquote and unquote-splicing are ordinary head symbols -- so the
+// interesting shape is the nesting, not the punctuation.
+func (g *generator) quasi(depth int) {
+	g.pad()
+	g.raw("(quasiquote")
+	g.needSep = true
+	switch g.choose(6) {
+	case 0:
+		g.token("(unquote")
+		g.form(depth + 2)
+		g.raw(")")
+	case 1:
+		g.token("(list")
+		g.token("(unquote-splicing")
+		g.form(depth + 3)
+		g.raw("))")
+	case 2:
+		g.token("(quasiquote (unquote (unquote-splicing")
+		g.form(depth + 4)
+		g.raw(")))")
+	default:
+		g.form(depth + 1)
+	}
+	g.raw(")")
+	g.needSep = true
+}
+
+// special writes a form with a real head symbol, so the formatter's per-form
+// indentation table and the minifier's binding-form handling are exercised
+// with the shapes they actually special-case.
+func (g *generator) special(depth int) {
+	g.pad()
+	switch g.choose(8) {
+	case 0:
+		g.raw("(defun ")
+		g.raw(symbols[g.pick(len(symbols))])
+		g.raw(" (x &optional y &rest z)")
+		g.needSep = true
+		g.form(depth + 1)
+		g.raw(")")
+	case 1:
+		g.raw("(let ([a ")
+		g.needSep = false
+		g.form(depth + 2)
+		g.raw("] [b 2])")
+		g.needSep = true
+		g.form(depth + 1)
+		g.raw(")")
+	case 2:
+		g.raw("(lambda (&key k)")
+		g.needSep = true
+		g.form(depth + 1)
+		g.raw(")")
+	case 3:
+		g.raw("(in-package 'pkg)")
+		g.needSep = true
+	case 4:
+		g.raw("(handler-bind ((condition (lambda (c) c)))")
+		g.needSep = true
+		g.form(depth + 1)
+		g.raw(")")
+	case 5:
+		g.raw("(defmacro m (x)")
+		g.needSep = true
+		g.form(depth + 1)
+		g.raw(")")
+	case 6:
+		g.raw("(cond ([")
+		g.needSep = false
+		g.form(depth + 2)
+		g.raw("] 1) (:else 2))")
+		g.needSep = true
+	default:
+		g.raw("(progn")
+		g.needSep = true
+		g.form(depth + 1)
+		g.raw(")")
+	}
+}
+
+// nestBurst writes a run of nesting in one step, so the mutator can reach a
+// deep tree without needing a long script to build it one level at a time.
+// The run is clamped to the remaining depth budget.
+func (g *generator) nestBurst(depth int) {
+	n := g.pick(8) + 1
+	if room := g.lim.MaxDepth - depth; n > room {
+		n = room
+	}
+	if n <= 0 {
+		g.atom()
+		return
+	}
+	g.pad()
+	open, closer := "(", ")"
+	switch g.choose(4) {
+	case 0:
+		open, closer = "[", "]"
+	case 1:
+		open, closer = "'(", ")"
+	case 2:
+		// A run of quotes over a single atom.  Quote nesting has no closing
+		// token, so it is generated on its own rather than as a bracket pair.
+		g.raw(strings.Repeat("'", n))
+		g.needSep = false
+		g.atomNoPad(0)
+		g.needSep = true
+		return
+	}
+	g.raw(strings.Repeat(open, n))
+	g.needSep = false
+	if !g.spent() {
+		g.form(depth + n)
+	}
+	g.raw(strings.Repeat(closer, n))
+	g.needSep = true
+}
+
+// huge writes an oversized but legal token.  Size is where the scanner's
+// buffer-extension path, the printer's line-width logic and the minifier's
+// name table all change behaviour, and none of that is reachable from a
+// literal the mutator has to build one byte at a time.
+func (g *generator) huge() {
+	switch g.choose(6) {
+	case 0:
+		g.token(strings.Repeat("z", 300))
+	case 1:
+		g.token(`"` + strings.Repeat("s", 400) + `"`)
+	case 2:
+		g.token(`"""` + strings.Repeat("r", 400) + `"""`)
+	case 3:
+		g.token(strings.Repeat("λ", 100))
+	case 4:
+		g.token("pkg:" + strings.Repeat("q", 200))
+	default:
+		// 100 escaped backslashes: the trailing-backslash parity path at a
+		// size no byte-at-a-time mutator is going to build by accident.
+		g.token(`"` + strings.Repeat(`\\`, 100) + `"`)
+	}
+}

--- a/internal/fuzzgen/fuzzgen_test.go
+++ b/internal/fuzzgen/fuzzgen_test.go
@@ -1,0 +1,247 @@
+// Copyright © 2026 The ELPS authors
+
+package fuzzgen_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/internal/fuzzgen"
+)
+
+// formProductions is the arity of the switch in generator.form.  A seed per
+// production is what makes the corpus reach every construct on the very first
+// pass instead of waiting for the mutator to stumble onto one; if the switch
+// grows and this does not, TestSeedScriptsReachEveryProduction says so.
+const formProductions = 24
+
+// seedScripts returns the f.Add corpus.
+//
+// The entries are SCRIPTS, not ELPS source.  Generation is a pure function of
+// the script, so the script is the reproducible artifact -- committing source
+// would leave the fuzzing engine mutating text it does not actually consume.
+//
+// Layout of the first three bytes, from generator.program and generator.form:
+// byte 0 chooses whether a hash-bang is written (choose(6)), byte 1 the
+// top-level comment shape (choose(10)), byte 2 the production in form
+// (choose(24)).  The systematic block below therefore lands on each production
+// in turn, and the tail gives it script to expand into.
+func seedScripts() [][]byte {
+	scripts := [][]byte{
+		nil,
+		{},
+		{0},
+		{255},
+		{0, 0, 0, 0, 0, 0, 0, 0},
+		{255, 255, 255, 255, 255, 255, 255, 255},
+		[]byte("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"),
+		[]byte("elps fmt round trip"),
+		[]byte(";;;;;;;;;;;;;;;;"),
+		[]byte("''''''''''''''''"),
+		// A shebang (byte 0 divisible by 6) followed by prefix-form material:
+		// the shape whose comment handling broke the parser's own output.
+		{0, 0, 10, 3, 1, 0, 10, 3, 1},
+		{0, 1, 10, 7, 16, 10, 3, 2, 9, 4},
+		// Long tails of one repeated byte drive a single production to its
+		// depth or byte bound.
+		bytes.Repeat([]byte{13}, 64),
+		bytes.Repeat([]byte{9}, 64),
+		bytes.Repeat([]byte{4}, 64),
+		bytes.Repeat([]byte{16}, 64),
+	}
+	for k := range formProductions {
+		s := []byte{1, 9, byte(k)}
+		for i := range 24 {
+			s = append(s, byte(i*7+k))
+		}
+		scripts = append(scripts, s)
+	}
+	return scripts
+}
+
+// lcgScripts returns n deterministic pseudo-random scripts.  A fixed linear
+// congruential generator rather than math/rand so the sample is identical on
+// every platform and every Go release: a sweep that silently changes shape is
+// not a gate.
+func lcgScripts(n int, seed uint64) [][]byte {
+	state := seed | 1
+	next := func() uint64 {
+		state = state*6364136223846793005 + 1442695040888963407
+		return state >> 33
+	}
+	out := make([][]byte, 0, n)
+	for range n {
+		script := make([]byte, next()%400)
+		for i := range script {
+			script[i] = byte(next())
+		}
+		out = append(out, script)
+	}
+	return out
+}
+
+// TestGeneratedProgramsAlwaysParse pins fuzzgen's central contract.  Every
+// assertion in FuzzGeneratedPipeline rests on it: without it a rejected
+// program cannot be told apart from the ordinary garbage a raw-byte fuzz
+// target feeds the parser, and the two lexer defects that showed up as
+// "the parser refused input the language accepts" would be invisible.
+//
+// It also protects the fuzz target from fuzzgen itself.  A generator bug
+// reports as a crash in FuzzGeneratedPipeline; this test catches it in `go
+// test` instead, where the failure names the generator.
+func TestGeneratedProgramsAlwaysParse(t *testing.T) {
+	scripts := append(seedScripts(), lcgScripts(6000, 1)...)
+	for _, lim := range limitProfiles {
+		for _, script := range scripts {
+			src := fuzzgen.GenerateLimited(script, lim)
+			if _, err := parseProgram(src); err != nil {
+				t.Fatalf("generated program does not parse (limits %+v, script %q): %v\n--- source ---\n%s",
+					lim, script, err, src)
+			}
+		}
+	}
+}
+
+// TestGenerateIsDeterministic pins the property the corpus depends on: a
+// crasher recorded as a script has to render the same source on every replay,
+// on every machine.
+func TestGenerateIsDeterministic(t *testing.T) {
+	for _, script := range append(seedScripts(), lcgScripts(500, 7)...) {
+		first := fuzzgen.Generate(script)
+		for range 3 {
+			if again := fuzzgen.Generate(script); !bytes.Equal(first, again) {
+				t.Fatalf("Generate is not deterministic for script %q:\n%q\n%q", script, first, again)
+			}
+		}
+	}
+}
+
+// TestGenerateRespectsLimits checks the three bounds.  A generator that can
+// emit an unbounded program hands the mutator a seed costing seconds per
+// execution, which is how a coverage-guided run stops making progress.
+//
+// The byte budget is a stopping condition rather than a hard cap: generation
+// refuses to open new constructs past it, then finishes the construct in
+// flight and closes its brackets.  The slack allowed here covers the largest
+// single token fuzzgen writes (a 400-byte literal), one closing bracket per
+// level of nesting, and the tail of one special form.
+func TestGenerateRespectsLimits(t *testing.T) {
+	for _, lim := range limitProfiles {
+		slack := 512 + 4*lim.MaxDepth
+		for _, script := range lcgScripts(3000, 3) {
+			src := fuzzgen.GenerateLimited(script, lim)
+			if len(src) > lim.MaxBytes+slack {
+				t.Fatalf("limits %+v: generated %d bytes, budget %d + %d slack (script %q)",
+					lim, len(src), lim.MaxBytes, slack, script)
+			}
+			if d := maxParenDepth(src); d > lim.MaxDepth+8 {
+				t.Fatalf("limits %+v: nesting depth %d exceeds cap %d (script %q)\n%s",
+					lim, d, lim.MaxDepth, script, src)
+			}
+		}
+	}
+}
+
+// maxParenDepth measures bracket nesting outside string literals and comments.
+// It is deliberately approximate -- the point is to catch a generator that has
+// stopped bounding depth at all, not to re-implement the lexer.
+func maxParenDepth(src []byte) int {
+	depth, maxDepth := 0, 0
+	inString, inRaw, inComment := false, false, false
+	for i := 0; i < len(src); i++ {
+		c := src[i]
+		switch {
+		case inComment:
+			if c == '\n' {
+				inComment = false
+			}
+		case inRaw:
+			if c == '"' && i+2 < len(src) && src[i+1] == '"' && src[i+2] == '"' {
+				inRaw = false
+				i += 2
+			}
+		case inString:
+			if c == '\\' {
+				i++
+			} else if c == '"' {
+				inString = false
+			}
+		case c == ';':
+			inComment = true
+		case c == '"':
+			if i+2 < len(src) && src[i+1] == '"' && src[i+2] == '"' {
+				inRaw = true
+				i += 2
+			} else {
+				inString = true
+			}
+		case c == '(' || c == '[':
+			depth++
+			maxDepth = max(maxDepth, depth)
+		case c == ')' || c == ']':
+			depth--
+		}
+	}
+	return maxDepth
+}
+
+// TestSeedScriptsReachEveryProduction fails when a production is added to
+// generator.form without a seed that lands on it.  A construct nothing seeds
+// is one the mutator has to discover by chance, which for a 24-way switch
+// three bytes into the script it largely will not.
+func TestSeedScriptsReachEveryProduction(t *testing.T) {
+	seen := make(map[int]bool)
+	for _, script := range seedScripts() {
+		if len(script) >= 3 && script[0]%6 != 0 && script[1]%10 >= 4 {
+			seen[int(script[2])%formProductions] = true
+		}
+	}
+	for k := range formProductions {
+		if !seen[k] {
+			t.Errorf("no seed script reaches generator.form production %d", k)
+		}
+	}
+}
+
+// TestGeneratedProgramsCoverTheGrammar guards against the generator quietly
+// losing a construct -- a table renamed, a switch arm folded away -- which
+// would leave the pipeline target running at full speed over a grammar with a
+// hole in it.  The markers are the ones the whole exercise is about: reader
+// macros, both bracket kinds, keyword and package-qualified symbols, unicode
+// identifiers, exponents, comments, oversized tokens.
+func TestGeneratedProgramsCoverTheGrammar(t *testing.T) {
+	markers := map[string]string{
+		"funref":            "#'",
+		"unbound":           "#^",
+		"hash-bang":         "#!",
+		"quote":             "'",
+		"paren":             "(",
+		"brace":             "[",
+		"keyword-symbol":    ":a",
+		"qualified-symbol":  "lisp:car",
+		"unicode-symbol":    "日本語",
+		"float-exponent":    "e5",
+		"negative-literal":  "-1",
+		"hex-literal":       "#x",
+		"octal-literal":     "#o",
+		"raw-string":        `"""`,
+		"escaped-backslash": `\\`,
+		"comment":           ";",
+		"quasiquote":        "quasiquote",
+		"unquote-splicing":  "unquote-splicing",
+		"huge-token":        strings.Repeat("z", 300),
+		"deep-nesting":      "((((",
+	}
+	var all strings.Builder
+	for _, script := range append(seedScripts(), lcgScripts(4000, 11)...) {
+		all.Write(fuzzgen.Generate(script))
+		all.WriteByte('\n')
+	}
+	corpus := all.String()
+	for name, marker := range markers {
+		if !strings.Contains(corpus, marker) {
+			t.Errorf("generated corpus never contains %s (%q)", name, marker)
+		}
+	}
+}

--- a/internal/fuzzgen/fuzzgen_test.go
+++ b/internal/fuzzgen/fuzzgen_test.go
@@ -128,7 +128,10 @@ func TestGenerateIsDeterministic(t *testing.T) {
 // level of nesting, and the tail of one special form.
 func TestGenerateRespectsLimits(t *testing.T) {
 	for _, lim := range limitProfiles {
-		slack := 512 + 4*lim.MaxDepth
+		// One long token may already have been in flight when the budget ran
+		// out (fuzzgen.longRun caps only the ones started after), plus a
+		// closing bracket and a short trailing comment per open level.
+		slack := 512 + 40*lim.MaxDepth
 		for _, script := range lcgScripts(3000, 3) {
 			src := fuzzgen.GenerateLimited(script, lim)
 			if len(src) > lim.MaxBytes+slack {
@@ -162,9 +165,10 @@ func maxParenDepth(src []byte) int {
 				i += 2
 			}
 		case inString:
-			if c == '\\' {
+			switch c {
+			case '\\':
 				i++
-			} else if c == '"' {
+			case '"':
 				inString = false
 			}
 		case c == ';':

--- a/internal/fuzzgen/pipeline_fuzz_test.go
+++ b/internal/fuzzgen/pipeline_fuzz_test.go
@@ -136,10 +136,39 @@ func commentTexts(src []byte) []string {
 				out = append(out, tok.Text)
 			case token.EOF, token.ERROR, token.INVALID:
 				return out
+			default:
+				// Every other token type is irrelevant here.
 			}
 		}
 	}
 	return out
+}
+
+// interiorBlankLines counts blank lines strictly between the first and last
+// non-blank lines of src.  Leading and trailing blank runs are excluded so the
+// count survives the formatter's trailing-newline normalisation, which is not
+// what this is measuring.
+func interiorBlankLines(src []byte) int {
+	lines := strings.Split(string(src), "\n")
+	first, last := -1, -1
+	for i, l := range lines {
+		if strings.TrimSpace(l) != "" {
+			if first < 0 {
+				first = i
+			}
+			last = i
+		}
+	}
+	if first < 0 {
+		return 0
+	}
+	n := 0
+	for _, l := range lines[first : last+1] {
+		if strings.TrimSpace(l) == "" {
+			n++
+		}
+	}
+	return n
 }
 
 func sameStrings(a, b []string) bool {
@@ -156,7 +185,7 @@ func sameStrings(a, b []string) bool {
 
 func FuzzGeneratedPipeline(f *testing.F) {
 	for _, script := range seedScripts() {
-		for shape := range len(limitProfiles) {
+		for shape := range limitProfiles {
 			f.Add(script, uint8(shape)) //nolint:gosec // G115: bounded by len(limitProfiles)
 		}
 	}
@@ -205,7 +234,28 @@ func FuzzGeneratedPipeline(f *testing.F) {
 				beforeComments, afterComments, src, first)
 		}
 
-		// (5) Idempotence.  runFormatTests and TestEdgeIdempotency assert it
+		// (5) Blank lines are never INVENTED.  Every blank line the printer
+		// writes comes from a count the parser measured in the source and the
+		// printer then clamps to cfg.MaxBlankLines -- blankLinesBefore,
+		// writeBlankLinesAfterComments, writeInnerTrailingComments -- so the
+		// interior blank-line count can shrink but has no legitimate way to
+		// grow.
+		//
+		// This is the only assertion here that catches a formatter which
+		// REFLOWS rather than rewrites.  Inserting a blank line leaves the AST
+		// identical, leaves every comment in place, and leaves the output a
+		// perfectly stable fixed point, so (3), (4) and (6) all pass: the
+		// prefix-form blank-line regression turned "(a)\n; c\n\n#'f\n" into
+		// "(a)\n\n; c\n\n#'f\n" and nothing else could see it.  That matters
+		// because a comment's POSITION carries meaning -- the `; <-` markers
+		// in editors/vscode/test/grammar/basics.lisp are syntax-test
+		// assertions about the line above them.
+		if b, a := interiorBlankLines(src), interiorBlankLines(first); a > b {
+			t.Fatalf("Format invented %d blank line(s) (%d -> %d)\n--- source ---\n%q\n--- output ---\n%q",
+				a-b, b, a, src, first)
+		}
+
+		// (6) Idempotence.  runFormatTests and TestEdgeIdempotency assert it
 		// for fixed inputs; a non-idempotent formatter makes `elps fmt`
 		// produce diff churn forever.
 		second, err := formatter.Format(first, nil)
@@ -217,7 +267,7 @@ func FuzzGeneratedPipeline(f *testing.F) {
 				first, second, src)
 		}
 
-		// (6) Minification.  Its only failure mode is the parse it does
+		// (7) Minification.  Its only failure mode is the parse it does
 		// itself (minifier.parseFile), so rejecting formatted output that
 		// the parser accepts is unambiguously a defect.
 		minified, symbols, err := minifier.MinifySource(first, "fuzzgen.lisp", nil)
@@ -246,7 +296,7 @@ func FuzzGeneratedPipeline(f *testing.F) {
 			}
 		}
 
-		// (7) The minified program parses and has the shape it started with.
+		// (8) The minified program parses and has the shape it started with.
 		// Names are what minification is allowed to change, so only the type
 		// skeleton is compared -- the same contract FuzzMinifySource asserts.
 		after, err := parseProgram(minified)
@@ -258,7 +308,7 @@ func FuzzGeneratedPipeline(f *testing.F) {
 				want, got, minified)
 		}
 
-		// (8) Formatting the minified output.  This is the state a build
+		// (9) Formatting the minified output.  This is the state a build
 		// pipeline reaches when a shipped bundle is read back, and it is a
 		// different input class from anything a human writes: no comments, no
 		// blank lines, one-letter names, everything on as few lines as

--- a/internal/fuzzgen/pipeline_fuzz_test.go
+++ b/internal/fuzzgen/pipeline_fuzz_test.go
@@ -1,0 +1,293 @@
+// Copyright © 2026 The ELPS authors
+
+package fuzzgen_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/formatter"
+	"github.com/luthersystems/elps/internal/fuzzgen"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/minifier"
+	"github.com/luthersystems/elps/parser/lexer"
+	"github.com/luthersystems/elps/parser/rdparser"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// FuzzGeneratedPipeline drives the whole source-rewriting pipeline --
+//
+//	parse -> format -> re-parse -> format again -> minify -> re-parse ->
+//	format the minified output -> re-parse
+//
+// -- over programs that are syntactically valid by construction.  Together
+// `elps fmt` and `elps minify` are the two commands that REWRITE a customer's
+// source, and downstream (luthersystems/substrate) the minified output IS the
+// chaincode that gets uploaded and executed.  A defect anywhere in that chain
+// is a silent edit to someone's program.
+//
+// Every assertion below restates a property the repository already tests for
+// fixed inputs, generalised to arbitrary generated input.  Nothing is asserted
+// about how a program is laid out, which names the minifier picks, or what any
+// of it MEANS -- those belong to the unit tests, and asserting them here would
+// manufacture crashes out of legitimate formatting choices.
+//
+// The one genuinely new assertion is the first: the generator's own contract
+// that its output parses.  Without it a rejected program is indistinguishable
+// from the millions of rejections a raw-byte target sees every second, and
+// neither of the two lexer defects this target found -- "1e5" and a string
+// ending in a backslash, both of them VALID input the lexer refused -- would
+// have been visible.  A failure of that assertion is a defect in the parser or
+// in fuzzgen, and triage has to consider both; TestGeneratedProgramsAlwaysParse
+// sweeps a large deterministic sample so a generator defect is normally caught
+// by `go test` first.
+
+// maxCommentTokens bounds the comment scan.  The lexer answers forever once
+// wedged, so the loop needs its own bound; generated programs are capped at a
+// couple of KiB, which cannot hold anywhere near this many tokens.
+const maxCommentTokens = 1 << 16
+
+// limitProfiles give the mutator a knob for the SHAPE of a program
+// independently of its content: the same script can be rendered deep and
+// narrow or shallow and wide.  All of them are small -- the oversized inputs
+// live in fuzzseed.Pathological, which unit tests run once each.
+var limitProfiles = []fuzzgen.Limits{
+	{MaxBytes: 2048, MaxDepth: 10, MaxForms: 10}, // the default shape
+	{MaxBytes: 256, MaxDepth: 3, MaxForms: 4},    // small and shallow
+	{MaxBytes: 4096, MaxDepth: 40, MaxForms: 2},  // deep and narrow
+	{MaxBytes: 4096, MaxDepth: 2, MaxForms: 40},  // flat and wide
+}
+
+// programString renders a parsed program as formatter_test.go's roundTripEqual
+// does -- LVal.String() per top-level form -- so this target and the table
+// tests agree on what "the same AST" means.  ParseProgram rather than a Parse
+// loop, because it is what lisp.Reader.Read calls and the only entry point
+// that consumes a leading hash-bang.
+func programString(src []byte) (string, error) {
+	p := rdparser.New(token.NewScanner("fuzzgen", bytes.NewReader(src)))
+	exprs, err := p.ParseProgram()
+	if err != nil {
+		return "", err
+	}
+	parts := make([]string, 0, len(exprs))
+	for _, expr := range exprs {
+		parts = append(parts, expr.String())
+	}
+	return strings.Join(parts, "\n"), nil
+}
+
+// skeleton renders a program's structure with every symbol, string and number
+// replaced by its type name, so two programs compare equal iff they have the
+// same shape.  Minification renames identifiers, which is exactly what a
+// skeleton ignores.
+func skeleton(exprs []*lisp.LVal) string {
+	var b strings.Builder
+	for _, expr := range exprs {
+		writeSkeleton(&b, expr)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func writeSkeleton(b *strings.Builder, v *lisp.LVal) {
+	if v == nil {
+		b.WriteString("<nil>")
+		return
+	}
+	if v.Quoted {
+		b.WriteByte('\'')
+	}
+	b.WriteString(v.Type.String())
+	if len(v.Cells) == 0 {
+		return
+	}
+	b.WriteByte('(')
+	for i, c := range v.Cells {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		writeSkeleton(b, c)
+	}
+	b.WriteByte(')')
+}
+
+func parseProgram(src []byte) ([]*lisp.LVal, error) {
+	p := rdparser.New(token.NewScanner("fuzzgen", bytes.NewReader(src)))
+	return p.ParseProgram()
+}
+
+// commentTexts returns the text of every comment token in src, in order.  A
+// hash-bang lexes as HASH_BANG plus a COMMENT holding the rest of the line, so
+// both types count.
+//
+// This is the only way to see a dropped comment.  Comments are not part of the
+// AST, so `elps fmt` deleting one leaves programString unchanged AND leaves
+// Format idempotent -- the formatted output is a stable fixed point that is
+// simply missing a line of the user's file.  Four separate defects presented
+// exactly that way.
+func commentTexts(src []byte) []string {
+	lx := lexer.New(token.NewScanner("fuzzgen", bytes.NewReader(src)))
+	out := []string{}
+	for range maxCommentTokens {
+		for _, tok := range lx.ReadToken() {
+			switch tok.Type {
+			case token.COMMENT, token.HASH_BANG:
+				out = append(out, tok.Text)
+			case token.EOF, token.ERROR, token.INVALID:
+				return out
+			}
+		}
+	}
+	return out
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func FuzzGeneratedPipeline(f *testing.F) {
+	for _, script := range seedScripts() {
+		for shape := range len(limitProfiles) {
+			f.Add(script, uint8(shape)) //nolint:gosec // G115: bounded by len(limitProfiles)
+		}
+	}
+	f.Fuzz(func(t *testing.T, script []byte, shape uint8) {
+		src := fuzzgen.GenerateLimited(script, limitProfiles[int(shape)%len(limitProfiles)])
+
+		// (1) The generator's contract.  See the package comment on fuzzgen:
+		// a failure here is a parser defect or a generator defect.
+		before, err := parseProgram(src)
+		if err != nil {
+			t.Fatalf("generated program does not parse: %v\n--- source ---\n%s", err, src)
+		}
+		beforeAST, err := programString(src)
+		if err != nil {
+			t.Fatalf("re-parse of the generated program failed: %v", err)
+		}
+		beforeComments := commentTexts(src)
+
+		// (2) Format accepts exactly what the parser accepts.  FuzzFormat
+		// asserts the other direction (Format succeeded, parser rejected);
+		// together they say `elps fmt` can read every file elps can run.
+		// Format-preserving mode only ATTACHES metadata to the same tree the
+		// standard parser builds -- FuzzParseFormatting pins that -- so it has
+		// no reason of its own to reject anything.
+		first, err := formatter.Format(src, nil)
+		if err != nil {
+			t.Fatalf("Format rejected a program the parser accepted: %v\n--- source ---\n%s", err, src)
+		}
+
+		// (3) AST preservation.  formatter_test.go's roundTripEqual asserts
+		// this for the repository's .lisp files.
+		afterAST, err := programString(first)
+		if err != nil {
+			t.Fatalf("the parser rejected formatted output: %v\n--- output ---\n%s", err, first)
+		}
+		if beforeAST != afterAST {
+			t.Fatalf("Format changed the AST\n--- before ---\n%s\n--- after ---\n%s\n--- source ---\n%s\n--- output ---\n%s",
+				beforeAST, afterAST, src, first)
+		}
+
+		// (4) Comment preservation.  Not an AST property, so nothing above
+		// can see it.  The default config does not strip comments, and a
+		// formatter that deletes one is editing the user's file.
+		if afterComments := commentTexts(first); !sameStrings(beforeComments, afterComments) {
+			t.Fatalf("Format changed the comments\n--- before ---\n%q\n--- after ---\n%q\n--- source ---\n%s\n--- output ---\n%s",
+				beforeComments, afterComments, src, first)
+		}
+
+		// (5) Idempotence.  runFormatTests and TestEdgeIdempotency assert it
+		// for fixed inputs; a non-idempotent formatter makes `elps fmt`
+		// produce diff churn forever.
+		second, err := formatter.Format(first, nil)
+		if err != nil {
+			t.Fatalf("Format rejected its own output: %v\n--- output ---\n%s", err, first)
+		}
+		if !bytes.Equal(first, second) {
+			t.Fatalf("Format is not idempotent\n--- pass 1 ---\n%q\n--- pass 2 ---\n%q\n--- source ---\n%s",
+				first, second, src)
+		}
+
+		// (6) Minification.  Its only failure mode is the parse it does
+		// itself (minifier.parseFile), so rejecting formatted output that
+		// the parser accepts is unambiguously a defect.
+		minified, symbols, err := minifier.MinifySource(first, "fuzzgen.lisp", nil)
+		if err != nil {
+			t.Fatalf("MinifySource rejected formatted output: %v\n--- input ---\n%s", err, first)
+		}
+
+		// Determinism, as TestMinifySource_DeterministicAndScopeAware asserts:
+		// a non-deterministic minifier makes builds unreproducible and its
+		// symbol map useless for decoding a trace.
+		minified2, symbols2, err := minifier.MinifySource(first, "fuzzgen.lisp", nil)
+		if err != nil {
+			t.Fatalf("second MinifySource of the same input failed: %v", err)
+		}
+		if !bytes.Equal(minified, minified2) {
+			t.Fatalf("MinifySource is not deterministic\n--- run 1 ---\n%s\n--- run 2 ---\n%s", minified, minified2)
+		}
+		if len(symbols.Entries) != len(symbols2.Entries) {
+			t.Fatalf("symbol map is not deterministic: %d entries then %d",
+				len(symbols.Entries), len(symbols2.Entries))
+		}
+		for i := range symbols.Entries {
+			if symbols.Entries[i] != symbols2.Entries[i] {
+				t.Fatalf("symbol map entry %d differs between runs: %+v vs %+v",
+					i, symbols.Entries[i], symbols2.Entries[i])
+			}
+		}
+
+		// (7) The minified program parses and has the shape it started with.
+		// Names are what minification is allowed to change, so only the type
+		// skeleton is compared -- the same contract FuzzMinifySource asserts.
+		after, err := parseProgram(minified)
+		if err != nil {
+			t.Fatalf("the parser rejected minified output: %v\n--- output ---\n%s", err, minified)
+		}
+		if got, want := skeleton(after), skeleton(before); got != want {
+			t.Fatalf("minification changed the program shape\n--- before ---\n%s\n--- after ---\n%s\n--- output ---\n%s",
+				want, got, minified)
+		}
+
+		// (8) Formatting the minified output.  This is the state a build
+		// pipeline reaches when a shipped bundle is read back, and it is a
+		// different input class from anything a human writes: no comments, no
+		// blank lines, one-letter names, everything on as few lines as
+		// possible.  The same three properties apply, against the MINIFIED
+		// program rather than the original.
+		formattedMin, err := formatter.Format(minified, nil)
+		if err != nil {
+			t.Fatalf("Format rejected minified output: %v\n--- input ---\n%s", err, minified)
+		}
+		minAST, err := programString(minified)
+		if err != nil {
+			t.Fatalf("re-parse of minified output failed: %v\n--- output ---\n%s", err, minified)
+		}
+		formattedMinAST, err := programString(formattedMin)
+		if err != nil {
+			t.Fatalf("the parser rejected formatted minified output: %v\n--- output ---\n%s", err, formattedMin)
+		}
+		if minAST != formattedMinAST {
+			t.Fatalf("formatting minified output changed the AST\n--- before ---\n%s\n--- after ---\n%s\n--- output ---\n%s",
+				minAST, formattedMinAST, formattedMin)
+		}
+		formattedMin2, err := formatter.Format(formattedMin, nil)
+		if err != nil {
+			t.Fatalf("Format rejected its own output on the minified program: %v\n--- output ---\n%s",
+				err, formattedMin)
+		}
+		if !bytes.Equal(formattedMin, formattedMin2) {
+			t.Fatalf("Format is not idempotent on minified output\n--- pass 1 ---\n%q\n--- pass 2 ---\n%q",
+				formattedMin, formattedMin2)
+		}
+	})
+}

--- a/internal/fuzzgen/testdata/fuzz/FuzzGeneratedPipeline/empty-sexpr-comments
+++ b/internal/fuzzgen/testdata/fuzz/FuzzGeneratedPipeline/empty-sexpr-comments
@@ -1,0 +1,3 @@
+go test fuzz v1
+[]byte("00&2\xde002")
+byte('\n')

--- a/internal/fuzzgen/testdata/fuzz/FuzzGeneratedPipeline/negative-after-comment
+++ b/internal/fuzzgen/testdata/fuzz/FuzzGeneratedPipeline/negative-after-comment
@@ -1,0 +1,3 @@
+go test fuzz v1
+[]byte("007200000A")
+byte('\x03')

--- a/internal/fuzzgen/testdata/fuzz/FuzzGeneratedPipeline/prefix-blank-line
+++ b/internal/fuzzgen/testdata/fuzz/FuzzGeneratedPipeline/prefix-blank-line
@@ -1,0 +1,3 @@
+go test fuzz v1
+[]byte("020$00A701!0\"")
+byte('\x00')

--- a/internal/fuzzgen/testdata/fuzz/FuzzGeneratedPipeline/prefix-operand-comments
+++ b/internal/fuzzgen/testdata/fuzz/FuzzGeneratedPipeline/prefix-operand-comments
@@ -1,0 +1,3 @@
+go test fuzz v1
+[]byte("00\"")
+byte('\x01')

--- a/internal/fuzzgen/testdata/fuzz/FuzzGeneratedPipeline/sexpr-head-comments
+++ b/internal/fuzzgen/testdata/fuzz/FuzzGeneratedPipeline/sexpr-head-comments
@@ -1,0 +1,3 @@
+go test fuzz v1
+[]byte("00%07X")
+byte('\x00')

--- a/parser/lexer/lexer.go
+++ b/parser/lexer/lexer.go
@@ -149,7 +149,19 @@ func (lex *Lexer) readToken() []*token.Token {
 			if lex.scanner.Accept(func(c rune) bool { return c == '\n' }) {
 				return lex.errorf("unterminated string literal")
 			}
-			if lex.scanner.Rune() == '\\' {
+			// The run just accepted stopped at a '"' (or at EOF).  Whether
+			// that quote CLOSES the string depends on how many backslashes
+			// immediately precede it: an odd number means the last one
+			// escapes the quote, an even number means they escape each other
+			// and the quote is the terminator.
+			//
+			// The parity has to be counted, not read off the last rune.
+			// Testing `Rune() == '\\'` treats every run ending in a backslash
+			// as an escape, so "a\\" -- a string whose value is a single
+			// backslash -- consumed its own closing quote and then ran off the
+			// end of the input as an unterminated literal.  NO elps string
+			// could end in a backslash.  Found by FuzzGeneratedPipeline.
+			if trailingBackslashes(lex.scanner.Text())%2 == 1 {
 				// Wait until parsing to check the escaped character
 				if !lex.scanner.Accept(func(c rune) bool { return true }) {
 					return lex.errorf("unterminated string literal %q", lex.peekRune())
@@ -338,9 +350,6 @@ func (lex *Lexer) readNumber() []*token.Token {
 	case lex.scanner.AcceptRune('.'):
 		return lex.readFloatFraction()
 	case lex.scanner.AcceptAny("eE"):
-		if !lex.scanner.Accept(func(c rune) bool { return true }) {
-			return lex.errorf("invalid floating point literal starting: %v", lex.scanner.Text())
-		}
 		return lex.readFloatExponent()
 	default:
 		return lex.emitText(token.INT)
@@ -355,21 +364,37 @@ func (lex *Lexer) readFloatFraction() []*token.Token {
 	}
 	switch {
 	case lex.scanner.AcceptAny("eE"):
-		if !lex.scanner.Accept(func(c rune) bool { return true }) {
-			return lex.errorf("invalid floating point literal starting: %v", lex.scanner.Text())
-		}
 		return lex.readFloatExponent()
 	default:
 		return lex.emitText(token.FLOAT)
 	}
 }
 
+// readFloatExponent scans the exponent part of a float literal, with the 'e'
+// or 'E' already consumed by the caller.  The grammar is [+-]?digit+.
+//
+// Both callers used to consume one UNCONDITIONAL rune before getting here,
+// which made the exponent require TWO characters: "1e5" was rejected as an
+// invalid float while "1e55" was accepted, and so were "1e+5" and "1.5e-2"
+// (the sign supplying the extra rune).  Rejecting a literal every other lisp
+// accepts is a source-compatibility hole, not just a formatter bug -- elps
+// could not read back a float it printed itself.  Found by
+// FuzzGeneratedPipeline.
 func (lex *Lexer) readFloatExponent() []*token.Token {
 	lex.scanner.AcceptAny("+-") // optional sign
 	if lex.scanner.AcceptSeqDigit() == 0 {
 		return lex.errorf("invalid floating point literal starting: %v", lex.scanner.Text())
 	}
 	return lex.emitText(token.FLOAT)
+}
+
+// trailingBackslashes counts the backslashes at the end of s.
+func trailingBackslashes(s string) int {
+	n := 0
+	for i := len(s) - 1; i >= 0 && s[i] == '\\'; i-- {
+		n++
+	}
+	return n
 }
 
 func (lex *Lexer) skipWhitespace() {

--- a/parser/lexer/literal_test.go
+++ b/parser/lexer/literal_test.go
@@ -1,0 +1,162 @@
+// Copyright © 2026 The ELPS authors
+
+package lexer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// lexAll returns the token types and texts produced for src, stopping at EOF
+// or the first ERROR/INVALID token.
+func lexAll(t *testing.T, src string) ([]*token.Token, bool) {
+	t.Helper()
+	lex := New(token.NewScanner("test", strings.NewReader(src)))
+	var out []*token.Token
+	for range 64 {
+		for _, tok := range lex.ReadToken() {
+			switch tok.Type {
+			case token.EOF:
+				return out, true
+			case token.ERROR, token.INVALID:
+				return out, false
+			}
+			out = append(out, tok)
+		}
+	}
+	t.Fatalf("lexer did not terminate on %q", src)
+	return nil, false
+}
+
+// TestFloatExponentSingleDigit pins the exponent grammar, [+-]?digit+ after
+// e/E.  readNumber and readFloatFraction each consumed one UNCONDITIONAL rune
+// before handing over to readFloatExponent, which then demanded a sign-or-digit
+// of its own, so an exponent needed TWO characters: "1e5" was a scan error
+// while "1e55" and "1e+5" both lexed.  Every other lisp accepts "1e5", and elps
+// itself prints floats in a form it could not read back.
+//
+// The rejections are pinned alongside the acceptances because the fix WIDENS
+// the accepted language, and a fix that widens it too far is just as wrong.
+func TestFloatExponentSingleDigit(t *testing.T) {
+	accept := []struct {
+		src  string
+		text string
+	}{
+		{"1e5", "1e5"},
+		{"2e3", "2e3"},
+		{"1E5", "1E5"},
+		{"1.5e2", "1.5e2"},
+		{"1e+5", "1e+5"},
+		{"1e-5", "1e-5"},
+		{"1.5e-2", "1.5e-2"},
+		{"1e55", "1e55"},
+		{"0.0e0", "0.0e0"},
+		{"1e308", "1e308"},
+	}
+	for _, tt := range accept {
+		t.Run("accept/"+tt.src, func(t *testing.T) {
+			toks, ok := lexAll(t, tt.src)
+			if !ok {
+				t.Fatalf("%q was rejected", tt.src)
+			}
+			if len(toks) != 1 || toks[0].Type != token.FLOAT || toks[0].Text != tt.text {
+				t.Fatalf("%q lexed as %v, want a single FLOAT %q", tt.src, toks, tt.text)
+			}
+		})
+	}
+
+	reject := []string{"1e", "1e+", "1e-", "1.", "1.e5", "1.5e", "1.5e+"}
+	for _, src := range reject {
+		t.Run("reject/"+src, func(t *testing.T) {
+			if _, ok := lexAll(t, src); ok {
+				t.Fatalf("%q was accepted; it is not a valid float literal", src)
+			}
+		})
+	}
+
+	// Shapes that must keep SPLITTING rather than becoming one token.  This is
+	// how the lexer has always treated a number glued to a word ("1abc" is INT
+	// then SYMBOL), so "1e5e5" following suit is the consistent outcome.
+	split := map[string][]string{
+		"1e5e5":   {"1e5", "e5"},
+		"1abc":    {"1", "abc"},
+		"1.2.3e4": {"1.2", ".3e4"},
+	}
+	for src, want := range split {
+		t.Run("split/"+src, func(t *testing.T) {
+			toks, ok := lexAll(t, src)
+			if !ok {
+				t.Fatalf("%q was rejected, expected it to split into %v", src, want)
+			}
+			if len(toks) != len(want) {
+				t.Fatalf("%q lexed into %d tokens, want %d (%v)", src, len(toks), len(want), toks)
+			}
+			for i := range want {
+				if toks[i].Text != want[i] {
+					t.Fatalf("%q token %d = %q, want %q", src, i, toks[i].Text, want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestStringTrailingBackslash pins the escape-parity rule.  The lexer inferred
+// "the next quote is escaped" from the LAST RUNE of a maximal non-quote run,
+// so any run ending in a backslash consumed the following quote -- and no elps
+// string could end in a backslash at all.  "a\\", whose value is a single
+// backslash, ran off the end of the input as an unterminated literal.
+//
+// Parity has to be counted: an even number of trailing backslashes escape each
+// other and leave the quote as the terminator.
+func TestStringTrailingBackslash(t *testing.T) {
+	accept := []string{
+		`"a\\"`,        // value: a\
+		`"\\"`,         // value: \
+		`"\\\\"`,       // value: \\
+		`"a\"b"`,       // an escaped quote still works
+		`"a\\b"`,       //
+		`"a\\\"b"`,     // backslash then escaped quote
+		`"\\\\\\\\"`,   // four backslashes
+		`"x\\" "y\\"`,  // two of them in a row
+		`""`,           //
+		`"\n"`,         //
+		`"c:\\path\\"`, //
+	}
+	for _, src := range accept {
+		t.Run("accept/"+src, func(t *testing.T) {
+			if _, ok := lexAll(t, src); !ok {
+				t.Fatalf("%q was rejected", src)
+			}
+		})
+	}
+
+	// Genuinely unterminated literals must STILL be rejected -- an odd number
+	// of trailing backslashes really does escape the quote.
+	reject := []string{
+		`"`,
+		`"abc`,
+		`"a\`,
+		`"a\"`,
+		`"\\\"`,
+		"\"a\nb\"",
+	}
+	for _, src := range reject {
+		t.Run("reject/"+src, func(t *testing.T) {
+			if _, ok := lexAll(t, src); ok {
+				t.Fatalf("%q was accepted; it is not terminated", src)
+			}
+		})
+	}
+
+	// Token boundaries, not just acceptance: the whole point is that the
+	// closing quote is recognised as the terminator rather than swallowed.
+	toks, ok := lexAll(t, `"a\\" b`)
+	if !ok {
+		t.Fatal(`"a\\" b was rejected`)
+	}
+	if len(toks) != 2 || toks[0].Type != token.STRING || toks[0].Text != `"a\\"` || toks[1].Text != "b" {
+		t.Fatalf(`"a\\" b lexed as %v, want STRING("a\\\\") then SYMBOL(b)`, toks)
+	}
+}

--- a/parser/lexer/literal_test.go
+++ b/parser/lexer/literal_test.go
@@ -22,6 +22,8 @@ func lexAll(t *testing.T, src string) ([]*token.Token, bool) {
 				return out, true
 			case token.ERROR, token.INVALID:
 				return out, false
+			default:
+				// Anything else is a token the caller wants to see.
 			}
 			out = append(out, tok)
 		}

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -322,11 +322,13 @@ func (p *Parser) ParseQuote() *lisp.LVal {
 	}
 	prefixNewlines := p.src.Token.PrecedingNewlines
 	prefixSpaces := p.src.Token.PrecedingSpaces
+	leading := p.takeLeadingComments()
 	quoteLoc := p.Location() // save ' location before parsing inner expression
 	inner := p.ParseExpression()
 	result := p.Quote(inner)
 	inheritEndPos(result, inner)
 	applyPrefixLocation(result, quoteLoc)
+	p.attachLeadingComments(result, leading)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
 }
@@ -337,6 +339,7 @@ func (p *Parser) ParseUnbound() *lisp.LVal {
 	}
 	prefixNewlines := p.src.Token.PrecedingNewlines
 	prefixSpaces := p.src.Token.PrecedingSpaces
+	leading := p.takeLeadingComments()
 	prefixLoc := p.Location() // save #^ location before parsing inner expression
 	expr := p.ParseExpression()
 	if expr.Type == lisp.LError {
@@ -354,6 +357,7 @@ func (p *Parser) ParseUnbound() *lisp.LVal {
 	p.recordSynthesizedBrackets(result)
 	inheritEndPos(result, expr)
 	applyPrefixLocation(result, prefixLoc)
+	p.attachLeadingComments(result, leading)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
 }
@@ -365,6 +369,7 @@ func (p *Parser) ParseFunRef() *lisp.LVal {
 	}
 	prefixNewlines := p.src.Token.PrecedingNewlines
 	prefixSpaces := p.src.Token.PrecedingSpaces
+	leading := p.takeLeadingComments()
 	prefixLoc := p.Location() // save #' location before parsing inner expression
 	name := p.ParseSymbol()
 	if name.Type == lisp.LError {
@@ -392,6 +397,7 @@ func (p *Parser) ParseFunRef() *lisp.LVal {
 	p.recordSynthesizedBrackets(result)
 	inheritEndPos(result, name)
 	applyPrefixLocation(result, prefixLoc)
+	p.attachLeadingComments(result, leading)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
 }
@@ -438,6 +444,49 @@ func applyPrefixLocation(v *lisp.LVal, loc *token.Location) {
 	}
 }
 
+// takeLeadingComments detaches the comments collected in front of the token a
+// prefix parser has just consumed, so that the operand parsed next does not
+// swallow them.
+//
+// tokenLVal drains p.pendingComments onto whatever LVal it is building, and
+// for a prefix form the FIRST LVal built is the operand -- not the node the
+// comments belong to.  For ' that was survivable by accident (lisp.Quote
+// shallow-copies the operand, Meta pointer included, so the outer node saw the
+// same comments), but #' and #^ build a fresh two-cell s-expression whose Meta
+// is new, and the printer's shorthand path writes only the prefix and the
+// operand.  The comments were therefore DELETED: `elps fmt` turned
+//
+//	; c
+//	#'a
+//
+// into "#'a".  Worse, when the operand could not be re-sugared the longhand
+// path printed the comment INSIDE the form, so "#!/usr/bin/env elps\n#':%"
+// formatted to "(lisp:function\n  #!/usr/bin/env elps\n  :%)" -- output the
+// parser then rejected, because a hash-bang is only legal at the start of a
+// program.  Found by FuzzGeneratedPipeline.
+func (p *Parser) takeLeadingComments() []*token.Token {
+	if !p.preserveFormat || len(p.pendingComments) == 0 {
+		return nil
+	}
+	comments := p.pendingComments
+	p.pendingComments = nil
+	return comments
+}
+
+// attachLeadingComments puts comments taken by takeLeadingComments in front of
+// any the node picked up while its operand was parsed.  It must run BEFORE
+// applyPrefixNewlines, which reads LeadingComments to decide which gap the
+// node's newline metadata describes.
+func (p *Parser) attachLeadingComments(v *lisp.LVal, comments []*token.Token) {
+	if !p.preserveFormat || len(comments) == 0 || v.Type == lisp.LError {
+		return
+	}
+	if v.Meta == nil {
+		v.Meta = &lisp.SourceMeta{}
+	}
+	v.Meta.LeadingComments = append(comments, v.Meta.LeadingComments...)
+}
+
 // applyPrefixNewlines sets the newline and spacing metadata on a prefix form
 // (quote, #', #^) using the prefix token's values, which would otherwise be
 // lost because tokenLVal reads from the inner expression's token.
@@ -449,21 +498,39 @@ func (p *Parser) applyPrefixNewlines(v *lisp.LVal, newlines int, spaces int) {
 		v.Meta = &lisp.SourceMeta{}
 	}
 	if len(v.Meta.LeadingComments) > 0 {
-		// With leading comments attached, NewlineBefore / BlankLinesBefore
-		// describe the gap before the first COMMENT, which tokenLVal already
-		// took from that comment -- overwriting them from the prefix token
-		// would double-count.  What the prefix token measures is the gap
-		// between the last comment and this node, because the prefix IS this
-		// node's first token.
+		// Two independent gaps have to be recorded here, and NEITHER can be
+		// left to tokenLVal.
 		//
-		// tokenLVal derived that gap from the INNER expression's token, which
-		// sits after the prefix and so measures the wrong whitespace.  For
-		// ";\n'\n\n0" it recorded the blank line between ' and 0 instead of
-		// the (none) between ; and ', so the blank line moved on every
-		// re-format and Format stopped being idempotent.  Found by FuzzFormat.
+		// BlankLinesAfterComments is the gap between the last comment and
+		// this node, which the prefix token measures because the prefix IS
+		// this node's first token.  tokenLVal derived it from the INNER
+		// expression's token, which sits after the prefix and so measures the
+		// wrong whitespace: for ";\n'\n\n0" it recorded the blank line
+		// between ' and 0 instead of the (none) between ; and ', so the blank
+		// line moved on every re-format and Format stopped being idempotent.
+		// Found by FuzzFormat.
+		//
+		// NewlineBefore / BlankLinesBefore describe the gap before the FIRST
+		// COMMENT.  These used to be left alone on the premise that tokenLVal
+		// had already taken them from that comment -- true only while the
+		// comments were still reaching tokenLVal, which takeLeadingComments
+		// stopped.  tokenLVal now sees no comments and copies the OPERAND
+		// token's gap instead, and for #' the operand inherits the prefix's
+		// own PrecedingNewlines (readFunRef emits FUN_REF and its symbol from
+		// a single readToken, without an intervening skipWhitespace).  So
+		// "(a)\n; c\n\n#'f\n" reported one blank line before the comment and
+		// `elps fmt` inserted one -- reflowing a comment that describes the
+		// line above it.  It reaches real source: the `; <-` markers in
+		// editors/vscode/test/grammar/basics.lisp are syntax-test assertions
+		// ABOUT the preceding line, so moving them changes what they assert.
 		v.Meta.BlankLinesAfterComments = 0
 		if newlines > 1 {
 			v.Meta.BlankLinesAfterComments = newlines - 1
+		}
+		v.Meta.NewlineBefore = true
+		v.Meta.BlankLinesBefore = 0
+		if n := v.Meta.LeadingComments[0].PrecedingNewlines; n > 1 {
+			v.Meta.BlankLinesBefore = n - 1
 		}
 	} else {
 		if newlines >= 1 {
@@ -482,7 +549,22 @@ func (p *Parser) ParseNegative() *lisp.LVal {
 	}
 	switch p.PeekType() {
 	case token.INT, token.FLOAT, token.SYMBOL:
+		// The sign and the digits are two tokens that become one literal, so
+		// the merged token has to inherit the SIGN's position AND its
+		// whitespace bookkeeping -- the sign is the literal's first character,
+		// so it is the sign that measures the gap in front of it.  The digits
+		// are glued to the sign and always report a gap of zero.
+		//
+		// Only Source was carried over.  PrecedingNewlines therefore collapsed
+		// to zero, tokenLVal cleared NewlineBefore, and the formatter put the
+		// literal back on the previous line -- which, when that line ended in
+		// a comment, meant "(a ; c\n-1)" formatted to "(a ; c -1)" and the
+		// -1 was swallowed by the comment.  `elps fmt` silently deleting a
+		// term from the program it was tidying.  Found by
+		// FuzzGeneratedPipeline.
 		p.src.Peek().Source = p.Location()
+		p.src.Peek().PrecedingNewlines = p.src.Token.PrecedingNewlines
+		p.src.Peek().PrecedingSpaces = p.src.Token.PrecedingSpaces
 		p.src.Peek().Text = p.TokenText() + p.src.Peek().Text
 	default:
 		return p.Symbol(p.TokenText())

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -322,14 +322,12 @@ func (p *Parser) ParseQuote() *lisp.LVal {
 	}
 	prefixNewlines := p.src.Token.PrecedingNewlines
 	prefixSpaces := p.src.Token.PrecedingSpaces
-	leading := p.takeLeadingComments()
 	quoteLoc := p.Location() // save ' location before parsing inner expression
 	inner := p.ParseExpression()
 	result := p.Quote(inner)
 	inheritEndPos(result, inner)
 	applyPrefixLocation(result, quoteLoc)
 	p.hoistOperandComments(result, inner)
-	p.attachLeadingComments(result, leading)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
 }
@@ -340,7 +338,6 @@ func (p *Parser) ParseUnbound() *lisp.LVal {
 	}
 	prefixNewlines := p.src.Token.PrecedingNewlines
 	prefixSpaces := p.src.Token.PrecedingSpaces
-	leading := p.takeLeadingComments()
 	prefixLoc := p.Location() // save #^ location before parsing inner expression
 	expr := p.ParseExpression()
 	if expr.Type == lisp.LError {
@@ -359,7 +356,6 @@ func (p *Parser) ParseUnbound() *lisp.LVal {
 	inheritEndPos(result, expr)
 	applyPrefixLocation(result, prefixLoc)
 	p.hoistOperandComments(result, expr)
-	p.attachLeadingComments(result, leading)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
 }
@@ -371,7 +367,6 @@ func (p *Parser) ParseFunRef() *lisp.LVal {
 	}
 	prefixNewlines := p.src.Token.PrecedingNewlines
 	prefixSpaces := p.src.Token.PrecedingSpaces
-	leading := p.takeLeadingComments()
 	prefixLoc := p.Location() // save #' location before parsing inner expression
 	name := p.ParseSymbol()
 	if name.Type == lisp.LError {
@@ -400,7 +395,6 @@ func (p *Parser) ParseFunRef() *lisp.LVal {
 	inheritEndPos(result, name)
 	applyPrefixLocation(result, prefixLoc)
 	p.hoistOperandComments(result, name)
-	p.attachLeadingComments(result, leading)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
 }
@@ -447,53 +441,37 @@ func applyPrefixLocation(v *lisp.LVal, loc *token.Location) {
 	}
 }
 
-// takeLeadingComments detaches the comments collected in front of the token a
-// prefix parser has just consumed, so that the operand parsed next does not
-// swallow them.
+// hoistOperandComments moves comments that landed on a prefix form's OPERAND
+// up onto the prefix node itself.
 //
 // tokenLVal drains p.pendingComments onto whatever LVal it is building, and
-// for a prefix form the FIRST LVal built is the operand -- not the node the
-// comments belong to.  For ' that was survivable by accident (lisp.Quote
-// shallow-copies the operand, Meta pointer included, so the outer node saw the
-// same comments), but #' and #^ build a fresh two-cell s-expression whose Meta
-// is new, and the printer's shorthand path writes only the prefix and the
-// operand.  The comments were therefore DELETED: `elps fmt` turned
+// for a prefix form the first LVal built is the operand.  Every comment
+// written anywhere in front of the operand therefore ends up attached to it --
+// the ones before the prefix token ("; c\n#\'a") and the ones in the gap after
+// it ("#^; c\na") alike.
+//
+// The printer reaches an operand through writeQuote or tryPrefixForm, and
+// neither writes a child's LeadingComments; the s-expression and list printers
+// do, but a prefix form is printed as neither.  Those comments were therefore
+// DELETED: `elps fmt` turned
 //
 //	; c
 //	#'a
 //
-// into "#'a".  Worse, when the operand could not be re-sugared the longhand
-// path printed the comment INSIDE the form, so "#!/usr/bin/env elps\n#':%"
-// formatted to "(lisp:function\n  #!/usr/bin/env elps\n  :%)" -- output the
-// parser then rejected, because a hash-bang is only legal at the start of a
-// program.  Found by FuzzGeneratedPipeline.
-func (p *Parser) takeLeadingComments() []*token.Token {
-	if !p.preserveFormat || len(p.pendingComments) == 0 {
-		return nil
-	}
-	comments := p.pendingComments
-	p.pendingComments = nil
-	return comments
-}
-
-// hoistOperandComments moves comments the OPERAND collected -- the ones
-// written between the prefix token and the thing it applies to -- up onto the
-// prefix node.
-//
-// The printer reaches a prefix node's operand through writeQuote or
-// tryPrefixForm, neither of which writes a child's LeadingComments (the
-// s-expression and list printers do, but a prefix form is not printed as
-// either).  Comments left on the operand are therefore DELETED: "'\n; c\n[a]"
-// formatted to "'[a]" and "#^; c\na" to "#^a".
+// into "#'a", and "'\n; c\n[a]" into "'[a]".  Worse, when the operand could
+// not be re-sugared the longhand path printed the comment INSIDE the form, so
+// "#!/usr/bin/env elps\n#':%" formatted to "(lisp:function\n  #!/usr/bin/env
+// elps\n  :%)" -- output the parser then rejected, because a hash-bang is only
+// legal at the start of a program.  Found by FuzzGeneratedPipeline.
 //
 // It only bites when the prefix node has a Meta of its OWN.  lisp.Quote
 // shallow-copies an unquoted operand, Meta pointer included, so "'\n; c\na"
-// happened to survive -- the comment simply moved above the quote.  Quoting an
-// ALREADY-quoted operand builds an LQuote node with a fresh Meta, and #'/#^
-// build a fresh two-cell s-expression, and those three lost the comment.
+// happened to survive -- the outer node saw the very same comments.  Quoting
+// an ALREADY-quoted operand builds an LQuote node with a fresh Meta, and #'
+// and #^ build a fresh two-cell s-expression, and those three lost them.
 //
-// Called before attachLeadingComments so the comments end up in source order:
-// the ones written before the prefix, then the ones written after it.
+// Must run BEFORE applyPrefixNewlines, which reads LeadingComments to decide
+// which gap the node's newline metadata describes.
 func (p *Parser) hoistOperandComments(outer, inner *lisp.LVal) {
 	if !p.preserveFormat || outer.Type == lisp.LError || inner == nil {
 		return
@@ -511,20 +489,6 @@ func (p *Parser) hoistOperandComments(outer, inner *lisp.LVal) {
 	}
 	outer.Meta.LeadingComments = append(outer.Meta.LeadingComments, inner.Meta.LeadingComments...)
 	inner.Meta.LeadingComments = nil
-}
-
-// attachLeadingComments puts comments taken by takeLeadingComments in front of
-// any the node picked up while its operand was parsed.  It must run BEFORE
-// applyPrefixNewlines, which reads LeadingComments to decide which gap the
-// node's newline metadata describes.
-func (p *Parser) attachLeadingComments(v *lisp.LVal, comments []*token.Token) {
-	if !p.preserveFormat || len(comments) == 0 || v.Type == lisp.LError {
-		return
-	}
-	if v.Meta == nil {
-		v.Meta = &lisp.SourceMeta{}
-	}
-	v.Meta.LeadingComments = append(comments, v.Meta.LeadingComments...)
 }
 
 // applyPrefixNewlines sets the newline and spacing metadata on a prefix form
@@ -552,17 +516,20 @@ func (p *Parser) applyPrefixNewlines(v *lisp.LVal, newlines int, spaces int) {
 		//
 		// NewlineBefore / BlankLinesBefore describe the gap before the FIRST
 		// COMMENT.  These used to be left alone on the premise that tokenLVal
-		// had already taken them from that comment -- true only while the
-		// comments were still reaching tokenLVal, which takeLeadingComments
-		// stopped.  tokenLVal now sees no comments and copies the OPERAND
-		// token's gap instead, and for #' the operand inherits the prefix's
-		// own PrecedingNewlines (readFunRef emits FUN_REF and its symbol from
-		// a single readToken, without an intervening skipWhitespace).  So
-		// "(a)\n; c\n\n#'f\n" reported one blank line before the comment and
-		// `elps fmt` inserted one -- reflowing a comment that describes the
-		// line above it.  It reaches real source: the `; <-` markers in
-		// editors/vscode/test/grammar/basics.lisp are syntax-test assertions
-		// ABOUT the preceding line, so moving them changes what they assert.
+		// had already taken them from that comment.  That held only while this
+		// branch was reachable ONLY for a node sharing its operand's Meta --
+		// the quote-a-plain-symbol case, where tokenLVal really did see the
+		// comments.  hoistOperandComments made it reachable for #', #^ and
+		// LQuote too, and those have a Meta of their OWN that tokenLVal filled
+		// in BEFORE the hoist, from the operand token.  For #' that operand
+		// inherits the prefix's own PrecedingNewlines -- readFunRef emits
+		// FUN_REF and its symbol from a single readToken, with no
+		// skipWhitespace between them -- so "(a)\n; c\n\n#'f\n" reported one
+		// blank line before the comment and `elps fmt` INSERTED one, reflowing
+		// a comment that describes the line above it.  It reaches real source:
+		// the `; <-` markers in editors/vscode/test/grammar/basics.lisp are
+		// syntax-test assertions ABOUT the preceding line, so moving them
+		// changes what they assert.
 		v.Meta.BlankLinesAfterComments = 0
 		if newlines > 1 {
 			v.Meta.BlankLinesAfterComments = newlines - 1

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -328,6 +328,7 @@ func (p *Parser) ParseQuote() *lisp.LVal {
 	result := p.Quote(inner)
 	inheritEndPos(result, inner)
 	applyPrefixLocation(result, quoteLoc)
+	p.hoistOperandComments(result, inner)
 	p.attachLeadingComments(result, leading)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
@@ -357,6 +358,7 @@ func (p *Parser) ParseUnbound() *lisp.LVal {
 	p.recordSynthesizedBrackets(result)
 	inheritEndPos(result, expr)
 	applyPrefixLocation(result, prefixLoc)
+	p.hoistOperandComments(result, expr)
 	p.attachLeadingComments(result, leading)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
@@ -397,6 +399,7 @@ func (p *Parser) ParseFunRef() *lisp.LVal {
 	p.recordSynthesizedBrackets(result)
 	inheritEndPos(result, name)
 	applyPrefixLocation(result, prefixLoc)
+	p.hoistOperandComments(result, name)
 	p.attachLeadingComments(result, leading)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
@@ -471,6 +474,43 @@ func (p *Parser) takeLeadingComments() []*token.Token {
 	comments := p.pendingComments
 	p.pendingComments = nil
 	return comments
+}
+
+// hoistOperandComments moves comments the OPERAND collected -- the ones
+// written between the prefix token and the thing it applies to -- up onto the
+// prefix node.
+//
+// The printer reaches a prefix node's operand through writeQuote or
+// tryPrefixForm, neither of which writes a child's LeadingComments (the
+// s-expression and list printers do, but a prefix form is not printed as
+// either).  Comments left on the operand are therefore DELETED: "'\n; c\n[a]"
+// formatted to "'[a]" and "#^; c\na" to "#^a".
+//
+// It only bites when the prefix node has a Meta of its OWN.  lisp.Quote
+// shallow-copies an unquoted operand, Meta pointer included, so "'\n; c\na"
+// happened to survive -- the comment simply moved above the quote.  Quoting an
+// ALREADY-quoted operand builds an LQuote node with a fresh Meta, and #'/#^
+// build a fresh two-cell s-expression, and those three lost the comment.
+//
+// Called before attachLeadingComments so the comments end up in source order:
+// the ones written before the prefix, then the ones written after it.
+func (p *Parser) hoistOperandComments(outer, inner *lisp.LVal) {
+	if !p.preserveFormat || outer.Type == lisp.LError || inner == nil {
+		return
+	}
+	if inner.Meta == nil || len(inner.Meta.LeadingComments) == 0 {
+		return
+	}
+	if outer.Meta == inner.Meta {
+		// Shared Meta: the comments are already on the node the printer
+		// writes.  Moving them would move them onto themselves.
+		return
+	}
+	if outer.Meta == nil {
+		outer.Meta = &lisp.SourceMeta{}
+	}
+	outer.Meta.LeadingComments = append(outer.Meta.LeadingComments, inner.Meta.LeadingComments...)
+	inner.Meta.LeadingComments = nil
 }
 
 // attachLeadingComments puts comments taken by takeLeadingComments in front of


### PR DESCRIPTION
Stacked on #311 — this PR targets `claude/elps-fieldalignment`, not `main`.

## What this adds

`internal/fuzzgen` turns the fuzzer's byte script into **syntactically valid but semantically hostile** ELPS, and `FuzzGeneratedPipeline` drives the whole source-rewriting chain over it:

```
parse -> format -> re-parse -> format again -> minify -> re-parse
      -> format the minified output -> re-parse
```

Every existing target takes raw bytes, so the mutator spends most of its budget on input that dies at the first token. The states *behind* a successful parse — comment attachment, blank-line bookkeeping, prefix-form re-sugaring, scope-aware renaming — are exactly where `elps fmt` and `elps minify` silently rewrite a customer's program, and raw bytes hardly ever get there.

Generation is a pure function of `(script, limits)`, bounded three ways (byte budget, nesting cap, script length). Corpora are committed as **scripts**, not `.lisp` source. Coverage: pathological nesting, quasiquote / unquote-splicing, `#'` and `#^`, both bracket kinds, keyword and package-qualified symbols, huge literals, unicode identifiers, and comments in every position the grammar permits one — before a form, between siblings, before a closing bracket, trailing on the same line, between a prefix macro and its operand, and at EOF.

**No dialects.** The previous iteration carried a `Core` subset defined as `rdparser ∩ regexparser`; regexparser is being deleted in #321, so that definition names nothing. One grammar, and the package comment says why. Nothing in this PR touches `parser/regexparser`.

## The invariants, and why each is safe to assert

| # | Invariant | Justified by |
|---|---|---|
| 1 | the generated program parses | fuzzgen's own contract, pinned by `TestGeneratedProgramsAlwaysParse` over 24k scripts × 4 limit profiles |
| 2 | `Format` accepts everything the parser accepts | `FuzzFormat` asserts the converse; formatting mode only *attaches* metadata to the same tree (`FuzzParseFormatting`) |
| 3 | `Format` preserves the AST | `formatter_test.go: roundTripEqual`, `FuzzFormat` |
| 4 | `Format` drops no comment | `TestCommentPreservesText` and the comment tests in `formatter_test.go`, generalised |
| 5 | `Format` invents no interior blank line | every blank line the printer writes comes from a source-measured count clamped to `MaxBlankLines`, so it can shrink but not grow |
| 6 | `Format` is idempotent | `runFormatTests`, `TestEdgeIdempotency`, `FuzzFormat` |
| 7 | minify accepts formatted source, is deterministic | `TestMinifySource_DeterministicAndScopeAware`, `FuzzMinifySource` |
| 8 | minified output parses, same type skeleton | `FuzzMinifySource` |
| 9 | formatting minified output round-trips and is idempotent | 3+6 applied to the minifier's output |

(4) and (5) are the ones that earn their keep. A formatter that **deletes a comment** or **inserts a blank line** leaves the AST identical, leaves the output a stable fixed point, and passes every other check — six of the nine defects below were fixed points that had simply lost, or gained, a line. Nothing is asserted about layout, chosen names, or semantics.

## Defects fixed

The four from #320 §C, plus C6 (which the C4 fix introduces — shipped together, never apart), plus four more of the same class the comment invariant turned up.

| | defect | effect |
|---|---|---|
| **C2** | float exponents rejected | `1e5`, `2e3`, `1E5`, `1.5e2` were scan errors while `1e55` and `1e+5` parsed — both call sites consumed one unconditional rune before `readFloatExponent`, so an exponent needed *two* characters. `1e`, `1e+`, `1e-`, `1.`, `1.5e` still rejected; `1e5e5` now splits into `1e5` + `e5`, matching how `1abc` has always split. |
| **C3** | no string could end in a backslash | escape parity was read off the *last rune* of a maximal run, so `"a\\"` consumed its own closing quote. Parity is now counted. Genuinely unterminated strings still rejected. |
| **C4** | comments before a prefix form deleted | `; c\n#'a` → `#'a`. And `#!/usr/bin/env elps\n#':%` printed the comment *inside* the longhand form, producing output the parser then rejected. |
| **C5** | signed literal swallowed by a comment | `(a ; c\n-1)` → `(a ; c -1)`, which re-parses as `(a)`. `ParseNegative` merged the sign token without its whitespace bookkeeping. |
| **C6** | blank line inserted before a comment | `(a)\n; c\n\n#'f\n` → `(a)\n\n; c\n\n#'f\n`. `applyPrefixNewlines` carried a premise the C4 fix invalidated. Only `#'` is affected, because `readFunRef` emits FUN_REF and its symbol from one `readToken` so the operand inherits the prefix's `PrecedingNewlines`; `'` and `#^` scan separately and report 0. **It hits a real file in two repos** — `editors/vscode/test/grammar/basics.lisp`, where the `; <-` markers are syntax-test assertions *about the line above*. |
| **N1** | comment in an empty form deleted | `(\n; c\n)` → `()`. `writeSExpr`'s empty-cells branch skipped both `InnerTrailingComments` and `ClosingBracketNewline`; `[...]`, `'(...)` and non-empty forms all reach `writeListInner`, which handles both. Now at parity. |
| **N2** | comment before a form's head deleted | `(\n; c\n f x)` → `(f x)`. `writeSExpr` never wrote the head child's leading comments. |
| **N3** | comment between a prefix and its operand deleted | `'\n; c\n[a]` → `'[a]`, `#^; c\na` → `#^a`. Now hoisted onto the prefix node. |
| **N4** | re-sugaring longhand deleted comments | `(lisp:function ; c\n f)` → `#'f`. The shorthand has nowhere to put them, so those forms stay longhand — except under `StripComments`, where nothing is lost. |

`takeLeadingComments`/`attachLeadingComments` and `hoistOperandComments` turned out to be the same fix from opposite ends: neutering the first left `Format` and `MinifySource` **byte-identical over 32,000 generated programs** with every test still passing. Collapsed onto one mechanism rather than shipping a fix no test can distinguish from its own absence.

## Evidence

**Mutation table** — each fix reverted individually; both the unit test and the committed fuzz corpus (seeds + `testdata/`) re-run at plain `go test`:

| defect | unit test | unit | fuzz corpus |
|---|---|---|---|
| C2 | `parser/lexer TestFloatExponentSingleDigit` | FAILS | FAILS |
| C3 | `parser/lexer TestStringTrailingBackslash` | FAILS | FAILS |
| C4 | `formatter TestCommentBeforePrefixForm` | FAILS | FAILS |
| C5 | `formatter TestNegativeLiteralAfterComment` | FAILS | FAILS |
| C6 | `formatter TestCommentBeforePrefixForm` | FAILS | FAILS |
| N1 | `formatter TestCommentInEmptySExpr` | FAILS | FAILS |
| N2 | `formatter TestCommentBeforeSExprHead` | FAILS | FAILS |
| N3 | `formatter TestCommentBetweenPrefixAndOperand` | FAILS | FAILS |
| N4 | `formatter TestLonghandPrefixFormKeepsComments` | FAILS | passes |

N4 is unit-test-only by construction: the generator has no reason to write `(lisp:function f)` in longhand, so the fuzz corpus cannot reach it.

The test-gap C6 exploited is closed: `TestCommentBeforePrefixForm` is now a matrix over {`'`, `#'`, `#^`, plain} × {first form, after a form} × {adjacent, blank line} — the original had neither a blank-line row nor a preceding-form row — with `'`/`#^`/plain as controls so an over-broad fix fails.

**Real-corpus round trip** — every `.lisp` in this repo (excluding `tree-sitter-elps/`) and in `luthersystems/substrate`, 126 files, through `elps fmt` and `elps minify`, before and after:

- **`minify`: byte-identical.** Zero diff.
- **`fmt`: 6 added lines, all restorations of content the old build deleted** — two comments and one blank line, in `editors/vscode/test/grammar/basics.lisp` in each repo. No file changed in any other way; no file gained or lost an error.
- `basics.lisp` still differs from its formatted form in 3 lines: `elps fmt` indents `;   ^^^^` markers inside a `defun` body. That behaviour is **unchanged from before this PR** (base produced the same 3), it is pre-existing and out of scope, and the CI gate already excludes these fixtures (`elps fmt -l --exclude 'grammar'`).

**Gates** (all green): `go build ./...` · `go test ./...` · `make race` · `make test-elpscheck` · `golangci-lint run ./...` **0 issues** · `golangci-lint run --build-tags elpscheck ./lisp/...` **0 issues** · `./elps doc -m` · `./elps fmt -l --exclude 'grammar' ./...` clean · `make ci-gates-test` **75 passed, 0 failed** · `./elps lint` **9 warnings, identical to base** · no new gofmt-unclean files (15 pre-existing, unchanged).

**Measured CI cost.** No workflow change: `scripts/fuzz.sh` discovers targets dynamically, so the new one is picked up automatically (12 targets, was 11).

- Fuzz workflow, PR path (`FUZZTIME=30s`): **+32s wall** for the new target, measured. Nightly (`10m`): +~10m, inside the existing 120-minute job backstop.
- Tests workflow: **+4s** for `./internal/fuzzgen` (the deterministic sweeps); `./formatter` still ~1s.
- Target throughput: ~2,000 exec/sec, 192 new interesting inputs in a 45s run.

## Not verified

- The blank-line invariant (5) is argued from the printer's structure and measured over 72,000 generated programs plus all 126 real files; it is not proven.
- `make race` passes here, so the `TestEngine_RequestPause` flake from #322 did not reproduce; I did not A/B it against a pristine checkout.
- The three `;   ^^^^` indentation differences in `basics.lisp` are unchanged from base and left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_