### PR TITLE
Tell a fuzz crash apart from a fuzz harness failure, and stop a Go coordinator race reddening the board

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -137,6 +137,14 @@ jobs:
       - name: Fuzz gate self-test
         run: bash scripts/ci-gates-test.sh
 
+      # The complement: ci-gates-test proves the gate can FAIL, this proves it
+      # fails for the right REASON. A crasher, a seed-corpus failure, a panic, a
+      # signal death and the upstream -fuzztime race (issue #335) must each be
+      # reported as what they are, and only the last may be retried. Runs
+      # against a stub toolchain, so it is seconds and needs no fuzzing budget.
+      - name: Fuzz failure-classifier self-test
+        run: bash scripts/fuzz-classify-test.sh
+
       - name: List discovered targets
         run: ./scripts/fuzz.sh --list
 
@@ -161,16 +169,27 @@ jobs:
           # no error anywhere.
           key: fuzz-corpus-${{ matrix.shard }}-${{ github.sha }}
 
-      # A crash is only useful if the input survives the runner. go test writes
-      # it into <package>/testdata/fuzz/<Target>/, so upload that tree whenever
-      # the run failed; the file is committed as a regression case.
+      # A crash is only useful if the input survives the runner -- but only the
+      # NEW input is a crash. This used to upload `**/testdata/fuzz/**`, which
+      # is the entire COMMITTED corpus: the failing run on PR #330 uploaded 62
+      # files and had found nothing, and the presence of the artifact was read
+      # as proof that a crasher existed. An artifact that is always produced
+      # cannot be evidence.
+      #
+      # scripts/fuzz.sh now diffs each target's testdata/fuzz/<Target>/ around
+      # the run and copies only genuinely-new inputs into fuzz-crashers/, with a
+      # MANIFEST.tsv carrying the reproduce command. The hashFiles guard means
+      # the step is skipped -- visibly -- when nothing new was written, so
+      # "no artifact" positively means "no crasher was produced", and
+      # if-no-files-found: error catches fuzz.sh promising files it did not
+      # write.
       - name: Upload crashing inputs
-        if: failure()
+        if: failure() && hashFiles('fuzz-crashers/**') != ''
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: fuzz-crashers-${{ github.run_id }}-shard${{ matrix.shard }}
-          path: "**/testdata/fuzz/**"
-          if-no-files-found: warn
+          path: fuzz-crashers/
+          if-no-files-found: error
           retention-days: 30
 
   # A STABLE check name over a matrix whose size may change.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ editors/vscode/dist/
 editors/vscode/bin/
 .vscode/
 .env
+
+# scripts/fuzz.sh collects genuinely-new crashers here so CI can upload those
+# rather than the whole committed corpus. Regenerated per run; never committed
+# (the crasher itself belongs in <package>/testdata/fuzz/<Target>/).
+fuzz-crashers/

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,16 @@ fuzz-budget-check:
 ci-gates-test:
 	bash scripts/ci-gates-test.sh
 
+# The complement to ci-gates-test: that suite proves the fuzz gate can FAIL,
+# this one proves it fails for the RIGHT REASON. It drives scripts/fuzz.sh
+# against a stub toolchain and asserts that a crasher, a seed-corpus failure,
+# a panic, a signal death and the upstream -fuzztime race (issue #335) are each
+# reported as what they are — the distinction that was missing when a harness
+# failure on PR #330 read as a minifier bug. No Go toolchain, runs in seconds.
+.PHONY: fuzz-classify-test
+fuzz-classify-test:
+	bash scripts/fuzz-classify-test.sh
+
 # Adjudicate a benchstat comparison locally, exactly as CI does:
 #   go test -bench=. -benchmem -benchtime=100ms -count=5 -run='^$$' ./... > pr.txt
 #   git stash && go test ... > base.txt && git stash pop

--- a/internal/fuzzwatch/fuzzwatch.go
+++ b/internal/fuzzwatch/fuzzwatch.go
@@ -1,0 +1,279 @@
+// Copyright © 2026 The ELPS authors
+
+// Package fuzzwatch bounds a fuzz target's watchdog by SCHEDULED time rather
+// than by wall-clock time.
+//
+// # The problem
+//
+// Three fuzz targets in this repository assert that a call terminates, using
+// the same shape:
+//
+//	select {
+//	case v := <-done:
+//	        ...
+//	case <-time.After(watchdog):
+//	        t.Fatalf("did not terminate")
+//	}
+//
+// The property being asserted is real and worth asserting: `go test -fuzz` has
+// no per-input deadline, the interpreter's own step and allocation budgets are
+// blind to a builtin that loops inside Go, and two of the three defects
+// FuzzApplyStdlib found were exactly that shape. But `time.After` measures the
+// wall clock, and the wall clock counts time during which this process was not
+// running at all. On a contended CI runner a call that would finish in a
+// millisecond can be descheduled for seconds, and the watchdog cannot tell
+// that from a genuine hang. It fails, no input is really to blame, and the
+// board goes red for a reason nobody can reproduce -- the failure mode this
+// repository has spent a lot of effort eliminating.
+//
+// Simply raising the watchdog does not fix it. The headroom is already
+// enormous: measured on a 4-core box, FuzzEval averages 0.33ms per input
+// against a 30s watchdog (~90,000x), FuzzApplyStdlib 0.73ms against 15s
+// (~20,000x) and FuzzSchemaValidate 0.91ms against 20s (~22,000x). A bound
+// four orders of magnitude above the mean is not too tight; it is measuring
+// the wrong thing.
+//
+// # What this measures instead
+//
+// A single heartbeat goroutine per process ticks at a fixed interval and
+// records how much wall clock passed during which it did NOT run on schedule.
+// That is a direct measurement of "this process was not being given the CPU",
+// and it is exactly the quantity a wall-clock watchdog wrongly charges to the
+// code under test.
+//
+// A [Budget] then spends only SCHEDULED time. When the caller's timer fires,
+// [Budget.Check] answers one of three things:
+//
+//   - Continue: the process was descheduled for part of the window, so the
+//     budget is not spent. Wait the returned amount longer.
+//   - Hung: the full budget of scheduled time elapsed with the process running
+//     normally. The call under test did not terminate; fail.
+//   - Inconclusive: the hard wall-clock cap was reached and the process was
+//     starved throughout. Nothing can be concluded about this input, so
+//     nothing is asserted about it.
+//
+// On a healthy machine no stall is ever recorded, Check returns Hung at
+// exactly the configured budget, and every target detects precisely what it
+// detected before. Detection is reduced only on a machine that is not running
+// us -- where the alternative is not detection but a coin flip.
+package fuzzwatch
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// tick is the heartbeat interval. Short enough to resolve the sub-second
+	// stalls that matter, long enough that one goroutine per fuzz worker
+	// process is free.
+	tick = 100 * time.Millisecond
+
+	// tolerance is how late a tick may land before it counts as the process
+	// having been descheduled. A timer is always a little late; 4x the
+	// interval is comfortably above ordinary jitter (measured p100 tick lag
+	// during a live 4-worker sweep on a 4-core box was well under this) and
+	// far below the multi-second stalls a contended runner produces.
+	tolerance = 4
+
+	// hardWallFactor caps total wall clock at a multiple of the budget, so a
+	// permanently starved process cannot wait forever -- `go test -timeout`
+	// would eventually kill the binary with no crasher written, which is worse
+	// than any verdict. A process given less than a quarter of the CPU for
+	// four consecutive budgets is comprehensively broken, and Inconclusive is
+	// the honest answer for it.
+	hardWallFactor = 4
+)
+
+// monitor accumulates scheduler stall observed by a heartbeat goroutine.
+//
+// Both fields are cumulative and monotonic, so a caller records a snapshot at
+// the start of a window and subtracts: no history, no lock, O(1).
+type monitor struct {
+	lostNanos    atomic.Int64
+	longestNanos atomic.Int64
+}
+
+var (
+	defaultMonitor monitor
+	startOnce      sync.Once
+)
+
+// start launches the process-wide heartbeat. Idempotent; every constructor
+// calls it, so a target never has to remember to.
+func start() {
+	startOnce.Do(func() {
+		go defaultMonitor.run(tick)
+	})
+}
+
+func (m *monitor) run(d time.Duration) {
+	t := time.NewTicker(d)
+	defer t.Stop()
+	last := time.Now()
+	for now := range t.C {
+		m.observe(now.Sub(last), d)
+		last = now
+	}
+}
+
+// observe records one heartbeat interval. Split out from run so the accounting
+// is testable without waiting on a real clock.
+func (m *monitor) observe(gap, nominal time.Duration) {
+	if gap <= nominal*tolerance {
+		return
+	}
+	// Charge only the EXCESS as lost: the nominal interval would have elapsed
+	// even on an idle machine.
+	m.lostNanos.Add(int64(gap - nominal))
+	for {
+		cur := m.longestNanos.Load()
+		if int64(gap) <= cur || m.longestNanos.CompareAndSwap(cur, int64(gap)) {
+			return
+		}
+	}
+}
+
+func (m *monitor) lost() time.Duration {
+	return time.Duration(m.lostNanos.Load())
+}
+
+func (m *monitor) longest() time.Duration {
+	return time.Duration(m.longestNanos.Load())
+}
+
+// Verdict is what a fired watchdog timer actually means.
+type Verdict int
+
+const (
+	// Continue means the process was descheduled for part of the window, so
+	// the budget of scheduled time is not spent. Wait longer.
+	Continue Verdict = iota
+	// Hung means the budget of scheduled time elapsed while the process was
+	// running normally. The call under test did not terminate.
+	Hung
+	// Inconclusive means the hard wall-clock cap was reached with the process
+	// starved throughout. Whether the call would have terminated is unknown,
+	// so nothing may be asserted about this input.
+	Inconclusive
+)
+
+func (v Verdict) String() string {
+	switch v {
+	case Continue:
+		return "continue"
+	case Hung:
+		return "hung"
+	case Inconclusive:
+		return "inconclusive"
+	}
+	return fmt.Sprintf("Verdict(%d)", int(v))
+}
+
+// Report describes what the wall clock was doing during a watchdog window. It
+// exists to be printed in a failure message: "did not terminate in 15s" is a
+// much weaker claim than "did not terminate in 15s of scheduled time, during
+// which the process was never descheduled by more than 120ms".
+type Report struct {
+	// Wall is the total wall-clock time since the budget was created.
+	Wall time.Duration
+	// Lost is the part of Wall during which this process was demonstrably not
+	// being scheduled.
+	Lost time.Duration
+	// LongestStall is the longest single heartbeat gap in the window.
+	LongestStall time.Duration
+}
+
+// Scheduled is the part of the window during which the process was actually
+// running -- the quantity a watchdog should be spending.
+func (r Report) Scheduled() time.Duration {
+	if r.Lost > r.Wall {
+		return 0
+	}
+	return r.Wall - r.Lost
+}
+
+// Starved reports whether scheduler stall dominated the window.
+func (r Report) Starved() bool {
+	return r.Lost*2 >= r.Wall
+}
+
+func (r Report) String() string {
+	return fmt.Sprintf("wall %s, of which %s scheduled and %s lost to scheduler stall (longest single stall %s)",
+		r.Wall.Round(time.Millisecond),
+		r.Scheduled().Round(time.Millisecond),
+		r.Lost.Round(time.Millisecond),
+		r.LongestStall.Round(time.Millisecond))
+}
+
+// Budget is a watchdog budget denominated in scheduled time.
+//
+// Create one before starting the work, arm an ordinary timer for [Budget.Total],
+// and call [Budget.Check] when it fires.
+type Budget struct {
+	total     time.Duration
+	hardWall  time.Duration
+	startedAt time.Time
+	lostAt    time.Duration
+	longestAt time.Duration
+}
+
+// New returns a Budget of d scheduled time.
+func New(d time.Duration) *Budget {
+	start()
+	return &Budget{
+		total:     d,
+		hardWall:  d * hardWallFactor,
+		startedAt: time.Now(),
+		lostAt:    defaultMonitor.lost(),
+		longestAt: defaultMonitor.longest(),
+	}
+}
+
+// Total is the budget the caller should arm its first timer for.
+func (b *Budget) Total() time.Duration { return b.total }
+
+// Report snapshots the window so far.
+func (b *Budget) Report() Report {
+	longest := defaultMonitor.longest()
+	if longest < b.longestAt {
+		longest = b.longestAt
+	}
+	r := Report{
+		Wall: time.Since(b.startedAt),
+		Lost: defaultMonitor.lost() - b.lostAt,
+	}
+	// longestNanos is a process-wide maximum, so it is only meaningful for this
+	// window when it grew during it.
+	if longest > b.longestAt {
+		r.LongestStall = longest
+	}
+	return r
+}
+
+// Check interprets a fired watchdog timer. When it returns Continue, the
+// second value is how much longer to wait before checking again.
+func (b *Budget) Check() (Verdict, time.Duration, Report) {
+	r := b.Report()
+	switch {
+	case r.Scheduled() >= b.total:
+		return Hung, 0, r
+	case r.Wall >= b.hardWall:
+		// Out of wall clock without ever spending the budget. Either the
+		// machine never gave us the CPU (Inconclusive), or the stall
+		// accounting under-counted and this really is a hang.
+		if r.Starved() {
+			return Inconclusive, 0, r
+		}
+		return Hung, 0, r
+	}
+	remaining := b.total - r.Scheduled()
+	// Never re-arm for less than a heartbeat: a shorter timer cannot observe
+	// any new stall, so it would spin.
+	if remaining < tick {
+		remaining = tick
+	}
+	return Continue, remaining, r
+}

--- a/internal/fuzzwatch/fuzzwatch_test.go
+++ b/internal/fuzzwatch/fuzzwatch_test.go
@@ -1,0 +1,157 @@
+// Copyright © 2026 The ELPS authors
+
+package fuzzwatch
+
+import (
+	"testing"
+	"time"
+)
+
+// The accounting is tested by driving observe() directly rather than by
+// sleeping: a test that manufactures a real multi-second scheduler stall is
+// both slow and, on a loaded machine, exactly as unreliable as the thing this
+// package exists to fix.
+
+func TestMonitorIgnoresOrdinaryJitter(t *testing.T) {
+	var m monitor
+	for range 100 {
+		m.observe(tick+20*time.Millisecond, tick)
+	}
+	// A tick landing 20ms late, a hundred times, is a healthy machine.
+	if got := m.lost(); got != 0 {
+		t.Fatalf("ordinary jitter was charged as scheduler stall: %s", got)
+	}
+	if got := m.longest(); got != 0 {
+		t.Fatalf("ordinary jitter recorded a longest stall: %s", got)
+	}
+}
+
+func TestMonitorChargesOnlyTheExcess(t *testing.T) {
+	var m monitor
+	m.observe(3*time.Second, tick)
+	// The nominal interval would have elapsed anyway; only the excess is time
+	// the process lost.
+	if want, got := 3*time.Second-tick, m.lost(); got != want {
+		t.Fatalf("lost = %s, want %s", got, want)
+	}
+	if want, got := 3*time.Second, m.longest(); got != want {
+		t.Fatalf("longest = %s, want %s", got, want)
+	}
+}
+
+func TestMonitorLongestIsAMaximum(t *testing.T) {
+	var m monitor
+	m.observe(5*time.Second, tick)
+	m.observe(2*time.Second, tick)
+	if want, got := 5*time.Second, m.longest(); got != want {
+		t.Fatalf("longest = %s, want %s (a later shorter stall must not lower it)", got, want)
+	}
+}
+
+func TestReportScheduled(t *testing.T) {
+	r := Report{Wall: 10 * time.Second, Lost: 7 * time.Second}
+	if want, got := 3*time.Second, r.Scheduled(); got != want {
+		t.Fatalf("Scheduled = %s, want %s", got, want)
+	}
+	if !r.Starved() {
+		t.Fatal("7s lost out of 10s wall is starved")
+	}
+	healthy := Report{Wall: 10 * time.Second, Lost: 100 * time.Millisecond}
+	if healthy.Starved() {
+		t.Fatal("100ms lost out of 10s wall is not starved")
+	}
+	// Defensive: the monitor is sampled at two instants, so Lost can in
+	// principle exceed Wall by a hair. It must not produce a negative.
+	odd := Report{Wall: time.Second, Lost: 2 * time.Second}
+	if got := odd.Scheduled(); got != 0 {
+		t.Fatalf("Scheduled = %s, want 0 for Lost > Wall", got)
+	}
+}
+
+// checkAt exercises Budget.Check against a synthetic window, so the verdict
+// logic is tested without a clock.
+func checkAt(b *Budget, wall, lost time.Duration) (Verdict, time.Duration, Report) {
+	b.startedAt = time.Now().Add(-wall)
+	b.lostAt = defaultMonitor.lost() - lost
+	return b.Check()
+}
+
+func TestCheckHungOnAHealthyMachine(t *testing.T) {
+	b := New(10 * time.Second)
+	v, _, r := checkAt(b, 10*time.Second, 0)
+	if v != Hung {
+		t.Fatalf("verdict = %v, want Hung (%s)", v, r)
+	}
+}
+
+func TestCheckContinuesWhenDescheduled(t *testing.T) {
+	b := New(10 * time.Second)
+	// 10s of wall clock, but 6s of it the process was not running: only 4s of
+	// the budget was actually spent.
+	v, more, r := checkAt(b, 10*time.Second, 6*time.Second)
+	if v != Continue {
+		t.Fatalf("verdict = %v, want Continue (%s)", v, r)
+	}
+	if more < 5*time.Second || more > 7*time.Second {
+		t.Fatalf("wait = %s, want the ~6s of budget still unspent", more)
+	}
+}
+
+func TestCheckInconclusiveAtTheWallCap(t *testing.T) {
+	b := New(10 * time.Second)
+	// Four budgets of wall clock have gone by and the process was starved for
+	// nearly all of it. Whether the call would terminate is unknowable.
+	v, _, r := checkAt(b, 40*time.Second, 39*time.Second)
+	if v != Inconclusive {
+		t.Fatalf("verdict = %v, want Inconclusive (%s)", v, r)
+	}
+}
+
+// The load-bearing negative: reaching the wall cap on a machine that WAS
+// running us is a hang, not an excuse. Without this, a slow-but-real hang on a
+// mildly noisy machine could be waved away.
+func TestCheckHungAtTheWallCapWhenNotStarved(t *testing.T) {
+	b := New(10 * time.Second)
+	v, _, r := checkAt(b, 40*time.Second, time.Second)
+	if v != Hung {
+		t.Fatalf("verdict = %v, want Hung (%s)", v, r)
+	}
+}
+
+func TestCheckNeverRearmsBelowAHeartbeat(t *testing.T) {
+	b := New(10 * time.Second)
+	// A sliver of budget left: re-arming for it would spin without ever
+	// observing another heartbeat.
+	v, more, _ := checkAt(b, 10*time.Second, time.Millisecond)
+	if v != Continue {
+		t.Fatalf("verdict = %v, want Continue", v)
+	}
+	if more < tick {
+		t.Fatalf("wait = %s, want at least one heartbeat (%s)", more, tick)
+	}
+}
+
+// End to end against the real clock, kept short. A budget that expires with
+// the machine idle must say Hung: this is the path every existing watchdog
+// takes today, and it must be unchanged.
+func TestBudgetExpiresOnAnIdleMachine(t *testing.T) {
+	b := New(150 * time.Millisecond)
+	time.Sleep(b.Total() + 50*time.Millisecond)
+	v, _, r := b.Check()
+	if v != Hung {
+		t.Fatalf("verdict = %v, want Hung on an idle machine (%s)", v, r)
+	}
+}
+
+func TestVerdictString(t *testing.T) {
+	for v, want := range map[Verdict]string{
+		Continue: "continue", Hung: "hung", Inconclusive: "inconclusive",
+	} {
+		if got := v.String(); got != want {
+			t.Errorf("Verdict(%d).String() = %q, want %q", int(v), got, want)
+		}
+	}
+	if got := Verdict(9).String(); got != "Verdict(9)" {
+		t.Errorf("unknown verdict rendered as %q", got)
+	}
+}

--- a/lisp/eval_fuzz_test.go
+++ b/lisp/eval_fuzz_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/luthersystems/elps/elpsutil"
 	"github.com/luthersystems/elps/internal/fuzzseed"
+	"github.com/luthersystems/elps/internal/fuzzwatch"
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/lisplib"
 	"github.com/luthersystems/elps/parser"
@@ -98,7 +99,9 @@ const (
 	// each evaluation step.
 	fuzzDeadline = 2 * time.Second
 
-	// watchdogTimeout is the outer bound.  It is deliberately an order of
+	// watchdogTimeout is the outer bound, denominated in SCHEDULED time (see
+	// internal/fuzzwatch): wall clock during which this process was not run by the
+	// OS is not charged to the evaluator.  It is deliberately an order of
 	// magnitude above fuzzDeadline: reaching it means evaluation ignored
 	// every budget it was given, which is itself the bug.
 	watchdogTimeout = 30 * time.Second
@@ -153,6 +156,10 @@ type evalOutcome struct {
 type fatalf interface {
 	Helper()
 	Fatalf(format string, args ...interface{})
+	// Skipf is how the harness declines to answer for one input when the
+	// process was starved throughout its watchdog window -- see
+	// internal/fuzzwatch. Both *testing.T and *testing.F have it.
+	Skipf(format string, args ...interface{})
 }
 
 // evalBudgeted parses and evaluates src under the budget, on its own
@@ -204,29 +211,50 @@ func evalBudgeted(t fatalf, src []byte) (evalOutcome, bool) {
 		ch <- done{result: result, steps: env.Runtime.TotalSteps(), elapsed: time.Since(start)}
 	}()
 
-	select {
-	case d := <-ch:
-		if d.result == nil {
-			t.Fatalf("evaluation returned a nil LVal")
-			return evalOutcome{}, false
+	// SCHEDULED time, not wall clock: see internal/fuzzwatch.  At a measured
+	// 0.33ms mean per input this bound is already ~90,000x the work, so
+	// widening it further would not buy anything -- the only way a healthy
+	// machine reaches it is a genuine hang, and the only other way to reach it
+	// is not being given the CPU, which is not the evaluator's fault.
+	budget := fuzzwatch.New(watchdogTimeout)
+	wait := budget.Total()
+	for {
+		select {
+		case d := <-ch:
+			if d.result == nil {
+				t.Fatalf("evaluation returned a nil LVal")
+				return evalOutcome{}, false
+			}
+			return evalOutcome{
+				Result:  d.result,
+				Stderr:  stderr.String(),
+				Steps:   d.steps,
+				Elapsed: d.elapsed,
+			}, true
+		case <-time.After(wait):
+			verdict, more, report := budget.Check()
+			switch verdict {
+			case fuzzwatch.Continue:
+				wait = more
+			case fuzzwatch.Inconclusive:
+				// Starved throughout. Nothing can be said about this input,
+				// and saying it anyway is how a gate stops meaning anything.
+				t.Skipf("no verdict: the process was starved throughout (%s)", report)
+				return evalOutcome{}, false
+			default:
+				// The evaluation goroutine is unstoppable by construction --
+				// if it were interruptible it would have honoured the context
+				// deadline fuzzDeadline seconds ago.  Leaking it is the price
+				// of reporting the failure at all; the process is about to
+				// fail the test regardless.
+				t.Fatalf("evaluation did not terminate within %s of SCHEDULED time despite a %s context deadline,"+
+					" a %d-step budget and a %d-iteration tail budget (%s)"+
+					"\n--- source (%d bytes) ---\n%q",
+					budget.Total(), fuzzDeadline, int64(fuzzMaxSteps), fuzzMaxTailIterations,
+					report, len(src), src)
+				return evalOutcome{}, false
+			}
 		}
-		return evalOutcome{
-			Result:  d.result,
-			Stderr:  stderr.String(),
-			Steps:   d.steps,
-			Elapsed: d.elapsed,
-		}, true
-	case <-time.After(watchdogTimeout):
-		// The evaluation goroutine is unstoppable by construction -- if it
-		// were interruptible it would have honoured the context deadline
-		// fuzzDeadline seconds ago.  Leaking it is the price of reporting the
-		// failure at all; the process is about to fail the test regardless.
-		t.Fatalf("evaluation did not terminate within %s despite a %s context deadline,"+
-			" a %d-step budget and a %d-iteration tail budget"+
-			"\n--- source (%d bytes) ---\n%q",
-			watchdogTimeout, fuzzDeadline, int64(fuzzMaxSteps), fuzzMaxTailIterations,
-			len(src), src)
-		return evalOutcome{}, false
 	}
 }
 

--- a/lisp/lisplib/fuzz_test.go
+++ b/lisp/lisplib/fuzz_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/luthersystems/elps/internal/fuzzval"
+	"github.com/luthersystems/elps/internal/fuzzwatch"
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/lisplib"
 	"github.com/luthersystems/elps/parser"
@@ -149,9 +150,10 @@ func FuzzApplyStdlib(f *testing.F) {
 // loop is reported rather than eating the target's whole -fuzztime.
 const callDeadline = 5 * time.Second
 
-// watchdogGrace is how long past callDeadline the watchdog waits before
-// declaring the call unbounded.  A call that has blown the context deadline by
-// this much is not "slow": it is in a loop that never consults the context.
+// watchdogGrace is how much SCHEDULED time past callDeadline the watchdog
+// waits before declaring the call unbounded.  A call that has blown the
+// context deadline by this much is not "slow": it is in a loop that never
+// consults the context.
 const watchdogGrace = 10 * time.Second
 
 // fuzzMaxAlloc is the per-operation allocation cap.  Deliberately tiny.  The
@@ -168,7 +170,12 @@ const fuzzMaxAlloc = 4096
 const fuzzMaxSteps = 20000
 
 // applyWithWatchdog applies fun to args on a separate goroutine and fails the
-// test if the call outlives the context deadline by watchdogGrace.
+// test if the call outlives the context deadline by watchdogGrace of SCHEDULED
+// time -- wall clock during which this process was not being run by the OS is
+// not charged to the callable.  See internal/fuzzwatch for why: at a measured
+// 0.73ms mean per input the 15s bound is already ~20,000x the work, so a
+// watchdog that fires is either a real hang or a starved runner, and only the
+// first is a defect.
 //
 // A watchdog is necessary because neither of the interpreter's own bounds sees
 // every loop.  checkLimits is consulted per EVALUATION; a builtin that loops
@@ -192,17 +199,37 @@ func applyWithWatchdog(t *testing.T, env *lisp.LEnv, name string, fun, args *lis
 		}()
 		done <- apply(env, fun, args)
 	}()
-	select {
-	case v := <-done:
-		return v
-	case r := <-panicked:
-		// Re-panic on the test goroutine so the fuzzing engine records the
-		// crasher and prints the stack.
-		panic(r)
-	case <-time.After(callDeadline + watchdogGrace):
-		t.Fatalf("%s did not terminate within %v despite a %v context deadline and a %d-step limit\n--- args ---\n%s",
-			name, callDeadline+watchdogGrace, callDeadline, fuzzMaxSteps, args)
-		return nil
+	// The budget is SCHEDULED time, not wall clock: see internal/fuzzwatch.  A
+	// plain time.After here charges the code under test for every second this
+	// process spent descheduled on a contended runner, which is a red board
+	// nobody can reproduce rather than a defect.
+	budget := fuzzwatch.New(callDeadline + watchdogGrace)
+	wait := budget.Total()
+	for {
+		select {
+		case v := <-done:
+			return v
+		case r := <-panicked:
+			// Re-panic on the test goroutine so the fuzzing engine records the
+			// crasher and prints the stack.
+			panic(r)
+		case <-time.After(wait):
+			verdict, more, report := budget.Check()
+			switch verdict {
+			case fuzzwatch.Continue:
+				wait = more
+			case fuzzwatch.Inconclusive:
+				// The machine never gave us the CPU. Whether this call
+				// terminates is unknown, and guessing in either direction is
+				// worse than declining to answer for one input out of millions.
+				t.Skipf("%s: no verdict, the process was starved throughout (%s)", name, report)
+				return nil
+			default:
+				t.Fatalf("%s did not terminate within %v of SCHEDULED time despite a %v context deadline and a %d-step limit (%s)\n--- args ---\n%s",
+					name, budget.Total(), callDeadline, fuzzMaxSteps, report, args)
+				return nil
+			}
+		}
 	}
 }
 

--- a/lisp/lisplib/libschema/fuzz_test.go
+++ b/lisp/lisplib/libschema/fuzz_test.go
@@ -9,7 +9,17 @@ import (
 	"time"
 
 	"github.com/luthersystems/elps/internal/fuzzval"
+	"github.com/luthersystems/elps/internal/fuzzwatch"
 	"github.com/luthersystems/elps/lisp"
+)
+
+// schemaDeadline is the context deadline one validation runs under, and
+// schemaWatchdog the out-of-band bound on a validation that ignores it.  The
+// watchdog is denominated in SCHEDULED time (see internal/fuzzwatch), so a
+// contended runner cannot spend it on this target's behalf.
+const (
+	schemaDeadline = 5 * time.Second
+	schemaWatchdog = 20 * time.Second
 )
 
 // FuzzSchemaValidate builds a schema out of fuzzer-chosen constraint fragments
@@ -57,7 +67,7 @@ func FuzzSchemaValidate(f *testing.F) {
 	f.Fuzz(func(t *testing.T, idx uint8, data []byte) {
 		before := lisp.TakeSingletonSnapshot()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), schemaDeadline)
 		defer cancel()
 
 		env := newSchemaEnv(t)
@@ -93,13 +103,34 @@ func FuzzSchemaValidate(f *testing.F) {
 			done <- env.LoadStringContext(ctx, "schema-fuzz", src)
 		}()
 
+		// SCHEDULED time, not wall clock: see internal/fuzzwatch.  At a
+		// measured 0.91ms mean per input the bound is already ~22,000x the
+		// work, so a watchdog that fires is either a real hang or a runner
+		// that stopped running us, and only the first is a defect here.
 		var res *lisp.LVal
-		select {
-		case res = <-done:
-		case r := <-panicked:
-			panic(r)
-		case <-time.After(20 * time.Second):
-			t.Fatalf("schema evaluation did not terminate despite a 5s deadline\n--- source ---\n%s", src)
+		budget := fuzzwatch.New(schemaWatchdog)
+		wait := budget.Total()
+	wait:
+		for {
+			select {
+			case res = <-done:
+				break wait
+			case r := <-panicked:
+				panic(r)
+			case <-time.After(wait):
+				verdict, more, report := budget.Check()
+				switch verdict {
+				case fuzzwatch.Continue:
+					wait = more
+				case fuzzwatch.Inconclusive:
+					t.Skipf("no verdict: the process was starved throughout (%s)", report)
+					return
+				default:
+					t.Fatalf("schema evaluation did not terminate within %s of SCHEDULED time despite a %s deadline (%s)\n--- source ---\n%s",
+						budget.Total(), schemaDeadline, report, src)
+					return
+				}
+			}
 		}
 
 		if res == nil {

--- a/scripts/fuzz-classify-test.sh
+++ b/scripts/fuzz-classify-test.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+#
+# Self-test for the failure CLASSIFIER in scripts/fuzz.sh.
+#
+# Why this is a separate suite
+# ----------------------------
+# scripts/ci-gates-test.sh proves the fuzz gate can FAIL -- it arms
+# FuzzGateSelfTest and asserts a non-zero exit.  That is the property that was
+# missing while the benchmark gate sat dead for 473 runs, and it is necessary.
+# It is not sufficient.  A gate that fails for the WRONG REASON is its own
+# failure mode: the FuzzMinifySource red on PR #330 and the FuzzFormat red
+# recorded in issue #318 were both the fuzzing harness falling over, not a
+# defect in the code under test, and nothing in the output distinguished them
+# from a real crash.  So the thing under test here is the distinction itself.
+#
+# Every scenario runs the REAL scripts/fuzz.sh against a stub `go` on PATH, so
+# the classifier, the retry budget, the crasher collection and the summary text
+# are exercised end to end without a Go toolchain and without waiting for a
+# fuzzing budget.  The stub is the only fake; fuzz.sh is untouched.
+#
+# The stub honours:
+#   STUB_SCRIPT   newline-separated per-attempt behaviours, one per `go test
+#                 -fuzz` invocation: `ok`, `fail:<fixture>`, or
+#                 `crash:<fixture>` (which also writes a new corpus file).
+#   STUB_STATE    file used to count attempts across invocations.
+#   STUB_TARGETS  how many fuzz targets the stub package declares (default 1),
+#                 so the per-SWEEP retry budget can be exercised.
+#
+# Usage:  scripts/fuzz-classify-test.sh
+# Exit:   0 all scenarios passed, 1 one or more failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUZZ="${SCRIPT_DIR}/fuzz.sh"
+
+passed=0
+failed=0
+
+ok() {
+	passed=$((passed + 1))
+	echo "PASS  $1"
+}
+
+bad() {
+	failed=$((failed + 1))
+	echo "FAIL  $1"
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------------------
+# The stub toolchain.
+# ---------------------------------------------------------------------------
+mkdir -p "${WORK}/bin" "${WORK}/pkg"
+cat >"${WORK}/bin/go" <<'STUB'
+#!/usr/bin/env bash
+# Minimal `go` for scripts/fuzz.sh: list, test -list, test -fuzz.
+set -uo pipefail
+
+case "${1:-}" in
+list)
+	# fuzz.sh asks for `-f '{{.ImportPath}}\t{{.Dir}}'`.
+	printf '%s\t%s\n' "example.com/stub" "${STUB_PKG_DIR}"
+	exit 0
+	;;
+test) ;;
+*) exit 1 ;;
+esac
+
+target=""
+prev=""
+for arg in "$@"; do
+	if [ "$arg" = "-list" ]; then
+		i=1
+		while [ "$i" -le "${STUB_TARGETS:-1}" ]; do
+			echo "FuzzStub${i}"
+			i=$((i + 1))
+		done
+		echo "ok  	example.com/stub	0.001s"
+		exit 0
+	fi
+	if [ "$prev" = "-fuzz" ]; then
+		target="${arg#^}"
+		target="${target%\$}"
+	fi
+	prev="$arg"
+done
+[ -n "$target" ] || target="FuzzStub1"
+
+# A fuzzing invocation. Take the next behaviour off the script.
+n=0
+[ -f "$STUB_STATE" ] && n="$(cat "$STUB_STATE")"
+n=$((n + 1))
+echo "$n" >"$STUB_STATE"
+behaviour="$(printf '%s\n' "$STUB_SCRIPT" | sed -n "${n}p")"
+[ -n "$behaviour" ] || behaviour="ok"
+
+kind="${behaviour%%:*}"
+fixture="${behaviour#*:}"
+
+case "$kind" in
+ok)
+	echo "fuzz: elapsed: 3s, execs: 1000 (333/sec), new interesting: 0 (total: 1)"
+	echo "PASS"
+	echo "ok  	example.com/stub	3.0s"
+	exit 0
+	;;
+crash)
+	# What the engine does when it finds an input: write it to the target's
+	# corpus directory and name it.
+	dir="${STUB_PKG_DIR}/testdata/fuzz/${target}"
+	mkdir -p "$dir"
+	printf 'go test fuzz v1\n[]byte("boom")\n' >"${dir}/deadbeefcafe"
+	echo "--- FAIL: ${target} (3.00s)"
+	echo "    --- FAIL: ${target}/deadbeefcafe (0.00s)"
+	echo "        stub_test.go:1: boom"
+	echo "Failing input written to testdata/fuzz/${target}/deadbeefcafe"
+	echo "FAIL"
+	exit 1
+	;;
+fail)
+	case "$fixture" in
+	deadline)
+		# The upstream -fuzztime race, issue #335: the entire failure output.
+		echo "fuzz: elapsed: 30s, execs: 105831 (0/sec), new interesting: 16 (total: 475)"
+		echo "--- FAIL: ${target} (31.03s)"
+		echo "    context deadline exceeded"
+		echo "FAIL"
+		;;
+	seed)
+		echo "failure while testing seed corpus entry: ${target}/seed_input"
+		echo "--- FAIL: ${target} (0.01s)"
+		echo "    stub_test.go:1: deliberate failure"
+		echo "FAIL"
+		;;
+	panicdeadline)
+		# A panic that ALSO happens to print the deadline text. Must not be
+		# mistaken for the benign race.
+		echo "--- FAIL: ${target} (31.03s)"
+		echo "    context deadline exceeded"
+		echo "panic: runtime error: index out of range [3]"
+		echo "FAIL"
+		;;
+	signal)
+		echo "--- FAIL: ${target} (12.00s)"
+		echo "    fuzzing process terminated by unexpected signal; no crash will be recorded: signal: killed"
+		echo "FAIL"
+		;;
+	build)
+		echo "# example.com/stub [build failed]"
+		echo "FAIL"
+		;;
+	*)
+		echo "--- FAIL: ${target} (1.00s)"
+		echo "    something else went wrong"
+		echo "FAIL"
+		;;
+	esac
+	exit 1
+	;;
+esac
+exit 1
+STUB
+chmod +x "${WORK}/bin/go"
+
+# run_scenario <name> <stub-script> [extra env assignments...]
+# Prints combined output to $WORK/out and sets $rc.
+run_scenario() {
+	local STUB_TARGETS="${STUB_TARGETS:-1}"
+	local name="$1" script="$2"
+	shift 2
+	local pkgdir="${WORK}/pkg/${name}"
+	rm -rf "$pkgdir" "${WORK}/crashers"
+	mkdir -p "$pkgdir"
+	# Pre-existing committed corpus: the classifier must not count these as
+	# new, which is the exact bug in uploading `**/testdata/fuzz/**`.
+	local i=1
+	while [ "$i" -le "${STUB_TARGETS:-1}" ]; do
+		mkdir -p "${pkgdir}/testdata/fuzz/FuzzStub${i}"
+		printf 'go test fuzz v1\n[]byte("already here")\n' \
+			>"${pkgdir}/testdata/fuzz/FuzzStub${i}/0000committed"
+		i=$((i + 1))
+	done
+	: >"${WORK}/state"
+	PATH="${WORK}/bin:${PATH}" \
+		STUB_PKG_DIR="$pkgdir" \
+		STUB_STATE="${WORK}/state" \
+		STUB_SCRIPT="$script" \
+		STUB_TARGETS="${STUB_TARGETS:-1}" \
+		FUZZ_CRASH_DIR="${WORK}/crashers" \
+		FUZZTIME=1s \
+		env "$@" bash "$FUZZ" ./stub/... >"${WORK}/out" 2>&1
+	rc=$?
+}
+
+expect_rc() {
+	if [ "$rc" -eq "$1" ]; then
+		ok "$2"
+	else
+		bad "$2 (exit ${rc}, want $1)"
+		sed 's/^/      | /' "${WORK}/out"
+	fi
+}
+
+expect_out() {
+	if grep -qF "$1" "${WORK}/out"; then
+		ok "$2"
+	else
+		bad "$2 — output did not contain: $1"
+		sed 's/^/      | /' "${WORK}/out"
+	fi
+}
+
+expect_not_out() {
+	if grep -qF "$1" "${WORK}/out"; then
+		bad "$2 — output unexpectedly contained: $1"
+		sed 's/^/      | /' "${WORK}/out"
+	else
+		ok "$2"
+	fi
+}
+
+echo
+echo "== a real crasher is still a failure, and is named ======================="
+
+run_scenario crasher 'crash:x'
+expect_rc 1 "a target that writes a crasher fails the sweep"
+expect_out "CRASHER" "the failure is classified as a crasher"
+expect_out "deadbeefcafe" "the new input is named"
+expect_out "reproduce with" "a reproduce command is printed"
+expect_not_out "retrying once" "a crasher is NEVER retried"
+if [ -f "${WORK}/crashers/example.com_stub/FuzzStub1/deadbeefcafe" ]; then
+	ok "the new crasher is collected for upload"
+else
+	bad "the new crasher was not collected into FUZZ_CRASH_DIR"
+fi
+if [ -f "${WORK}/crashers/example.com_stub/FuzzStub1/0000committed" ]; then
+	bad "the pre-existing committed corpus was collected as if it were new"
+else
+	ok "the pre-existing committed corpus is NOT collected (only new files are)"
+fi
+
+echo
+echo "== a seed-corpus failure writes no new file and must still be red ========"
+
+run_scenario seed 'fail:seed'
+expect_rc 1 "a seed-corpus failure fails the sweep"
+expect_out "SEED CORPUS" "it is classified as a seed failure, not as a flake"
+expect_not_out "retrying once" "a seed failure is NEVER retried"
+expect_out "NO new crasher was produced" "the reader is told not to hunt for an input"
+
+echo
+echo "== the upstream -fuzztime race (issue #335) =============================="
+
+run_scenario flake 'fail:deadline
+ok'
+expect_rc 0 "the race, clean on retry, does not redden the board"
+expect_out "retrying once" "the retry is announced"
+expect_out "FLAKE" "the flake is reported rather than buried"
+expect_out "335" "the report cites the issue"
+
+run_scenario recur 'fail:deadline
+fail:deadline'
+expect_rc 1 "the race RECURRING on the retry is a failure"
+expect_out "HARNESS" "a recurring harness failure is labelled, not silently retried forever"
+
+# Two targets, each hitting the race. The first consumes the sweep's single
+# retry; the second must NOT get one, or a shard could retry every target and
+# overrun the job timeout that fuzz-budget-check.sh sizes.
+STUB_TARGETS=2 run_scenario budget 'fail:deadline
+ok
+fail:deadline'
+expect_rc 1 "the retry budget is per SWEEP, not per target"
+expect_out "HARNESS" "the second target's race is reported once the budget is spent"
+expect_out "FLAKE" "the first target's retried flake is still reported"
+
+echo
+echo "== the race signature must not swallow a real failure ===================="
+
+run_scenario panicky 'fail:panicdeadline'
+expect_rc 1 "a panic that also prints the deadline text is NOT treated as the race"
+expect_not_out "retrying once" "a panic is never retried as a flake"
+expect_out "UNATTRIBUTED" "it is reported as unattributed, not as the known race"
+
+run_scenario killed 'fail:signal'
+expect_rc 1 "a worker killed by a signal is a failure"
+expect_not_out "retrying once" "a signal death is never retried as a flake"
+
+run_scenario broken 'fail:build'
+expect_rc 1 "a build failure is a failure"
+expect_not_out "retrying once" "a build failure is never retried as a flake"
+
+run_scenario other 'fail:other'
+expect_rc 1 "an unrecognised failure is a failure"
+expect_out "UNATTRIBUTED" "an unrecognised failure is labelled unattributed"
+
+echo
+echo "== opting out ============================================================"
+
+run_scenario noretry 'fail:deadline
+ok' FUZZ_MAX_RETRIES=0
+expect_rc 1 "FUZZ_MAX_RETRIES=0 makes the race fail immediately"
+
+echo
+echo "== a clean sweep stays clean and quiet ==================================="
+
+run_scenario clean 'ok'
+expect_rc 0 "a passing target passes"
+expect_not_out "FLAKE" "a clean run reports no flake"
+expect_not_out "NO new crasher" "a clean run does not print failure guidance"
+
+echo
+echo "=========================================================================="
+echo "fuzz-classify-test: ${passed} passed, ${failed} failed"
+[ "$failed" -eq 0 ] || exit 1
+exit 0

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -56,10 +56,48 @@
 # COUNT is the only thing balanced here -- targets are not equal-cost, but the
 # per-target budget is fixed, so count is the right proxy.
 #
+# Did it find a bug, or did the harness fall over?
+# ------------------------------------------------
+# `go test -fuzz` exits 1 for both, and from the outside they are identical --
+# which is how issue #318 ended up carrying an "unexplained" FuzzFormat failure
+# for weeks.  A REAL finding always leaves a new file under
+# <pkg>/testdata/fuzz/<Target>/ (or says why it could not write one), so this
+# script snapshots that directory around every target and reports which
+# happened.  Three classifications:
+#
+#   CRASHER    new file(s) appeared.  A defect.  Always fails the sweep, and
+#              the files are copied to $FUZZ_CRASH_DIR so CI can upload the
+#              genuinely-new inputs instead of the whole committed corpus.
+#   SEED       the seed corpus itself failed ("failure while testing seed
+#              corpus entry").  Also a defect; the input is already committed,
+#              which is why no new file appears.  Always fails.
+#   HARNESS    the run failed without producing any input to blame.  The one
+#              signature recognised here is the upstream `-fuzztime` race
+#              described below; anything else in this class still fails, loudly
+#              labelled as unattributed.
+#
+# The upstream -fuzztime race (issue #335)
+# ----------------------------------------
+# internal/fuzz.CoordinateFuzzing applies -fuzztime as a context deadline and
+# suppresses it as normal termination by comparing the PARENT context's error
+# against the CHILD's:
+#
+#     case <-doneC:  stop(ctx.Err())
+#     stop := func(err error) { if err == fuzzCtx.Err() { err = nil } ... }
+#
+# context.cancelCtx.cancel stores the parent's error and CLOSES the parent's
+# done channel before it walks its children, and cancelCtx.Err() is a lock-free
+# atomic load.  If the cancelling thread is preempted in that window, the
+# coordinator reads parent=DeadlineExceeded / child=nil, the suppression misses,
+# and the target is failed with a bare "context deadline exceeded" -- having
+# found nothing.  Reproduced by widening that window with a build overlay; see
+# issue #335.  It is target-independent and writes no crasher.
+#
+# A target that fails ONLY that way, with no new crasher, is retried once (see
+# FUZZ_MAX_RETRIES).  The retry runs the full budget, so nothing is detected
+# less; if the retry fails too, the sweep fails.
+#
 # Exit status: 0 if every target survived its budget, 1 if any target failed.
-# A failing target writes its crasher to <pkg>/testdata/fuzz/<Target>/ , which
-# the CI job uploads as an artifact and a developer commits as a regression
-# case.
 
 set -uo pipefail
 
@@ -73,6 +111,20 @@ FUZZTIME="${FUZZTIME-30s}"
 FUZZ_TIMEOUT_SLACK="${FUZZ_TIMEOUT_SLACK:-300}"
 FUZZMINIMIZETIME="${FUZZMINIMIZETIME:-30s}"
 FUZZ_TAGS="${FUZZ_TAGS:-}"
+
+# Where genuinely-new crashers are collected, so CI uploads those rather than
+# `**/testdata/fuzz/**` -- which is the entire COMMITTED corpus and therefore
+# uploads ~60 files whether or not anything was found.  An artifact that always
+# exists cannot be evidence that a crasher exists.
+FUZZ_CRASH_DIR="${FUZZ_CRASH_DIR:-${REPO_ROOT}/fuzz-crashers}"
+
+# Retries are budgeted for the WHOLE sweep, not per target, because the fuzz
+# job's timeout-minutes is derived from ceil(targets/shards) x FUZZTIME plus a
+# fixed overhead (scripts/fuzz-budget-check.sh).  One retry is exactly the
+# headroom that arithmetic leaves; per-target retries would silently overrun the
+# job timeout, which truncates the sweep -- the failure mode the budget check
+# exists to prevent.  Set to 0 to make the harness race fail immediately.
+FUZZ_MAX_RETRIES="${FUZZ_MAX_RETRIES:-1}"
 
 # Built once and reused, so discovery and execution can never disagree about
 # which build they are looking at -- a sweep that DISCOVERS the default build
@@ -161,7 +213,16 @@ list_targets() {
 	go test ${tagflags+"${tagflags[@]}"} -list '^Fuzz' "$1" 2>/dev/null | grep -E '^Fuzz[A-Za-z0-9_]*$'
 }
 
-mapfile -t pkg_list < <(go list ${tagflags+"${tagflags[@]}"} "${packages[@]}" 2>/dev/null)
+# Import path AND source directory in one pass: the directory is where
+# testdata/fuzz/<Target>/ lives, and the crasher snapshot below needs it.
+# Resolving it lazily per target would re-invoke `go list` once per target.
+declare -A pkg_dir=()
+declare -a pkg_list=()
+while IFS=$'\t' read -r _ip _dir; do
+	[ -n "$_ip" ] || continue
+	pkg_dir["$_ip"]="$_dir"
+	pkg_list+=("$_ip")
+done < <(go list ${tagflags+"${tagflags[@]}"} -f '{{.ImportPath}}'$'\t''{{.Dir}}' "${packages[@]}" 2>/dev/null)
 if [ "${#pkg_list[@]}" -eq 0 ]; then
 	echo "fuzz.sh: no packages matched ${packages[*]}" >&2
 	exit 2
@@ -198,9 +259,104 @@ if [ "$shard_total" -gt 1 ]; then
 	echo "fuzz.sh: shard ${shard_index}/${shard_total} -- ${#pairs[@]} of ${discovered} target(s)" >&2
 fi
 
+# corpus_snapshot prints the sorted file names currently in a target's
+# committed-crasher directory, or nothing if it does not exist yet.
+corpus_snapshot() {
+	local dir="$1"
+	[ -d "$dir" ] || return 0
+	find "$dir" -maxdepth 1 -type f -printf '%f\n' 2>/dev/null | LC_ALL=C sort
+}
+
+# classify_failure names what a non-zero `go test -fuzz` actually means, given
+# the log and whether new crasher files appeared.  Ordered most-specific first:
+# any evidence of a real finding wins over the harness signature, so a genuine
+# crash can never be reclassified as a flake.
+classify_failure() {
+	local log="$1" new_count="$2"
+	if [ "$new_count" -gt 0 ]; then
+		echo crasher
+		return
+	fi
+	# A seed-corpus failure writes no new file -- the input is already
+	# committed -- so it MUST be checked before the harness signature.
+	if grep -q 'failure while testing seed corpus entry' "$log"; then
+		echo seed
+		return
+	fi
+	# A crash the engine found but could not persist. Still a finding.
+	if grep -qE 'Failing input written to|could not write.*corpus' "$log"; then
+		echo crasher
+		return
+	fi
+	# The upstream -fuzztime race (issue #335): the ONLY output is the bare
+	# deadline error. Every other marker of a real failure disqualifies it --
+	# a panic, a signal death, a named failing input, or a build error.
+	if grep -qE '^[[:space:]]*context deadline exceeded[[:space:]]*$' "$log" &&
+		! grep -qE 'panic:|terminated by unexpected signal|--- FAIL: [A-Za-z0-9_]+/|\[build failed\]|cannot find|undefined:' "$log"; then
+		echo harness
+		return
+	fi
+	echo unattributed
+}
+
+# run_target runs one target once and prints its classification. Sets the
+# globals rc, elapsed, verdict and new_crashers.
+run_target() {
+	local pkg="$1" target="$2" attempt="$3"
+	local dir="${pkg_dir[$pkg]:-}"
+	local crashdir="${dir}/testdata/fuzz/${target}"
+	local log="${tmpdir}/${target}.${attempt}.log"
+
+	corpus_snapshot "$crashdir" >"${tmpdir}/before"
+
+	local start=$SECONDS
+	# -run '^$' skips the ordinary unit tests: the seed corpus is executed by
+	# the fuzzing engine anyway, and re-running the package's whole test suite
+	# per target would multiply the job's cost by the number of targets.
+	go test ${tagflags+"${tagflags[@]}"} "$pkg" \
+		-run '^$' \
+		-fuzz "^${target}\$" \
+		-fuzztime "$FUZZTIME" \
+		-fuzzminimizetime "$FUZZMINIMIZETIME" \
+		-timeout "${hard_timeout}s" 2>&1 | tee "$log"
+	rc="${PIPESTATUS[0]}"
+	elapsed=$((SECONDS - start))
+
+	corpus_snapshot "$crashdir" >"${tmpdir}/after"
+	mapfile -t new_crashers < <(LC_ALL=C comm -13 "${tmpdir}/before" "${tmpdir}/after")
+
+	if [ "$rc" -eq 0 ]; then
+		verdict=ok
+		return
+	fi
+	verdict="$(classify_failure "$log" "${#new_crashers[@]}")"
+
+	# Collect the genuinely-new inputs where CI can upload just those.
+	if [ "${#new_crashers[@]}" -gt 0 ]; then
+		local out="${FUZZ_CRASH_DIR}/${pkg//\//_}/${target}"
+		mkdir -p "$out"
+		local f
+		for f in "${new_crashers[@]}"; do
+			cp "${crashdir}/${f}" "${out}/${f}"
+			printf '%s\t%s\t%s\tgo test %s -run %s/%s\n' \
+				"$pkg" "$target" "$f" "$pkg" "$target" "$f" \
+				>>"${FUZZ_CRASH_DIR}/MANIFEST.tsv"
+		done
+	fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
 total=0
 failed=0
+retries_left="$FUZZ_MAX_RETRIES"
 declare -a failures=()
+declare -a flakes=()
+declare -a new_crashers=()
+rc=0
+elapsed=0
+verdict=ok
 
 for pair in ${pairs+"${pairs[@]}"}; do
 	pkg="${pair%%	*}"
@@ -212,23 +368,41 @@ for pair in ${pairs+"${pairs[@]}"}; do
 			continue
 		fi
 		echo "=== fuzz ${target}  (${pkg}, ${FUZZTIME}) ==================="
-		start=$SECONDS
-		# -run '^$' skips the ordinary unit tests: the seed corpus is
-		# executed by the fuzzing engine anyway, and re-running the package's
-		# whole test suite per target would multiply the job's cost by the
-		# number of targets.
-		go test ${tagflags+"${tagflags[@]}"} "$pkg" \
-			-run '^$' \
-			-fuzz "^${target}\$" \
-			-fuzztime "$FUZZTIME" \
-			-fuzzminimizetime "$FUZZMINIMIZETIME" \
-			-timeout "${hard_timeout}s"
-		rc=$?
-		elapsed=$((SECONDS - start))
+		run_target "$pkg" "$target" 1
+
+		# The harness race found nothing and blamed no input, so re-running is
+		# not "hoping for green": it spends another full budget on the same
+		# target. Bounded per sweep, and only ever reached when the run
+		# produced no crasher at all.
+		if [ "$verdict" = harness ] && [ "$retries_left" -gt 0 ]; then
+			retries_left=$((retries_left - 1))
+			echo "--- ${target}: failed with the upstream -fuzztime race and NO crasher (issue #335); retrying once ---"
+			first_elapsed="$elapsed"
+			run_target "$pkg" "$target" 2
+			if [ "$rc" -eq 0 ]; then
+				flakes+=("${pkg} ${target} (harness -fuzztime race after ${first_elapsed}s, clean on retry in ${elapsed}s)")
+				echo "--- ok ${target} in ${elapsed}s (after one harness flake) ---"
+				continue
+			fi
+		fi
+
 		if [ "$rc" -ne 0 ]; then
 			failed=$((failed + 1))
-			failures+=("${pkg} ${target} (exit ${rc}, ${elapsed}s)")
-			echo "--- FAIL ${target} after ${elapsed}s ---"
+			case "$verdict" in
+			crasher)
+				failures+=("${pkg} ${target} (exit ${rc}, ${elapsed}s) CRASHER: ${new_crashers[*]}")
+				;;
+			seed)
+				failures+=("${pkg} ${target} (exit ${rc}, ${elapsed}s) SEED CORPUS entry failed; no new crasher (the input is already committed)")
+				;;
+			harness)
+				failures+=("${pkg} ${target} (exit ${rc}, ${elapsed}s) HARNESS: the upstream -fuzztime race (issue #335) recurred; NO crasher was produced")
+				;;
+			*)
+				failures+=("${pkg} ${target} (exit ${rc}, ${elapsed}s) UNATTRIBUTED: failed without producing a crasher; read the log above")
+				;;
+			esac
+			echo "--- FAIL ${target} after ${elapsed}s (${verdict}) ---"
 		else
 			echo "--- ok ${target} in ${elapsed}s ---"
 		fi
@@ -259,13 +433,40 @@ if [ "$total" -eq 0 ]; then
 	exit 2
 fi
 echo "fuzz.sh: ${total} target(s), ${failed} failure(s), ${FUZZTIME} each${FUZZ_TAGS:+, -tags ${FUZZ_TAGS}}"
+
+# Reported even on a green sweep: a retried flake is not nothing, and burying
+# it is how #318 ended up with an unexplained result carried forward.
+if [ "${#flakes[@]}" -gt 0 ]; then
+	echo
+	echo "fuzz.sh: ${#flakes[@]} target(s) hit the upstream -fuzztime race and passed on retry:"
+	for f in "${flakes[@]}"; do
+		echo "  FLAKE $f"
+	done
+	echo "  This is golang/go's fuzzing coordinator, not this repository's code."
+	echo "  See issue #335. No input was implicated and no crasher was written."
+fi
+
 if [ "$failed" -ne 0 ]; then
+	echo
 	for f in "${failures[@]}"; do
 		echo "  FAIL  $f"
 	done
 	echo
-	echo "Crashing inputs were written under <package>/testdata/fuzz/<Target>/."
-	echo "Reproduce with: go test <package> -run '<Target>/<file>'"
+	if [ -d "$FUZZ_CRASH_DIR" ] && [ -f "${FUZZ_CRASH_DIR}/MANIFEST.tsv" ]; then
+		echo "New crashing inputs were written under <package>/testdata/fuzz/<Target>/"
+		echo "and collected in ${FUZZ_CRASH_DIR#"${REPO_ROOT}/"}/ :"
+		while IFS=$'\t' read -r _pkg _target _file _repro; do
+			echo "  ${_target}/${_file}    reproduce with: ${_repro}"
+		done <"${FUZZ_CRASH_DIR}/MANIFEST.tsv"
+	else
+		# The distinction #318 lacked. Saying this plainly is worth as much as
+		# any fix: it tells the reader not to go looking for an input.
+		echo "NO new crasher was produced by this run."
+		echo "Nothing was written under <package>/testdata/fuzz/<Target>/, so no"
+		echo "input is implicated -- do not go looking for one. Read the failure"
+		echo "classification above: a SEED failure names a committed input, and"
+		echo "HARNESS / UNATTRIBUTED mean the run itself fell over."
+	fi
 	exit 1
 fi
 echo "fuzz.sh: all targets survived their budget"


### PR DESCRIPTION
Closes #335. Resolves the "one unexplained result, carried forward" in #318.

`Fuzz shard 2/4` on #330 failed with `--- FAIL: FuzzMinifySource (31.03s) / context deadline exceeded`, on a PR that touches nothing the minifier depends on, having written no crasher.

## Where the deadline actually comes from

Not from elps. It is the error `internal/fuzz.CoordinateFuzzing` returns, printed by `testing.(*F).Fuzz` as `fmt.Fprintf(f.w, "%v\n", err)`.

`CoordinateFuzzing` applies `-fuzztime` as a context deadline and suppresses it as normal termination by comparing the **parent** context's error against the **child's**:

```go
case <-doneC:
    stop(ctx.Err())
...
stop := func(err error) {
    if err == fuzzCtx.Err() || isInterruptError(err) { err = nil }
    if err != nil && (fuzzErr == nil || fuzzErr == ctx.Err()) { fuzzErr = err }
```

`context.cancelCtx.cancel` stores the parent's error and **closes the parent's done channel before** it walks its children, and `cancelCtx.Err()` is a lock-free atomic load. So a goroutine woken by that close does not block behind the mutex — and if the cancelling thread is preempted in the gap, the coordinator reads parent=`DeadlineExceeded`, child=`nil`, the suppression misses, and the target is failed having found nothing.

Yes, the bound is wall-clock, and yes it is the `-fuzztime` deadline. But it is not too short: the target ran its full budget successfully and then failed on the way out. Nothing about the minifier, the budget, or PR #330 is implicated.

**Proof.** Widening exactly that window — one `runtime.Gosched()` between `close(d)` and the children walk, injected with `go test -overlay`, diagnostic only, nothing shipped — reproduces it byte-identically, on every target tried:

| target | window widened | unpatched control |
|---|---|---|
| `FuzzMinifySource` | FAIL `context deadline exceeded` | ok |
| `FuzzFormat` | FAIL `context deadline exceeded` | ok |
| `FuzzLexer` | FAIL `context deadline exceeded` | ok |
| `FuzzScanner` | FAIL `context deadline exceeded` | ok |
| `FuzzLoadJSON` | FAIL `context deadline exceeded` | ok |

`git status` stays clean after all of them: no crasher is ever written. Go 1.25.0 and 1.25.12 (the CI version) have byte-identical `internal/fuzz` sources, so this is not a patch-release regression.

`FuzzFormat` reproducing with the identical signature is what ties #318's carried-forward mystery to the same cause — the mechanism is target-independent by construction, since it lives in the coordinator above the fuzz function. Detail and caveats in the comment on #318.

## Two premises in the original reading that turned out to be wrong

**The `0/sec` lines are not CPU contention.** They are coverage-input minimisation: a worker in `workerServer.minimize` reports nothing until it finishes, and `fuzz.sh` sets `FUZZMINIMIZETIME=30s`, equal to the whole PR `FUZZTIME`. Measured on an **idle** 4-core box with `GODEBUG=fuzzdebug=1`: single minimisations of 8.3s and 17.4s, with the test processes pinned at ~280% CPU throughout the apparent stall. Instrumenting the fuzz body to log any input over 300ms found none, so it is not a slow input either.

**The four shards never shared a runner.** `runs-on: ubuntu-latest` gives each matrix job its own VM. Reducing the matrix, or keeping fuzz off the benchmark runner, would not have helped.

## What changed

**`scripts/fuzz.sh` classifies failures.** It snapshots each target's `testdata/fuzz/<Target>/` around the run and reports `CRASHER` (new files, named, with a reproduce command), `SEED` (the committed corpus failed, so no new file), `HARNESS` (the known race) or `UNATTRIBUTED`. The old unconditional "Crashing inputs were written under …" line — printed on the #330 failure, when none were — is gone; when nothing new was written it now says so.

**The known race is retried once per sweep.** Only when there is no new crasher and the output is *only* the bare deadline error; a panic, a signal death, a named failing input, a seed failure or a build error all disqualify it. The retry spends a full budget, so nothing is detected less, and a retried flake is reported loudly rather than buried. One retry is exactly the headroom `fuzz-budget-check.sh`'s arithmetic leaves (`4 × 10m + 10m = 50` against `timeout-minutes: 60`), which is why the budget is per sweep rather than per target. `FUZZ_MAX_RETRIES=0` opts out.

**`fuzz.yml` uploads only new crashers.** It globbed `**/testdata/fuzz/**`, i.e. the whole committed corpus — the failing run uploaded 62 files having found nothing, so the artifact's existence never meant anything. Now it uploads `fuzz-crashers/`, guarded by `hashFiles`, so absence of the artifact positively means no crasher.

**`scripts/fuzz-classify-test.sh`** is the complement to `ci-gates-test.sh`: that suite proves the gate can fail, this one proves it fails for the right reason. 33 assertions driving the real `fuzz.sh` against a stub toolchain, no Go toolchain needed, seconds to run, wired into `fuzz.yml` and `make fuzz-classify-test`. `ci-gates-test.sh` is untouched and still 116/116.

**`internal/fuzzwatch`** denominates the three in-target watchdogs in scheduled time. One heartbeat goroutine per process measures wall clock during which it did not run on schedule; a fired watchdog then resolves to Continue, Hung, or Inconclusive (starved throughout — assert nothing, `t.Skip` the input).

## Audit: every wall-clock bound in the fuzz surface

Per-input costs are means measured on a 4-core box from live exec rates.

| Bound | Value | Bounds | Measured cost | Headroom | Action |
|---|---|---|---|---|---|
| `-fuzztime` (Go's coordinator, set by `fuzz.sh`) | 30s PR / 10m nightly | the whole target run | — | — | **the one that flaked**; classified + retried in `fuzz.sh` |
| `eval_fuzz_test.go` `watchdogTimeout` | 30s | one evaluation | 0.33 ms | ~90,000x | now scheduled time |
| `lisplib/fuzz_test.go` `callDeadline+watchdogGrace` | 15s | one stdlib application | 0.73 ms | ~20,000x | now scheduled time |
| `libschema/fuzz_test.go` `schemaWatchdog` | 20s | one validation | 0.91 ms | ~22,000x | now scheduled time |
| `eval_fuzz_test.go` `fuzzDeadline` | 2s (context) | one evaluation | 0.33 ms | ~6,000x | unchanged — expiry is a normal non-failing outcome, not an assertion |
| `lisplib` `callDeadline` | 5s (context) | one application | 0.73 ms | ~6,800x | unchanged, same reason |
| `libschema` `schemaDeadline` | 5s (context) | one validation | 0.91 ms | ~5,500x | unchanged, same reason |
| `parser/lexer/fuzz_test.go:115` | 30s | `TestLexerTerminatesOnUndecodableInput`, a unit test over 8 fixed inputs of ≤8 bytes — not the fuzz body | µs | ~10^7x | none |
| `parser/rdparser/fuzz_test.go:203` | 30s | `TestParserSurvivesPathologicalInput`, a unit test over `fuzzseed.Pathological()` — not the fuzz body | ms | ~10^4x | none |
| `fuzz.sh` `-timeout` | FUZZTIME+300s | the `go test` process | — | — | unchanged |
| `fuzz.yml` `timeout-minutes` | 60 | the shard | — | — | unchanged, still derived by `fuzz-budget-check.sh` |

The other 12 targets carry no wall-clock bound at all — `FuzzScanner`, `FuzzLexer`, the three `rdparser` targets, `FuzzFormat`, `FuzzFormatCompact`, `FuzzMinifySource`, `FuzzGeneratedPipeline`, `FuzzLoadJSON`, `FuzzDumpJSON`, `FuzzGateSelfTest` — because parsing n bytes is bounded by n.

**No bound was raised.** At 20,000-90,000x the measured cost they were never too small; they were measuring the wrong thing.

## Calibration: does this weaken detection?

The heartbeat, run as a bystander process:

| condition | p100 tick lag (nominal 100ms) | charged as lost |
|---|---|---|
| idle | 100ms | 0 |
| 4 fuzz workers saturating all 4 cores | 100ms | 0 |
| load average 29 (96 CPU burners) | 100ms | 0 |
| `SIGSTOP` for 3s (what CPU steal looks like from inside a process) | 3.1s | 3s |

Ordinary CPU contention does **not** delay a sleeping timer, so it is charged nothing and these targets behave exactly as before — the `tolerance` constant has a 4x margin over the worst lateness ever observed on a saturated box. Only a whole-process or whole-VM stall registers, which is the one event that could genuinely blow a 20,000x bound. This also means the in-target watchdogs were never realistically at risk from contention; `fuzzwatch` exists so that claim is measured rather than asserted, and so the failure message carries the evidence.

Detection is reduced in exactly one case: a machine that is not running us at all, for four consecutive budgets, where the alternative to "no verdict" is a coin flip.

## Reproduction, honestly

- **Reproduced deterministically** by widening the context-cancellation window with a build overlay: 5/5 targets, byte-identical signature, no crasher, controls clean.
- **Not reproduced under artificial load.** 40 runs of `FuzzMinifySource` with 96 CPU burners on 4 cores: **0/40**. That is consistent with the mechanism rather than against it — the window is opened by an involuntary preemption at a specific instruction, not by CPU pressure, and the heartbeat data above shows this box's scheduler stays punctual even at load 29. I could not manufacture the real thing, and I am not claiming otherwise.

Before and after, same widened window, same target:

```
BEFORE (origin/main scripts/fuzz.sh)
  --- FAIL FuzzMinifySource after 7s ---
  fuzz.sh: 1 target(s), 1 failure(s), 6s each
    FAIL  .../minifier FuzzMinifySource (exit 1, 7s)
  Crashing inputs were written under <package>/testdata/fuzz/<Target>/.     <- untrue
  Reproduce with: go test <package> -run '<Target>/<file>'                  <- no such file

AFTER, race clears on retry
  --- FuzzMinifySource: failed with the upstream -fuzztime race and NO crasher (issue #335); retrying once ---
  --- ok FuzzMinifySource in 7s (after one harness flake) ---
  fuzz.sh: 1 target(s) hit the upstream -fuzztime race and passed on retry:
    FLAKE .../minifier FuzzMinifySource (harness -fuzztime race after 7s, clean on retry in 7s)

AFTER, race recurs on retry (still red, but truthful)
    FAIL  .../minifier FuzzMinifySource (exit 1, 7s) HARNESS: the upstream -fuzztime race (issue #335) recurred; NO crasher was produced
  NO new crasher was produced by this run. ... do not go looking for one.
```

## Options weighed and rejected

- **Raise a timeout.** Rejected: measured headroom is already four to five orders of magnitude, and the bound that actually failed is Go's own `-fuzztime`, which no value would fix.
- **Reduce concurrency (shrink the matrix, move fuzz off the benchmark runner).** Rejected: each GitHub-hosted matrix job has its own VM. The premise that shards competed is false.
- **Make `-fuzztime` work-based (`-fuzztime 100000x`).** Genuinely tempting — with `Limit` set, `opts.Timeout` is 0, no deadline context is created, and the race becomes structurally impossible. Rejected because exec rates vary tenfold between targets and between runs (2,756/sec to 26,698/sec in the #330 log alone), so a per-target iteration count makes a shard's wall clock unpredictable. That destroys `fuzz-budget-check.sh`'s derived `timeout-minutes` and reintroduces the silently-truncated sweep that #328 removed. Worth revisiting if the budget check is ever reformulated.
- **Swallow the deadline error unconditionally.** Rejected: it would also swallow a real `CoordinateFuzzing` failure. The signature check plus "no crasher was written" plus a full-budget retry keeps every finding.

## Follow-up not done here

This is an upstream Go bug and worth reporting to golang/go; #335 documents the mechanism and the reproduction in enough detail to file it. The fix here is repo-side containment, deliberately narrow.

## Test plan

- `go build ./...`
- `go test ./...` — clean
- `golangci-lint run ./...` — 0 issues
- `make fuzz` (30s x 15 targets) — 15 targets, 0 failures, working tree clean afterwards
- `bash scripts/ci-gates-test.sh` — 116 passed, 0 failed (unchanged; the file is not touched)
- `bash scripts/fuzz-classify-test.sh` — 33 passed, 0 failed
- `bash scripts/fuzz-budget-check.sh` — the sweep fits, 10 min headroom
- `go test ./internal/fuzzwatch/...` — verdict logic, stall accounting, and the negative case (wall cap reached while *not* starved is still Hung)
- Rebased onto current `main` and re-verified after.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_