### PR TITLE
mcpserver: give the env factory a request context and a release handle (#307)

### DIFF
--- a/docs/embed.md
+++ b/docs/embed.md
@@ -262,6 +262,52 @@ For convenience, `lisplib.NewDocEnv()` creates a standard environment with the
 stdlib loaded. Embedders can use this as a starting point or create their own
 environment from scratch.
 
+### MCP Server Environments
+
+The `mcpserver` package exposes ELPS language tooling over MCP. Its `doc`,
+`eval`, and `test` tools each need an environment, which the embedder supplies
+with `mcpserver.WithRequestEnvFactory`:
+
+```go
+srv := mcpserver.New(
+    mcpserver.WithRegistry(env.Runtime.Registry),
+    mcpserver.WithWorkspaceRoot(root),
+    mcpserver.WithRequestEnvFactory(func(ctx context.Context) (*lisp.LEnv, func(), error) {
+        env, closeEnv, err := NewRuntime(ctx) // embedder runtime, may own a DB, files, goroutines
+        if err != nil {
+            return nil, nil, err // the factory cleans up after its own failure
+        }
+        return env, closeEnv, nil
+    }),
+)
+```
+
+The server calls `release` exactly once, as soon as it is finished with the
+environment — before the tool handler returns, and per environment in batch
+`eval`, so peak usage stays at one environment rather than one per expression.
+Do not tie the environment's lifetime to `ctx` alone: the request context is
+cancelled only after the response is written, and it outlives every individual
+environment a batch request builds. The context is there for the request's
+deadline and for correlating an environment with its request.
+
+An environment that owns nothing beyond memory can return a `nil` release; the
+server treats it as a no-op.
+
+`WithEnvFactory(func() (*lisp.LEnv, error))` is the older form of the same
+option and is deprecated: it has no way to signal that an environment is
+finished with, so environments backed by OS resources or background goroutines
+accumulate for the life of the process.
+
+Two related options control which environment a tool sees:
+
+| Option | Effect |
+|--------|--------|
+| `mcpserver.WithDocEnv(env)` | One shared, reusable environment for the read-only `doc` tool. Documentation lookup is a symbol query, so it needs no per-request isolation. Never released by the server. |
+| `mcpserver.WithEnv(env)` | Backs `doc` *and* the diagnostics path (workspace macro loading and expansion). Use `WithDocEnv` when only the `doc` tool should be redirected. |
+
+For the `doc` tool the precedence is `WithDocEnv`, then `WithEnv`, then the
+request env factory, then a default stdlib documentation environment.
+
 ### Reusing the CLI Commands (Recommended)
 
 The `cmd` package exports `LintCommand()` and `DocCommand()` factory functions

--- a/mcpserver/envlifetime_test.go
+++ b/mcpserver/envlifetime_test.go
@@ -1,0 +1,349 @@
+package mcpserver
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// envTracker is a RequestEnvFactory that records how many environments it has
+// handed out and how many have been released. It stands in for an embedder
+// whose environments own external resources (substrate's shirotester mcp backs
+// each env with an in-memory Badger DB, see issue #307): the counters are the
+// observable proxy for "the resource was reclaimed".
+//
+// release deliberately does NOT guard with sync.Once — a double release shows
+// up as released > created rather than being silently swallowed.
+type envTracker struct {
+	mu       sync.Mutex
+	created  int
+	released int
+	live     int
+	maxLive  int
+	ctxs     []context.Context
+}
+
+func (tr *envTracker) newEnv(ctx context.Context) (*lisp.LEnv, func(), error) {
+	env, err := lisplib.NewDocEnv()
+	if err != nil {
+		return nil, nil, err
+	}
+	tr.mu.Lock()
+	tr.created++
+	tr.live++
+	if tr.live > tr.maxLive {
+		tr.maxLive = tr.live
+	}
+	tr.ctxs = append(tr.ctxs, ctx)
+	tr.mu.Unlock()
+
+	return env, func() {
+		tr.mu.Lock()
+		defer tr.mu.Unlock()
+		tr.released++
+		tr.live--
+	}, nil
+}
+
+func (tr *envTracker) counts() (created, released, live, maxLive int) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	return tr.created, tr.released, tr.live, tr.maxLive
+}
+
+func (tr *envTracker) contexts() []context.Context {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	return append([]context.Context(nil), tr.ctxs...)
+}
+
+// testRegistry returns a stdlib package registry. Servers built with an env
+// factory pass it so New does not fall back to building a default doc env,
+// which would short-circuit the factory for the doc tool. This mirrors how
+// embedders wire the server (see cmd/mcp.go).
+func testRegistry(t *testing.T) *lisp.PackageRegistry {
+	t.Helper()
+	env, err := lisplib.NewDocEnv()
+	require.NoError(t, err)
+	return env.Runtime.Registry
+}
+
+// TestRequestEnvFactoryReleasesEveryEnv is the regression test for #307: every
+// environment the factory hands to a tool must be released by the time that
+// tool call returns, so nothing accumulates across a session.
+func TestRequestEnvFactoryReleasesEveryEnv(t *testing.T) {
+	calls := []struct {
+		name string
+		tool string
+		args func(t *testing.T, root string) map[string]any
+	}{
+		{"doc", "doc", func(*testing.T, string) map[string]any {
+			return map[string]any{"query": "map"}
+		}},
+		{"doc-batch", "doc", func(*testing.T, string) map[string]any {
+			return map[string]any{"queries": []string{"map", "foldl"}}
+		}},
+		{"eval", "eval", func(*testing.T, string) map[string]any {
+			return map[string]any{"expression": "(+ 1 2)"}
+		}},
+		{"eval-batch", "eval", func(*testing.T, string) map[string]any {
+			return map[string]any{"expressions": []string{"(+ 1 1)", "(+ 2 2)"}}
+		}},
+		{"test", "test", func(t *testing.T, root string) map[string]any {
+			t.Helper()
+			path := filepath.Join(root, "lifetime_test.lisp")
+			writeTestFile(t, path, `(test "adds" (assert= 3 (+ 1 2)))`)
+			return map[string]any{"path": path}
+		}},
+	}
+
+	for _, tc := range calls {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &envTracker{}
+			root := t.TempDir()
+			session, serverSession := connectTestServer(t, New(
+				WithRegistry(testRegistry(t)),
+				WithRequestEnvFactory(tr.newEnv),
+				WithWorkspaceRoot(root),
+			))
+			defer closeClientSession(t, session)
+			defer closeServerSession(t, serverSession)
+
+			params := &mcp.CallToolParams{Name: tc.tool, Arguments: tc.args(t, root)}
+
+			const iterations = 3
+			for range iterations {
+				res, err := session.CallTool(context.Background(), params)
+				require.NoError(t, err)
+				require.False(t, res.IsError)
+
+				// Checked after every call, not just at the end: the point of
+				// the release handle is that nothing survives its request.
+				created, released, live, _ := tr.counts()
+				assert.Positive(t, created, "tool must use the env factory")
+				assert.Equal(t, created, released,
+					"every env handed out must be released by the time the call returns")
+				assert.Zero(t, live, "no env may outlive its request")
+			}
+		})
+	}
+}
+
+// TestRequestEnvFactoryBatchEvalReleasesEachEnv checks the batch path holds at
+// most one environment at a time. Batch eval builds one env per expression, so
+// a lifetime tied to the request (rather than to the env) would pin all of them
+// until the request ended.
+func TestRequestEnvFactoryBatchEvalReleasesEachEnv(t *testing.T) {
+	tr := &envTracker{}
+	session, serverSession := connectTestServer(t, New(
+		WithRegistry(testRegistry(t)),
+		WithRequestEnvFactory(tr.newEnv),
+		WithWorkspaceRoot(t.TempDir()),
+	))
+	defer closeClientSession(t, session)
+	defer closeServerSession(t, serverSession)
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "eval",
+		Arguments: map[string]any{
+			"expressions": []string{"(+ 1 1)", "(+ 2 2)", "(+ 3 3)", "(+ 4 4)"},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	got := decodeStructured[EvalResponse](t, res)
+	require.Len(t, got.Batch, 4)
+
+	created, released, live, maxLive := tr.counts()
+	assert.Equal(t, 4, created, "batch eval isolates each expression in its own env")
+	assert.Equal(t, created, released)
+	assert.Zero(t, live)
+	assert.Equal(t, 1, maxLive,
+		"each batch env must be released before the next is built")
+}
+
+// TestRequestEnvFactoryReceivesRequestContext checks the factory is handed the
+// live request context, so an embedder can key cleanup off cancellation or use
+// it to correlate an env with its request.
+func TestRequestEnvFactoryReceivesRequestContext(t *testing.T) {
+	tr := &envTracker{}
+	session, serverSession := connectTestServer(t, New(
+		WithRegistry(testRegistry(t)),
+		WithRequestEnvFactory(tr.newEnv),
+		WithWorkspaceRoot(t.TempDir()),
+	))
+	defer closeClientSession(t, session)
+	defer closeServerSession(t, serverSession)
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "doc",
+		Arguments: map[string]any{"query": "map"},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	ctxs := tr.contexts()
+	require.Len(t, ctxs, 1)
+	require.NotNil(t, ctxs[0])
+
+	// The request context is cancelled once the request finishes, which is what
+	// makes it usable as a per-request lifetime signal. Cancellation happens
+	// after the response is written, so poll rather than assert immediately.
+	deadline := time.Now().Add(2 * time.Second)
+	for ctxs[0].Err() == nil && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	assert.Error(t, ctxs[0].Err(), "request context should be cancelled once the request completes")
+}
+
+// TestWithEnvFactoryStillSupported pins the backward-compatibility promise: the
+// deprecated option keeps working, and a factory with no release handle does
+// not panic.
+func TestWithEnvFactoryStillSupported(t *testing.T) {
+	var calls int
+	session, serverSession := connectTestServer(t, New(
+		WithRegistry(testRegistry(t)),
+		WithEnvFactory(func() (*lisp.LEnv, error) {
+			calls++
+			return lisplib.NewDocEnv()
+		}),
+		WithWorkspaceRoot(t.TempDir()),
+	))
+	defer closeClientSession(t, session)
+	defer closeServerSession(t, serverSession)
+
+	for _, name := range []string{"doc", "eval"} {
+		args := map[string]any{"query": "map"}
+		if name == "eval" {
+			args = map[string]any{"expression": "(+ 1 2)"}
+		}
+		res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+			Name:      name,
+			Arguments: args,
+		})
+		require.NoError(t, err)
+		require.False(t, res.IsError, name)
+	}
+	assert.Equal(t, 2, calls, "legacy factory must still back doc and eval")
+}
+
+// TestWithRequestEnvFactoryOverridesWithEnvFactory documents that the two
+// options write the same slot, so the last one applied wins.
+func TestWithRequestEnvFactoryOverridesWithEnvFactory(t *testing.T) {
+	var legacy, current int
+	srv := New(
+		WithRegistry(testRegistry(t)),
+		WithEnvFactory(func() (*lisp.LEnv, error) {
+			legacy++
+			return lisplib.NewDocEnv()
+		}),
+		WithRequestEnvFactory(func(context.Context) (*lisp.LEnv, func(), error) {
+			current++
+			env, err := lisplib.NewDocEnv()
+			return env, nil, err
+		}),
+	)
+	session, serverSession := connectTestServer(t, srv)
+	defer closeClientSession(t, session)
+	defer closeServerSession(t, serverSession)
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "doc",
+		Arguments: map[string]any{"query": "map"},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	assert.Zero(t, legacy)
+	assert.Equal(t, 1, current)
+}
+
+// TestWithDocEnvSharesOneEnvForDoc covers the third improvement in #307: doc is
+// a read-only symbol lookup, so an embedder can supply one shared env for it
+// instead of paying for a fresh env per call.
+func TestWithDocEnvSharesOneEnvForDoc(t *testing.T) {
+	shared, err := lisplib.NewDocEnv()
+	require.NoError(t, err)
+
+	tr := &envTracker{}
+	srv := New(
+		WithRegistry(testRegistry(t)),
+		WithDocEnv(shared),
+		WithRequestEnvFactory(tr.newEnv),
+		WithWorkspaceRoot(t.TempDir()),
+	)
+	session, serverSession := connectTestServer(t, srv)
+	defer closeClientSession(t, session)
+	defer closeServerSession(t, serverSession)
+
+	for range 5 {
+		res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+			Name:      "doc",
+			Arguments: map[string]any{"query": "map"},
+		})
+		require.NoError(t, err)
+		require.False(t, res.IsError)
+		got := decodeStructured[DocResponse](t, res)
+		require.True(t, got.Found)
+	}
+
+	created, _, _, _ := tr.counts()
+	assert.Zero(t, created, "doc must reuse the shared env, not the request factory")
+
+	// Unlike WithEnv, WithDocEnv must not redirect the diagnostics path.
+	assert.Nil(t, srv.service.env, "WithDocEnv must not populate the diagnostics env")
+	assert.Same(t, shared, srv.service.sharedDocEnv)
+
+	// eval still gets isolated per-request envs from the factory.
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "eval",
+		Arguments: map[string]any{"expression": "(+ 1 2)"},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	created, released, live, _ := tr.counts()
+	assert.Equal(t, 1, created)
+	assert.Equal(t, created, released)
+	assert.Zero(t, live)
+}
+
+// TestWithDocEnvTakesPrecedenceOverWithEnv pins the documented precedence order
+// for the doc tool.
+func TestWithDocEnvTakesPrecedenceOverWithEnv(t *testing.T) {
+	docOnly, err := lisplib.NewDocEnv()
+	require.NoError(t, err)
+	diagnostics, err := lisplib.NewDocEnv()
+	require.NoError(t, err)
+
+	srv := New(WithEnv(diagnostics), WithDocEnv(docOnly))
+	env, release, err := srv.service.docEnv(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, release)
+	release()
+	assert.Same(t, docOnly, env)
+	assert.Same(t, diagnostics, srv.service.env)
+}
+
+// TestRequestEnvFactoryErrorSkipsRelease pins the error contract: a factory that
+// fails owns its own cleanup and the server must not call the release handle.
+func TestRequestEnvFactoryErrorSkipsRelease(t *testing.T) {
+	var released int
+	boom := assert.AnError
+	srv := New(WithRequestEnvFactory(func(context.Context) (*lisp.LEnv, func(), error) {
+		return nil, func() { released++ }, boom
+	}))
+
+	_, release, err := srv.service.newTestEnv(context.Background())
+	require.ErrorIs(t, err, boom)
+	require.NotNil(t, release, "release must be safe to defer even on error")
+	release()
+	assert.Zero(t, released, "the server must not call release when the factory errors")
+}

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -18,10 +18,30 @@ const (
 
 type Option func(*Server)
 
+// RequestEnvFactory creates an environment for a single tool request and
+// returns a release function that the server calls exactly once, when the
+// request no longer needs the environment.
+//
+// The context is the request context of the tool call being served: it carries
+// the request's deadline and is cancelled once the request completes, so it can
+// also be used to correlate an environment with the request that created it.
+//
+// The returned release function must be safe to call once. It may be nil, in
+// which case the server treats it as a no-op. When the factory returns a
+// non-nil error it must release any partially constructed resources itself; the
+// server does not call release in that case.
+//
+// Release is called when the environment becomes unreachable to the server,
+// which is before the tool handler returns — not when the context is cancelled.
+// Tools that build several environments for one request (batch `eval`) release
+// each one as soon as it is done, so peak usage stays at one environment.
+type RequestEnvFactory func(ctx context.Context) (env *lisp.LEnv, release func(), err error)
+
 type Server struct {
 	registry        *lisp.PackageRegistry
 	env             *lisp.LEnv
-	envFactory      func() (*lisp.LEnv, error)
+	docEnv          *lisp.LEnv
+	envFactory      RequestEnvFactory
 	workspaceRoot   string
 	perfConfig      *perf.Config
 	excludePatterns []string
@@ -42,6 +62,23 @@ func WithRegistry(reg *lisp.PackageRegistry) Option {
 
 func WithEnv(env *lisp.LEnv) Option {
 	return func(s *Server) { s.env = env }
+}
+
+// WithDocEnv sets a shared, reusable environment used only by the read-only
+// `doc` tool. Documentation lookup is a symbol query that mutates nothing, so
+// it needs no per-request isolation; supplying an environment here avoids
+// building one per `doc` call.
+//
+// Unlike WithEnv, this option does not redirect the diagnostics path
+// (workspace macro loading and macro expansion), so it can be used as a
+// doc-only override alongside WithRegistry or WithRequestEnvFactory.
+//
+// The environment is shared across concurrent requests and is never released
+// by the server; the embedder owns its lifetime. Precedence for the `doc` tool
+// is WithDocEnv, then WithEnv, then the request env factory, then a default
+// stdlib doc environment.
+func WithDocEnv(env *lisp.LEnv) Option {
+	return func(s *Server) { s.docEnv = env }
 }
 
 func WithWorkspaceRoot(root string) Option {
@@ -74,10 +111,45 @@ func WithLogger(logger *slog.Logger) Option {
 }
 
 // WithEnvFactory sets a factory function that creates fresh LEnv instances
-// for the eval and test tools. Each call gets an isolated environment.
+// for the doc, eval, and test tools. Each call gets an isolated environment.
 // Embedders (e.g., substrate) should use this to inject their full runtime
-// (shirocore builtins, test harness, etc.) into eval/test environments.
+// (shirocore builtins, test harness, etc.) into those environments.
+//
+// Deprecated: use WithRequestEnvFactory. This signature has no way to report
+// that an environment is finished with, so an environment owning OS resources
+// or background goroutines is never released and the server leaks one per
+// request. Migration is mechanical:
+//
+//	WithEnvFactory(func() (*lisp.LEnv, error) { ... })
+//
+//	WithRequestEnvFactory(func(context.Context) (*lisp.LEnv, func(), error) {
+//		env, err := ...
+//		if err != nil {
+//			return nil, nil, err
+//		}
+//		return env, func() { /* release env resources */ }, nil
+//	})
 func WithEnvFactory(factory func() (*lisp.LEnv, error)) Option {
+	return func(s *Server) {
+		if factory != nil {
+			s.envFactory = func(context.Context) (*lisp.LEnv, func(), error) {
+				env, err := factory()
+				return env, nil, err
+			}
+		}
+	}
+}
+
+// WithRequestEnvFactory sets a factory that creates a fresh LEnv for a single
+// tool request (doc, eval, or test) and returns a release function the server
+// calls when it is finished with the environment. It supersedes WithEnvFactory:
+// the release handle lets embedders whose environments own external resources
+// (open files, background goroutines, embedded databases) tie their lifetime to
+// the request that created them.
+//
+// See RequestEnvFactory for the release contract. Only the last of
+// WithEnvFactory / WithRequestEnvFactory takes effect.
+func WithRequestEnvFactory(factory RequestEnvFactory) Option {
 	return func(s *Server) {
 		if factory != nil {
 			s.envFactory = factory
@@ -119,6 +191,7 @@ func New(opts ...Option) *Server {
 	s.service = newService(serviceConfig{
 		registry:        s.registry,
 		env:             s.env,
+		docEnv:          s.docEnv,
 		envFactory:      s.envFactory,
 		workspaceRoot:   s.workspaceRoot,
 		perfConfig:      s.perfConfig,

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -36,7 +36,8 @@ const builtinScheme = "elps-builtin"
 type serviceConfig struct {
 	registry        *lisp.PackageRegistry
 	env             *lisp.LEnv
-	envFactory      func() (*lisp.LEnv, error)
+	docEnv          *lisp.LEnv
+	envFactory      RequestEnvFactory
 	workspaceRoot   string
 	perfConfig      *perf.Config
 	excludePatterns []string
@@ -47,7 +48,8 @@ type serviceConfig struct {
 type service struct {
 	registry        *lisp.PackageRegistry
 	env             *lisp.LEnv
-	envFactory      func() (*lisp.LEnv, error)
+	sharedDocEnv    *lisp.LEnv
+	envFactory      RequestEnvFactory
 	workspaceRoot   string
 	perfConfig      *perf.Config
 	excludePatterns []string
@@ -81,6 +83,7 @@ func newService(cfg serviceConfig) *service {
 	return &service{
 		registry:                    cfg.registry,
 		env:                         cfg.env,
+		sharedDocEnv:                cfg.docEnv,
 		envFactory:                  cfg.envFactory,
 		workspaceRoot:               cfg.workspaceRoot,
 		perfConfig:                  clonePerfConfig(cfg.perfConfig),
@@ -1636,15 +1639,16 @@ func paginateSlice[T any](items []T, offset, limit int) []T {
 	return items
 }
 
-func (s *service) docTool(_ context.Context, _ *mcp.CallToolRequest, in DocInput) (*mcp.CallToolResult, DocResponse, error) {
+func (s *service) docTool(ctx context.Context, _ *mcp.CallToolRequest, in DocInput) (*mcp.CallToolResult, DocResponse, error) {
 	start := time.Now()
 	if in.Query == "" && len(in.Queries) == 0 {
 		return nil, DocResponse{}, newToolErr("invalid_input", "query or queries is required", "")
 	}
-	env, err := s.docEnv()
+	env, release, err := s.docEnv(ctx)
 	if err != nil {
 		return nil, DocResponse{}, err
 	}
+	defer release()
 
 	// Batch mode: look up multiple symbols at once.
 	if len(in.Queries) > 0 {
@@ -1702,16 +1706,45 @@ func docSymbolFromLib(sd libhelp.SymbolDoc) DocSymbol {
 	return ds
 }
 
-func (s *service) docEnv() (*lisp.LEnv, error) {
+// noopRelease is the release function used for environments the service does
+// not own: shared environments supplied by the embedder, and factories that
+// return no release handle.
+func noopRelease() {}
+
+// callEnvFactory invokes the embedder's request env factory and normalizes the
+// release handle so callers can always `defer release()`. A factory that
+// returns an error is assumed to have cleaned up after itself, per the
+// RequestEnvFactory contract.
+func (s *service) callEnvFactory(ctx context.Context) (*lisp.LEnv, func(), error) {
+	env, release, err := s.envFactory(ctx)
+	if err != nil {
+		return nil, noopRelease, err
+	}
+	if release == nil {
+		release = noopRelease
+	}
+	return env, release, nil
+}
+
+// docEnv resolves the environment backing the read-only doc tool. It returns a
+// release function that the caller must invoke when it is done with the
+// environment; for shared environments the release is a no-op.
+func (s *service) docEnv(ctx context.Context) (*lisp.LEnv, func(), error) {
+	// A doc-only shared env wins: doc is a symbol lookup that needs no
+	// isolation, so an embedder can opt out of per-request construction here
+	// without redirecting the diagnostics path the way WithEnv does.
+	if s.sharedDocEnv != nil {
+		return s.sharedDocEnv, noopRelease, nil
+	}
 	if s.env != nil {
-		return s.env, nil
+		return s.env, noopRelease, nil
 	}
 	if s.envFactory != nil {
-		return s.envFactory()
+		return s.callEnvFactory(ctx)
 	}
 	env, err := lisplib.NewDocEnv()
 	if err != nil {
-		return nil, err
+		return nil, noopRelease, err
 	}
 	if s.registry != nil {
 		for name, pkg := range s.registry.Packages {
@@ -1720,10 +1753,10 @@ func (s *service) docEnv() (*lisp.LEnv, error) {
 			}
 		}
 	}
-	return env, nil
+	return env, noopRelease, nil
 }
 
-func (s *service) testTool(_ context.Context, _ *mcp.CallToolRequest, in TestInput) (*mcp.CallToolResult, TestResponse, error) {
+func (s *service) testTool(ctx context.Context, _ *mcp.CallToolRequest, in TestInput) (*mcp.CallToolResult, TestResponse, error) {
 	start := time.Now()
 	if in.Path == "" && in.Content == nil {
 		return nil, TestResponse{}, newToolErr("invalid_input", "path or content is required", "")
@@ -1753,10 +1786,11 @@ func (s *service) testTool(_ context.Context, _ *mcp.CallToolRequest, in TestInp
 		}
 	}
 
-	env, testErr := s.newTestEnv()
+	env, release, testErr := s.newTestEnv(ctx)
 	if testErr != nil {
 		return nil, TestResponse{}, testErr
 	}
+	defer release()
 
 	// Load and evaluate the test file.
 	lerr := env.InPackage(lisp.String(lisp.DefaultUserPackage))
@@ -1834,35 +1868,39 @@ func (s *service) testTool(_ context.Context, _ *mcp.CallToolRequest, in TestInp
 	}, nil
 }
 
-func (s *service) newTestEnv() (*lisp.LEnv, error) {
+// newTestEnv builds an isolated environment for the eval and test tools. It
+// returns a release function that the caller must invoke once it is done with
+// the environment.
+func (s *service) newTestEnv(ctx context.Context) (*lisp.LEnv, func(), error) {
 	if s.envFactory != nil {
-		return s.envFactory()
+		return s.callEnvFactory(ctx)
 	}
 	env := lisp.NewEnv(nil)
 	env.Runtime.Reader = parser.NewReader()
 	env.Runtime.Library = &lisp.RelativeFileSystemLibrary{}
 	rc := lisp.InitializeUserEnv(env)
 	if lisp.GoError(rc) != nil {
-		return nil, fmt.Errorf("env init: %w", lisp.GoError(rc))
+		return nil, noopRelease, fmt.Errorf("env init: %w", lisp.GoError(rc))
 	}
 	rc = lisplib.LoadLibrary(env)
 	if lisp.GoError(rc) != nil {
-		return nil, fmt.Errorf("load library: %w", lisp.GoError(rc))
+		return nil, noopRelease, fmt.Errorf("load library: %w", lisp.GoError(rc))
 	}
-	return env, nil
+	return env, noopRelease, nil
 }
 
-func (s *service) evalTool(_ context.Context, _ *mcp.CallToolRequest, in EvalInput) (*mcp.CallToolResult, EvalResponse, error) {
+func (s *service) evalTool(ctx context.Context, _ *mcp.CallToolRequest, in EvalInput) (*mcp.CallToolResult, EvalResponse, error) {
 	start := time.Now()
 	if in.Expression == "" && len(in.Expressions) == 0 {
 		return nil, EvalResponse{}, newToolErr("invalid_input", "expression or expressions is required", "")
 	}
 
-	// Batch mode: each expression gets its own isolated env.
+	// Batch mode: each expression gets its own isolated env, released as soon
+	// as that expression is done so peak usage stays at one environment.
 	if len(in.Expressions) > 0 {
 		batch := make([]EvalResult, 0, len(in.Expressions))
 		for _, expr := range in.Expressions {
-			result := s.evalSingle(expr)
+			result := s.evalSingle(ctx, expr)
 			batch = append(batch, result)
 		}
 		return nil, EvalResponse{
@@ -1872,10 +1910,11 @@ func (s *service) evalTool(_ context.Context, _ *mcp.CallToolRequest, in EvalInp
 	}
 
 	// Single expression mode.
-	env, err := s.newTestEnv()
+	env, release, err := s.newTestEnv(ctx)
 	if err != nil {
 		return nil, EvalResponse{}, err
 	}
+	defer release()
 	lerr := env.InPackage(lisp.String(lisp.DefaultUserPackage))
 	if lisp.GoError(lerr) != nil {
 		return nil, EvalResponse{}, fmt.Errorf("package error: %w", lisp.GoError(lerr))
@@ -1917,11 +1956,12 @@ func (s *service) evalTool(_ context.Context, _ *mcp.CallToolRequest, in EvalInp
 	}, nil
 }
 
-func (s *service) evalSingle(expression string) EvalResult {
-	env, err := s.newTestEnv()
+func (s *service) evalSingle(ctx context.Context, expression string) EvalResult {
+	env, release, err := s.newTestEnv(ctx)
 	if err != nil {
 		return EvalResult{Expression: expression, Error: err.Error()}
 	}
+	defer release()
 	lerr := env.InPackage(lisp.String(lisp.DefaultUserPackage))
 	if lisp.GoError(lerr) != nil {
 		return EvalResult{Expression: expression, Error: lisp.GoError(lerr).Error()}


### PR DESCRIPTION
Fixes #307.

`WithEnvFactory` takes `func() (*lisp.LEnv, error)` and is called once per request by the `doc`, `test` and `eval` tools. The factory learns nothing about the request and hands back no cleanup handle, so an embedder whose environments own external resources cannot tie their lifetime to the request that created them. Measured in substrate (`shirotester mcp`, each env owning an in-memory Badger DB): +87,640 kB heapInuse and +14 goroutines per env, never reclaimed.

## API shape chosen

**Shape 2 — return a cleanup — with the request context passed as well.**

```go
type RequestEnvFactory func(ctx context.Context) (env *lisp.LEnv, release func(), err error)

func WithRequestEnvFactory(factory RequestEnvFactory) Option
```

The cleanup handle is the load-bearing part; the context rides along because it is free and gives the embedder the request's deadline and identity. Three reasons the cleanup, not the context, has to be the primary mechanism:

- **A request is not the right lifetime for a batch request.** Batch `eval` builds one environment per expression. Under context-only semantics all of them are pinned until the request ends — exactly the accumulation the issue reports, just bounded by batch size instead of session length. With a release handle each env is freed as soon as its expression is done and peak usage stays at one.
- **Release happens earlier and deterministically.** The go-sdk cancels a request context in `jsonrpc2`'s `processResult`, i.e. after the handler has returned and the response has been written. Cleanup at handler return frees the resource strictly sooner, in the handler's own goroutine.
- **No embedder cooperation required.** `ctx.Done()` obliges every embedder to spawn a watcher goroutine per environment and get the teardown race right. `release()` is a function call.

The context is still delivered and still useful (deadline propagation, correlating an env with its request, cancelling embedder-side work early), so nothing that shape 1 enables is lost.

Contract, documented on the type: release is called exactly once; a `nil` release is treated as a no-op; a factory that returns an error owns its own cleanup and the server will not call the release it returned.

## Backward compatibility

**Source-compatible — nothing an embedder has today stops compiling or changes behaviour.**

`WithEnvFactory(func() (*lisp.LEnv, error))` keeps its exact signature and is now a deprecated adapter that stores the old factory with a no-op release. Both options write the same field, so the last one applied wins. Existing embedders are unaffected until they choose to migrate; they simply keep leaking, which is the status quo.

Migration is mechanical:

```go
// before
WithEnvFactory(func() (*lisp.LEnv, error) { return NewRuntime() })

// after
WithRequestEnvFactory(func(ctx context.Context) (*lisp.LEnv, func(), error) {
    env, closeEnv, err := NewRuntime(ctx)
    if err != nil {
        return nil, nil, err
    }
    return env, closeEnv, nil
})
```

For substrate specifically, this removes the need for the pool + `AddReceivingMiddleware` request-bracketing workaround in luthersystems/substrate#365: the release fires per environment, so the imprecision that forced "cap and refuse" (a long `test` call pinning envs belonging to short `doc` calls) goes away.

## Third improvement: shared doc env

Also included, since it is small and independent: `WithDocEnv(env)` supplies one shared, reusable environment used **only** by the read-only `doc` tool. `doc` is a symbol lookup that mutates nothing, so it needs no per-request isolation, yet it built a fresh env per call. `WithEnv` could not serve as a doc-only override because it also redirects the diagnostics path (`LoadWorkspaceMacros` / `MacroExpander`); `WithDocEnv` leaves `s.env` alone. Precedence for `doc` is `WithDocEnv` → `WithEnv` → request factory → default stdlib doc env. The shared env is never released by the server; the embedder owns it. Concurrency exposure is unchanged — `WithEnv` already shared one env across requests, and the doc path only performs read-only registry/scope lookups.

## Tests

`mcpserver/envlifetime_test.go`, driven through a live in-memory MCP session:

- every env handed to `doc` / `doc` batch / `eval` / `eval` batch / `test` is released by the time the call returns — asserted after **each** of three iterations, so an accumulating env fails on the spot rather than at teardown
- batch `eval` holds at most one env at a time (`maxLive == 1`)
- the factory receives the request context, and that context is cancelled once the request completes
- the deprecated `WithEnvFactory` still backs `doc` and `eval`, and its nil release does not panic
- `WithRequestEnvFactory` applied after `WithEnvFactory` wins
- `WithDocEnv` serves `doc` from the shared env without populating the diagnostics env, while `eval` keeps getting isolated per-request envs
- a factory that errors keeps its own cleanup — the server never calls the release it returned

The tracker's release deliberately has no `sync.Once`, so a double release surfaces as `released > created` instead of being swallowed.

## Mutation verification

Each mutation was applied to a clean tree, observed to fail, then reverted; the tree was confirmed clean and green afterwards.

| Mutation | Result |
|---|---|
| **A.** `callEnvFactory` discards the factory's release and returns a no-op (the pre-fix behaviour with the new API intact) | **FAIL** — all 5 `TestRequestEnvFactoryReleasesEveryEnv` subtests, `TestRequestEnvFactoryBatchEvalReleasesEachEnv`, and `TestWithDocEnvSharesOneEnvForDoc` |
| **B.** batch `eval` releases via `context.AfterFunc(ctx, release)` instead of `defer` — i.e. shape 1's semantics | **FAIL** — `.../eval-batch` (`no env may outlive its request`) and `TestRequestEnvFactoryBatchEvalReleasesEachEnv` (`each batch env must be released before the next is built`). This is the empirical case for choosing shape 2. |
| **C.** `docEnv` ignores `sharedDocEnv` | **FAIL** — `TestWithDocEnvSharesOneEnvForDoc`, `TestWithDocEnvTakesPrecedenceOverWithEnv` |

## Verification

`go build ./...`, `make test` (Go + example lisp), `go test -race ./mcpserver/`, `golangci-lint run ./...` (0 issues), `./elps fmt -l ./...`, `./elps lint --workspace=. --exclude grammar --include _examples ./...`, `./elps doc -m` — all clean.

## Notes for review

- **`New` still builds a default doc env when neither `WithEnv` nor `WithRegistry` is given**, and that env short-circuits `docEnv()` ahead of the factory. So `New(WithEnvFactory(f))` alone has never routed `doc` through `f` — only `test`/`eval`. Embedders that see the reported `doc` leak are passing `WithRegistry` (as `cmd/mcp.go` does). Left as-is: suppressing the default when a factory is present would silently strip the diagnostics registry. The tests pass `WithRegistry` for the same reason, mirroring real wiring.
- Nothing deferred. All three items in the issue are addressed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_