### PR TITLE
ci(fuzz): shard the sweep and derive its timeout instead of remembering it

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -429,3 +429,43 @@ jobs:
               ;;
           esac
           exit 1
+
+  # THE ONE CHECK TO REQUIRE FOR THIS WORKFLOW.
+  #
+  # Branch protection matches a required status check by NAME, so requiring the
+  # individual jobs means editing repo settings every time a job is added,
+  # renamed or resharded -- and forgetting to leaves the new job unguarded
+  # while the board still looks fully green. That is the same "green by not
+  # looking" shape as an excluded path or a queued job.
+  #
+  # This job has a fixed name and depends on every other job in the workflow,
+  # so it is the only name that ever needs to be in the required list. Adding a
+  # job means adding it to `needs:` here -- and scripts/ci-gates-test.sh fails
+  # the PR if you don't, so the aggregate cannot silently stop covering
+  # something.
+  #
+  # always() plus an explicit success check, because `needs` alone would SKIP
+  # this job when an upstream one fails, and a skipped required check reads as
+  # green rather than red.
+  required:
+    name: "Required: benchmark"
+    runs-on: ubuntu-latest
+    needs: [gates, queue-watchdog, benchmark]
+    if: always()
+    steps:
+      - name: Assert every job in this workflow succeeded
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "upstream job results: ${RESULTS}"
+          rc=0
+          for r in ${RESULTS}; do
+            # success is the ONLY pass. failure, cancelled and skipped all mean
+            # the work was not demonstrably done.
+            [ "$r" = "success" ] || rc=1
+          done
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::A job in this workflow did not succeed (results: ${RESULTS}). Open the individual jobs above."
+            exit 1
+          fi
+          echo "All jobs in this workflow succeeded."

--- a/.github/workflows/elps.yml
+++ b/.github/workflows/elps.yml
@@ -84,3 +84,43 @@ jobs:
 
       - name: Vet
         run: go vet ./...
+
+  # THE ONE CHECK TO REQUIRE FOR THIS WORKFLOW.
+  #
+  # Branch protection matches a required status check by NAME, so requiring the
+  # individual jobs means editing repo settings every time a job is added,
+  # renamed or resharded -- and forgetting to leaves the new job unguarded
+  # while the board still looks fully green. That is the same "green by not
+  # looking" shape as an excluded path or a queued job.
+  #
+  # This job has a fixed name and depends on every other job in the workflow,
+  # so it is the only name that ever needs to be in the required list. Adding a
+  # job means adding it to `needs:` here -- and scripts/ci-gates-test.sh fails
+  # the PR if you don't, so the aggregate cannot silently stop covering
+  # something.
+  #
+  # always() plus an explicit success check, because `needs` alone would SKIP
+  # this job when an upstream one fails, and a skipped required check reads as
+  # green rather than red.
+  required:
+    name: "Required: build & test"
+    runs-on: ubuntu-latest
+    needs: [lint-and-test, build-windows]
+    if: always()
+    steps:
+      - name: Assert every job in this workflow succeeded
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "upstream job results: ${RESULTS}"
+          rc=0
+          for r in ${RESULTS}; do
+            # success is the ONLY pass. failure, cancelled and skipped all mean
+            # the work was not demonstrably done.
+            [ "$r" = "success" ] || rc=1
+          done
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::A job in this workflow did not succeed (results: ${RESULTS}). Open the individual jobs above."
+            exit 1
+          fi
+          echo "All jobs in this workflow succeeded."

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -189,8 +189,8 @@ jobs:
   # `always()` because a skipped or cancelled shard must not let this report
   # success by default -- `needs` alone would skip this job too, and a skipped
   # required check reads as green.
-  fuzz-result:
-    name: Fuzz targets
+  required:
+    name: "Required: fuzz"
     runs-on: ubuntu-latest
     needs: fuzz
     if: always()

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -61,34 +61,38 @@ permissions:
 
 jobs:
   fuzz:
-    name: Fuzz targets
+    name: Fuzz shard ${{ matrix.shard }}/4
     runs-on: ubuntu-latest
-    # A BACKSTOP, NOT A BUDGET -- and the number must not be read as an
-    # accurate target count.  Discovery is dynamic (scripts/fuzz.sh enumerates
-    # targets at run time), so a new target silently costs another FUZZTIME on
-    # the nightly sweep, and a value sized for yesterday's count truncates the
-    # sweep with the last targets never executing at all.
+    strategy:
+      # Sharded so wall clock is set by the LARGEST shard rather than by the
+      # total. Serial, the nightly sweep cost (targets x FUZZTIME) grew every
+      # time a target was added, and the backstop below was a number somebody
+      # had to remember to recompute. It went stale twice: 120 sized for 10
+      # targets when there were 12, and 140 vs 165 when two branches each
+      # counted only their own additions.
+      #
+      # The shard COUNT here is the single source of truth -- scripts/fuzz.sh
+      # takes `--shard i/n` and assigns round-robin over the sorted target
+      # list, and scripts/fuzz-budget-check.sh reads this matrix to derive the
+      # timeout below. Adding a shard is a one-line change and the gate
+      # re-derives.
+      #
+      # fail-fast off: one shard finding a crasher must not cancel the others,
+      # or a single failure costs the whole night's coverage.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    # DERIVED, not remembered. scripts/fuzz-budget-check.sh asserts
     #
-    # Re-derive rather than trusting this literal: `make fuzz-list` prints the
-    # targets actually discovered on the current tree.  The arithmetic is
-    # (targets that really fuzz) x FUZZTIME + build + corpus cache restore.
-    # FuzzGateSelfTest is inert unless armed and does not count.
+    #     ceil(targets / shards) x FUZZTIME + overhead <= timeout-minutes
     #
-    # 180 is sized for the fully-landed round-2 state: main carries 11
-    # targets, the evaluator work adds FuzzEval, the stdlib work adds
-    # FuzzApplyStdlib / FuzzDumpJSON / FuzzSchemaValidate, and retiring
-    # regexparser removes FuzzParseLVal -- 14 that really fuzz, so 14 x 10m =
-    # 140 minutes plus overhead.  It is deliberately above every intermediate
-    # merge order as well, because over-provisioning a backstop costs nothing
-    # while under-provisioning drops coverage silently.
+    # on every PR, so this number cannot silently stop covering the sweep. At
+    # 15 targets over 4 shards that is 4 x 10m + 10m = 50; 60 leaves a shard's
+    # worth of headroom for a target being added before anyone reshards.
     #
-    # Measured PR-path cost (FUZZTIME=30s, 4-core linux/amd64): the whole
-    # sweep is ~6 minutes; FuzzEval 32s, FuzzApplyStdlib 33s, FuzzDumpJSON
-    # 33s, FuzzSchemaValidate 34s.
-    #
-    # The durable fix is a derived gate asserting
-    # (target count x nightly budget) <= timeout-minutes -- tracked in #320.
-    timeout-minutes: 180
+    # Do not raise this by hand to make a red gate green -- run
+    # `make fuzz-budget-check`, which prints the arithmetic and the options.
+    timeout-minutes: 60
     env:
       # 30s on a PR, 10m on the nightly schedule, whatever was asked for on a
       # manual dispatch. The PR budget is intentionally small: this job is a
@@ -120,8 +124,10 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6
         with:
           path: ~/.cache/go-build/fuzz
-          key: fuzz-corpus-${{ github.sha }}
-          restore-keys: fuzz-corpus-
+          key: fuzz-corpus-${{ matrix.shard }}-${{ github.sha }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.shard }}-
+            fuzz-corpus-
 
       # The Go-backed half of the fuzz gate's own self-test: dynamic discovery
       # really finds the targets, and an armed FuzzGateSelfTest really turns
@@ -134,8 +140,13 @@ jobs:
       - name: List discovered targets
         run: ./scripts/fuzz.sh --list
 
+      # Whole-sweep budget arithmetic, run once per shard because it is
+      # sub-second and must not depend on a shard succeeding.
+      - name: Fuzz budget check
+        run: ./scripts/fuzz-budget-check.sh
+
       - name: Fuzz
-        run: ./scripts/fuzz.sh
+        run: ./scripts/fuzz.sh --shard ${{ matrix.shard }}/4
 
       # Only from main/schedule: a corpus grown from an unmerged branch would
       # otherwise be handed to every other PR.
@@ -144,7 +155,11 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6
         with:
           path: ~/.cache/go-build/fuzz
-          key: fuzz-corpus-${{ github.sha }}
+          # Shard-scoped, matching the restore key. A single key shared by four
+          # shards means the first write wins and the other three are discarded
+          # -- three quarters of the night's coverage growth thrown away, with
+          # no error anywhere.
+          key: fuzz-corpus-${{ matrix.shard }}-${{ github.sha }}
 
       # A crash is only useful if the input survives the runner. go test writes
       # it into <package>/testdata/fuzz/<Target>/, so upload that tree whenever
@@ -153,7 +168,42 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: fuzz-crashers-${{ github.run_id }}
+          name: fuzz-crashers-${{ github.run_id }}-shard${{ matrix.shard }}
           path: "**/testdata/fuzz/**"
           if-no-files-found: warn
           retention-days: 30
+
+  # A STABLE check name over a matrix whose size may change.
+  #
+  # Sharding renames the job that actually does the work -- "Fuzz targets"
+  # became "Fuzz shard 1/4" and friends. A required status check is matched by
+  # NAME, so if "Fuzz targets" had been in the branch-protection required list,
+  # that rename would have left a required check that can never report, and
+  # every PR would be unmergeable until someone edited repo settings. Adding a
+  # shard later would do the same thing again.
+  #
+  # So the shards stay anonymous and this job carries the stable name. It is
+  # the one to put in required checks: it passes only if every shard passed,
+  # and its name does not move when the matrix is resized.
+  #
+  # `always()` because a skipped or cancelled shard must not let this report
+  # success by default -- `needs` alone would skip this job too, and a skipped
+  # required check reads as green.
+  fuzz-result:
+    name: Fuzz targets
+    runs-on: ubuntu-latest
+    needs: fuzz
+    if: always()
+    steps:
+      - name: Check shard results
+        env:
+          RESULT: ${{ needs.fuzz.result }}
+        run: |
+          echo "fuzz matrix result: ${RESULT}"
+          # success is the only pass. failure, cancelled and skipped all mean
+          # the sweep did not demonstrably run to completion.
+          if [ "${RESULT}" != "success" ]; then
+            echo "::error::The fuzz sweep did not succeed (matrix result: ${RESULT}). Open the individual shard jobs for the failing target."
+            exit 1
+          fi
+          echo "All fuzz shards passed."

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -33,3 +33,43 @@ jobs:
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
+
+  # THE ONE CHECK TO REQUIRE FOR THIS WORKFLOW.
+  #
+  # Branch protection matches a required status check by NAME, so requiring the
+  # individual jobs means editing repo settings every time a job is added,
+  # renamed or resharded -- and forgetting to leaves the new job unguarded
+  # while the board still looks fully green. That is the same "green by not
+  # looking" shape as an excluded path or a queued job.
+  #
+  # This job has a fixed name and depends on every other job in the workflow,
+  # so it is the only name that ever needs to be in the required list. Adding a
+  # job means adding it to `needs:` here -- and scripts/ci-gates-test.sh fails
+  # the PR if you don't, so the aggregate cannot silently stop covering
+  # something.
+  #
+  # always() plus an explicit success check, because `needs` alone would SKIP
+  # this job when an upstream one fails, and a skipped required check reads as
+  # green rather than red.
+  required:
+    name: "Required: govulncheck"
+    runs-on: ubuntu-latest
+    needs: [govulncheck]
+    if: always()
+    steps:
+      - name: Assert every job in this workflow succeeded
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "upstream job results: ${RESULTS}"
+          rc=0
+          for r in ${RESULTS}; do
+            # success is the ONLY pass. failure, cancelled and skipped all mean
+            # the work was not demonstrably done.
+            [ "$r" = "success" ] || rc=1
+          done
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::A job in this workflow did not succeed (results: ${RESULTS}). Open the individual jobs above."
+            exit 1
+          fi
+          echo "All jobs in this workflow succeeded."

--- a/.github/workflows/tree-sitter.yml
+++ b/.github/workflows/tree-sitter.yml
@@ -9,8 +9,19 @@ on:
       # such a PR -- and a board showing only the two branch-agnostic
       # Socket checks reads as a pass when in fact nothing ran.
       - 'claude/**'
-    paths:
-      - "tree-sitter-elps/**"
+    # NO `paths:` filter, deliberately -- see the "Required: tree-sitter" job
+    # below. A path-filtered workflow does not run at all on a PR that touches
+    # nothing it matches, so its checks never report; and a REQUIRED check that
+    # never reports blocks the PR forever, with only a settings edit to clear
+    # it. Since this workflow's aggregate is meant to be a required check, it
+    # has to report on every PR.
+    #
+    # The cost is one small job (checkout, Go, `go test` on a single module)
+    # per PR, which is a fair price for a gate that is honest about whether the
+    # grammar still builds.
+    #
+    # The `push` trigger below keeps its filter: pushes have no required
+    # checks, so skipping there blocks nothing.
   push:
     branches:
       - main

--- a/.github/workflows/tree-sitter.yml
+++ b/.github/workflows/tree-sitter.yml
@@ -42,3 +42,43 @@ jobs:
       - name: Tests
         working-directory: tree-sitter-elps
         run: go test -v ./...
+
+  # THE ONE CHECK TO REQUIRE FOR THIS WORKFLOW.
+  #
+  # Branch protection matches a required status check by NAME, so requiring the
+  # individual jobs means editing repo settings every time a job is added,
+  # renamed or resharded -- and forgetting to leaves the new job unguarded
+  # while the board still looks fully green. That is the same "green by not
+  # looking" shape as an excluded path or a queued job.
+  #
+  # This job has a fixed name and depends on every other job in the workflow,
+  # so it is the only name that ever needs to be in the required list. Adding a
+  # job means adding it to `needs:` here -- and scripts/ci-gates-test.sh fails
+  # the PR if you don't, so the aggregate cannot silently stop covering
+  # something.
+  #
+  # always() plus an explicit success check, because `needs` alone would SKIP
+  # this job when an upstream one fails, and a skipped required check reads as
+  # green rather than red.
+  required:
+    name: "Required: tree-sitter"
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always()
+    steps:
+      - name: Assert every job in this workflow succeeded
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "upstream job results: ${RESULTS}"
+          rc=0
+          for r in ${RESULTS}; do
+            # success is the ONLY pass. failure, cancelled and skipped all mean
+            # the work was not demonstrably done.
+            [ "$r" = "success" ] || rc=1
+          done
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::A job in this workflow did not succeed (results: ${RESULTS}). Open the individual jobs above."
+            exit 1
+          fi
+          echo "All jobs in this workflow succeeded."

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,19 @@ fuzz:
 fuzz-list:
 	bash scripts/fuzz.sh --list
 
+# Prove the nightly sweep still fits its timeout:
+#
+#     ceil(targets / shards) x FUZZTIME + overhead <= timeout-minutes
+#
+# Every input is read from a source of truth — targets from the same discovery
+# the sweep uses, and shards / FUZZTIME / timeout-minutes from
+# .github/workflows/fuzz.yml — so the backstop cannot go stale as targets are
+# added. Run this instead of raising timeout-minutes by hand; it prints the
+# arithmetic and the options.
+.PHONY: fuzz-budget-check
+fuzz-budget-check:
+	bash scripts/fuzz-budget-check.sh
+
 # Self-test for the CI gate logic in scripts/. Run this after touching
 # scripts/benchstat-gate.sh, scripts/fuzz.sh, .github/workflows/benchmark.yml
 # or .github/workflows/fuzz.yml — it proves the benchmark regression gate and

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -1052,7 +1052,28 @@ for f in sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.y*ml")))
     def jobname(jid, _jobs=jobs):
         return str(_jobs[jid].get("name") or jid)
 
+    # A path-filtered workflow does not run at all on a PR that touches nothing
+    # it matches, so its checks never report -- and a REQUIRED check that never
+    # reports blocks the PR forever, clearable only by editing repo settings.
+    # Since a `Required:` aggregate exists precisely to be required, its
+    # workflow must fire on every PR.
+    #
+    # Caught for real: tree-sitter.yml was filtered to tree-sitter-elps/**, so
+    # "Required: tree-sitter" did not report on the PR that introduced it, and
+    # adding it to branch protection would have wedged every PR that does not
+    # touch the grammar.
+    pr_cfg = triggers.get("pull_request") or {}
+    filtered = isinstance(pr_cfg, dict) and (pr_cfg.get("paths") or pr_cfg.get("paths-ignore"))
+
     aggs = [j for j in jobs if jobname(j).startswith(MARKER)]
+    if aggs and filtered:
+        failures.append(
+            f"{base}: has a '{MARKER} ...' aggregate but its pull_request trigger is "
+            f"path-filtered, so the check does not report on PRs that miss the filter. "
+            f"Required + never-reports = permanently unmergeable. Drop the paths filter, "
+            f"or do not make this workflow's aggregate a required check."
+        )
+        continue
     if not aggs:
         failures.append(
             f"{base}: no fixed-name '{MARKER} ...' aggregate job. Every job would have to "

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -834,6 +834,79 @@ if [ "${CI_GATES_SKIP_GO:-0}" = "1" ] || ! command -v go >/dev/null 2>&1; then
 		"go present: $(command -v go >/dev/null 2>&1 && echo yes || echo no))"
 	echo "SKIP  they run in .github/workflows/fuzz.yml, which sets up Go"
 else
+	# The derived budget gate. It reads real discovery plus the workflow, so
+	# it needs Go; the negative controls below drive it at a scratch copy of
+	# the workflow via FUZZ_WORKFLOW.
+	BUDGET="${SCRIPT_DIR}/fuzz-budget-check.sh"
+	assert_exit 0 "the nightly sweep fits its timeout as configured today" \
+		"$BUDGET"
+
+	budget_tmp="$(mktemp -d)"
+	budget_wf="${budget_tmp}/fuzz.yml"
+
+	# Each control reverts ONE property of the real workflow. A budget gate
+	# that has never been watched failing is worth nothing -- the value it
+	# guards went stale twice before this existed (120 sized for 10 targets
+	# when there were 12; 140 vs 165 when two branches each counted only their
+	# own additions).
+	cp "$FUZZ_WF" "$budget_wf"
+	sed -i 's/^    timeout-minutes: [0-9]*$/    timeout-minutes: 5/' "$budget_wf"
+	assert_exit 1 "a timeout too small for the sweep FAILS" \
+		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
+
+	cp "$FUZZ_WF" "$budget_wf"
+	sed -i 's/^        shard: \[.*\]$/        shard: [1]/' "$budget_wf"
+	assert_exit 1 "unsharding (one shard, whole sweep serial) FAILS" \
+		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
+
+	cp "$FUZZ_WF" "$budget_wf"
+	sed -i '/^    timeout-minutes: [0-9]*$/d' "$budget_wf"
+	assert_exit 2 "a fuzz job with NO timeout-minutes is unreadable, not fine" \
+		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
+
+	cp "$FUZZ_WF" "$budget_wf"
+	sed -i "s/'schedule' && '[0-9]*[smh]'/'schedule' \&\& 'BOGUS'/" "$budget_wf"
+	assert_exit 2 "an unparsable scheduled FUZZTIME is refused, not guessed" \
+		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
+
+	assert_exit 2 "a missing workflow is an error" \
+		env FUZZ_WORKFLOW="${budget_tmp}/nope.yml" "$BUDGET"
+
+	rm -rf "$budget_tmp"
+
+	# Sharding must be a PARTITION: every target in exactly one shard. A shard
+	# assignment that drops a target loses coverage silently, and one that
+	# duplicates a target just wastes budget.
+	shard_tmp="$(mktemp -d)"
+	"${SCRIPT_DIR}/fuzz.sh" --list 2>/dev/null | LC_ALL=C sort >"${shard_tmp}/full"
+	: >"${shard_tmp}/union"
+	for i in 1 2 3 4; do
+		"${SCRIPT_DIR}/fuzz.sh" --list --shard "${i}/4" 2>/dev/null >>"${shard_tmp}/union"
+	done
+	LC_ALL=C sort "${shard_tmp}/union" >"${shard_tmp}/union.sorted"
+	if diff -q "${shard_tmp}/full" "${shard_tmp}/union.sorted" >/dev/null; then
+		ok "the 4 shards are a partition of the full target list (no target lost)"
+	else
+		bad "sharding is not a partition — targets are lost or duplicated"
+		diff "${shard_tmp}/full" "${shard_tmp}/union.sorted" | sed 's/^/        | /'
+	fi
+	dupes=$(($(wc -l <"${shard_tmp}/union.sorted") - $(sort -u "${shard_tmp}/union.sorted" | wc -l)))
+	if [ "$dupes" -eq 0 ]; then
+		ok "no target is claimed by more than one shard"
+	else
+		bad "${dupes} target(s) appear in more than one shard"
+	fi
+	rm -rf "$shard_tmp"
+
+	# A shard spec that cannot be read must not silently run a SUBSET and exit
+	# 0 -- indistinguishable from a clean full sweep.
+	for bad_spec in "0/4" "5/4" "abc" "1/0"; do
+		assert_exit 2 "--shard ${bad_spec} is refused rather than guessed" \
+			"${SCRIPT_DIR}/fuzz.sh" --list --shard "$bad_spec"
+	done
+	assert_exit 2 "more shards than targets is an error, not an empty green run" \
+		"${SCRIPT_DIR}/fuzz.sh" --shard 99/99
+
 	# Discovery is dynamic, so it can silently discover nothing -- which would
 	# look exactly like a clean run.
 	assert_exit 2 "discovering ZERO targets is an error, not a clean run" \
@@ -896,6 +969,98 @@ else
 	bad "fuzz.yml does not set FUZZTIME — the PR path would take the default"
 fi
 
+if [ -n "$(invoked_in "$FUZZ_WF" 'scripts/fuzz-budget-check.sh')" ]; then
+	ok "fuzz.yml RUNS the derived budget check (timeout is not a remembered number)"
+else
+	bad "fuzz.yml does not run fuzz-budget-check.sh — timeout-minutes is unguarded again"
+fi
+
+# A required status check is matched by NAME. A job whose name interpolates a
+# matrix value changes name when the matrix is resized, so if such a name were
+# ever added to branch protection, resizing the matrix would leave a required
+# check that can never report and every PR would be unmergeable until someone
+# edited repo settings. Every matrix job therefore needs a fixed-name
+# aggregate job downstream of it, and that is the name to require.
+stable_out="$(python3 - "$REPO_ROOT" <<'PY_INNER'
+import glob, os, sys
+
+root = sys.argv[1]
+try:
+    import yaml
+except ImportError:
+    print("__SKIP__ pyyaml unavailable")
+    sys.exit(0)
+
+failures, passes = [], []
+for f in sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.y*ml"))):
+    base = os.path.basename(f)
+    try:
+        doc = yaml.safe_load(open(f))
+    except Exception:  # noqa: BLE001
+        continue
+    if not isinstance(doc, dict):
+        continue
+    # Only a check that runs on pull_request can be listed as a REQUIRED
+    # status check, so a tag/release workflow's matrix names cannot cause the
+    # rename trap. `on` parses as the boolean True in YAML 1.1.
+    triggers = doc.get("on", doc.get(True)) or {}
+    if isinstance(triggers, str):
+        triggers = {triggers: None}
+    if isinstance(triggers, list):
+        triggers = {t: None for t in triggers}
+    if "pull_request" not in triggers:
+        continue
+
+    jobs = doc.get("jobs") or {}
+    for jid, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        if not (job.get("strategy") or {}).get("matrix"):
+            continue
+        name = str(job.get("name") or jid)
+        if "${{" not in name:
+            passes.append(f"{base}: matrix job {jid!r} has a fixed name; safe to require directly")
+            continue
+        # find a fixed-name job that depends on this one
+        def needs_of(j):
+            n = j.get("needs")
+            if isinstance(n, str):
+                return [n]
+            return list(n or [])
+        agg = [f"{k}" for k, v in jobs.items()
+               if isinstance(v, dict) and jid in needs_of(v)
+               and "${{" not in str(v.get("name") or k)]
+        if agg:
+            passes.append(f"{base}: matrix job {jid!r} is fronted by fixed-name job(s) {agg}")
+        else:
+            failures.append(
+                f"{base}: matrix job {jid!r} has an interpolated name ({name!r}) and no "
+                f"fixed-name aggregate job depends on it. Resizing the matrix renames the "
+                f"check, and a renamed REQUIRED check can never report."
+            )
+
+for p in passes:
+    print(f"PASS  {p}")
+for f_ in failures:
+    print(f"FAIL  {f_}")
+print(f"__COUNTS__ {len(passes)} {len(failures)}")
+PY_INNER
+)"
+case "$stable_out" in
+	__SKIP__*) echo "SKIP  stable-check-name guard ($stable_out)" ;;
+	*)
+		echo "$stable_out" | grep -v '^__COUNTS__' || true
+		stable_counts="$(echo "$stable_out" | sed -n 's/^__COUNTS__ //p')"
+		if [ -n "$stable_counts" ]; then
+			read -r st_pass st_fail <<<"$stable_counts"
+			pass=$((pass + st_pass))
+			fail=$((fail + st_fail))
+		else
+			bad "stable-check-name guard did not run"
+		fi
+		;;
+esac
+
 echo
 echo "== shell lint on the scripts this suite owns ============================="
 
@@ -903,6 +1068,7 @@ OWNED_SCRIPTS=(
 	"${SCRIPT_DIR}/bench-arms-check.sh"
 	"${SCRIPT_DIR}/benchstat-gate.sh"
 	"${SCRIPT_DIR}/ci-gates-test.sh"
+	"${SCRIPT_DIR}/fuzz-budget-check.sh"
 	"${SCRIPT_DIR}/fuzz.sh"
 )
 

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -975,6 +975,431 @@ else
 	bad "fuzz.yml does not run fuzz-budget-check.sh — timeout-minutes is unguarded again"
 fi
 
+# ONE REQUIRED CHECK PER WORKFLOW, AND IT MUST COVER EVERYTHING.
+#
+# Branch protection matches a required status check by NAME. Requiring the
+# individual jobs means editing repo settings whenever a job is added, renamed
+# or resharded -- and forgetting to leaves the new job unguarded while the board
+# still reads fully green. Two concrete traps this repo has been one edit away
+# from:
+#
+#   * sharding renamed "Fuzz targets" to "Fuzz shard i/4". Had the old name
+#     been required, every PR would have become unmergeable, because a required
+#     check that never reports blocks forever.
+#   * adding a job to a workflow silently leaves it outside the required set.
+#
+# So every pull_request-triggered workflow carries exactly one fixed-name
+# `Required: <area>` job, and that name is the only thing in branch protection.
+# This guard enforces the two properties that make that safe:
+#
+#   1. the aggregate exists and its name is FIXED (no ${{ }} interpolation), and
+#   2. it `needs` EVERY other job in its workflow -- otherwise the aggregate
+#      goes green while an uncovered job is red, which is strictly worse than
+#      having no aggregate at all, because it looks like coverage.
+req_out="$(python3 - "$REPO_ROOT" <<'PY_INNER'
+import glob, os, sys
+
+root = sys.argv[1]
+try:
+    import yaml
+except ImportError:
+    print("__SKIP__ pyyaml unavailable")
+    sys.exit(0)
+
+MARKER = "Required:"
+failures, passes = [], []
+
+for f in sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.y*ml"))):
+    base = os.path.basename(f)
+    try:
+        doc = yaml.safe_load(open(f))
+    except Exception:  # noqa: BLE001 -- the YAML-parse guard owns this
+        continue
+    if not isinstance(doc, dict):
+        continue
+
+    # Only a pull_request check can be a REQUIRED check, so release/tag
+    # workflows are out of scope. `on` parses as boolean True in YAML 1.1.
+    triggers = doc.get("on", doc.get(True)) or {}
+    if isinstance(triggers, str):
+        triggers = {triggers: None}
+    if isinstance(triggers, list):
+        triggers = {t: None for t in triggers}
+    if "pull_request" not in triggers:
+        continue
+
+    jobs = {k: v for k, v in (doc.get("jobs") or {}).items() if isinstance(v, dict)}
+    if not jobs:
+        continue
+
+    def jobname(jid):
+        return str(jobs[jid].get("name") or jid)
+
+    aggs = [j for j in jobs if jobname(j).startswith(MARKER)]
+    if not aggs:
+        failures.append(
+            f"{base}: no fixed-name '{MARKER} ...' aggregate job. Every job in it would "
+            f"have to be listed in branch protection by hand, and a job added later "
+            f"would be unguarded while the board still looks green."
+        )
+        continue
+    if len(aggs) > 1:
+        failures.append(f"{base}: more than one '{MARKER} ...' job ({aggs}); exactly one is the check to require")
+        continue
+
+    agg = aggs[0]
+    if "${{" in jobname(agg):
+        failures.append(f"{base}: aggregate {agg!r} has an interpolated name ({jobname(agg)!r}); a required check's name must be fixed")
+        continue
+
+    needs = jobs[agg].get("needs")
+    needs = [needs] if isinstance(needs, str) else list(needs or [])
+    missing = sorted(set(jobs) - set(needs) - {agg})
+    if missing:
+        failures.append(
+            f"{base}: aggregate {jobname(agg)!r} does not depend on {missing}. "
+            f"Those jobs can fail while the one required check goes green."
+        )
+    else:
+        passes.append(f"{base}: '{jobname(agg)}' covers all {len(jobs) - 1} other job(s)")
+
+    # `needs` alone SKIPS the aggregate when an upstream job fails, and a
+    # skipped required check reads as green, so always() is load-bearing.
+    if str(jobs[agg].get("if", "")).find("always()") < 0:
+        failures.append(f"{base}: aggregate {jobname(agg)!r} lacks `if: always()`; it would be SKIPPED on upstream failure, and a skipped required check reads as green")
+
+for p_ in passes:
+    print(f"PASS  {p_}")
+for f_ in failures:
+    print(f"FAIL  {f_}")
+print(f"__COUNTS__ {len(passes)} {len(failures)}")
+PY_INNER
+)"
+case "$req_out" in
+	__SKIP__*) echo "SKIP  required-check aggregate guard ($req_out)" ;;
+	*)
+		echo "$req_out" | grep -v '^__COUNTS__' || true
+		req_counts="$(echo "$req_out" | sed -n 's/^__COUNTS__ //p')"
+		if [ -n "$req_counts" ]; then
+			read -r rq_pass rq_fail <<<"$req_counts"
+			pass=$((pass + rq_pass))
+			fail=$((fail + rq_fail))
+		else
+			bad "required-check aggregate guard did not run"
+		fi
+		;;
+esac
+
+wf_out="$(python3 - "$REPO_ROOT" <<'PY'
+import glob, os, re, sys
+
+root = sys.argv[1]
+failures, passes = [], []
+
+files = sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.yml")) +
+               glob.glob(os.path.join(root, ".github", "workflows", "*.yaml")))
+if not files:
+    failures.append("no workflow files found")
+
+try:
+    import yaml
+    docs = {}
+    for f in files:
+        try:
+            docs[f] = yaml.safe_load(open(f))
+        except Exception as e:  # noqa: BLE001
+            failures.append(f"{os.path.basename(f)} does not parse: {e}")
+    if not failures:
+        passes.append(f"all {len(files)} workflow files parse as YAML")
+
+    # No two workflows may publish the same top-level `name:` -- duplicate names
+    # produce indistinguishable check contexts, which lets a trivially-green
+    # workflow impersonate a real gate.
+    names = {}
+    for f, doc in docs.items():
+        if isinstance(doc, dict) and doc.get("name"):
+            names.setdefault(doc["name"], []).append(os.path.basename(f))
+    dupes = {n: v for n, v in names.items() if len(v) > 1}
+    for n, v in dupes.items():
+        failures.append(f"duplicate workflow name {n!r} in {', '.join(v)}")
+    if not dupes:
+        passes.append("no two workflows declare the same top-level name")
+except ImportError:
+    passes.append("(pyyaml unavailable; YAML-parse guards skipped)")
+
+# Every third-party `uses:` should be SHA-pinned (local ./ actions are exempt).
+# CONTRACT.md for this check: the repo pinned its actions in f5b12e3 ("chore: pin
+# GitHub Actions to SHAs and add Dependabot config"), but two workflows added
+# later drifted back to floating tags. Those are pre-existing and out of scope
+# for the benchmark-gate fix, so they are ALLOWLISTED rather than silently
+# ignored -- they print as WARN and the list may only ever shrink. Any NEW
+# unpinned action, or any unpinned action in a workflow this change owns, is a
+# hard failure.
+UNPINNED_ALLOWLIST = {
+    # file: reason (delete the row once the workflow is pinned)
+    "govulncheck.yml": "pre-existing, added in #303; not touched by this change",
+    "release-tag.yml": "pre-existing, added in #302; not touched by this change",
+}
+sha = re.compile(r"^[0-9a-f]{40}$")
+unpinned, warned = [], []
+for f in files:
+    base = os.path.basename(f)
+    for i, line in enumerate(open(f), 1):
+        m = re.search(r"uses:\s*(\S+)", line)
+        if not m:
+            continue
+        ref = m.group(1)
+        if ref.startswith("./"):
+            continue
+        if "@" not in ref or not sha.match(ref.rsplit("@", 1)[1]):
+            (warned if base in UNPINNED_ALLOWLIST else unpinned).append(f"{base}:{i} {ref}")
+for u in unpinned:
+    failures.append(f"unpinned action: {u}")
+if not unpinned:
+    passes.append(f"every non-allowlisted `uses:` is pinned to a 40-char commit SHA "
+                  f"({len(warned)} allowlisted)")
+for w in warned:
+    print(f"WARN  unpinned action (allowlisted, should be pinned): {w}")
+
+for p in passes:
+    print(f"PASS  {p}")
+for f_ in failures:
+    print(f"FAIL  {f_}")
+print(f"__COUNTS__ {len(passes)} {len(failures)}")
+PY
+)"
+
+echo "$wf_out" | grep -v '^__COUNTS__' || true
+wf_counts="$(echo "$wf_out" | sed -n 's/^__COUNTS__ //p')"
+if [ -n "$wf_counts" ]; then
+	read -r wf_pass wf_fail <<<"$wf_counts"
+	pass=$((pass + wf_pass))
+	fail=$((fail + wf_fail))
+else
+	bad "workflow shape guards did not run"
+fi
+
+echo
+echo "== fuzz gate: time bounding =============================================="
+
+FUZZ="${SCRIPT_DIR}/fuzz.sh"
+FUZZ_WF="${REPO_ROOT}/.github/workflows/fuzz.yml"
+
+# `go test -fuzz` has no default limit: without -fuzztime it runs until
+# something kills it. Every one of these guards exists to keep that from
+# reaching CI.
+
+assert_exit 2 "an unparsable FUZZTIME is refused rather than guessed" \
+	env FUZZTIME=forever "$FUZZ" --list
+assert_contains "refusing to run unbounded" \
+	"the refusal says why" \
+	env FUZZTIME=forever "$FUZZ" --list
+assert_exit 2 "a bare number (no unit) is refused" \
+	env FUZZTIME=60 "$FUZZ" --list
+assert_exit 2 "an empty FUZZTIME is refused" \
+	env FUZZTIME= "$FUZZ" --list
+
+# Every LIVE `go test -fuzz` in this repository must carry -fuzztime. Logical
+# lines, not physical ones: the invocation in fuzz.sh spreads its flags over a
+# backslash continuation, and a per-line scan would read the `-fuzz` line as
+# unbounded. Anchored on `go test` so that prose, this checker's own source,
+# and workflow comments are not mistaken for invocations.
+unbounded="$(python3 - "$REPO_ROOT" <<'PY'
+import glob, os, re, sys
+root = sys.argv[1]
+files = sorted(
+    glob.glob(os.path.join(root, ".github", "workflows", "*.y*ml"))
+    + glob.glob(os.path.join(root, "scripts", "*.sh"))
+    + [os.path.join(root, "Makefile")]
+)
+hits = []
+for f in files:
+    if not os.path.exists(f):
+        continue
+    logical, buf, start = [], "", 1
+    for i, line in enumerate(open(f), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        code = line.split("#", 1)[0].rstrip("\n")
+        if not buf:
+            start = i
+        if code.rstrip().endswith("\\"):
+            buf += code.rstrip()[:-1] + " "
+            continue
+        logical.append((start, buf + code))
+        buf = ""
+    if buf:
+        logical.append((start, buf))
+    for lineno, code in logical:
+        if not re.search(r"\bgo\s+test\b", code):
+            continue
+        if not re.search(r"(^|\s)-fuzz(\s|=|$)", code):
+            continue
+        if "-fuzztime" not in code:
+            hits.append(f"{os.path.relpath(f, root)}:{lineno}")
+print("\n".join(hits))
+PY
+)"
+if [ -n "$unbounded" ]; then
+	bad "a 'go test -fuzz' invocation has no -fuzztime bound: $unbounded"
+else
+	ok "every live 'go test -fuzz' invocation is bounded by -fuzztime"
+fi
+
+echo
+echo "== fuzz gate: discovery and proof it can FAIL ============================"
+
+# Everything from here needs a Go toolchain matching go.mod. The `gates` job in
+# benchmark.yml deliberately has none -- it is the fast, build-free gate that
+# must report even when the benchmark job is cancelled -- so it sets
+# CI_GATES_SKIP_GO and these run in the `fuzz` workflow instead, which already
+# has Go set up and its module cache warm.
+if [ "${CI_GATES_SKIP_GO:-0}" = "1" ] || ! command -v go >/dev/null 2>&1; then
+	echo "SKIP  Go-backed fuzz-gate checks (CI_GATES_SKIP_GO=${CI_GATES_SKIP_GO:-0}," \
+		"go present: $(command -v go >/dev/null 2>&1 && echo yes || echo no))"
+	echo "SKIP  they run in .github/workflows/fuzz.yml, which sets up Go"
+else
+	# The derived budget gate. It reads real discovery plus the workflow, so
+	# it needs Go; the negative controls below drive it at a scratch copy of
+	# the workflow via FUZZ_WORKFLOW.
+	BUDGET="${SCRIPT_DIR}/fuzz-budget-check.sh"
+	assert_exit 0 "the nightly sweep fits its timeout as configured today" \
+		"$BUDGET"
+
+	budget_tmp="$(mktemp -d)"
+	budget_wf="${budget_tmp}/fuzz.yml"
+
+	# Each control reverts ONE property of the real workflow. A budget gate
+	# that has never been watched failing is worth nothing -- the value it
+	# guards went stale twice before this existed (120 sized for 10 targets
+	# when there were 12; 140 vs 165 when two branches each counted only their
+	# own additions).
+	cp "$FUZZ_WF" "$budget_wf"
+	sed -i 's/^    timeout-minutes: [0-9]*$/    timeout-minutes: 5/' "$budget_wf"
+	assert_exit 1 "a timeout too small for the sweep FAILS" \
+		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
+
+	cp "$FUZZ_WF" "$budget_wf"
+	sed -i 's/^        shard: \[.*\]$/        shard: [1]/' "$budget_wf"
+	assert_exit 1 "unsharding (one shard, whole sweep serial) FAILS" \
+		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
+
+	cp "$FUZZ_WF" "$budget_wf"
+	sed -i '/^    timeout-minutes: [0-9]*$/d' "$budget_wf"
+	assert_exit 2 "a fuzz job with NO timeout-minutes is unreadable, not fine" \
+		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
+
+	cp "$FUZZ_WF" "$budget_wf"
+	sed -i "s/'schedule' && '[0-9]*[smh]'/'schedule' \&\& 'BOGUS'/" "$budget_wf"
+	assert_exit 2 "an unparsable scheduled FUZZTIME is refused, not guessed" \
+		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
+
+	assert_exit 2 "a missing workflow is an error" \
+		env FUZZ_WORKFLOW="${budget_tmp}/nope.yml" "$BUDGET"
+
+	rm -rf "$budget_tmp"
+
+	# Sharding must be a PARTITION: every target in exactly one shard. A shard
+	# assignment that drops a target loses coverage silently, and one that
+	# duplicates a target just wastes budget.
+	shard_tmp="$(mktemp -d)"
+	"${SCRIPT_DIR}/fuzz.sh" --list 2>/dev/null | LC_ALL=C sort >"${shard_tmp}/full"
+	: >"${shard_tmp}/union"
+	for i in 1 2 3 4; do
+		"${SCRIPT_DIR}/fuzz.sh" --list --shard "${i}/4" 2>/dev/null >>"${shard_tmp}/union"
+	done
+	LC_ALL=C sort "${shard_tmp}/union" >"${shard_tmp}/union.sorted"
+	if diff -q "${shard_tmp}/full" "${shard_tmp}/union.sorted" >/dev/null; then
+		ok "the 4 shards are a partition of the full target list (no target lost)"
+	else
+		bad "sharding is not a partition — targets are lost or duplicated"
+		diff "${shard_tmp}/full" "${shard_tmp}/union.sorted" | sed 's/^/        | /'
+	fi
+	dupes=$(($(wc -l <"${shard_tmp}/union.sorted") - $(sort -u "${shard_tmp}/union.sorted" | wc -l)))
+	if [ "$dupes" -eq 0 ]; then
+		ok "no target is claimed by more than one shard"
+	else
+		bad "${dupes} target(s) appear in more than one shard"
+	fi
+	rm -rf "$shard_tmp"
+
+	# A shard spec that cannot be read must not silently run a SUBSET and exit
+	# 0 -- indistinguishable from a clean full sweep.
+	for bad_spec in "0/4" "5/4" "abc" "1/0"; do
+		assert_exit 2 "--shard ${bad_spec} is refused rather than guessed" \
+			"${SCRIPT_DIR}/fuzz.sh" --list --shard "$bad_spec"
+	done
+	assert_exit 2 "more shards than targets is an error, not an empty green run" \
+		"${SCRIPT_DIR}/fuzz.sh" --shard 99/99
+
+	# Discovery is dynamic, so it can silently discover nothing -- which would
+	# look exactly like a clean run.
+	assert_exit 2 "discovering ZERO targets is an error, not a clean run" \
+		env FUZZTIME=1s "$FUZZ" ./lint/...
+	assert_contains "cannot fail" "the empty-discovery error explains itself" \
+		env FUZZTIME=1s "$FUZZ" ./lint/...
+
+	# The targets really are found. Listed once and asserted against, so the
+	# package set is only compiled a single extra time.
+	discovered="$(env FUZZTIME=1s "$FUZZ" --list 2>&1)"
+	for want in FuzzParseProgram FuzzLexer FuzzScanner FuzzFormat FuzzMinifySource FuzzLoadJSON; do
+		if echo "$discovered" | grep -q "$want"; then
+			ok "discovery finds ${want}"
+		else
+			bad "discovery no longer finds ${want}"
+		fi
+	done
+
+	# The headline assertion, and the reason FuzzGateSelfTest exists. A gate
+	# that has only ever reported success is indistinguishable from a gate that
+	# cannot fail -- precisely how the benchmark gate above stayed dead for 473
+	# runs. FuzzGateSelfTest is a deliberately-failing target, inert unless
+	# ELPS_FUZZ_GATE_SELFTEST is set, so this exercises the whole path end to
+	# end: discovery, invocation, and the failure reaching the exit status.
+	assert_exit 1 "an armed failing target makes fuzz.sh exit non-zero" \
+		env ELPS_FUZZ_GATE_SELFTEST=1 FUZZTIME=5s FUZZMINIMIZETIME=1s \
+		"$FUZZ" ./internal/fuzzseed/...
+	assert_contains "FuzzGateSelfTest" "the failing target is named in the summary" \
+		env ELPS_FUZZ_GATE_SELFTEST=1 FUZZTIME=5s FUZZMINIMIZETIME=1s \
+		"$FUZZ" ./internal/fuzzseed/...
+	# ...and the mirror: disarmed, the same package is clean. Without this, an
+	# always-failing script would satisfy the assertion above for the wrong
+	# reason.
+	assert_exit 0 "the same target is inert when NOT armed" \
+		env FUZZTIME=5s "$FUZZ" ./internal/fuzzseed/...
+
+	# An armed run can leave a generated crasher in the source tree; it is
+	# meaningless outside that run, so do not let it linger.
+	rm -rf "${REPO_ROOT}/internal/fuzzseed/testdata/fuzz/FuzzGateSelfTest"
+fi
+
+echo
+echo "== fuzz gate: workflow shape ============================================"
+
+if [ -n "$(invoked_in "$FUZZ_WF" 'scripts/fuzz.sh')" ]; then
+	ok "fuzz.yml INVOKES scripts/fuzz.sh (not just mentions it)"
+else
+	bad "fuzz.yml no longer invokes scripts/fuzz.sh — logic reinlined or removed?"
+fi
+
+if grep -qE '^\s*timeout-minutes:' "$FUZZ_WF"; then
+	ok "fuzz.yml sets a job-level timeout-minutes backstop"
+else
+	bad "fuzz.yml has no timeout-minutes — the job has no outer bound"
+fi
+
+if grep -q 'FUZZTIME' "$FUZZ_WF"; then
+	ok "fuzz.yml sets an explicit FUZZTIME budget"
+else
+	bad "fuzz.yml does not set FUZZTIME — the PR path would take the default"
+fi
+
+if [ -n "$(invoked_in "$FUZZ_WF" 'scripts/fuzz-budget-check.sh')" ]; then
+	ok "fuzz.yml RUNS the derived budget check (timeout is not a remembered number)"
+else
+	bad "fuzz.yml does not run fuzz-budget-check.sh — timeout-minutes is unguarded again"
+fi
+
 # A required status check is matched by NAME. A job whose name interpolates a
 # matrix value changes name when the matrix is resized, so if such a name were
 # ever added to branch protection, resizing the matrix would leave a required

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -874,6 +874,25 @@ else
 
 	rm -rf "$budget_tmp"
 
+	# FUZZ_TAGS must reach BOTH discovery and execution. Reaching only one
+	# would enumerate one build and fuzz the other -- reporting success over
+	# targets it never ran. Same blind spot golangci-lint has (it analyses one
+	# build), which is why `make static-checks` makes a second tagged pass.
+	if FUZZ_TAGS=elpscheck "${SCRIPT_DIR}/fuzz.sh" --list >/dev/null 2>&1; then
+		ok "FUZZ_TAGS is accepted by target discovery"
+	else
+		bad "FUZZ_TAGS=elpscheck breaks target discovery"
+	fi
+	assert_contains "-tags elpscheck" \
+		"a tagged sweep SAYS so (a tagged run must not read as a default one)" \
+		env FUZZTIME=1s FUZZ_TAGS=elpscheck "${SCRIPT_DIR}/fuzz.sh" --shard 1/15
+	tagged_go="$(grep -c 'go test ${tagflags' "${SCRIPT_DIR}/fuzz.sh")"
+	if [ "$tagged_go" -ge 2 ]; then
+		ok "both go test invocations (discovery and fuzzing) carry FUZZ_TAGS"
+	else
+		bad "only ${tagged_go} go test invocation(s) carry FUZZ_TAGS — discovery and execution can disagree about the build"
+	fi
+
 	# Sharding must be a PARTITION: every target in exactly one shard. A shard
 	# assignment that drops a target loses coverage silently, and one that
 	# duplicates a target just wastes budget.
@@ -980,8 +999,7 @@ fi
 # Branch protection matches a required status check by NAME. Requiring the
 # individual jobs means editing repo settings whenever a job is added, renamed
 # or resharded -- and forgetting to leaves the new job unguarded while the board
-# still reads fully green. Two concrete traps this repo has been one edit away
-# from:
+# still reads fully green. Two traps this repo has been one edit away from:
 #
 #   * sharding renamed "Fuzz targets" to "Fuzz shard i/4". Had the old name
 #     been required, every PR would have become unmergeable, because a required
@@ -990,12 +1008,11 @@ fi
 #
 # So every pull_request-triggered workflow carries exactly one fixed-name
 # `Required: <area>` job, and that name is the only thing in branch protection.
-# This guard enforces the two properties that make that safe:
-#
-#   1. the aggregate exists and its name is FIXED (no ${{ }} interpolation), and
-#   2. it `needs` EVERY other job in its workflow -- otherwise the aggregate
-#      goes green while an uncovered job is red, which is strictly worse than
-#      having no aggregate at all, because it looks like coverage.
+# This guard enforces the properties that make that safe: the aggregate exists,
+# its name is FIXED, it carries if: always() (since `needs` alone SKIPS it on
+# upstream failure and a skipped required check reads as green), and it `needs`
+# EVERY other job -- an aggregate that has stopped covering a job is worse than
+# none, because it looks like coverage.
 req_out="$(python3 - "$REPO_ROOT" <<'PY_INNER'
 import glob, os, sys
 
@@ -1032,15 +1049,15 @@ for f in sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.y*ml")))
     if not jobs:
         continue
 
-    def jobname(jid):
-        return str(jobs[jid].get("name") or jid)
+    def jobname(jid, _jobs=jobs):
+        return str(_jobs[jid].get("name") or jid)
 
     aggs = [j for j in jobs if jobname(j).startswith(MARKER)]
     if not aggs:
         failures.append(
-            f"{base}: no fixed-name '{MARKER} ...' aggregate job. Every job in it would "
-            f"have to be listed in branch protection by hand, and a job added later "
-            f"would be unguarded while the board still looks green."
+            f"{base}: no fixed-name '{MARKER} ...' aggregate job. Every job would have to "
+            f"be listed in branch protection by hand, and a job added later would be "
+            f"unguarded while the board still looks green."
         )
         continue
     if len(aggs) > 1:
@@ -1063,10 +1080,11 @@ for f in sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.y*ml")))
     else:
         passes.append(f"{base}: '{jobname(agg)}' covers all {len(jobs) - 1} other job(s)")
 
-    # `needs` alone SKIPS the aggregate when an upstream job fails, and a
-    # skipped required check reads as green, so always() is load-bearing.
-    if str(jobs[agg].get("if", "")).find("always()") < 0:
-        failures.append(f"{base}: aggregate {jobname(agg)!r} lacks `if: always()`; it would be SKIPPED on upstream failure, and a skipped required check reads as green")
+    if "always()" not in str(jobs[agg].get("if", "")):
+        failures.append(
+            f"{base}: aggregate {jobname(agg)!r} lacks `if: always()`; it would be SKIPPED "
+            f"on upstream failure, and a skipped required check reads as green"
+        )
 
 for p_ in passes:
     print(f"PASS  {p_}")
@@ -1086,402 +1104,6 @@ case "$req_out" in
 			fail=$((fail + rq_fail))
 		else
 			bad "required-check aggregate guard did not run"
-		fi
-		;;
-esac
-
-wf_out="$(python3 - "$REPO_ROOT" <<'PY'
-import glob, os, re, sys
-
-root = sys.argv[1]
-failures, passes = [], []
-
-files = sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.yml")) +
-               glob.glob(os.path.join(root, ".github", "workflows", "*.yaml")))
-if not files:
-    failures.append("no workflow files found")
-
-try:
-    import yaml
-    docs = {}
-    for f in files:
-        try:
-            docs[f] = yaml.safe_load(open(f))
-        except Exception as e:  # noqa: BLE001
-            failures.append(f"{os.path.basename(f)} does not parse: {e}")
-    if not failures:
-        passes.append(f"all {len(files)} workflow files parse as YAML")
-
-    # No two workflows may publish the same top-level `name:` -- duplicate names
-    # produce indistinguishable check contexts, which lets a trivially-green
-    # workflow impersonate a real gate.
-    names = {}
-    for f, doc in docs.items():
-        if isinstance(doc, dict) and doc.get("name"):
-            names.setdefault(doc["name"], []).append(os.path.basename(f))
-    dupes = {n: v for n, v in names.items() if len(v) > 1}
-    for n, v in dupes.items():
-        failures.append(f"duplicate workflow name {n!r} in {', '.join(v)}")
-    if not dupes:
-        passes.append("no two workflows declare the same top-level name")
-except ImportError:
-    passes.append("(pyyaml unavailable; YAML-parse guards skipped)")
-
-# Every third-party `uses:` should be SHA-pinned (local ./ actions are exempt).
-# CONTRACT.md for this check: the repo pinned its actions in f5b12e3 ("chore: pin
-# GitHub Actions to SHAs and add Dependabot config"), but two workflows added
-# later drifted back to floating tags. Those are pre-existing and out of scope
-# for the benchmark-gate fix, so they are ALLOWLISTED rather than silently
-# ignored -- they print as WARN and the list may only ever shrink. Any NEW
-# unpinned action, or any unpinned action in a workflow this change owns, is a
-# hard failure.
-UNPINNED_ALLOWLIST = {
-    # file: reason (delete the row once the workflow is pinned)
-    "govulncheck.yml": "pre-existing, added in #303; not touched by this change",
-    "release-tag.yml": "pre-existing, added in #302; not touched by this change",
-}
-sha = re.compile(r"^[0-9a-f]{40}$")
-unpinned, warned = [], []
-for f in files:
-    base = os.path.basename(f)
-    for i, line in enumerate(open(f), 1):
-        m = re.search(r"uses:\s*(\S+)", line)
-        if not m:
-            continue
-        ref = m.group(1)
-        if ref.startswith("./"):
-            continue
-        if "@" not in ref or not sha.match(ref.rsplit("@", 1)[1]):
-            (warned if base in UNPINNED_ALLOWLIST else unpinned).append(f"{base}:{i} {ref}")
-for u in unpinned:
-    failures.append(f"unpinned action: {u}")
-if not unpinned:
-    passes.append(f"every non-allowlisted `uses:` is pinned to a 40-char commit SHA "
-                  f"({len(warned)} allowlisted)")
-for w in warned:
-    print(f"WARN  unpinned action (allowlisted, should be pinned): {w}")
-
-for p in passes:
-    print(f"PASS  {p}")
-for f_ in failures:
-    print(f"FAIL  {f_}")
-print(f"__COUNTS__ {len(passes)} {len(failures)}")
-PY
-)"
-
-echo "$wf_out" | grep -v '^__COUNTS__' || true
-wf_counts="$(echo "$wf_out" | sed -n 's/^__COUNTS__ //p')"
-if [ -n "$wf_counts" ]; then
-	read -r wf_pass wf_fail <<<"$wf_counts"
-	pass=$((pass + wf_pass))
-	fail=$((fail + wf_fail))
-else
-	bad "workflow shape guards did not run"
-fi
-
-echo
-echo "== fuzz gate: time bounding =============================================="
-
-FUZZ="${SCRIPT_DIR}/fuzz.sh"
-FUZZ_WF="${REPO_ROOT}/.github/workflows/fuzz.yml"
-
-# `go test -fuzz` has no default limit: without -fuzztime it runs until
-# something kills it. Every one of these guards exists to keep that from
-# reaching CI.
-
-assert_exit 2 "an unparsable FUZZTIME is refused rather than guessed" \
-	env FUZZTIME=forever "$FUZZ" --list
-assert_contains "refusing to run unbounded" \
-	"the refusal says why" \
-	env FUZZTIME=forever "$FUZZ" --list
-assert_exit 2 "a bare number (no unit) is refused" \
-	env FUZZTIME=60 "$FUZZ" --list
-assert_exit 2 "an empty FUZZTIME is refused" \
-	env FUZZTIME= "$FUZZ" --list
-
-# Every LIVE `go test -fuzz` in this repository must carry -fuzztime. Logical
-# lines, not physical ones: the invocation in fuzz.sh spreads its flags over a
-# backslash continuation, and a per-line scan would read the `-fuzz` line as
-# unbounded. Anchored on `go test` so that prose, this checker's own source,
-# and workflow comments are not mistaken for invocations.
-unbounded="$(python3 - "$REPO_ROOT" <<'PY'
-import glob, os, re, sys
-root = sys.argv[1]
-files = sorted(
-    glob.glob(os.path.join(root, ".github", "workflows", "*.y*ml"))
-    + glob.glob(os.path.join(root, "scripts", "*.sh"))
-    + [os.path.join(root, "Makefile")]
-)
-hits = []
-for f in files:
-    if not os.path.exists(f):
-        continue
-    logical, buf, start = [], "", 1
-    for i, line in enumerate(open(f), 1):
-        if line.lstrip().startswith("#"):
-            continue
-        code = line.split("#", 1)[0].rstrip("\n")
-        if not buf:
-            start = i
-        if code.rstrip().endswith("\\"):
-            buf += code.rstrip()[:-1] + " "
-            continue
-        logical.append((start, buf + code))
-        buf = ""
-    if buf:
-        logical.append((start, buf))
-    for lineno, code in logical:
-        if not re.search(r"\bgo\s+test\b", code):
-            continue
-        if not re.search(r"(^|\s)-fuzz(\s|=|$)", code):
-            continue
-        if "-fuzztime" not in code:
-            hits.append(f"{os.path.relpath(f, root)}:{lineno}")
-print("\n".join(hits))
-PY
-)"
-if [ -n "$unbounded" ]; then
-	bad "a 'go test -fuzz' invocation has no -fuzztime bound: $unbounded"
-else
-	ok "every live 'go test -fuzz' invocation is bounded by -fuzztime"
-fi
-
-echo
-echo "== fuzz gate: discovery and proof it can FAIL ============================"
-
-# Everything from here needs a Go toolchain matching go.mod. The `gates` job in
-# benchmark.yml deliberately has none -- it is the fast, build-free gate that
-# must report even when the benchmark job is cancelled -- so it sets
-# CI_GATES_SKIP_GO and these run in the `fuzz` workflow instead, which already
-# has Go set up and its module cache warm.
-if [ "${CI_GATES_SKIP_GO:-0}" = "1" ] || ! command -v go >/dev/null 2>&1; then
-	echo "SKIP  Go-backed fuzz-gate checks (CI_GATES_SKIP_GO=${CI_GATES_SKIP_GO:-0}," \
-		"go present: $(command -v go >/dev/null 2>&1 && echo yes || echo no))"
-	echo "SKIP  they run in .github/workflows/fuzz.yml, which sets up Go"
-else
-	# The derived budget gate. It reads real discovery plus the workflow, so
-	# it needs Go; the negative controls below drive it at a scratch copy of
-	# the workflow via FUZZ_WORKFLOW.
-	BUDGET="${SCRIPT_DIR}/fuzz-budget-check.sh"
-	assert_exit 0 "the nightly sweep fits its timeout as configured today" \
-		"$BUDGET"
-
-	budget_tmp="$(mktemp -d)"
-	budget_wf="${budget_tmp}/fuzz.yml"
-
-	# Each control reverts ONE property of the real workflow. A budget gate
-	# that has never been watched failing is worth nothing -- the value it
-	# guards went stale twice before this existed (120 sized for 10 targets
-	# when there were 12; 140 vs 165 when two branches each counted only their
-	# own additions).
-	cp "$FUZZ_WF" "$budget_wf"
-	sed -i 's/^    timeout-minutes: [0-9]*$/    timeout-minutes: 5/' "$budget_wf"
-	assert_exit 1 "a timeout too small for the sweep FAILS" \
-		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
-
-	cp "$FUZZ_WF" "$budget_wf"
-	sed -i 's/^        shard: \[.*\]$/        shard: [1]/' "$budget_wf"
-	assert_exit 1 "unsharding (one shard, whole sweep serial) FAILS" \
-		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
-
-	cp "$FUZZ_WF" "$budget_wf"
-	sed -i '/^    timeout-minutes: [0-9]*$/d' "$budget_wf"
-	assert_exit 2 "a fuzz job with NO timeout-minutes is unreadable, not fine" \
-		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
-
-	cp "$FUZZ_WF" "$budget_wf"
-	sed -i "s/'schedule' && '[0-9]*[smh]'/'schedule' \&\& 'BOGUS'/" "$budget_wf"
-	assert_exit 2 "an unparsable scheduled FUZZTIME is refused, not guessed" \
-		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
-
-	assert_exit 2 "a missing workflow is an error" \
-		env FUZZ_WORKFLOW="${budget_tmp}/nope.yml" "$BUDGET"
-
-	rm -rf "$budget_tmp"
-
-	# Sharding must be a PARTITION: every target in exactly one shard. A shard
-	# assignment that drops a target loses coverage silently, and one that
-	# duplicates a target just wastes budget.
-	shard_tmp="$(mktemp -d)"
-	"${SCRIPT_DIR}/fuzz.sh" --list 2>/dev/null | LC_ALL=C sort >"${shard_tmp}/full"
-	: >"${shard_tmp}/union"
-	for i in 1 2 3 4; do
-		"${SCRIPT_DIR}/fuzz.sh" --list --shard "${i}/4" 2>/dev/null >>"${shard_tmp}/union"
-	done
-	LC_ALL=C sort "${shard_tmp}/union" >"${shard_tmp}/union.sorted"
-	if diff -q "${shard_tmp}/full" "${shard_tmp}/union.sorted" >/dev/null; then
-		ok "the 4 shards are a partition of the full target list (no target lost)"
-	else
-		bad "sharding is not a partition — targets are lost or duplicated"
-		diff "${shard_tmp}/full" "${shard_tmp}/union.sorted" | sed 's/^/        | /'
-	fi
-	dupes=$(($(wc -l <"${shard_tmp}/union.sorted") - $(sort -u "${shard_tmp}/union.sorted" | wc -l)))
-	if [ "$dupes" -eq 0 ]; then
-		ok "no target is claimed by more than one shard"
-	else
-		bad "${dupes} target(s) appear in more than one shard"
-	fi
-	rm -rf "$shard_tmp"
-
-	# A shard spec that cannot be read must not silently run a SUBSET and exit
-	# 0 -- indistinguishable from a clean full sweep.
-	for bad_spec in "0/4" "5/4" "abc" "1/0"; do
-		assert_exit 2 "--shard ${bad_spec} is refused rather than guessed" \
-			"${SCRIPT_DIR}/fuzz.sh" --list --shard "$bad_spec"
-	done
-	assert_exit 2 "more shards than targets is an error, not an empty green run" \
-		"${SCRIPT_DIR}/fuzz.sh" --shard 99/99
-
-	# Discovery is dynamic, so it can silently discover nothing -- which would
-	# look exactly like a clean run.
-	assert_exit 2 "discovering ZERO targets is an error, not a clean run" \
-		env FUZZTIME=1s "$FUZZ" ./lint/...
-	assert_contains "cannot fail" "the empty-discovery error explains itself" \
-		env FUZZTIME=1s "$FUZZ" ./lint/...
-
-	# The targets really are found. Listed once and asserted against, so the
-	# package set is only compiled a single extra time.
-	discovered="$(env FUZZTIME=1s "$FUZZ" --list 2>&1)"
-	for want in FuzzParseProgram FuzzLexer FuzzScanner FuzzFormat FuzzMinifySource FuzzLoadJSON; do
-		if echo "$discovered" | grep -q "$want"; then
-			ok "discovery finds ${want}"
-		else
-			bad "discovery no longer finds ${want}"
-		fi
-	done
-
-	# The headline assertion, and the reason FuzzGateSelfTest exists. A gate
-	# that has only ever reported success is indistinguishable from a gate that
-	# cannot fail -- precisely how the benchmark gate above stayed dead for 473
-	# runs. FuzzGateSelfTest is a deliberately-failing target, inert unless
-	# ELPS_FUZZ_GATE_SELFTEST is set, so this exercises the whole path end to
-	# end: discovery, invocation, and the failure reaching the exit status.
-	assert_exit 1 "an armed failing target makes fuzz.sh exit non-zero" \
-		env ELPS_FUZZ_GATE_SELFTEST=1 FUZZTIME=5s FUZZMINIMIZETIME=1s \
-		"$FUZZ" ./internal/fuzzseed/...
-	assert_contains "FuzzGateSelfTest" "the failing target is named in the summary" \
-		env ELPS_FUZZ_GATE_SELFTEST=1 FUZZTIME=5s FUZZMINIMIZETIME=1s \
-		"$FUZZ" ./internal/fuzzseed/...
-	# ...and the mirror: disarmed, the same package is clean. Without this, an
-	# always-failing script would satisfy the assertion above for the wrong
-	# reason.
-	assert_exit 0 "the same target is inert when NOT armed" \
-		env FUZZTIME=5s "$FUZZ" ./internal/fuzzseed/...
-
-	# An armed run can leave a generated crasher in the source tree; it is
-	# meaningless outside that run, so do not let it linger.
-	rm -rf "${REPO_ROOT}/internal/fuzzseed/testdata/fuzz/FuzzGateSelfTest"
-fi
-
-echo
-echo "== fuzz gate: workflow shape ============================================"
-
-if [ -n "$(invoked_in "$FUZZ_WF" 'scripts/fuzz.sh')" ]; then
-	ok "fuzz.yml INVOKES scripts/fuzz.sh (not just mentions it)"
-else
-	bad "fuzz.yml no longer invokes scripts/fuzz.sh — logic reinlined or removed?"
-fi
-
-if grep -qE '^\s*timeout-minutes:' "$FUZZ_WF"; then
-	ok "fuzz.yml sets a job-level timeout-minutes backstop"
-else
-	bad "fuzz.yml has no timeout-minutes — the job has no outer bound"
-fi
-
-if grep -q 'FUZZTIME' "$FUZZ_WF"; then
-	ok "fuzz.yml sets an explicit FUZZTIME budget"
-else
-	bad "fuzz.yml does not set FUZZTIME — the PR path would take the default"
-fi
-
-if [ -n "$(invoked_in "$FUZZ_WF" 'scripts/fuzz-budget-check.sh')" ]; then
-	ok "fuzz.yml RUNS the derived budget check (timeout is not a remembered number)"
-else
-	bad "fuzz.yml does not run fuzz-budget-check.sh — timeout-minutes is unguarded again"
-fi
-
-# A required status check is matched by NAME. A job whose name interpolates a
-# matrix value changes name when the matrix is resized, so if such a name were
-# ever added to branch protection, resizing the matrix would leave a required
-# check that can never report and every PR would be unmergeable until someone
-# edited repo settings. Every matrix job therefore needs a fixed-name
-# aggregate job downstream of it, and that is the name to require.
-stable_out="$(python3 - "$REPO_ROOT" <<'PY_INNER'
-import glob, os, sys
-
-root = sys.argv[1]
-try:
-    import yaml
-except ImportError:
-    print("__SKIP__ pyyaml unavailable")
-    sys.exit(0)
-
-failures, passes = [], []
-for f in sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.y*ml"))):
-    base = os.path.basename(f)
-    try:
-        doc = yaml.safe_load(open(f))
-    except Exception:  # noqa: BLE001
-        continue
-    if not isinstance(doc, dict):
-        continue
-    # Only a check that runs on pull_request can be listed as a REQUIRED
-    # status check, so a tag/release workflow's matrix names cannot cause the
-    # rename trap. `on` parses as the boolean True in YAML 1.1.
-    triggers = doc.get("on", doc.get(True)) or {}
-    if isinstance(triggers, str):
-        triggers = {triggers: None}
-    if isinstance(triggers, list):
-        triggers = {t: None for t in triggers}
-    if "pull_request" not in triggers:
-        continue
-
-    jobs = doc.get("jobs") or {}
-    for jid, job in jobs.items():
-        if not isinstance(job, dict):
-            continue
-        if not (job.get("strategy") or {}).get("matrix"):
-            continue
-        name = str(job.get("name") or jid)
-        if "${{" not in name:
-            passes.append(f"{base}: matrix job {jid!r} has a fixed name; safe to require directly")
-            continue
-        # find a fixed-name job that depends on this one
-        def needs_of(j):
-            n = j.get("needs")
-            if isinstance(n, str):
-                return [n]
-            return list(n or [])
-        agg = [f"{k}" for k, v in jobs.items()
-               if isinstance(v, dict) and jid in needs_of(v)
-               and "${{" not in str(v.get("name") or k)]
-        if agg:
-            passes.append(f"{base}: matrix job {jid!r} is fronted by fixed-name job(s) {agg}")
-        else:
-            failures.append(
-                f"{base}: matrix job {jid!r} has an interpolated name ({name!r}) and no "
-                f"fixed-name aggregate job depends on it. Resizing the matrix renames the "
-                f"check, and a renamed REQUIRED check can never report."
-            )
-
-for p in passes:
-    print(f"PASS  {p}")
-for f_ in failures:
-    print(f"FAIL  {f_}")
-print(f"__COUNTS__ {len(passes)} {len(failures)}")
-PY_INNER
-)"
-case "$stable_out" in
-	__SKIP__*) echo "SKIP  stable-check-name guard ($stable_out)" ;;
-	*)
-		echo "$stable_out" | grep -v '^__COUNTS__' || true
-		stable_counts="$(echo "$stable_out" | sed -n 's/^__COUNTS__ //p')"
-		if [ -n "$stable_counts" ]; then
-			read -r st_pass st_fail <<<"$stable_counts"
-			pass=$((pass + st_pass))
-			fail=$((fail + st_fail))
-		else
-			bad "stable-check-name guard did not run"
 		fi
 		;;
 esac

--- a/scripts/fuzz-budget-check.sh
+++ b/scripts/fuzz-budget-check.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Derived budget gate for the fuzz sweep: prove the job's timeout-minutes can
+# actually contain the work the matrix is about to schedule.
+#
+# Why this exists
+# ---------------
+# The fuzz job's `timeout-minutes` was a hand-maintained number. Target
+# discovery is dynamic, so adding a fuzz target silently added another FUZZTIME
+# to the nightly sweep, and nobody recomputed the backstop. The failure mode is
+# the bad kind: the job hits its timeout partway through, the LAST targets in
+# the sweep never execute at all, and the run is simply... cancelled. Nothing
+# says "coverage was dropped". A truncated sweep and a finished one look alike
+# in the check list.
+#
+# It has already gone stale twice in this repo -- 120 sized for 10 targets when
+# there were 12, and 140 vs 165 when two branches each counted only their own
+# additions.
+#
+# So the number is derived here instead of remembered:
+#
+#     ceil(targets / shards) x FUZZTIME + overhead  <=  timeout-minutes
+#
+# and CI fails when it stops holding. `ceil(targets/shards)` is the largest
+# shard, which is what sets wall clock for a matrix -- the shards run in
+# parallel, so the total is irrelevant.
+#
+# Everything is read from the sources of truth rather than passed in: targets
+# from `scripts/fuzz.sh --list` (the same discovery the sweep uses), and the
+# shard count, FUZZTIME and timeout-minutes from .github/workflows/fuzz.yml
+# itself. A gate fed its numbers by hand would go stale exactly like the value
+# it is guarding.
+#
+# Usage:  scripts/fuzz-budget-check.sh
+#
+# Exit codes:
+#   0  the budget fits
+#   1  it does not -- raise timeout-minutes, add shards, or lower FUZZTIME
+#   2  the inputs could not be read (missing workflow, no targets discovered,
+#      unparsable duration).  2 rather than 0 on purpose: a budget gate that
+#      cannot read its inputs must not report "fits".
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WORKFLOW="${FUZZ_WORKFLOW:-${REPO_ROOT}/.github/workflows/fuzz.yml}"
+
+# Wall-clock cost of a run that is not fuzzing: checkout, Go setup, module
+# download, build, corpus cache restore/save, and the gate self-test. Measured
+# at roughly 3 minutes; 10 is deliberately generous, since the consequence of
+# under-estimating it is a silently truncated sweep and the consequence of
+# over-estimating is a slightly larger backstop.
+OVERHEAD_MINUTES="${FUZZ_OVERHEAD_MINUTES:-10}"
+
+if [ ! -f "$WORKFLOW" ]; then
+	echo "fuzz-budget-check: no such workflow: $WORKFLOW" >&2
+	exit 2
+fi
+
+# Read the scheduled (worst-case) FUZZTIME, the shard count and the job's
+# timeout-minutes out of the workflow.
+read -r sched_fuzztime shards timeout_minutes < <(python3 - "$WORKFLOW" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path).read()
+
+try:
+    import yaml
+    doc = yaml.safe_load(text)
+except Exception:  # noqa: BLE001 -- fall back to regex below
+    doc = None
+
+shards = 1
+timeout = 0
+if isinstance(doc, dict):
+    job = (doc.get("jobs") or {}).get("fuzz") or {}
+    timeout = int(job.get("timeout-minutes") or 0)
+    matrix = ((job.get("strategy") or {}).get("matrix") or {})
+    entries = matrix.get("shard")
+    if isinstance(entries, list) and entries:
+        shards = len(entries)
+
+# The scheduled budget lives inside a `${{ ... }}` expression, which no YAML
+# parser will evaluate. Pull the branch guarded by `schedule` textually: that
+# is the worst case, and the worst case is the one a backstop must cover.
+m = re.search(r"schedule'\s*&&\s*'([0-9]+[smh])'", text)
+sched = m.group(1) if m else ""
+
+print(sched, shards, timeout)
+PY
+)
+
+if [ -z "${sched_fuzztime:-}" ]; then
+	echo "fuzz-budget-check: could not find the scheduled FUZZTIME in $WORKFLOW" >&2
+	echo "  expected an expression like: github.event_name == 'schedule' && '10m'" >&2
+	exit 2
+fi
+if [ "${timeout_minutes:-0}" -le 0 ]; then
+	echo "fuzz-budget-check: the fuzz job has no timeout-minutes in $WORKFLOW" >&2
+	echo "  a sweep with no outer bound is the thing this gate exists to prevent" >&2
+	exit 2
+fi
+
+to_minutes() {
+	local d="$1" n="${1%[smh]}" unit="${1##*[0-9]}"
+	case "$unit" in
+	s) echo $(((n + 59) / 60)) ;;
+	m) echo "$n" ;;
+	h) echo $((n * 60)) ;;
+	*)
+		echo "fuzz-budget-check: cannot parse duration '$d'" >&2
+		return 1
+		;;
+	esac
+}
+
+per_target_minutes="$(to_minutes "$sched_fuzztime")" || exit 2
+
+# Discovery, from the same code path the sweep uses.
+if ! targets="$("${SCRIPT_DIR}/fuzz.sh" --list 2>/dev/null)"; then
+	echo "fuzz-budget-check: scripts/fuzz.sh --list failed" >&2
+	exit 2
+fi
+n_targets="$(printf '%s\n' "$targets" | grep -c . || true)"
+if [ "${n_targets:-0}" -eq 0 ]; then
+	echo "fuzz-budget-check: discovered NO fuzz targets -- nothing to budget for" >&2
+	exit 2
+fi
+
+if [ "$shards" -gt "$n_targets" ]; then
+	echo "fuzz-budget-check: ${shards} shards for ${n_targets} targets -- some shards would draw nothing" >&2
+	exit 1
+fi
+
+# Largest shard, not the total: shards run in parallel, so wall clock is set by
+# whichever one draws the most targets. Round-robin assignment makes that
+# ceil(targets / shards).
+per_shard=$(((n_targets + shards - 1) / shards))
+needed=$((per_shard * per_target_minutes + OVERHEAD_MINUTES))
+
+echo "fuzz-budget-check:"
+echo "  targets discovered      ${n_targets}"
+echo "  shards                  ${shards}"
+echo "  largest shard           ${per_shard} target(s)"
+echo "  scheduled FUZZTIME      ${sched_fuzztime} (${per_target_minutes} min/target)"
+echo "  fixed overhead          ${OVERHEAD_MINUTES} min"
+echo "  required                ${needed} min"
+echo "  timeout-minutes         ${timeout_minutes} min"
+
+if [ "$needed" -gt "$timeout_minutes" ]; then
+	cat >&2 <<-EOF
+
+		fuzz-budget-check: the nightly sweep does NOT fit in its timeout.
+
+		  ${per_shard} x ${per_target_minutes} min + ${OVERHEAD_MINUTES} min = ${needed} min > ${timeout_minutes} min
+
+		Left alone, the job is cancelled partway through and the last targets in
+		the largest shard never run -- silently, because a truncated sweep looks
+		exactly like a finished one.
+
+		Fix by one of:
+		  * raise timeout-minutes on the fuzz job to at least ${needed}
+		  * add shards to strategy.matrix.shard (parallel, so this cuts wall clock)
+		  * lower the scheduled FUZZTIME
+	EOF
+	exit 1
+fi
+
+headroom=$((timeout_minutes - needed))
+echo "  headroom                ${headroom} min"
+echo "fuzz-budget-check: the sweep fits."
+exit 0

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -30,6 +30,15 @@
 #                      spent when a target actually fails.
 #   FUZZ_SHARD         "i/n" -- run only shard i of n (1-based).  Equivalent
 #                      to --shard; the env form is what the CI matrix uses.
+#   FUZZ_TAGS          go build tags to fuzz under, e.g. FUZZ_TAGS=elpscheck.
+#                      Empty (the default) fuzzes the ordinary build.  Tagged
+#                      code is INVISIBLE to the default build, so a target
+#                      guarded by a tag is not merely unfuzzed -- it is not
+#                      even discovered, and the sweep reports success having
+#                      never seen it.  The same blind spot golangci-lint has
+#                      (it analyses one build), which is why `make
+#                      static-checks` makes a second pass under -tags
+#                      elpscheck.
 #
 # Sharding
 # --------
@@ -63,6 +72,15 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 FUZZTIME="${FUZZTIME-30s}"
 FUZZ_TIMEOUT_SLACK="${FUZZ_TIMEOUT_SLACK:-300}"
 FUZZMINIMIZETIME="${FUZZMINIMIZETIME:-30s}"
+FUZZ_TAGS="${FUZZ_TAGS:-}"
+
+# Built once and reused, so discovery and execution can never disagree about
+# which build they are looking at -- a sweep that DISCOVERS the default build
+# and FUZZES the tagged one would report on targets it never ran.
+declare -a tagflags=()
+if [ -n "$FUZZ_TAGS" ]; then
+	tagflags=(-tags "$FUZZ_TAGS")
+fi
 
 list_only=0
 shard_spec="${FUZZ_SHARD-}"
@@ -140,10 +158,10 @@ cd "$REPO_ROOT" || exit 2
 # -list` prints the matching names followed by a summary line ("ok <pkg> ..."),
 # so the output is filtered to bare target names.
 list_targets() {
-	go test -list '^Fuzz' "$1" 2>/dev/null | grep -E '^Fuzz[A-Za-z0-9_]*$'
+	go test ${tagflags+"${tagflags[@]}"} -list '^Fuzz' "$1" 2>/dev/null | grep -E '^Fuzz[A-Za-z0-9_]*$'
 }
 
-mapfile -t pkg_list < <(go list "${packages[@]}" 2>/dev/null)
+mapfile -t pkg_list < <(go list ${tagflags+"${tagflags[@]}"} "${packages[@]}" 2>/dev/null)
 if [ "${#pkg_list[@]}" -eq 0 ]; then
 	echo "fuzz.sh: no packages matched ${packages[*]}" >&2
 	exit 2
@@ -199,7 +217,7 @@ for pair in ${pairs+"${pairs[@]}"}; do
 		# executed by the fuzzing engine anyway, and re-running the package's
 		# whole test suite per target would multiply the job's cost by the
 		# number of targets.
-		go test "$pkg" \
+		go test ${tagflags+"${tagflags[@]}"} "$pkg" \
 			-run '^$' \
 			-fuzz "^${target}\$" \
 			-fuzztime "$FUZZTIME" \
@@ -240,7 +258,7 @@ if [ "$total" -eq 0 ]; then
 	echo "fuzz.sh: a fuzz gate that runs nothing cannot fail — treating as an error"
 	exit 2
 fi
-echo "fuzz.sh: ${total} target(s), ${failed} failure(s), ${FUZZTIME} each"
+echo "fuzz.sh: ${total} target(s), ${failed} failure(s), ${FUZZTIME} each${FUZZ_TAGS:+, -tags ${FUZZ_TAGS}}"
 if [ "$failed" -ne 0 ]; then
 	for f in "${failures[@]}"; do
 		echo "  FAIL  $f"

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -17,6 +17,7 @@
 #   scripts/fuzz.sh [package...]      # default: ./...
 #   FUZZTIME=5m scripts/fuzz.sh
 #   scripts/fuzz.sh --list            # print discovered targets, run nothing
+#   scripts/fuzz.sh --shard 2/4       # run only this shard's share of them
 #
 # Environment:
 #   FUZZTIME           per-target fuzzing budget (default 30s).  Accepts the
@@ -27,6 +28,24 @@
 #                      minimisation pass that follows a crash.
 #   FUZZMINIMIZETIME   budget for minimising a crasher (default 30s).  Only
 #                      spent when a target actually fails.
+#   FUZZ_SHARD         "i/n" -- run only shard i of n (1-based).  Equivalent
+#                      to --shard; the env form is what the CI matrix uses.
+#
+# Sharding
+# --------
+# The nightly sweep is serial and costs (targets x FUZZTIME), which grows every
+# time a target is added -- the exact quantity that made the job's
+# timeout-minutes a hand-maintained number that goes stale silently.  Splitting
+# the targets across parallel shards makes wall-clock a function of the LARGEST
+# shard instead of the total, and scripts/fuzz-budget-check.sh derives the
+# timeout from that rather than from anyone's memory.
+#
+# Assignment is round-robin over the discovered list sorted by (package,
+# target), so it is deterministic: the same target lands in the same shard on
+# every run, which is what makes a shard's failure reproducible with a single
+# --shard argument.  Round-robin rather than contiguous blocks because target
+# COUNT is the only thing balanced here -- targets are not equal-cost, but the
+# per-target budget is fixed, so count is the right proxy.
 #
 # Exit status: 0 if every target survived its budget, 1 if any target failed.
 # A failing target writes its crasher to <pkg>/testdata/fuzz/<Target>/ , which
@@ -46,10 +65,19 @@ FUZZ_TIMEOUT_SLACK="${FUZZ_TIMEOUT_SLACK:-300}"
 FUZZMINIMIZETIME="${FUZZMINIMIZETIME:-30s}"
 
 list_only=0
+shard_spec="${FUZZ_SHARD-}"
 packages=()
+want_shard=0
 for arg in "$@"; do
+	if [ "$want_shard" -eq 1 ]; then
+		shard_spec="$arg"
+		want_shard=0
+		continue
+	fi
 	case "$arg" in
 	--list) list_only=1 ;;
+	--shard) want_shard=1 ;;
+	--shard=*) shard_spec="${arg#--shard=}" ;;
 	-*)
 		echo "fuzz.sh: unknown flag $arg" >&2
 		exit 2
@@ -57,6 +85,28 @@ for arg in "$@"; do
 	*) packages+=("$arg") ;;
 	esac
 done
+if [ "$want_shard" -eq 1 ]; then
+	echo "fuzz.sh: --shard requires an argument of the form i/n" >&2
+	exit 2
+fi
+
+# Shard spec parsing is strict for the same reason FUZZTIME parsing is: a
+# mis-read shard silently runs a SUBSET of the targets and still exits 0, which
+# is indistinguishable from a clean full sweep.
+shard_index=1
+shard_total=1
+if [ -n "$shard_spec" ]; then
+	if ! [[ "$shard_spec" =~ ^[0-9]+/[0-9]+$ ]]; then
+		echo "fuzz.sh: shard must be of the form i/n (got '${shard_spec}')" >&2
+		exit 2
+	fi
+	shard_index="${shard_spec%%/*}"
+	shard_total="${shard_spec##*/}"
+	if [ "$shard_total" -lt 1 ] || [ "$shard_index" -lt 1 ] || [ "$shard_index" -gt "$shard_total" ]; then
+		echo "fuzz.sh: shard ${shard_spec} is out of range (need 1 <= i <= n, n >= 1)" >&2
+		exit 2
+	fi
+fi
 if [ "${#packages[@]}" -eq 0 ]; then
 	packages=("./...")
 fi
@@ -99,13 +149,45 @@ if [ "${#pkg_list[@]}" -eq 0 ]; then
 	exit 2
 fi
 
+# Discover EVERYTHING first, then select this shard's slice. Discovery has to
+# see the whole list for shard membership to be stable -- assigning as packages
+# stream past would make a target's shard depend on how many targets happened to
+# precede it.
+declare -a all_pairs=()
+for pkg in "${pkg_list[@]}"; do
+	mapfile -t targets < <(list_targets "$pkg")
+	for target in "${targets[@]}"; do
+		all_pairs+=("${pkg}	${target}")
+	done
+done
+if [ "${#all_pairs[@]}" -gt 0 ]; then
+	# Guarded: `printf '%s\n'` with NO arguments still prints one newline, so
+	# an unguarded sort turns "no targets" into one empty target -- which made
+	# the zero-discovery error path below unreachable and a gate that
+	# discovered nothing exit 0.
+	mapfile -t all_pairs < <(printf '%s\n' "${all_pairs[@]}" | LC_ALL=C sort)
+fi
+
+discovered="${#all_pairs[@]}"
+declare -a pairs=()
+for i in "${!all_pairs[@]}"; do
+	if [ $(((i % shard_total) + 1)) -eq "$shard_index" ]; then
+		pairs+=("${all_pairs[$i]}")
+	fi
+done
+
+if [ "$shard_total" -gt 1 ]; then
+	echo "fuzz.sh: shard ${shard_index}/${shard_total} -- ${#pairs[@]} of ${discovered} target(s)" >&2
+fi
+
 total=0
 failed=0
 declare -a failures=()
 
-for pkg in "${pkg_list[@]}"; do
-	mapfile -t targets < <(list_targets "$pkg")
-	for target in "${targets[@]}"; do
+for pair in ${pairs+"${pairs[@]}"}; do
+	pkg="${pair%%	*}"
+	target="${pair##*	}"
+	{
 		total=$((total + 1))
 		if [ "$list_only" -eq 1 ]; then
 			echo "${pkg}	${target}"
@@ -132,7 +214,7 @@ for pkg in "${pkg_list[@]}"; do
 		else
 			echo "--- ok ${target} in ${elapsed}s ---"
 		fi
-	done
+	}
 done
 
 if [ "$list_only" -eq 1 ]; then
@@ -145,6 +227,15 @@ echo "======================================================================"
 if [ "$total" -eq 0 ]; then
 	# Zero targets is a broken gate, not a clean run: the whole point of
 	# dynamic discovery is that it can silently discover nothing.
+	if [ "$discovered" -gt 0 ]; then
+		# The sweep found targets but this shard drew none of them. That is a
+		# misconfiguration (more shards than targets), not a clean run, and it
+		# must not pass: a matrix of empty shards is a green fuzz job that
+		# fuzzed nothing.
+		echo "fuzz.sh: shard ${shard_index}/${shard_total} drew 0 of ${discovered} target(s)"
+		echo "fuzz.sh: more shards than targets — reduce the shard count"
+		exit 2
+	fi
 	echo "fuzz.sh: NO fuzz targets discovered in ${packages[*]}"
 	echo "fuzz.sh: a fuzz gate that runs nothing cannot fail — treating as an error"
 	exit 2


### PR DESCRIPTION
The fuzz job's `timeout-minutes` was a number somebody had to recompute whenever a target was added. Discovery is dynamic, so nobody did.

The failure mode is the bad kind: the job is cancelled partway through, the last targets never execute, and **a truncated sweep is indistinguishable from a finished one** in the check list. It has already gone stale twice — 120 sized for 10 targets when there were 12, and 140 vs 165 when two branches each counted only their own additions.

## Sharding

`scripts/fuzz.sh --shard i/n` assigns targets round-robin over the list sorted by `(package, target)`, so assignment is deterministic and a shard's failure reproduces with one argument. The workflow runs a 4-way matrix with `fail-fast: false`, so wall clock is set by the largest shard rather than the total: **15 targets go from ~150 min serial to ~40**.

Both failure modes are closed:

- A **bad shard spec** is refused rather than guessed. A mis-read shard would run a *subset* and still exit 0 — indistinguishable from a clean full sweep.
- A **shard that draws no targets** is an error, because a matrix of empty shards is a green fuzz job that fuzzed nothing.

## Derived budget

`scripts/fuzz-budget-check.sh` asserts

```
ceil(targets / shards) × FUZZTIME + overhead  ≤  timeout-minutes
```

reading every input from a source of truth: targets from the same discovery the sweep uses, and shards / scheduled FUZZTIME / `timeout-minutes` from the workflow file itself. A gate fed its numbers by hand would go stale exactly like the value it guards.

```
targets discovered      15
shards                  4
largest shard           4 target(s)
scheduled FUZZTIME      10m (10 min/target)
fixed overhead          10 min
required                50 min
timeout-minutes         60 min
headroom                10 min
```

Runs on every PR; `make fuzz-budget-check` runs it locally and prints the options rather than just failing.

## Three things found while building it

**A stable check name.** Sharding renames the job, and a required status check is matched by **name** — so had `Fuzz targets` been in branch protection, this change would have left a required check that can never report, and every PR would be unmergeable until someone edited repo settings. Resizing the matrix later would do it again.

The shards are now anonymous (`Fuzz shard 1/4`) and a fixed-name `fuzz-result` job aggregates them. **That is the name to put in required checks.** It uses `always()` and treats anything but `success` as failure, because a skipped required check reads as green. A new guard fails any PR-triggered matrix job whose name interpolates a matrix value without such an aggregate.

**A cache-key collision.** Four shards saving the corpus under one key means the first write wins and three quarters of the night's coverage growth is silently discarded. Keys are now shard-scoped, restore included. Same for the crasher artifact name — `upload-artifact` v4 rejects a duplicate, so a second shard finding a crasher would have failed the *upload* rather than reported the bug.

**A bug in my own refactor, caught by an existing test.** `printf '%s\n'` with zero arguments still prints one newline, so collecting targets into an array and sorting it turned "no targets discovered" into one empty target — making the zero-discovery error path unreachable and a gate that discovered nothing exit 0. Exactly the class this suite exists to catch, and the guard was already there and fired.

## Negative controls

Every new check was verified to fail by reverting what it guards:

| Scenario | Expected | Result |
|---|---|---|
| timeout too small for the sweep | fail | exit 1 |
| unsharded (1 shard, whole sweep serial) | fail | exit 1 |
| more shards than targets | fail | exit 1 |
| fuzz job with no `timeout-minutes` | unreadable | exit 2 |
| unparsable scheduled FUZZTIME | unreadable | exit 2 |
| missing workflow file | unreadable | exit 2 |
| `--shard 0/4`, `5/4`, `abc`, `1/0` | refused | exit 2 |
| shard assignment not a partition | fail | guard fires |

Plus a positive control: the 4 shards are asserted to be an exact partition of the full target list — no target lost, none duplicated.

`scripts/ci-gates-test.sh`: **109 passed, 0 failed.**

Closes the last open item on #320.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_