### PR TITLE
Fix data race: lambdaVars wrote to the shared singletonNil

### DIFF
--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -1298,11 +1298,31 @@ func bodyStr(exprs []*LVal) string {
 	return buf.String()
 }
 
+// lambdaVars renders a function's formals and closure bindings as a
+// single unquoted list, for (*LVal).str.
+//
+// builtinConcat does NOT always hand back a freshly allocated list --
+// the comment that used to sit on the unquote here claimed it did, and
+// that was the bug in issue #333. builtinConcatSeq short-circuits the
+// empty case with `return Nil()`, so a function with no formals AND no
+// bound vars made this write `Quoted = false` straight into the
+// process-wide singletonNil. It stored the value the field already
+// held, which made it invisible to SingletonSnapshot.Verify (see the
+// note on checkSingleton), but it was still a write to shared memory
+// and raced with every concurrent (*LEnv).eval reading `v.Quoted` off a
+// Nil().
+//
+// shallowUnquote copies before clearing Quoted, so lambdaVars mutates
+// only a value it owns. It copies unconditionally rather than only when
+// builtinConcat happens to share, which makes the contract the simple
+// one -- lambdaVars returns a value the caller owns -- instead of the
+// fragile one, "the result is usually fresh, but don't write to it."
+// That contract is checkable without the race detector; see
+// TestLambdaVarsDoesNotReturnSingleton. The extra LVal is noise next to
+// the fmt.Sprintf this feeds, and only printing a function reaches it.
 func lambdaVars(formals *LVal, bound *LVal) *LVal {
 	s := SExpr([]*LVal{Quote(Symbol("list")), formals, bound})
-	s = builtinConcat(nil, s)
-	s.Quoted = false // This is fine because builtinConcat returns a new list
-	return s
+	return shallowUnquote(builtinConcat(nil, s))
 }
 
 func boundVars(v *LVal) *LVal {

--- a/lisp/main_test.go
+++ b/lisp/main_test.go
@@ -8,14 +8,24 @@ import (
 	"testing"
 )
 
-// TestMain wraps the package test suite to detect inadvertent mutations
-// of the shared singleton LVals (singletonNil, singletonTrue,
-// singletonFalse). Any test that corrupts a singleton — directly or via
-// a tree-walker that fails to guard against them — will fail the suite
-// even if the offending test itself passed. See issue #274.
+// TestMain wraps the package test suite with two complementary
+// singleton guards.
+//
+// The snapshot check detects a singleton whose *value* differs at the
+// end of the run from the start — a tree-walker that failed to guard
+// against them, say. See issue #274.
+//
+// The write watchdog covers what the snapshot structurally cannot: a
+// write that stores the value the field already held. Issue #333 was
+// one of those, and only `-race` ever saw it, and only when two
+// goroutines happened to collide. The watchdog makes any unsynchronized
+// write to a singleton race deterministically under `make race`. See
+// singleton_watchdog_test.go for its scope and limits.
 func TestMain(m *testing.M) {
 	snap := TakeSingletonSnapshot()
+	stopWatchdog := startSingletonWriteWatchdog()
 	code := m.Run()
+	stopWatchdog()
 	if drift := snap.Verify(); drift != "" {
 		fmt.Fprintf(os.Stderr,
 			"FATAL: singleton %s was mutated during test run\n  Nil=%+v\n  True=%+v\n  False=%+v\n",

--- a/lisp/singleton.go
+++ b/lisp/singleton.go
@@ -77,6 +77,13 @@ func TakeSingletonSnapshot() SingletonSnapshot {
 // Verify compares the current singleton state to the snapshot. If any
 // singleton has drifted it returns the name of the offender; otherwise
 // it returns the empty string.
+//
+// Verify detects drift in VALUES. A write that stores the value a field
+// already holds leaves no drift and Verify reports nothing, even though
+// such a write still races with every concurrent reader — that was issue
+// #333. Do not read an empty return as "no code mutated a singleton".
+// See the "What this does NOT catch" section on checkSingleton in
+// singleton_check_elpscheck.go for what covers that case.
 func (s SingletonSnapshot) Verify() string {
 	if !singletonLValEqual(&s.nilV, singletonNil) {
 		return "Nil()"

--- a/lisp/singleton_check_default.go
+++ b/lisp/singleton_check_default.go
@@ -7,5 +7,10 @@ package lisp
 // checkSingleton is a zero-cost no-op in production builds. In the
 // elpscheck build (//go:build elpscheck) it verifies that the three
 // singleton LVals are bit-identical to their init-time snapshot and
-// panics if any has drifted. See singleton_check_elpscheck.go.
+// panics if any has drifted.
+//
+// It compares values, so it cannot see a write that stores the value a
+// field already holds — the shape of issue #333. See the "What this does
+// NOT catch" section on the elpscheck implementation in
+// singleton_check_elpscheck.go before relying on this guard.
 func checkSingleton(_ *LVal) {}

--- a/lisp/singleton_check_elpscheck.go
+++ b/lisp/singleton_check_elpscheck.go
@@ -24,6 +24,49 @@ func init() {
 //
 // Cost: three struct-field compares per call. Only enabled under the
 // `elpscheck` build tag.
+//
+// # What this does NOT catch
+//
+// This is a value-drift detector, not a write detector. It compares
+// field values against the snapshot, so a write that stores the value a
+// field ALREADY HOLDS is invisible to it — and so is the same write in
+// SingletonSnapshot.Verify, which shares the comparison.
+//
+// That gap is not theoretical. Issue #333 was `s.Quoted = false`
+// executed against singletonNil, whose Quoted was already false:
+//
+//	s = builtinConcat(nil, s) // returns Nil() when the result is empty
+//	s.Quoted = false
+//
+// A same-value write is still a write to shared memory, and it still
+// races with every concurrent reader — in #333, with `if v.Quoted` in
+// (*LEnv).eval. Neither this function nor the "Singleton integrity
+// (elpscheck)" CI job could ever have seen it, no matter how often they
+// ran. Only `go test -race` did, and only on a loaded runner where two
+// goroutines happened to overlap.
+//
+// Closing the gap here is not possible cheaply. A bool field has no
+// spare bit patterns to poison, so there is no value we could store that
+// a same-value write would disturb, and detecting the write itself needs
+// either memory protection (mmap + mprotect: unsafe, platform-specific,
+// and it breaks the tests that mutate singletons on purpose) or the race
+// detector.
+//
+// So the coverage is split, and you should know which guard covers what:
+//
+//   - value drift, any build, cheap: this function + Verify.
+//   - unsynchronized writes including same-value ones: `make race`, plus
+//     the write watchdog in lisp/singleton_watchdog_test.go, which keeps
+//     an unsynchronized read of all three singletons live for the whole
+//     package test run so such a write races deterministically instead
+//     of only when goroutines collide by luck.
+//   - a specific helper handing a singleton out to a caller that will
+//     mutate it: an identity assertion in a plain test, e.g.
+//     TestLambdaVarsDoesNotReturnSingleton.
+//
+// If you are adding a mutation guard, prefer removing the mutation. The
+// codebase's copy-on-write helpers (Quote, Splice, shallowUnquote) exist
+// so that no caller has to reason about whether a value is shared.
 func checkSingleton(_ *LVal) {
 	if drift := initSnapshot.Verify(); drift != "" {
 		panic(fmt.Sprintf("singleton corruption detected: %s mutated\n  current Nil=%+v\n  current True=%+v\n  current False=%+v",

--- a/lisp/singleton_check_elpscheck_test.go
+++ b/lisp/singleton_check_elpscheck_test.go
@@ -19,6 +19,11 @@ import (
 // panic. The test restores the singleton before returning so it does
 // not poison the rest of the suite (TestMain would otherwise fail).
 func TestCheckSingleton_DetectsCorruption(t *testing.T) {
+	// Deliberate singleton mutation — pause the write watchdog so it is
+	// not reported as a data race under -race. See
+	// singleton_watchdog_test.go.
+	defer pauseSingletonWatchdog()()
+
 	orig := singletonTrue.Source
 	defer func() {
 		singletonTrue.Source = orig

--- a/lisp/singleton_race_lambdavars_test.go
+++ b/lisp/singleton_race_lambdavars_test.go
@@ -1,0 +1,138 @@
+// Copyright © 2026 The ELPS authors
+
+// Singleton mutation regression test for issue #333.
+//
+// Pre-fix, lambdaVars (lisp.go) did:
+//
+//	s := SExpr([]*LVal{Quote(Symbol("list")), formals, bound})
+//	s = builtinConcat(nil, s)
+//	s.Quoted = false // This is fine because builtinConcat returns a new list
+//
+// The comment was wrong. builtinConcatSeq short-circuits the empty case
+// with `return Nil()` -- the process-wide shared singleton. So printing
+// any lambda with no formals AND no bound vars wrote straight into
+// singletonNil, racing with every concurrent (*LEnv).eval reading
+// `v.Quoted` off a Nil().
+//
+// The write stored the value the field already held, so it was
+// invisible to SingletonSnapshot.Verify() / the elpscheck build, which
+// compare values rather than observing writes. Only -race caught it.
+//
+// Two tests here:
+//
+//   - TestLambdaVarsDoesNotReturnSingleton is deterministic and needs no
+//     -race: it asserts the identity invariant directly.
+//   - TestSingletonRaceLambdaVars drives the real production path
+//     ((*LVal).String() on a zero-formal lambda) against concurrent
+//     evaluation. Run with `go test -race` to observe the failure
+//     pre-fix.
+
+package lisp
+
+import (
+	"sync"
+	"testing"
+)
+
+// zeroArgLambda builds a `(lambda () 1)` -- no formals, and a fresh
+// closure scope with no bound vars. Its printed representation is the
+// path that reached the offending write.
+func zeroArgLambda(t *testing.T) (*LEnv, *LVal) {
+	t.Helper()
+	env := NewEnv(nil)
+	if rc := InitializeUserEnv(env); rc.Type == LError {
+		t.Fatalf("InitializeUserEnv: %v", rc)
+	}
+	fn := env.Lambda(QExpr(nil), []*LVal{Int(1)})
+	if fn.Type == LError {
+		t.Fatalf("Lambda: %v", fn)
+	}
+	return env, fn
+}
+
+// TestLambdaVarsDoesNotReturnSingleton pins the identity invariant that
+// makes the mutation safe. lambdaVars writes to the value it returns, so
+// that value must never be one of the shared singletons -- regardless of
+// what builtinConcat decides to hand back for the empty case.
+func TestLambdaVarsDoesNotReturnSingleton(t *testing.T) {
+	_, fn := zeroArgLambda(t)
+
+	vars := lambdaVars(fn.Cells[0], boundVars(fn))
+	if isSingleton(vars) {
+		t.Fatalf("lambdaVars returned a shared singleton (%v); mutating it races with every concurrent reader", vars.Type)
+	}
+	if vars.Len() != 0 {
+		t.Errorf("lambdaVars returned %d cells, want 0", vars.Len())
+	}
+	if got, want := fn.String(), "(lambda () 1)"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+// TestSingletonRaceLambdaVars reproduces issue #333 under `go test
+// -race`: printers stringify a zero-formal lambda (write side, via
+// lambdaVars) while evaluators evaluate Nil() (read side, `if v.Quoted`
+// in (*LEnv).eval). Pre-fix both touch singletonNil and the race
+// detector fires.
+//
+// Each goroutine owns its LEnv -- LEnv is not safe for concurrent use.
+// The race is on the process-wide singleton, not on any env.
+func TestSingletonRaceLambdaVars(t *testing.T) {
+	const (
+		printers   = 4
+		evaluators = 4
+		iterations = 3000
+	)
+
+	lambdas := make([]*LVal, printers)
+	for i := range lambdas {
+		_, lambdas[i] = zeroArgLambda(t)
+	}
+	evalEnvs := make([]*LEnv, evaluators)
+	for i := range evalEnvs {
+		evalEnvs[i], _ = zeroArgLambda(t)
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	wg.Add(printers)
+	for i := range printers {
+		go func(fn *LVal) {
+			defer wg.Done()
+			<-start
+			for range iterations {
+				// Write side: str() -> lambdaVars -> builtinConcat
+				// returns Nil() for the empty case -> `s.Quoted = false`.
+				_ = fn.String()
+			}
+		}(lambdas[i])
+	}
+
+	wg.Add(evaluators)
+	for i := range evaluators {
+		go func(env *LEnv) {
+			defer wg.Done()
+			<-start
+			for range iterations {
+				// Read side: (*LEnv).eval reads `v.Quoted` off the
+				// same singletonNil.
+				env.Eval(Nil())
+			}
+		}(evalEnvs[i])
+	}
+
+	close(start)
+	wg.Wait()
+
+	// Belt and braces: the singleton must still be pristine. This
+	// cannot catch the same-value write that started #333 (see the
+	// comment on checkSingleton), but it catches any future variant
+	// that writes a *different* value.
+	if singletonNil.Quoted {
+		t.Error("singletonNil.Quoted was set by concurrent lambda printing")
+	}
+	if singletonNil.Len() != 0 {
+		t.Errorf("singletonNil grew to %d cells", singletonNil.Len())
+	}
+}

--- a/lisp/singleton_test.go
+++ b/lisp/singleton_test.go
@@ -37,6 +37,11 @@ func TestAssertNotSingleton_AllowsNonSingleton(t *testing.T) {
 }
 
 func TestSingletonSnapshot_DetectsMutation(t *testing.T) {
+	// This test writes to a singleton on purpose. Pause the write
+	// watchdog so the deliberate mutation is ordered against its reads
+	// and does not show up as a data race under `make race`.
+	defer pauseSingletonWatchdog()()
+
 	// Save originals so we can restore after the test — TestMain
 	// snapshot will verify singletons are intact at suite end.
 	origSource := singletonTrue.Source

--- a/lisp/singleton_watchdog_test.go
+++ b/lisp/singleton_watchdog_test.go
@@ -1,0 +1,96 @@
+// Copyright © 2025 The ELPS authors
+
+package lisp
+
+import (
+	"sync"
+	"time"
+)
+
+// The singleton write watchdog closes the blind spot described on
+// checkSingleton: SingletonSnapshot.Verify compares *values*, so a write
+// that stores the value a field already holds is invisible to it. That
+// is not a hypothetical -- issue #333 was exactly that write
+// (`s.Quoted = false` into singletonNil, whose Quoted was already
+// false), and the only thing that ever caught it was `go test -race` on
+// a loaded CI runner where two goroutines happened to overlap.
+//
+// The watchdog removes the "happened to overlap" part. It runs for the
+// lifetime of the package test binary and periodically reads all three
+// singletons without synchronizing against anything else. Under -race
+// that read sits in the race detector's shadow memory, so ANY
+// unsynchronized write to a singleton -- from a single-goroutine test,
+// storing any value, same or different -- is reported as a data race
+// with a stack trace naming the offending line.
+//
+// Scope and limits, so nobody over-trusts this either:
+//
+//   - It only has teeth under -race (`make race`). Without -race the
+//     goroutine is a no-op that burns a few microseconds.
+//   - It only watches package lisp's test binary. Writes originating in
+//     other packages' tests are not covered; the singletons and every
+//     historical offender (macro.go #274, lisp.go #333) live here.
+//   - It detects unsynchronized writes, not writes as such. A write made
+//     while holding singletonWatchdogMu is ordered against the watchdog
+//     and stays silent -- which is what pauseSingletonWatchdog is for.
+
+// singletonWatchdogInterval is how often the watchdog re-reads the
+// singletons. It does not need to be tight: the race detector reports on
+// happens-before, not wall-clock overlap, so a read from a moment ago is
+// still in shadow memory and still races with a later unsynchronized
+// write. Only the watchdog and a would-be offender ever touch these
+// words, so nothing else evicts the read.
+const singletonWatchdogInterval = 200 * time.Microsecond
+
+// singletonWatchdogMu orders the watchdog's reads against the handful of
+// tests that mutate a singleton on purpose to prove the value-drift
+// guard works. Deliberate mutators take it via pauseSingletonWatchdog;
+// nothing else does, so an accidental write anywhere else stays
+// unordered and gets reported.
+var singletonWatchdogMu sync.Mutex
+
+// singletonWatchdogSink receives the watchdog's loads so the compiler
+// cannot elide them. Only the watchdog goroutine writes it.
+var singletonWatchdogSink SingletonSnapshot
+
+// startSingletonWriteWatchdog launches the watchdog and returns a
+// function that stops it and waits for it to exit.
+func startSingletonWriteWatchdog() (stop func()) {
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		tick := time.NewTicker(singletonWatchdogInterval)
+		defer tick.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-tick.C:
+			}
+			singletonWatchdogMu.Lock()
+			// A whole-struct copy reads every field, including the
+			// Cells slice header -- no field can be added to LVal and
+			// silently fall outside the watch.
+			singletonWatchdogSink = TakeSingletonSnapshot()
+			singletonWatchdogMu.Unlock()
+		}
+	}()
+	return func() {
+		close(done)
+		<-stopped
+	}
+}
+
+// pauseSingletonWatchdog blocks the watchdog so a test can deliberately
+// mutate a singleton without tripping the race detector. Call the
+// returned function to resume:
+//
+//	defer pauseSingletonWatchdog()()
+//
+// Only tests that are *about* singleton corruption should use this.
+// Production code has no business writing to a singleton at all.
+func pauseSingletonWatchdog() (resume func()) {
+	singletonWatchdogMu.Lock()
+	return singletonWatchdogMu.Unlock
+}

--- a/lisp/singleton_watchdog_test.go
+++ b/lisp/singleton_watchdog_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2025 The ELPS authors
+// Copyright © 2026 The ELPS authors
 
 package lisp
 


### PR DESCRIPTION
Fixes #333.

## The bug

CI caught a `DATA RACE` under `make race`. Both sides touch the same fixed data-segment address — a package-level singleton.

```
Write  lisp.lambdaVars()   lisp/lisp.go:1304   -- s.Quoted = false
Read   (*LEnv).eval()      lisp/env.go:980     -- if v.Quoted
```

`lambdaVars` cleared `Quoted` in place on `builtinConcat`'s return value, with a comment asserting that was safe:

```go
s = builtinConcat(nil, s)
s.Quoted = false // This is fine because builtinConcat returns a new list
```

The comment was wrong. `builtinConcatSeq` short-circuits the empty case with `return Nil()`, the process-wide shared singleton. So printing any function with **no formals and no bound vars** — `(lambda () 1)` — wrote straight into `singletonNil`.

## Reproduced first

`TestSingletonRaceLambdaVars` drives the real production path (`(*LVal).String()` on a zero-arg lambda) against concurrent `env.Eval(Nil())`. Pre-fix it reproduces the CI trace exactly, same address, same two frames. `TestLambdaVarsDoesNotReturnSingleton` pins the same invariant deterministically, no `-race` needed.

## The fix

Route the unquote through the existing copy-on-write helper `shallowUnquote`, so the value being mutated is always one `lambdaVars` owns.

It copies unconditionally rather than only when `builtinConcat` happens to share. That makes the contract the simple one — *`lambdaVars` returns a value the caller owns* — instead of the fragile *"the result is usually fresh, but don't write to it"*, and the strong form is checkable without the race detector. One small allocation on a path that only printing a function reaches, next to a `fmt.Sprintf`.

The leaked `evalBudgeted` goroutine in `eval_fuzz_test.go` is untouched. It exposed the bug; it wasn't the bug.

## Class audit

I inventoried every write to an `LVal` field outside tests — all 40 sites in `lisp/`, plus `parser/`, `analysis/`, `minifier/`, `formatter/`, `lint/`, `repl/`, `lsp/`, `elpstest/`, `internal/`, `lisp/x/`.

**`lambdaVars` was the only offender.** Every other site mutates a value it allocated itself (`SExpr(nil)`, `QExpr(...)`, `Array(...)`, `env.Lambda(...)`, an `env.Errorf` error, or an explicit `Copy()`). Notes from the sweep:

- The codebase already has the right idiom throughout — `Quote`, `Splice`, and `shallowUnquote` all copy before setting `Quoted`/`Spliced`. `lambdaVars` was the one place that skipped it.
- `lambdaVars` is the sole Go-internal caller of `builtinConcat`, so this was the only reachable instance of "caller mutates a possibly-shared concat result".
- `stampMacroExpansion` (#274) already carries an identity-based `isSingleton` guard.
- `builtinAppendMutate` / `builtinSelect` / `builtinReject` mutate in place, but only `LArray` values, and the singletons are `LSExpr`/`LSymbol` — not reachable.
- No package outside `lisp/` constructs a singleton at all (no `lisp.Nil()` / `lisp.Bool()` anywhere in `parser/`, `analysis/`, `minifier/`, `formatter/`, `lint/`), so the AST-mutating tooling cannot reach one.

## The guard's blind spot

`singletonNil.Quoted` was **already `false`**. The write stored the value the field already held, so `SingletonSnapshot.Verify()` — which compares values — saw no drift. The entire `elpscheck` build tag and its CI job are structurally incapable of catching this, no matter how often they run.

I could not close that inside `checkSingleton` cheaply, and I don't think it can be: a `bool` has no spare bit patterns to poison, so there is no value we could store that a same-value write would disturb. Observing the write itself needs either memory protection (`mmap` + `mprotect` — `unsafe`, platform-specific, invisible to the GC, and it hard-crashes the tests that mutate singletons on purpose) or the race detector. Neither is cheap.

So I did both halves of the fallback:

**1. A write watchdog** (`lisp/singleton_watchdog_test.go`, test-only, no public API). It keeps an unsynchronized read of all three singletons live for the whole package test run. Under `-race` that read sits in shadow memory, so **any** unsynchronized write to a singleton is reported with a stack trace naming the offending line — same-value or not, single-goroutine or not. This converts the class from "intermittent, needs two goroutines to collide on a loaded runner" to deterministic under the existing `make race` job. No workflow changes. The two tests that mutate singletons deliberately pause it via `pauseSingletonWatchdog`.

Its limits are documented in the file header: it only has teeth under `-race`, it only covers package `lisp`'s test binary (where the singletons and both historical offenders live), and it detects *unsynchronized* writes rather than writes as such.

**2. Precise documentation** at `checkSingleton` (both build variants) and on `Verify`, with a "What this does NOT catch" section citing #333 as the concrete example and naming which guard covers which case — so the next person doesn't trust the elpscheck job further than it goes.

## Mutation verification

Reverted the one-line fix and re-ran:

| Check | Result |
|---|---|
| `TestSingletonRaceLambdaVars` under `-race` | **FAIL** — `DATA RACE`, `lambdaVars()` vs `(*LEnv).eval()` |
| `TestLambdaVarsDoesNotReturnSingleton`, no `-race` | **FAIL** — "lambdaVars returned a shared singleton (list)" |
| A **single-goroutine** `fn.String()` loop under `-race` | **FAIL** — `DATA RACE`, `lambdaVars()` vs `TakeSingletonSnapshot()` |

The third is the one that matters for the guard work: with no concurrency in the test at all, the watchdog still catches it. Pre-watchdog that write was silent. Fix restored, all three pass.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `make race`
- [x] `make test-elpscheck`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `golangci-lint run --build-tags elpscheck ./lisp/...` — 0 issues
- [x] `./elps doc -m`
- [x] `make test` (Go tests + `_examples` lisp files)
- [x] `gofmt -l` — no newly unformatted files

---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_