### PR TITLE
fix(formatter): keep a comment written in column 0 in column 0

### DIFF
--- a/.github/workflows/elps.yml
+++ b/.github/workflows/elps.yml
@@ -51,7 +51,15 @@ jobs:
       - name: Check formatting
         run: |
           go build -o elps .
-          ./elps fmt -l --exclude 'grammar' ./...
+          # No --exclude here, deliberately. The 'grammar' carve-out existed
+          # only because `elps fmt` rewrote editors/vscode/test/grammar/*.lisp,
+          # whose `; <-` / `; ^^^` comments are POSITIONAL assertions about the
+          # line above -- so the reflow changed what the fixture asserted. The
+          # carve-out made CI green by not looking, which also meant CI could
+          # never catch a future formatter change that broke those files again.
+          # Now that a column-0 comment stays in column 0 they are fixed points,
+          # so the fixtures are back under the gate.
+          ./elps fmt -l ./...
 
       - name: Lint ELPS source
         run: ./elps lint --workspace=. --exclude 'grammar' --include '_examples' ./...

--- a/formatter/comment_column_test.go
+++ b/formatter/comment_column_test.go
@@ -1,0 +1,128 @@
+// Copyright © 2026 The ELPS authors
+
+package formatter_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luthersystems/elps/formatter"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommentInColumnZeroIsPreserved pins the rule in printer.go's
+// commentIndent: a comment written in column 0 stays in column 0, even inside
+// an indented form.
+//
+// The rule exists because a flush-left comment can be column-aligned against
+// the line ABOVE it, in which case its column carries meaning that
+// re-indenting destroys. The case that forced it is
+// editors/vscode/test/grammar/*.lisp, whose TextMate syntax-test assertions
+// look like
+//
+//	(defun f (x &optional y)
+//	;           ^^^^^^^^^ variable.parameter.elps
+//
+// where the caret column IS the assertion. `elps fmt` indented those comments
+// by the form's indent, silently changing which characters they asserted
+// about while appearing to succeed. TestGrammarFixturesAreFormatFixedPoints
+// below is the end-to-end guard on the real files.
+//
+// Every case comes in a pair: the column-0 input and the same shape written
+// with the comment indented. The indented half is the one that proves the
+// rule keys off the comment's ORIGINAL column instead of just always writing
+// column 0 -- without it, a bug that flattened every comment to the left
+// margin would pass.
+func TestCommentInColumnZeroIsPreserved(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "defun body/column 0 stays",
+			input:    "(defun f (x)\n; c\n(+ x 1))\n",
+			expected: "(defun f (x)\n; c\n  (+ x 1))\n",
+		},
+		{
+			name:     "defun body/indented stays indented",
+			input:    "(defun f (x)\n  ; c\n(+ x 1))\n",
+			expected: "(defun f (x)\n  ; c\n  (+ x 1))\n",
+		},
+		{
+			name:     "nested form/column 0 stays",
+			input:    "(g (h\n; c\nx))\n",
+			expected: "(g (h\n; c\n     x))\n",
+		},
+		{
+			name:     "nested form/indented is re-indented to the form",
+			input:    "(g (h\n ; c\nx))\n",
+			expected: "(g (h\n     ; c\n     x))\n",
+		},
+		{
+			// The alignment case itself, reduced. The carets must still line
+			// up under `&optional` after formatting.
+			name:     "alignment assertion under a defun signature",
+			input:    "(defun f (x &optional y)\n;           ^^^^^^^^^ variable.parameter.elps\nx)\n",
+			expected: "(defun f (x &optional y)\n;           ^^^^^^^^^ variable.parameter.elps\n  x)\n",
+		},
+		{
+			// A top-level comment was already written at column 0, so this is
+			// a control: it must be unaffected by the rule.
+			name:     "top level is unchanged",
+			input:    "; c\n(f x)\n",
+			expected: "; c\n(f x)\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := formatter.Format([]byte(tt.input), formatter.DefaultConfig())
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, string(out))
+
+			// Formatting is a fixed point: a second pass must not move it
+			// again. A rule that reads the ORIGINAL column has to survive
+			// being fed its own output, where the column is now whatever it
+			// just wrote.
+			out2, err := formatter.Format(out, formatter.DefaultConfig())
+			require.NoError(t, err)
+			require.Equal(t, string(out), string(out2), "second format pass changed the output")
+		})
+	}
+}
+
+// TestGrammarFixturesAreFormatFixedPoints is the end-to-end guard, and the
+// reason it is a test rather than a comment: editors/vscode/test/grammar/*.lisp
+// are fixtures for vscode-tmgrammar-test, where `; <-` and `; ^^^` comments
+// are POSITIONAL assertions about the line above. Any reflow of those lines
+// changes what the fixture asserts, so the formatter must leave these files
+// byte-identical.
+//
+// CI runs `elps fmt -l --exclude 'grammar'`, which skips these files, so
+// nothing else in the build would notice a regression here -- the exclusion
+// hides it. That is exactly why this guard reads the real files instead of
+// trusting the CLI's exclusion list.
+func TestGrammarFixturesAreFormatFixedPoints(t *testing.T) {
+	dir := filepath.Join("..", "editors", "vscode", "test", "grammar")
+	entries, err := filepath.Glob(filepath.Join(dir, "*.lisp"))
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "no grammar fixtures found at %s -- did they move?", dir)
+
+	for _, path := range entries {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			// #nosec G304 -- path comes from a Glob over a fixed directory
+			// literal in this test, not from input.
+			src, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			out, err := formatter.Format(src, formatter.DefaultConfig())
+			require.NoError(t, err)
+			require.Equal(t, string(src), string(out),
+				"elps fmt would rewrite %s; its `; <-` / `; ^^^` comments are "+
+					"positional assertions about the line above, so any reflow "+
+					"changes what the grammar test asserts", path)
+		})
+	}
+}

--- a/formatter/comment_column_test.go
+++ b/formatter/comment_column_test.go
@@ -100,10 +100,18 @@ func TestCommentInColumnZeroIsPreserved(t *testing.T) {
 // changes what the fixture asserts, so the formatter must leave these files
 // byte-identical.
 //
-// CI runs `elps fmt -l --exclude 'grammar'`, which skips these files, so
-// nothing else in the build would notice a regression here -- the exclusion
-// hides it. That is exactly why this guard reads the real files instead of
-// trusting the CLI's exclusion list.
+// CI used to run `elps fmt -l --exclude 'grammar'`, which skipped these files
+// entirely -- green by not looking. The exclusion is removed in the same
+// change that added this test, so `elps fmt -l ./...` now covers them too.
+//
+// This test is kept alongside that, not replaced by it, for two reasons: it
+// exercises the library rather than the CLI, so it still fires if the two ever
+// diverge; and it fails with a message that says WHY these particular files
+// must not move, which a bare "file is not formatted" from `fmt -l` does not.
+//
+// The same fixtures exist in luthersystems/substrate (with one more,
+// substrate.lisp). Measured there: 4 of its 6 are not fixed points under the
+// old behaviour and all 6 are under this change.
 func TestGrammarFixturesAreFormatFixedPoints(t *testing.T) {
 	dir := filepath.Join("..", "editors", "vscode", "test", "grammar")
 	entries, err := filepath.Glob(filepath.Join(dir, "*.lisp"))

--- a/formatter/comment_preservation_test.go
+++ b/formatter/comment_preservation_test.go
@@ -170,7 +170,7 @@ func TestLonghandPrefixFormKeepsComments(t *testing.T) {
 		{
 			name:     "funref/leading",
 			input:    "(lisp:function\n; c\nf)\n",
-			expected: "(lisp:function\n  ; c\n  f)\n",
+			expected: "(lisp:function\n; c\n  f)\n",
 		},
 		{
 			name:     "funref/trailing-on-head",
@@ -240,11 +240,16 @@ func TestCommentInEmptySExpr(t *testing.T) {
 // child's leading comments, which is why the bracketed forms are the controls.
 func TestCommentBeforeSExprHead(t *testing.T) {
 	tests := []formatTest{
-		{name: "call", input: "(\n; c\nf x)\n", expected: "(\n ; c\n f x)\n"},
-		{name: "call/two", input: "(\n; a\n; b\nf x)\n", expected: "(\n ; a\n ; b\n f x)\n"},
-		{name: "data-list", input: "(\n; c\n1 2)\n", expected: "(\n ; c\n 1 2)\n"},
-		{name: "brace", input: "[\n; c\nf x]\n", expected: "[\n ; c\n f x]\n"},
-		{name: "nested", input: "(g (\n; c\nf x))\n", expected: "(g (\n    ; c\n    f x))\n"},
+		{name: "call", input: "(\n; c\nf x)\n", expected: "(\n; c\n f x)\n"},
+		{name: "call/two", input: "(\n; a\n; b\nf x)\n", expected: "(\n; a\n; b\n f x)\n"},
+		{name: "data-list", input: "(\n; c\n1 2)\n", expected: "(\n; c\n 1 2)\n"},
+		{name: "brace", input: "[\n; c\nf x]\n", expected: "[\n; c\n f x]\n"},
+		{name: "nested", input: "(g (\n; c\nf x))\n", expected: "(g (\n; c\n    f x))\n"},
+		// Same shapes with the comment INDENTED in the source: it is re-indented
+		// to the form, which is what pins that commentIndent keys off the
+		// comment's ORIGINAL column rather than always writing column 0.
+		{name: "call/indented", input: "(\n ; c\nf x)\n", expected: "(\n ; c\n f x)\n"},
+		{name: "nested/indented", input: "(g (\n    ; c\nf x))\n", expected: "(g (\n    ; c\n    f x))\n"},
 		// Controls: no comment, so the head keeps being pulled up next to the
 		// bracket for a call and left in place for a data list.
 		{name: "call-newline", input: "(\nf x)\n", expected: "(f x)\n"},
@@ -272,7 +277,8 @@ func TestNegativeLiteralAfterComment(t *testing.T) {
 		{name: "float", input: "(a ; c\n-1.5)\n", expected: "(a ; c\n  -1.5)\n"},
 		{name: "symbol", input: "(a ; c\n-x)\n", expected: "(a ; c\n  -x)\n"},
 		{name: "exponent", input: "(a ; c\n-1e5)\n", expected: "(a ; c\n  -1e5)\n"},
-		{name: "leading-comment", input: "(a\n; c\n-1)\n", expected: "(a\n  ; c\n  -1)\n"},
+		{name: "leading-comment", input: "(a\n; c\n-1)\n", expected: "(a\n; c\n  -1)\n"},
+		{name: "leading-comment/indented", input: "(a\n  ; c\n-1)\n", expected: "(a\n  ; c\n  -1)\n"},
 		{name: "top-level", input: "; c\n-1\n", expected: "; c\n-1\n"},
 		// Controls: an unsigned literal in the same position, and a signed one
 		// with no comment in play.

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -368,8 +368,17 @@ func TestCommentInsideSExpr(t *testing.T) {
 func TestCommentInsideList(t *testing.T) {
 	runFormatTests(t, []formatTest{
 		{
+			// A comment written in column 0 stays in column 0 (see
+			// commentIndent); the sibling it precedes is still indented.
 			name:  "comment inside brackets",
 			input: "[a\n; comment\nb]",
+			expected: "[a\n" +
+				"; comment\n" +
+				" b]\n",
+		},
+		{
+			name:  "comment inside brackets, indented in source",
+			input: "[a\n ; comment\nb]",
 			expected: "[a\n" +
 				" ; comment\n" +
 				" b]\n",
@@ -1276,8 +1285,20 @@ func TestPatternBlankLineAfterComment(t *testing.T) {
 			expected: "; storage key format\n; prefix:id\n\n(set 'storage-prefix \"data\")\n",
 		},
 		{
+			// The comment was written flush left, so it stays flush left --
+			// see commentIndent. gofmt does the same for a `//` comment in
+			// column 1 inside a function body. The blank line after it, which
+			// is what this test is actually about, is preserved either way.
 			name:  "blank line after comment inside body",
 			input: "(defun foo ()\n; setup\n\n(init)\n(run))",
+			expected: "(defun foo ()\n" +
+				"; setup\n\n" +
+				"  (init)\n" +
+				"  (run))\n",
+		},
+		{
+			name:  "blank line after indented comment inside body",
+			input: "(defun foo ()\n  ; setup\n\n(init)\n(run))",
 			expected: "(defun foo ()\n" +
 				"  ; setup\n\n" +
 				"  (init)\n" +

--- a/formatter/printer.go
+++ b/formatter/printer.go
@@ -68,6 +68,58 @@ func (p *printer) writeTopLevel(exprs []*lisp.LVal, trailingComments []*token.To
 	}
 }
 
+// beganInColumnOne reports whether c started at the very beginning of its
+// source line.
+//
+// Source.Col is 1-based, and 0 when the reader did not track positions, so
+// there is a fallback: a comment with a newline before it and no spaces after
+// that newline also began in column one.  (PrecedingSpaces is same-line only,
+// so it is the indentation of the comment's own line.)
+func beganInColumnOne(c *token.Token) bool {
+	if c.Source != nil && c.Source.Col > 0 {
+		return c.Source.Col == 1
+	}
+	return c.PrecedingNewlines > 0 && c.PrecedingSpaces == 0
+}
+
+// commentIndent returns the column a LEADING comment should be written at:
+// normally the enclosing form's indent, but column 0 for a comment that began
+// in column 0.
+//
+// Leading comments only, deliberately. This rule exists because a flush-left
+// comment is column-aligned against the line ABOVE it; an inner-trailing
+// comment sits between the last child and the closing bracket, where there is
+// no such line and nothing to align with, so it keeps the form's indent (see
+// writeInnerTrailingComments).
+//
+// This mirrors gofmt, which leaves a `//` comment starting in column 1 in
+// column 1, and for the same reason: a flush-left comment inside an indented
+// body is a deliberate signal, not an accident of layout, so re-indenting it
+// destroys information the author put in the column.
+//
+// The case that forced it here is editors/vscode/test/grammar/basics.lisp,
+// whose TextMate syntax-test assertions look like
+//
+//	(defun f (x &optional y)
+//	;           ^^^^^^^^^ variable.parameter.elps
+//
+// The caret column IS the assertion -- it points at characters on the line
+// above -- so indenting the comment by the form's indent silently changes
+// what the test asserts, and `elps fmt` corrupted the fixture while appearing
+// to succeed.  Anything else whose content is column-aligned against the
+// preceding line (ASCII diagrams, ruler comments, commented-out code kept
+// flush so diffs stay readable) has the same property.
+//
+// Deliberately NOT special-cased to `;` followed by `<`/`^`: the rule is
+// about the author having chosen column 0, not about one downstream tool's
+// assertion syntax.
+func commentIndent(c *token.Token, indent int) int {
+	if indent == 0 || beganInColumnOne(c) {
+		return 0
+	}
+	return indent
+}
+
 // writeLeadingComments writes comments that precede a node.
 func (p *printer) writeLeadingComments(v *lisp.LVal, indent int) {
 	if p.cfg.StripComments {
@@ -86,7 +138,7 @@ func (p *printer) writeLeadingComments(v *lisp.LVal, indent int) {
 				p.newline()
 			}
 		}
-		p.writeIndent(indent)
+		p.writeIndent(commentIndent(c, indent))
 		p.writeString(c.Text)
 		p.newline()
 		p.first = false


### PR DESCRIPTION
`elps fmt` re-indented every own-line comment to its enclosing form's indent. When a comment's content is column-aligned against the line **above** it, the column *is* meaning, and re-indenting destroys it silently.

## The victims

`editors/vscode/test/grammar/*.lisp` are fixtures for `vscode-tmgrammar-test`, where `; <-` and `; ^^^` comments are **positional assertions about the preceding line**:

```lisp
(defun f (x &optional y)
;           ^^^^^^^^^ variable.parameter.elps
```

Formatting shifted those carets two columns right. The fixture kept asserting — about the wrong characters. `elps fmt` corrupted the test while reporting success.

## The rule

gofmt's, adopted for gofmt's reason: a `//` comment starting in column 1 stays in column 1, because a flush-left comment inside an indented body is a deliberate signal rather than an accident of layout.

`commentIndent` keys off the comment's **original** column, so an indented comment is still re-indented to its form. Only column 0 is sticky.

**Scoped to leading comments.** Inner-trailing comments sit between the last child and the closing bracket, where there is no line above and nothing to align against. Applying the rule there produced strictly worse output for no benefit:

```
(lisp:function f
; c                     <- worse
               )
```

## Blast radius, measured

Of **33** `.lisp` files in the repo, exactly **3** format differently — and all 3 are the grammar fixtures. No real ELPS code in the tree writes a column-0 comment inside a form. All five fixtures are now byte-identical under `elps fmt`, and every file in the tree is idempotent under it.

## The tradeoff, stated plainly

An unindented comment inside a nested form now stays flush left:

```lisp
(defun foo ()
; setup

  (init)
  (run))
```

That is intended, and gofmt does the same to the equivalent Go. It is the cost of the rule, and it is why the measurement above matters: no real code in this repo hits it.

## Tests changed

Nine assertions from #326 moved. Every one is a case whose *input* put `; c` in column 0 because it was written as a terse Go string literal, not because anything was expressing intent about the column.

Each changed row gained a **companion row with the comment indented**, so the table now pins both directions. Without those, a bug that flattened every comment to the left margin would pass every one of these tests.

## Guards, both verified to fail

| Guard | What it pins |
|---|---|
| `TestCommentInColumnZeroIsPreserved` | Paired column-0 / indented cases, including the alignment shape itself. Each case also asserts the **second** format pass is a no-op — a rule that reads the original column has to survive being fed its own output. |
| `TestGrammarFixturesAreFormatFixedPoints` | Reads the five real fixture files and requires byte-identical output. |

The second exists as a test rather than a note for a specific reason: **CI runs `elps fmt -l --exclude 'grammar'`**, so the exclusion means nothing else in the build would ever notice this regression. A guard that depends on the tool whose exclusion hid the bug is not a guard.

Reverting `commentIndent` fails both: 3 of 6 subtests in the first, 3 of 5 fixtures in the second.

## Verification

- `go test ./...` — pass
- `golangci-lint run ./formatter/...` — 0 issues
- `gofmt -l formatter/` — clean
- `./elps doc -m` — all documented
- `./elps fmt -l --exclude 'grammar' ./...` — clean
- Every `.lisp` in the tree is idempotent under `elps fmt`; 0 non-idempotent files

Refs #320

---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_