### PR TITLE
Bound time:sleep by the evaluation context (#314)

### DIFF
--- a/docs/lang.md
+++ b/docs/lang.md
@@ -969,6 +969,14 @@ If the context is cancelled or its deadline expires during evaluation, a
     (long-running-computation))
 ```
 
+The context is normally observed *between* evaluation steps, so a builtin
+that blocks for a long time inside a single step can outlive the deadline.
+`time:sleep` is the exception that is checked explicitly: it waits on the
+context as well as on its timer, so it wakes on cancellation and never sleeps
+past the deadline, raising `context-cancelled` instead of returning nil when
+it is cut short.  With no context configured, `time:sleep` sleeps for the
+full duration it was given, however long that is.
+
 ### Step Limits
 
 A step limit caps the number of evaluation steps in a **single top-level

--- a/lisp/lisplib/fuzz_test.go
+++ b/lisp/lisplib/fuzz_test.go
@@ -287,15 +287,15 @@ func genArgs(gen *fuzzval.Gen, fun *lisp.LVal) []*lisp.LVal {
 // the gate.
 func skipCallable(name string) bool {
 	switch name {
-	case "time:sleep":
-		// BuiltinSleep blocks for a caller-supplied duration inside a single
-		// evaluation step.  No budget in the interpreter can bound it: the
-		// step counter is not consulted mid-builtin and the context is not
-		// threaded into time.Sleep.  That is issue #314 and is out of scope
-		// here -- fixing it means changing the builtin's contract, not the
-		// fuzz harness.  Excluded by NAME rather than by a duration cap so
-		// the exclusion is visible and reviewable.
-		return true
+	// time:sleep was excluded here until issue #314 was fixed: it blocked for
+	// a caller-supplied duration inside a single evaluation step and no
+	// budget in the interpreter could bound it.  It now selects on the
+	// evaluation context and caps its wait at the context deadline, so
+	// callDeadline bounds it like everything else and it is back in the
+	// sweep.  Coverage of the sleeping path is nominal rather than real:
+	// fuzzval has no time.Duration among its nativeValues, so generated
+	// arguments reach the builtin's type check and stop there.  The bound
+	// itself is asserted directly in libtime's TestSleep* tests.
 	case "testing:test", "testing:test-let", "testing:test-let*",
 		"testing:benchmark", "testing:benchmark-simple":
 		// libtesting drives the Go testing runner through the environment and

--- a/lisp/lisplib/libtime/libtime.go
+++ b/lisp/lisplib/libtime/libtime.go
@@ -369,11 +369,11 @@ func BuiltinSleep(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 // the wait at the remaining time before the deadline.
 //
 // The deadline cap is belt-and-braces alongside the ctx.Done() select, not a
-// substitute for it.  A context.Context may legally report a Deadline while
-// returning a nil Done channel (context.WithoutCancel over a deadline-bearing
-// parent used to be the awkward case, and custom implementations still are),
-// and selecting on a nil channel blocks forever -- exactly the bug being
-// fixed.  Capping the timer means the wait ends at the deadline either way.
+// substitute for it.  The Context interface permits an implementation to
+// report a Deadline while returning a nil Done channel; the stdlib's own
+// types do not, but wrappers written by embedders can, and selecting on a nil
+// channel blocks forever -- exactly the bug being fixed.  Capping the timer
+// means the wait ends at the deadline either way.
 //
 // WHAT DOES NOT CHANGE.  When the context has neither a Done channel nor a
 // deadline -- which is the default, context.Background(), for every embedder

--- a/lisp/lisplib/libtime/libtime.go
+++ b/lisp/lisplib/libtime/libtime.go
@@ -3,6 +3,7 @@
 package libtime
 
 import (
+	"context"
 	"time"
 
 	"github.com/luthersystems/elps/lisp"
@@ -116,7 +117,12 @@ var builtins = []*libutil.Builtin{
 		if the value overflows an int.`),
 	libutil.FunctionDoc("sleep", lisp.Formals("time-duration"), BuiltinSleep,
 		`Pauses execution for the specified duration. The argument must
-		be a native duration value (from parse-duration). Returns nil.`),
+		be a native duration value (from parse-duration). Returns nil.
+		The pause is interruptible: if the evaluation's context is
+		cancelled, or its deadline would expire before the duration
+		elapses, sleep wakes at that point and raises a
+		context-cancelled condition instead of returning nil. With no
+		context configured the full duration is always slept.`),
 }
 
 func BuiltinUTCNow(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
@@ -328,7 +334,11 @@ func BuiltinDurationNS(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	return lisp.Int(int(d))
 }
 
-// BulitinSleep sleeps for the given duration before returning.
+// BuiltinSleep sleeps for the given duration before returning.
+//
+// The sleep is bounded by the evaluation's context (see LEnv.Context): it
+// wakes early if the context is cancelled, and never sleeps past the
+// context's deadline.  See sleepContext for the full rationale.
 func BuiltinSleep(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	lt := args.Cells[0]
 	if lt.Type != lisp.LNative {
@@ -338,6 +348,83 @@ func BuiltinSleep(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	if !ok {
 		return env.Errorf("argument is not a duration: %v", lt)
 	}
-	time.Sleep(d)
+	return sleepContext(env, d)
+}
+
+// sleepContext pauses for d, bounded by env's context.
+//
+// WHY THIS IS NOT time.Sleep(d).  A plain time.Sleep blocks inside a single
+// evaluation step, and no containment mechanism the interpreter offers can
+// see it: MaxSteps is not consulted mid-builtin, MaxAlloc sees no allocation,
+// the stack limits see no frames and no tail calls, and the context deadline
+// is only observed BETWEEN steps.  A caller-supplied duration therefore had
+// no upper bound at all -- "9223372036854775807ns" parses cleanly and blocks
+// for roughly 292 years.  Downstream (luthersystems/substrate) the caller is
+// customer-supplied phylum source running as chaincode, which made this the
+// only known unbounded-execution shape no embedder configuration could stop.
+// See issue #314.
+//
+// The fix makes the EXISTING context deadline authoritative rather than
+// adding a new knob nobody sets: select on a timer and on ctx.Done(), and cap
+// the wait at the remaining time before the deadline.
+//
+// The deadline cap is belt-and-braces alongside the ctx.Done() select, not a
+// substitute for it.  A context.Context may legally report a Deadline while
+// returning a nil Done channel (context.WithoutCancel over a deadline-bearing
+// parent used to be the awkward case, and custom implementations still are),
+// and selecting on a nil channel blocks forever -- exactly the bug being
+// fixed.  Capping the timer means the wait ends at the deadline either way.
+//
+// WHAT DOES NOT CHANGE.  When the context has neither a Done channel nor a
+// deadline -- which is the default, context.Background(), for every embedder
+// that uses Eval rather than EvalContext and never passes WithContext -- this
+// is a plain time.Sleep with the historical behaviour, 292-year sleeps
+// included.  Bounding that case would require a new default limit, which
+// would break every program that legitimately sleeps longer than it.
+func sleepContext(env *lisp.LEnv, d time.Duration) *lisp.LVal {
+	if d <= 0 {
+		// time.Sleep returns immediately for a non-positive duration.
+		return lisp.Nil()
+	}
+	ctx := env.Context()
+	done := ctx.Done()
+	deadline, hasDeadline := ctx.Deadline()
+	if done == nil && !hasDeadline {
+		time.Sleep(d)
+		return lisp.Nil()
+	}
+	if err := ctx.Err(); err != nil {
+		return errContextCancelled(env, err)
+	}
+	truncated := false
+	if hasDeadline {
+		if remaining := time.Until(deadline); remaining < d {
+			d, truncated = remaining, true
+		}
+	}
+	if d > 0 {
+		timer := time.NewTimer(d)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-done:
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return errContextCancelled(env, err)
+	}
+	if truncated {
+		// The wait ended at the deadline but ctx has not observed it yet
+		// (a nil Done channel, or a race with the context's own timer).
+		// Report it anyway: the sleep did not run to completion.
+		return errContextCancelled(env, context.DeadlineExceeded)
+	}
 	return lisp.Nil()
+}
+
+// errContextCancelled renders the interruption using the same condition and
+// message shape the interpreter's own between-steps check produces, so a
+// handler-bind on context-cancelled sees one consistent error.
+func errContextCancelled(env *lisp.LEnv, err error) *lisp.LVal {
+	return env.ErrorConditionf(lisp.CondContextCancelled, "context cancelled: %v", err)
 }

--- a/lisp/lisplib/libtime/sleep_test.go
+++ b/lisp/lisplib/libtime/sleep_test.go
@@ -1,0 +1,255 @@
+// Copyright © 2026 The ELPS authors
+
+// NOTE:  This file uses package name suffixed with _test to avoid an import
+// cycle.  packages outside the standard library shouldn't need to use a _test
+// suffix in their test files.
+package libtime_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libtime"
+	"github.com/luthersystems/elps/parser"
+)
+
+// forever is longer than any test is willing to wait.  It stands in for the
+// unbounded duration issue #314 is about ("9223372036854775807ns" parses to
+// time.Duration(math.MaxInt64), roughly 292 years); a value this size proves
+// the same property without making a failing test hang for the full
+// -timeout.
+const forever = time.Hour
+
+// slack is how long past the intended wake-up a correct implementation may
+// take before the test calls it a hang.  Generous because CI runners are
+// noisy; still four orders of magnitude below `forever`.
+const slack = 30 * time.Second
+
+// sleepEnv builds a minimal environment with the time package loaded and ctx
+// installed as the evaluation context.  A nil ctx leaves the environment at
+// its default, where LEnv.Context() reports context.Background().
+func sleepEnv(t *testing.T, ctx context.Context) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	var configs []lisp.Config
+	if ctx != nil {
+		configs = append(configs, lisp.WithContext(ctx))
+	}
+	if rc := lisp.InitializeUserEnv(env, configs...); rc.Type == lisp.LError {
+		t.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := libtime.LoadPackage(env); rc.Type == lisp.LError {
+		t.Fatalf("load time package: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		t.Fatalf("in-package: %v", rc)
+	}
+	return env
+}
+
+// callSleep invokes the builtin directly with a native duration.  Direct
+// application is what the fuzz sweep does and it keeps the timing assertions
+// free of parser and evaluator noise.
+func callSleep(env *lisp.LEnv, d time.Duration) *lisp.LVal {
+	return libtime.BuiltinSleep(env, lisp.SExpr([]*lisp.LVal{libtime.Duration(d)}))
+}
+
+// requireCancelled asserts v is the context-cancelled condition.  Any other
+// error type would mean the sleep failed for an unrelated reason and the test
+// would otherwise pass on the wrong evidence.
+func requireCancelled(t *testing.T, v *lisp.LVal) {
+	t.Helper()
+	if v.Type != lisp.LError {
+		t.Fatalf("expected an error, got %v (%v)", v.Type, v)
+	}
+	if v.Str != lisp.CondContextCancelled {
+		t.Fatalf("expected condition %q, got %q (%v)", lisp.CondContextCancelled, v.Str, v)
+	}
+}
+
+// runBounded runs fn on its own goroutine and fails if it outlives limit.
+//
+// A bare `go test -timeout` would also catch a hang, but it kills the whole
+// binary with a goroutine dump and no indication of which assertion was being
+// made.  The goroutine is deliberately leaked on timeout: an uninterruptible
+// sleep is precisely the defect under test, so there is nothing to cancel.
+func runBounded(t *testing.T, limit time.Duration, fn func() *lisp.LVal) (*lisp.LVal, time.Duration) {
+	t.Helper()
+	type result struct {
+		v       *lisp.LVal
+		elapsed time.Duration
+	}
+	done := make(chan result, 1)
+	go func() {
+		start := time.Now()
+		v := fn()
+		done <- result{v, time.Since(start)}
+	}()
+	select {
+	case r := <-done:
+		return r.v, r.elapsed
+	case <-time.After(limit):
+		t.Fatalf("sleep did not return within %v", limit)
+		return nil, 0
+	}
+}
+
+// TestSleepInterruptedByContextDeadline is the regression test for issue
+// #314: a sleep far longer than the context deadline must end at the
+// deadline, not at the caller's duration.
+func TestSleepInterruptedByContextDeadline(t *testing.T) {
+	t.Parallel()
+	const budget = 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+	env := sleepEnv(t, ctx)
+
+	v, elapsed := runBounded(t, slack, func() *lisp.LVal { return callSleep(env, forever) })
+	requireCancelled(t, v)
+	if elapsed >= forever {
+		t.Fatalf("slept %v, expected to wake at the %v deadline", elapsed, budget)
+	}
+}
+
+// TestSleepInterruptedByCancel covers the other half of the contract: an
+// explicit cancel, with no deadline involved, wakes the sleep too.
+func TestSleepInterruptedByCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := sleepEnv(t, ctx)
+
+	time.AfterFunc(50*time.Millisecond, cancel)
+	v, elapsed := runBounded(t, slack, func() *lisp.LVal { return callSleep(env, forever) })
+	requireCancelled(t, v)
+	if elapsed >= forever {
+		t.Fatalf("slept %v, expected to wake on cancel", elapsed)
+	}
+}
+
+// TestSleepInterruptedThroughEval proves the context actually reaches the
+// builtin through ordinary evaluation, not just through a direct Go call.
+// LEnv.call bridges the evaluation context onto the environment at the
+// builtin boundary; if that bridge broke, the direct-call tests above would
+// still pass while real ELPS programs stayed unbounded.
+func TestSleepInterruptedThroughEval(t *testing.T) {
+	t.Parallel()
+	env := sleepEnv(t, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	v, elapsed := runBounded(t, slack, func() *lisp.LVal {
+		// 9223372036854775807ns is time.Duration(math.MaxInt64) -- the
+		// literal from the issue, reachable from source alone.
+		return env.LoadStringContext(ctx, "sleep_test.lisp",
+			`(time:sleep (time:parse-duration "9223372036854775807ns"))`)
+	})
+	requireCancelled(t, v)
+	if elapsed >= slack {
+		t.Fatalf("slept %v, expected to wake at the deadline", elapsed)
+	}
+}
+
+// TestSleepCompletesWithinDeadline guards the other direction: a sleep that
+// fits inside the deadline must run to completion and return nil.  Without
+// this a "cap everything" implementation that always errored would look
+// correct.
+func TestSleepCompletesWithinDeadline(t *testing.T) {
+	t.Parallel()
+	const nap = 20 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), slack)
+	defer cancel()
+	env := sleepEnv(t, ctx)
+
+	v, elapsed := runBounded(t, slack, func() *lisp.LVal { return callSleep(env, nap) })
+	if v.Type == lisp.LError {
+		t.Fatalf("expected nil, got error: %v", v)
+	}
+	if !v.IsNil() {
+		t.Fatalf("expected nil, got %v", v)
+	}
+	if elapsed < nap {
+		t.Fatalf("returned after %v, expected at least %v", elapsed, nap)
+	}
+}
+
+// TestSleepNoContextUnaffected pins the no-context path, which is the
+// compatibility promise: with no context configured the full duration is
+// slept and nil is returned, exactly as before issue #314.
+//
+// It cannot assert the 292-year case directly, so it asserts the property
+// that would break it: the default environment's context has no deadline and
+// no Done channel, so there is nothing for the sleep to be truncated
+// against, and a real sleep of a measurable length runs its full course.
+func TestSleepNoContextUnaffected(t *testing.T) {
+	t.Parallel()
+	env := sleepEnv(t, nil)
+
+	ctx := env.Context()
+	if _, ok := ctx.Deadline(); ok {
+		t.Fatalf("default environment context unexpectedly has a deadline")
+	}
+	if ctx.Done() != nil {
+		t.Fatalf("default environment context unexpectedly has a Done channel")
+	}
+
+	const nap = 20 * time.Millisecond
+	v, elapsed := runBounded(t, slack, func() *lisp.LVal { return callSleep(env, nap) })
+	if v.Type == lisp.LError {
+		t.Fatalf("expected nil, got error: %v", v)
+	}
+	if !v.IsNil() {
+		t.Fatalf("expected nil, got %v", v)
+	}
+	if elapsed < nap {
+		t.Fatalf("returned after %v, expected at least the full %v", elapsed, nap)
+	}
+}
+
+// TestSleepAlreadyCancelled covers entry with a context that is already done:
+// the sleep must not start at all.
+func TestSleepAlreadyCancelled(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	env := sleepEnv(t, ctx)
+
+	v, _ := runBounded(t, slack, func() *lisp.LVal { return callSleep(env, forever) })
+	requireCancelled(t, v)
+}
+
+// TestSleepNonPositive keeps the degenerate durations a no-op under every
+// context, matching time.Sleep.
+func TestSleepNonPositive(t *testing.T) {
+	t.Parallel()
+	for _, d := range []time.Duration{0, -time.Hour} {
+		ctx, cancel := context.WithTimeout(context.Background(), slack)
+		env := sleepEnv(t, ctx)
+		v := callSleep(env, d)
+		if v.Type == lisp.LError || !v.IsNil() {
+			t.Errorf("sleep(%v) = %v, want nil", d, v)
+		}
+		cancel()
+	}
+}
+
+// TestSleepRejectsNonDuration keeps the argument checks intact -- they run
+// before any waiting, so a bad argument is still an immediate error.
+func TestSleepRejectsNonDuration(t *testing.T) {
+	t.Parallel()
+	env := sleepEnv(t, nil)
+	for _, arg := range []*lisp.LVal{lisp.Int(5), lisp.Native("not-a-duration")} {
+		v := libtime.BuiltinSleep(env, lisp.SExpr([]*lisp.LVal{arg}))
+		if v.Type != lisp.LError {
+			t.Errorf("sleep(%v) = %v, want an error", arg, v)
+			continue
+		}
+		if !strings.Contains(v.String(), "not a duration") {
+			t.Errorf("sleep(%v) error = %v, want a duration type error", arg, v)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #314.

`time:sleep` called `time.Sleep(d)` with a caller-supplied duration inside a single evaluation step, where none of the interpreter's containment mechanisms could see it — `MaxSteps` is not consulted mid-builtin, `MaxAlloc` sees no allocation, the stack limits see no frames and no tail calls, and the context deadline is only observed *between* steps. `(time:sleep (time:parse-duration "9223372036854775807ns"))` blocked for ~292 years and no embedder setting could stop it.

This takes directions (1) + (2) from the issue, which compose: `select` on a timer and `ctx.Done()`, and cap the wait at the remaining time before the context deadline. It makes the **existing** `EvalContext` deadline authoritative rather than adding a `Runtime.MaxSleep` knob nobody sets. No new configuration surface.

## Exactly what behaviour changes

Only for a sleep evaluated under a context that has a `Done` channel or a deadline — i.e. `EvalContext` / `FunCallContext` / `Load*Context`, or `lisp.WithContext`:

| Situation | Before | After |
|---|---|---|
| No context configured (`Eval`, default `context.Background()`) | sleeps `d`, returns nil | **unchanged** — sleeps `d`, returns nil |
| `d` fits inside the deadline, no cancellation | sleeps `d`, returns nil | unchanged — sleeps `d`, returns nil |
| Context cancelled during the sleep | sleeps the full `d`, returns nil; cancellation is only noticed at the *next* eval step | wakes on cancel, returns a `context-cancelled` condition |
| `d` extends past the deadline | sleeps the full `d` | wakes at the deadline, returns a `context-cancelled` condition |
| Context already cancelled on entry | sleeps the full `d` | returns `context-cancelled` without sleeping |
| `d <= 0` | returns immediately | unchanged |
| Argument is not a native duration | immediate type error | unchanged (checked before any waiting) |

**With no context set, today's behaviour is unchanged — deliberately, and stated explicitly.** When `ctx.Done() == nil && !hasDeadline` the code is still a plain `time.Sleep(d)`, 292-year sleeps included. Bounding that case needs a new default limit, and any default small enough to be useful would break programs that legitimately sleep longer than it. An embedder that runs untrusted source and wants the bound must pass a context with a deadline — which is the same thing they already have to do to bound any other long-running builtin.

Two smaller judgement calls worth a look:

- **The error, not an early nil return.** An interrupted sleep raises `context-cancelled` with the same message shape (`"context cancelled: %v"`) that the interpreter's own between-steps check produces, so one `handler-bind` clause catches both. The alternative — return nil early and let the next eval step raise it — hides a truncated sleep from a program that immediately does something time-sensitive.
- **The deadline cap is belt-and-braces**, not a substitute for the `ctx.Done()` select. The `Context` interface permits reporting a `Deadline` with a nil `Done` channel; stdlib types do not do this, but embedder wrappers can, and selecting on a nil channel blocks forever — the exact bug being fixed. It also avoids arming a 292-year timer.

## Substrate grep result

Substrate re-exports this exact function: `internal/substrate/shiro/libcc/cctime/cctime.go:113` registers `libtime.BuiltinSleep` as **`cc:sleep`**, so the change reaches phylum code directly. Every `.lisp` / phylum-source use of it:

| Location | Call |
|---|---|
| `e2e/sample-network/phylum_a/main.lisp:212` (and its build copy) | `(cc:sleep (cc:parse-duration "5s"))` |
| `cmd/substratehcp/stresstest/mockstress_test.go:59` | `(cc:sleep (cc:parse-duration "500ms"))` |
| `internal/substrate/shiro/preheat/preheat_test.go:156,326` | `(cc:sleep (cc:parse-duration "300ms"))` |

All short, all deliberate. More importantly: **substrate sets no deadline on phylum evaluation today.** Its eval sites pass `env.Context()` (`ccstorage`, `libduration`, `ccbptree`, `preheat`, `shirotester`), nothing calls `lisp.WithContext` with a deadline, and the only `context.WithTimeout` under `internal/substrate/` is in `ccfetchurl` for an outbound HTTP call. So `env.Context()` is `context.Background()` there and **this change is a no-op for substrate as it stands** — the 5s e2e sleep keeps working. What it does is give substrate the lever: once it threads a deadline into phylum evaluation, `cc:sleep` is bounded by it, and the 292-year block stops being reachable. Substrate should expect the 5s e2e phylum to start failing with `context-cancelled` if the deadline it eventually picks is under 5s.

## Mutation verification

Reverted the fix in place (`return sleepContext(env, d)` → `time.Sleep(d); return lisp.Nil()`), rebuilt, and ran the new tests. Four of the seven failed, each on the containment property:

```
--- FAIL: TestSleepInterruptedThroughEval (30.02s)     sleep did not return within 30s
--- FAIL: TestSleepInterruptedByContextDeadline (30.02s) sleep did not return within 30s
--- FAIL: TestSleepInterruptedByCancel (30.00s)         sleep did not return within 30s
--- FAIL: TestSleepAlreadyCancelled (30.00s)            sleep did not return within 30s
```

The other three (`CompletesWithinDeadline`, `NoContextUnaffected`, `NonPositive`, plus `RejectsNonDuration`) passed under the mutation, which is the point: they are the no-regression guards and must pass both before and after. Restored via `git checkout`, confirmed clean, all seven green in 0.08s.

The tests use `forever = time.Hour` rather than `math.MaxInt64` ns so a regression fails in 30s instead of hanging the runner for the full `-timeout`, and each sleep runs behind a bounded-wait goroutine so the failure names the assertion instead of dumping every goroutine. `TestSleepInterruptedThroughEval` goes through `LoadStringContext` with the literal `"9223372036854775807ns"` from the issue, because the direct-call tests would still pass if `LEnv.call`'s context bridge broke while real ELPS programs stayed unbounded.

## Also in this PR

- **`time:sleep` is back in the stdlib fuzz sweep.** The `skipCallable` exclusion existed only because #314 made it unboundable; `callDeadline` now bounds it like everything else. The replacement comment is honest that coverage of the *sleeping* path is nominal: `internal/fuzzval` has no `time.Duration` among its `nativeValues`, so generated arguments reach the type check and stop. Re-inclusion costs nothing measurable — the `lisp/lisplib` seed corpus still runs in 0.5s uncached.
- **`docs/lang.md`** notes under "Context Cancellation" that the context is normally observed only between steps and that `time:sleep` is the one builtin that consults it mid-step.
- The docstring is updated (`elps doc -m` clean, rendering checked).

## Verification

`go build ./...`, `go test ./...`, `make test` (incl. `_examples`), `golangci-lint run ./...` (0 issues), `./elps fmt -l ./...`, `./elps lint ./...`, `./elps doc -m` — all clean.

## Things I am not sure about

1. **Whether the truncated case should fail fast instead of sleeping to the deadline.** As written, `(time:sleep 100s)` under a 60s deadline blocks for 60s and then errors. Erroring immediately would be stronger containment and free up the remaining budget for cleanup, but it changes behaviour for more programs and diverges from the issue's wording ("sleep on `min(d, time.Until(deadline))` and return a budget error if truncated"). I went with the issue's version.
2. **Whether `context-cancelled` is the right condition for a truncated sleep**, versus a distinct one. Reusing it means existing handlers catch it, but a program cannot distinguish "my sleep was cut short" from "the deadline expired elsewhere". Reusing it seemed better than minting a condition for one builtin.
3. **Whether `internal/fuzzval` should gain a `time.Duration` native** so the sweep actually exercises the sleeping path. Deliberately not done here — it widens the surface for every builtin that switches on `Native`, and a generated `MaxInt64` duration would cost a full `callDeadline` (5s) per matching iteration. Worth its own issue.
4. **`d <= 0` returns nil even under an already-cancelled context.** It matches `time.Sleep`, and the next eval step raises the cancellation anyway, but it is an inconsistency someone might reasonably want removed.
5. The prose in `lisp/runtime.go` still says a context deadline "is the only limit here that measures time" without noting it is only observed between steps. Still true as far as it goes, and pre-existing, so I left it out of this diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_