### PR TITLE
Fix s:may-have-key looking its key up as a symbol (#325)

### DIFF
--- a/lisp/lisplib/libschema/README.md
+++ b/lisp/lisplib/libschema/README.md
@@ -227,6 +227,11 @@ Requires the value to match the supplied pattern. Any regular expression that ca
 * `(s:may-have-key name[ type [type2 typeN]])`
   If a map has the key `name` set, optionally require the value therein to be of type `type` (or `type2` ... `typeN`). 
   You may wish to use this without a type set when using `no-more-keys`.
+  `name` is a string and is looked up as a string, exactly as `s:has-key` looks its key up. Before
+  [#325](https://github.com/luthersystems/elps/issues/325) it was looked up as a symbol, which a
+  map decoded by `json:load-string` rejects outright — so on JSON-derived maps the constraint
+  silently behaved as though the key were always absent. A string key matches symbol-keyed entries
+  of a literal `sorted-map` too, so nothing is lost.
   
 
 * `(s:no-more-keys field-constraint[ field-constraint2 field-constraintN])`

--- a/lisp/lisplib/libschema/key_lookup_test.go
+++ b/lisp/lisplib/libschema/key_lookup_test.go
@@ -1,0 +1,392 @@
+// Copyright © 2026 The ELPS authors
+
+package libschema_test
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// These tests cover issue #325: s:may-have-key looked its key up as a SYMBOL
+// while s:has-key, s:when and s:no-other-keys looked the same key up as a
+// STRING.
+//
+// WHY THAT MATTERS AT ALL, given lisp.Symbol("a") and lisp.String("a") carry
+// the same Str: lisp.Map is an INTERFACE, and its implementations disagree
+// about key types.
+//
+//   - lisp/maps.go sortedmap keys on LVal.Str for both LString and LSymbol.
+//     A symbol lookup and a string lookup are the same lookup, and either
+//     finds an entry stored under the other. The asymmetry is INVISIBLE here,
+//     which is why the literal (sorted-map "a" 1) named in #325 was in fact
+//     never affected -- worth recording, because it is the case a reader
+//     reaches for first when checking the report.
+//   - libjson.SortedMap -- what json:load-string returns -- rejects any key
+//     whose Type is not LString and answers (LError, false).
+//
+// may-have-key read that false as "the key is absent" and passed. So against
+// a JSON-decoded map -- the case the constraint is most often written for --
+// it was a total no-op: an optional key holding a wrong-typed value validated
+// clean. A wrong answer rather than a crash, which is why no fuzz target
+// found it.
+//
+// The tests below pin the fixed behaviour across all three map flavours and
+// all four key-taking constraints, and pin the two sites where an error from
+// may-have-key is INVERTED rather than propagated.
+
+// value is one payload written two ways, because a JSON-decoded map has to be
+// built from JSON source rather than from ELPS literals.
+type value struct{ name, elps, json string }
+
+var (
+	vString = value{"string", `"str"`, `"str"`}
+	vNumber = value{"number", `1`, `1`}
+	vBool   = value{"bool", `true`, `true`}
+	vMap    = value{"map", `(sorted-map "n" 1)`, `{"n": 1}`}
+	vYes    = value{"yes", `"yes"`, `"yes"`}
+	vNo     = value{"no", `"no"`, `"no"`}
+)
+
+// mapFlavour is one way of building a sorted-map that reaches a constraint.
+// The three of them exercise the three distinct key/Map behaviours described
+// above; a constraint must not be able to tell them apart.
+type mapFlavour struct {
+	name string
+	// expr builds a sorted-map with key "a" bound to v, plus an unrelated
+	// numeric key "z" so the map is never empty.
+	expr func(v value) string
+	// absent builds the same shape with no "a" key at all.
+	absent string
+}
+
+var mapFlavours = []mapFlavour{
+	{
+		name:   "native-string-keys",
+		expr:   func(v value) string { return `(sorted-map "a" ` + v.elps + ` "z" 0)` },
+		absent: `(sorted-map "z" 0)`,
+	},
+	{
+		// A literal symbol key. The built-in map stores it under the same Str,
+		// so a string lookup must still find it -- this is the half of the
+		// contract that a "just use symbols everywhere instead" fix would
+		// have kept, and it must survive the string decision too.
+		name:   "native-symbol-keys",
+		expr:   func(v value) string { return `(sorted-map 'a ` + v.elps + ` 'z 0)` },
+		absent: `(sorted-map 'z 0)`,
+	},
+	{
+		// The flavour #325 is actually about.
+		name:   "json-decoded",
+		expr:   func(v value) string { return jsonMap(`"a": ` + v.json + `, "z": 0`) },
+		absent: jsonMap(`"z": 0`),
+	},
+}
+
+// jsonMap wraps JSON object body in a json:load-string call, escaping it for
+// the ELPS string literal it lands in.
+func jsonMap(body string) string {
+	return `(json:load-string "{` + strings.ReplaceAll(body, `"`, `\"`) + `}")`
+}
+
+// validates reports whether src validated cleanly, failing the test if it
+// crashed rather than answering.
+func validates(t *testing.T, name, src string) bool {
+	t.Helper()
+	env := newSchemaEnv(t)
+	res := env.LoadStringContext(context.Background(), name, src)
+	if lisp.IsInternalPanic(res) {
+		t.Fatalf("%s panicked: %v\n--- source ---\n%s", name, res, src)
+	}
+	return res.Type != lisp.LError
+}
+
+// TestKeyConstraintsAgreeAcrossMapImplementations is the headline test: every
+// key-taking constraint must give the same answer for the same logical map,
+// whichever implementation is carrying it.
+//
+// Before the fix the may-have-key/json-decoded/present-wrong-type row
+// returned "valid" -- the silent no-op.
+func TestKeyConstraintsAgreeAcrossMapImplementations(t *testing.T) {
+	cases := []struct {
+		name string
+		// def is a constraint expression placed in a sorted-map deftype.
+		def string
+		// at is the value bound to key "a", or nil to omit the key.
+		at    *value
+		valid bool
+	}{
+		// s:has-key -- the constraint that was already right, kept here as
+		// the control the other three are compared against.
+		{"has-key/present-ok", `(s:has-key "a" s:string)`, &vString, true},
+		{"has-key/present-wrong-type", `(s:has-key "a" s:string)`, &vNumber, false},
+		{"has-key/absent", `(s:has-key "a" s:string)`, nil, false},
+
+		// s:may-have-key -- #325.
+		{"may-have-key/present-ok", `(s:may-have-key "a" s:string)`, &vString, true},
+		{"may-have-key/present-wrong-type", `(s:may-have-key "a" s:string)`, &vNumber, false},
+		{"may-have-key/absent", `(s:may-have-key "a" s:string)`, nil, true},
+
+		// s:when reads the value at a key too.
+		{"when/guard-met-check-fails", `(s:when "a" (s:in "yes") "z" (s:gt 100))`, &vYes, false},
+		{"when/guard-met-check-passes", `(s:when "a" (s:in "yes") "z" (s:lt 100))`, &vYes, true},
+		{"when/guard-not-met", `(s:when "a" (s:in "yes") "z" (s:gt 100))`, &vNo, true},
+		{"when/guard-key-absent", `(s:when "a" (s:in "yes") "z" (s:gt 100))`, nil, true},
+
+		// s:no-other-keys consumes the key names the two key constraints
+		// return, so it is downstream of the lookup as well.
+		{"no-other-keys/declared", `(s:no-other-keys (s:may-have-key "a" s:string) (s:may-have-key "z" s:number))`, &vString, true},
+		{"no-other-keys/declared-wrong-type", `(s:no-other-keys (s:may-have-key "a" s:string) (s:may-have-key "z" s:number))`, &vNumber, false},
+		{"no-other-keys/undeclared", `(s:no-other-keys (s:may-have-key "z" s:number))`, &vString, false},
+	}
+
+	for _, f := range mapFlavours {
+		for _, c := range cases {
+			t.Run(f.name+"/"+c.name, func(t *testing.T) {
+				m := f.absent
+				if c.at != nil {
+					m = f.expr(*c.at)
+				}
+				src := `(s:deftype "T" s:sorted-map ` + c.def + `)
+					(s:validate T ` + m + `)`
+				if got := validates(t, c.name, src); got != c.valid {
+					t.Fatalf("expected valid=%v, got %v\n--- source ---\n%s",
+						c.valid, got, src)
+				}
+			})
+		}
+	}
+}
+
+// TestMayHaveKeyAgreesWithHasKeyOnPresence states the invariant directly
+// rather than by enumeration: on a map that HAS the key, may-have-key and
+// has-key must return the same verdict. They may differ only when the key is
+// absent, which is the whole of may-have-key's job.
+//
+// This is the assertion that would have failed for every JSON map before the
+// fix, and it keeps failing if a future change reintroduces the divergence in
+// either direction.
+func TestMayHaveKeyAgreesWithHasKeyOnPresence(t *testing.T) {
+	for _, f := range mapFlavours {
+		for _, v := range []value{vString, vNumber, vBool, vMap} {
+			t.Run(f.name+"/"+v.name, func(t *testing.T) {
+				m := f.expr(v)
+				has := validates(t, "has", `(s:deftype "T" s:sorted-map (s:has-key "a" s:string))
+					(s:validate T `+m+`)`)
+				may := validates(t, "may", `(s:deftype "T" s:sorted-map (s:may-have-key "a" s:string))
+					(s:validate T `+m+`)`)
+				if has != may {
+					t.Fatalf("key is present, so s:has-key and s:may-have-key must agree: "+
+						"has-key valid=%v, may-have-key valid=%v, map %s.\n"+
+						"A may-have-key that passes where has-key fails is looking the key "+
+						"up differently -- see issue #325.", has, may, m)
+				}
+			})
+		}
+	}
+}
+
+// TestMayHaveKeyInversionSites is the B3a check, and it is here because the
+// #320 post-mortem records a libschema hardening fix that turned a loud crash
+// into a SILENTLY PASSING validation. Making may-have-key start returning
+// errors where it previously always succeeded is exactly the kind of change
+// that can invert somewhere downstream, so both inverting consumers are
+// pinned rather than reasoned about.
+//
+// The two sites that do NOT propagate an error from a constraint:
+//
+//   - s:not, which reads an error as "the inner constraint failed, so I pass".
+//   - s:when's guard slot, which reads an error as "the condition is not met,
+//     skip this clause".
+//
+// Neither is a defect introduced here. In both, the error may-have-key now
+// produces is a genuine DOMAIN answer ("the value at this key does not match")
+// and inverting a domain answer is what those combinators are for. That is the
+// distinction #320 B3a turned on: there the inverted error was an
+// INFRASTRUCTURE answer ("this is not a constraint at all"), which is why it
+// is rejected at construction and can never reach an inverting caller.
+//
+// What did change is the outcome for JSON maps, where may-have-key used to be
+// a constant success:
+//
+//	(s:not (s:may-have-key ...))     always FAILED  -> now data-dependent
+//	(s:when k (s:may-have-key ...))  always ran     -> now can skip
+//
+// A schema cannot meaningfully have depended on either, since neither looked
+// at the data, but the new answers are recorded here so the next change to
+// this area has to notice them.
+func TestMayHaveKeyInversionSites(t *testing.T) {
+	cases := []struct {
+		name  string
+		src   string
+		valid bool
+	}{
+		// s:not around may-have-key. The inner constraint is applied to the
+		// map itself.
+		{
+			"not/inner-passes-so-not-fails",
+			`(s:deftype "T" s:sorted-map (s:not (s:may-have-key "a" s:string)))
+			 (s:validate T (json:load-string "{\"a\": \"str\"}"))`,
+			false,
+		},
+		{
+			"not/inner-fails-so-not-passes",
+			`(s:deftype "T" s:sorted-map (s:not (s:may-have-key "a" s:string)))
+			 (s:validate T (json:load-string "{\"a\": 1}"))`,
+			true,
+		},
+		{
+			"not/key-absent-so-inner-passes-so-not-fails",
+			`(s:deftype "T" s:sorted-map (s:not (s:may-have-key "a" s:string)))
+			 (s:validate T (json:load-string "{\"z\": 0}"))`,
+			false,
+		},
+
+		// may-have-key in s:when's guard slot. The guard is applied to the
+		// VALUE at the key, so the value has to be a map itself.
+		{
+			"when-guard/guard-satisfied-clause-runs-and-fails",
+			`(s:deftype "T" s:sorted-map (s:when "sub" (s:may-have-key "a" s:string) "n" (s:gt 100)))
+			 (s:validate T (json:load-string "{\"sub\": {\"a\": \"str\"}, \"n\": 1}"))`,
+			false,
+		},
+		{
+			"when-guard/guard-unsatisfied-clause-skipped",
+			`(s:deftype "T" s:sorted-map (s:when "sub" (s:may-have-key "a" s:string) "n" (s:gt 100)))
+			 (s:validate T (json:load-string "{\"sub\": {\"a\": 1}, \"n\": 1}"))`,
+			true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := validates(t, c.name, c.src); got != c.valid {
+				t.Fatalf("expected valid=%v, got %v\n--- source ---\n%s", c.valid, got, c.src)
+			}
+		})
+	}
+}
+
+// strictKeyMap is a lisp.Map that refuses EVERY key, the way
+// libjson.SortedMap refuses non-string keys: it answers (LError, false).
+//
+// It stands in for a future Map implementation stricter than anything in the
+// tree today. The point is the shape of the answer, not the strictness: it
+// proves may-have-key distinguishes Get's two falses instead of folding
+// "cannot search this map" into "key is absent, so pass" -- the fold that
+// made #325 silent.
+type strictKeyMap struct{}
+
+func (strictKeyMap) Len() int { return 0 }
+
+func (strictKeyMap) Get(k *lisp.LVal) (*lisp.LVal, bool) {
+	return lisp.Errorf("this map cannot be searched by %s keys", lisp.GetType(k)), false
+}
+
+func (strictKeyMap) Set(k, v *lisp.LVal) *lisp.LVal {
+	return lisp.Errorf("this map cannot be searched by %s keys", lisp.GetType(k))
+}
+
+func (strictKeyMap) Del(k *lisp.LVal) *lisp.LVal {
+	return lisp.Errorf("this map cannot be searched by %s keys", lisp.GetType(k))
+}
+
+func (strictKeyMap) Keys() *lisp.LVal { return lisp.QExpr(nil) }
+
+func (strictKeyMap) Entries([]*lisp.LVal) *lisp.LVal { return lisp.Int(0) }
+
+var _ lisp.Map = strictKeyMap{}
+
+// TestMayHaveKeyCannotSilentlyPassOnAnUnsearchableMap closes the CLASS rather
+// than the instance. Swapping Symbol for String fixes libjson today; it does
+// not stop the next Map implementation from rejecting whatever key libschema
+// hands it and putting may-have-key straight back into "always passes".
+func TestMayHaveKeyCannotSilentlyPassOnAnUnsearchableMap(t *testing.T) {
+	env := newSchemaEnv(t)
+	m := lisp.SortedMapFromData(&lisp.MapData{Map: strictKeyMap{}})
+	if rc := env.PutGlobal(lisp.Symbol("hostile"), m); rc.Type == lisp.LError {
+		t.Fatalf("bind: %v", rc)
+	}
+	res := env.LoadStringContext(context.Background(), "hostile",
+		`(s:deftype "T" s:sorted-map (s:may-have-key "a" s:string)) (s:validate T hostile)`)
+	if lisp.IsInternalPanic(res) {
+		t.Fatalf("panicked instead of answering: %v", res)
+	}
+	if res.Type != lisp.LError {
+		t.Fatalf("s:may-have-key PASSED against a map that cannot be searched at all (%v).\n"+
+			"'Get said not-found' and 'Get said it cannot answer' are different, and "+
+			"folding the second into the first is what made issue #325 invisible.", res)
+	}
+
+	// Control: s:has-key on the same map already fails, so the test above is
+	// not merely observing that everything fails on a hostile map.
+	env2 := newSchemaEnv(t)
+	if rc := env2.PutGlobal(lisp.Symbol("hostile"),
+		lisp.SortedMapFromData(&lisp.MapData{Map: strictKeyMap{}})); rc.Type == lisp.LError {
+		t.Fatalf("bind: %v", rc)
+	}
+	if res := env2.LoadStringContext(context.Background(), "hostile-has",
+		`(s:deftype "T" s:sorted-map (s:has-key "a" s:string)) (s:validate T hostile)`); res.Type != lisp.LError {
+		t.Fatalf("s:has-key unexpectedly passed on an unsearchable map: %v", res)
+	}
+}
+
+// mapLookupRe matches a lisp.Map lookup. env.Get is an ENVIRONMENT lookup and
+// is excluded by envLookupRe below; every other .Get( in libschema.go reaches
+// a lisp.Map.
+var (
+	mapLookupRe = regexp.MustCompile(`\.Get\(|\bMapGet\(`)
+	envLookupRe = regexp.MustCompile(`\benv\.Get\(`)
+	keyedRe     = regexp.MustCompile(`\.Get\(schemaKey\(`)
+)
+
+// TestSchemaKeysAreLookedUpAsStrings is the drift guard.
+//
+// #325 was one call site out of four disagreeing with the other three about
+// the LVal type of a map key -- a difference invisible on the built-in map
+// and fatal on a strict one, so neither review nor fuzzing caught it. Fixing
+// the one site leaves the class wide open: the next person to add a key-taking
+// constraint has no reason to know the key type is load-bearing.
+//
+// Every map lookup therefore goes through schemaKey, and this test fails if
+// one does not. MapGet is banned outright because its *LVal overload takes
+// whatever key LVal it is handed.
+func TestSchemaKeysAreLookedUpAsStrings(t *testing.T) {
+	src, err := os.ReadFile("libschema.go")
+	if err != nil {
+		t.Fatalf("read libschema.go: %v", err)
+	}
+	var offenders []string
+	lookups := 0
+	for i, line := range strings.Split(string(src), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") {
+			continue // a doc comment naming Get is not a call site
+		}
+		if !mapLookupRe.MatchString(line) || envLookupRe.MatchString(line) {
+			continue
+		}
+		lookups++
+		if !keyedRe.MatchString(line) {
+			offenders = append(offenders, "libschema.go:"+strconv.Itoa(i+1)+": "+trimmed)
+		}
+	}
+	if lookups == 0 {
+		t.Fatal("found no sorted-map lookups in libschema.go at all -- this guard has " +
+			"gone vacuous, which means it is no longer guarding anything")
+	}
+	if len(offenders) != 0 {
+		t.Fatalf("sorted-map lookups that do not go through schemaKey:\n  %s\n\n"+
+			"lisp.Map implementations disagree about key types: the built-in "+
+			"sortedmap accepts LString and LSymbol interchangeably, libjson.SortedMap "+
+			"accepts only LString and answers (LError, false) for anything else. A "+
+			"lookup with the wrong key type therefore reports 'not found' instead of "+
+			"failing, and in s:may-have-key that read as 'absent, so pass' -- a "+
+			"validator that silently approved everything. See issue #325.",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/lisp/lisplib/libschema/libschema.go
+++ b/lisp/lisplib/libschema/libschema.go
@@ -172,7 +172,8 @@ var builtins = []*libutil.Builtin{
 		`Returns a constraint for sorted-maps that checks if the key
 		exists, and if so, validates its value matches one of the
 		allowed types. If the key is absent, validation passes.
-		Returns the key name on success (used by no-other-keys).`),
+		key is a string, matching has-key. Returns the key name on
+		success (used by no-other-keys).`),
 	libutil.FunctionDoc("no-other-keys", lisp.Formals("&rest", "constraints"), builtinNoOtherKeys,
 		`Returns a constraint for sorted-maps that rejects maps with
 		keys not declared by the given has-key or may-have-key
@@ -850,6 +851,34 @@ func builtinCheckNumber(env *lisp.LEnv, name string, constraints []*lisp.LVal) *
 	})
 }
 
+// schemaKey is the ONE place a schema key string is turned into the LVal used
+// to look it up in a sorted-map.  Every `.Get(` in this file goes through it,
+// and TestSchemaKeysAreLookedUpAsStrings fails if a raw key LVal ever appears
+// at a lookup again.
+//
+// THE KEY'S LVAL TYPE IS PART OF THE LOOKUP, NOT A LABEL ON IT.  lisp.Map is
+// an interface with more than one implementation and they do NOT agree:
+//
+//   - the built-in sortedmap (lisp/maps.go) keys on LVal.Str for both LString
+//     and LSymbol, so there a string lookup and a symbol lookup are the same
+//     lookup -- and a string lookup also finds a symbol-keyed entry; but
+//   - libjson.SortedMap -- what json:load-string returns -- REJECTS any key
+//     whose Type is not LString, returning (LError, false).
+//
+// s:may-have-key looked its key up as lisp.Symbol(key) while s:has-key,
+// s:when and s:no-other-keys all used strings.  On a JSON-decoded map that
+// made Get return "not found" unconditionally, and may-have-key's "key is
+// absent, so pass" branch swallowed it: the constraint was a silent no-op on
+// exactly the maps it is most often written for.  Wrong answer, not a crash,
+// so no fuzz target could see it.  See issue #325.
+//
+// STRING IS CANONICAL: it is what the other three constraints already used,
+// it is the only key type a strict Map accepts, and it loses nothing on the
+// built-in map where it matches symbol-keyed entries too.
+func schemaKey(key string) *lisp.LVal {
+	return lisp.String(key)
+}
+
 // Checks sorted-map has specified key and its type and constraints
 func builtinHasKey(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	key, ok := lisp.GoString(args.Cells[0])
@@ -871,7 +900,11 @@ func builtinHasKey(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 			return lisp.ErrorConditionf(WrongType, "Input is not sorted map")
 		}
 		matched := false
-		val, ok := input.Map().Get(lisp.String(key))
+		// The !ok branch here is already the LOUD one: a map that cannot be
+		// searched for this key and a map that simply lacks it both fail.
+		// s:may-have-key's equivalent branch PASSES, which is why it needs the
+		// extra distinction the sibling below draws.
+		val, ok := input.Map().Get(schemaKey(key))
 		if !ok {
 			return lisp.ErrorConditionf(FailedConstraint, "Map does not have key %s", key)
 		}
@@ -909,8 +942,20 @@ func builtinMayHaveKey(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 			return lisp.ErrorConditionf(WrongType, "Input is not sorted map")
 		}
 		matched := false
-		val, ok := input.Map().Get(lisp.Symbol(key))
+		val, ok := input.Map().Get(schemaKey(key))
 		if !ok {
+			// Get signals two different things through the same false: "no
+			// such key" (val is nil-ish) and "this map cannot hold a key of
+			// that type at all" (val is an LError).  Only the first means
+			// absent.  Treating the second as absent is precisely how #325
+			// hid -- the constraint passed on every input it was given.  No
+			// in-tree Map reaches this branch now that the key is always an
+			// LString; it is here so a future strict Map implementation
+			// cannot silently reproduce the same no-op.
+			if val != nil && val.Type == lisp.LError {
+				return lisp.ErrorConditionf(WrongType,
+					"Map cannot be searched for key %s: %v", key, val)
+			}
 			return lisp.String(key)
 		}
 		for _, compare := range compares {
@@ -979,10 +1024,18 @@ func builtinNoOtherKeys(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 // that quietly approves invalid data is worse.  Rejecting at construction, the
 // way s:not does, is the only placement where the inversion cannot bite.
 func builtinWhen(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
-	if _, ok := lisp.GoString(args.Cells[0]); !ok {
+	// Both keys are captured as Go strings at CONSTRUCTION and re-minted
+	// through schemaKey at application, rather than the argument LVals being
+	// handed to Get directly.  Behaviour is unchanged -- GoString only
+	// succeeds for an LString, so these were already string lookups -- but it
+	// puts s:when under the same single funnel as its siblings, which is what
+	// makes the drift guard able to see every lookup in the file.  See #325.
+	whenKey, ok := lisp.GoString(args.Cells[0])
+	if !ok {
 		return lisp.ErrorConditionf(FailedConstraint, "You must specify a key")
 	}
-	if _, ok := lisp.GoString(args.Cells[2]); !ok {
+	matchKey, ok := lisp.GoString(args.Cells[2])
+	if !ok {
 		return lisp.ErrorConditionf(FailedConstraint, "You must specify a match key")
 	}
 	whenConstraint := getHandler(env, args.Cells[1], "x", []*lisp.LVal{})
@@ -1010,8 +1063,8 @@ func builtinWhen(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 			return lisp.ErrorConditionf(WrongType, "Input is not sorted map")
 		}
 		lMap := input.Map()
-		whenVal, _ := lMap.Get(args.Cells[0])
-		testVal, _ := lMap.Get(args.Cells[2])
+		whenVal, _ := lMap.Get(schemaKey(whenKey))
+		testVal, _ := lMap.Get(schemaKey(matchKey))
 		val := applyConstraint(env, whenConstraint, whenVal)
 		if val.Type == lisp.LError {
 			// Guard not satisfied: this clause does not apply. Safe only

--- a/lisp/lisplib/libschema/libschema_test.lisp
+++ b/lisp/lisplib/libschema/libschema_test.lisp
@@ -224,3 +224,39 @@
                           (s:validate v (new mynil))))
   (assert-equal "ERROR" (handler-bind (('wrong-type (lambda (&rest _e) "ERROR")))
                           (s:validate v "a"))))
+
+; Issue #325.  s:may-have-key looked its key up as a symbol while s:has-key
+; looked the same key up as a string.  lisp.Map is an interface: the built-in
+; sorted-map keys on the string value either way, so the asymmetry is
+; invisible here, but the map json:load-string returns rejects a non-string
+; key outright -- so may-have-key never found anything and silently passed
+; whatever it was given.  The key type is now string everywhere.
+(test "may-have-key-key-type"
+  (s:deftype "optstr" s:sorted-map (s:may-have-key "a" s:string))
+
+  ; string-keyed literal map
+  (assert-nil (s:validate optstr (sorted-map "a" "str")))
+  (assert-nil (s:validate optstr (sorted-map "z" 0)))
+  (assert-equal "ERROR" (handler-bind (('wrong-type (lambda (&rest _e) "ERROR")))
+                          (s:validate optstr (sorted-map "a" 1))))
+
+  ; symbol-keyed literal map -- a string lookup must still match it
+  (assert-nil (s:validate optstr (sorted-map 'a "str")))
+  (assert-nil (s:validate optstr (sorted-map 'z 0)))
+  (assert-equal "ERROR" (handler-bind (('wrong-type (lambda (&rest _e) "ERROR")))
+                          (s:validate optstr (sorted-map 'a 1))))
+
+  ; json-decoded map -- the case that silently passed before the fix
+  (assert-nil (s:validate optstr (json:load-string "{\"a\": \"str\"}")))
+  (assert-nil (s:validate optstr (json:load-string "{\"z\": 0}")))
+  (assert-equal "ERROR" (handler-bind (('wrong-type (lambda (&rest _e) "ERROR")))
+                          (s:validate optstr (json:load-string "{\"a\": 1}"))))
+
+  ; s:has-key must give the same verdict whenever the key is present
+  (s:deftype "reqstr" s:sorted-map (s:has-key "a" s:string))
+  (assert-nil (s:validate reqstr (sorted-map "a" "str")))
+  (assert-nil (s:validate reqstr (sorted-map 'a "str")))
+  (assert-nil (s:validate reqstr (json:load-string "{\"a\": \"str\"}")))
+  (assert-equal "ERROR" (handler-bind (('wrong-type (lambda (&rest _e) "ERROR")))
+                          (s:validate reqstr (json:load-string "{\"a\": 1}"))))
+  )


### PR DESCRIPTION
Closes #325.

`s:may-have-key` called `input.Map().Get(lisp.Symbol(key))` while `s:has-key` looked the same key up as a string.

## Why the key's LVal type is load-bearing (and a correction to the report)

`lisp.Map` is an **interface**, and its two implementations disagree:

| implementation | key handling |
|---|---|
| `lisp/maps.go` `sortedmap` — what `(sorted-map ...)` builds | keys on `LVal.Str` for **both** `LString` and `LSymbol`, so a symbol lookup and a string lookup are the *same* lookup, and either finds an entry stored under the other |
| `libjson.SortedMap` — what `json:load-string` returns | **rejects** any key whose `Type` is not `LString`, answering `(LError, false)` |

`may-have-key` read that `false` as "the key is absent" and passed.

**Correction to the issue text:** `(sorted-map "a" 1)` was *never* affected — the built-in map normalises string and symbol keys, so the asymmetry is invisible there. Verified empirically before changing anything. The bug is real but its blast radius is **JSON-derived maps** (and any future strict `lisp.Map`), where `s:may-have-key` was a **total no-op**: an optional key holding a wrong-typed value validated clean.

```lisp
(s:deftype "T" s:sorted-map (s:may-have-key "a" s:string))
(s:validate T (json:load-string "{\"a\": 1}"))
;; before: ()  -- PASSES, though "a" is a number
;; after:  [wrong-type] Key a was of wrong type
```

## 1. Full audit of key-taking constraints

Every constraint in `libschema.go` that reaches a sorted-map by key. This is the audit item 1 of the issue asked for — `may-have-key` is the **only** one that disagreed.

| constraint | lookup, before | verdict |
|---|---|---|
| `s:has-key` | `Get(lisp.String(key))` | correct |
| `s:may-have-key` | `Get(lisp.Symbol(key))` | **the bug** |
| `s:when` (guard key + match key) | `Get(args.Cells[0])` / `Get(args.Cells[2])` — raw arg LVals, but both already proven `LString` by `lisp.GoString` at construction | correct, though it reached `Get` by a different route |
| `s:no-other-keys` | no lookup: iterates `Map().Keys()` and compares `mapKey.Str`, accepting `LString` and `LSymbol` map keys | correct, consistent with string-equality semantics |

Confirmed by running all four against all three map flavours before the change; only the `may-have-key` × JSON rows were wrong.

## 2. The decision: string is canonical

String, for three independent reasons — it is what the other three constraints already used; it is the only key type a *strict* `Map` accepts; and it loses nothing on the built-in map, where a string lookup matches symbol-keyed entries too (so `(s:may-have-key "a" ...)` still matches `(sorted-map 'a ...)`).

Every lookup now goes through a single `schemaKey(string) *lisp.LVal` funnel — the same one-chokepoint shape as the existing `applyConstraint`. `s:when` moves onto the funnel with **no behaviour change** (its keys were already `LString`); that is purely so the drift guard can see every lookup in the file.

`may-have-key` additionally distinguishes `Get`'s two different `false`s — "no such key" (pass) from "this map cannot hold a key of that type at all" (error). That branch is **unreachable for every in-tree `Map`** now the key is always an `LString`; it exists so a future strict implementation cannot silently reproduce the same no-op. Closing the class, not the instance.

## 3. Tests

`lisp/lisplib/libschema/key_lookup_test.go` (new, 56 subtests) + an ELPS-level case in `libschema_test.lisp`:

- **`TestKeyConstraintsAgreeAcrossMapImplementations`** — all four key-taking constraints × three map flavours (native string keys, native symbol keys, `json:load-string`) × present-ok / present-wrong-type / absent. Both key styles the issue asked for, plus the one that actually broke.
- **`TestMayHaveKeyAgreesWithHasKeyOnPresence`** — states the invariant rather than enumerating it: when the key *is* present, `has-key` and `may-have-key` must return the same verdict. They may differ only on absence.
- **`TestMayHaveKeyInversionSites`** — the B3a check, below.
- **`TestMayHaveKeyCannotSilentlyPassOnAnUnsearchableMap`** — a custom strict `lisp.Map` proves the unreachable branch is loud, with a `s:has-key` control so the test is not merely observing that everything fails.
- **`TestSchemaKeysAreLookedUpAsStrings`** — drift guard: every sorted-map lookup in `libschema.go` must go through `schemaKey`, `MapGet` is banned outright, and it self-fails if it ever finds zero lookups (so it cannot go vacuously green).

## 4. Substrate grep

**Nothing depends on the old behaviour. Substrate does not use libschema at all.**

- `grep -rn "may-have-key" --include=*.lisp` → **0 hits**
- `grep -rn "libschema|has-key" --include=*.go --include=*.lisp` → **0 hits**
- `grep -rln "s:deftype|s:make-validator|s:validate" --include=*.lisp` → **0 files**

The only apparent `s:when` hits were the substring `utils:when` in two `testfixtures/shiro.lisp` files. A sweep of every other checkout on the machine found `may-have-key` only inside elps itself. No validation that passes today starts failing.

## 5. B3a inversion check (#320 section B3a)

The hazard: making a constraint start returning errors where it previously always succeeded can *invert* somewhere downstream, turning a failing validation into a silently passing one. That is exactly what B3a was.

Two sites in `libschema.go` do not propagate an error from a constraint:

- **`s:not`** — reads an error as "the inner constraint failed, so I pass".
- **`s:when`'s guard slot** — reads an error as "the condition is not met, skip this clause".

**Neither can be inverted dangerously by this change, and the reason is the same distinction B3a turned on.** In B3a the inverted error was an *infrastructure* answer ("this is not a constraint at all") being misread as a *domain* answer — which is why the guard is rejected at construction and can never reach an inverting caller. The errors `may-have-key` now produces are genuine **domain** answers ("the value at this key does not match"), and inverting a domain answer is precisely what those two combinators are for. The construction-time rejection stays untouched; no new infrastructure error is introduced on any application-time path.

What *does* change, for JSON maps only, is that two previously-constant expressions become data-dependent:

```
(s:not (s:may-have-key ...))       always FAILED (regardless of data)  -> now data-dependent
(s:when k (s:may-have-key ...) …)  guard always satisfied, clause ran  -> can now skip
```

No schema can meaningfully have depended on either, since neither consulted the data. Both are now **pinned in both directions** by `TestMayHaveKeyInversionSites` rather than argued about, including the "guard unsatisfied → clause skipped" row, which is the one shaped like B3a.

The other three consumers move in the safe direction: `s:no-other-keys` propagates the error (pass→fail, loud), and `s:has-key` / `s:of` treat it as "this alternative did not match" and report wrong-type (pass→fail, loud).

## 6. Mutation verification

Four mutations, each applied, run, and reverted. Every test was watched failing.

| # | mutation | result |
|---|---|---|
| 1 | `may-have-key` lookup back to `lisp.Symbol(key)` | **5 test funcs FAIL**, including the drift guard, which names the exact line: `libschema.go:945: val, ok := input.Map().Get(lisp.Symbol(key))` |
| 2 | exact pre-fix code (symbol lookup **and** no strict-map branch) | **6 test funcs FAIL** — including the headline silent-wrong-answer row: `json-decoded/may-have-key/present-wrong-type: expected valid=false, got true`, and `key is present, so s:has-key and s:may-have-key must agree: has-key valid=false, may-have-key valid=true` |
| 3 | strict-map distinction removed, string lookup kept | **exactly 1 FAIL**, `TestMayHaveKeyCannotSilentlyPassOnAnUnsearchableMap`: *"s:may-have-key PASSED against a map that cannot be searched at all"* — the hardening is independently earned |
| 4 | `s:when` off the funnel (behaviour-identical) | **exactly 1 FAIL**, the drift guard, naming both `s:when` lookups — proving it covers them and that no behavioural test is silently doing the guard's job |

Mutations 1 and 2 differ instructively: under 1 the *present-ok* row fails instead of *present-wrong-type*, because the strict-map hardening converts the regressed no-op into a loud error rather than letting it pass. Belt and braces working as intended.

## Verification

All six steps of `/verify` green: `go build ./...`, `make test` (+ `go test ./...`), `golangci-lint run ./...` (0 issues), `./elps fmt -l ./...` (clean), `./elps lint --workspace=. --exclude grammar --include _examples ./...`, `./elps doc -m`.

## Judgement calls worth a reviewer's eye

1. **String over symbol.** Symbol would have required changing three constraints instead of one and would break `json:load-string` maps outright. Recorded here in case anyone prefers the other direction.
2. **The strict-`Map` branch is dead code today.** Deliberate: it is the poka-yoke for the class rather than the instance, it is unreachable for every in-tree `Map` (so zero behaviour change for existing users), and it is covered by a real test via a custom `lisp.Map`.
3. **`s:has-key`'s equivalent branch was left alone.** Its `!ok` path already fails loudly, so folding the distinction in would only change an unreachable error's condition type from `failed-constraint` to `wrong-type` — churn without benefit.
4. **`s:when` was touched despite being correct.** Zero behaviour change; it buys the drift guard complete coverage of the file. Mutation 4 is the evidence that this is the *only* thing it buys.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_