### PR TITLE
Raise invalid-string, not invalid-float, for a bad string literal

### DIFF
--- a/lisp/conditions.go
+++ b/lisp/conditions.go
@@ -12,6 +12,8 @@ const (
 	CondInvalidSymbol       = "invalid-symbol"
 	CondInvalidOctalLiteral = "invalid-octal-literal"
 	CondInvalidHexLiteral   = "invalid-hex-literal"
+	CondInvalidFloat        = "invalid-float"
+	CondInvalidString       = "invalid-string"
 	CondOverflow            = "integer-overflow-error"
 )
 

--- a/lisp/conditions_test.go
+++ b/lisp/conditions_test.go
@@ -46,5 +46,7 @@ func TestConditionConstants(t *testing.T) {
 	assert.Equal(t, "invalid-symbol", CondInvalidSymbol)
 	assert.Equal(t, "invalid-octal-literal", CondInvalidOctalLiteral)
 	assert.Equal(t, "invalid-hex-literal", CondInvalidHexLiteral)
+	assert.Equal(t, "invalid-float", CondInvalidFloat)
+	assert.Equal(t, "invalid-string", CondInvalidString)
 	assert.Equal(t, "integer-overflow-error", CondOverflow)
 }

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -276,7 +276,7 @@ func (p *Parser) ParseLiteralFloat() *lisp.LVal {
 	text := p.TokenText()
 	x, err := strconv.ParseFloat(text, 64)
 	if err != nil {
-		return p.errorf("invalid-float", "invalid floating point literal: %v", text)
+		return p.errorf(lisp.CondInvalidFloat, "invalid floating point literal: %v", text)
 	}
 	v := p.Float(x)
 	if p.preserveFormat && v.Meta != nil {
@@ -292,7 +292,7 @@ func (p *Parser) ParseLiteralString() *lisp.LVal {
 	text := p.TokenText()
 	s, err := strconv.Unquote(text)
 	if err != nil {
-		return p.errorf("invalid-float", "invalid string literal: %v", text)
+		return p.errorf(lisp.CondInvalidString, "invalid string literal: %v", text)
 	}
 	v := p.String(s)
 	if p.preserveFormat && v.Meta != nil {

--- a/parser/rdparser/parser_test.go
+++ b/parser/rdparser/parser_test.go
@@ -298,6 +298,25 @@ func TestCondition_InvalidHexLiteral(t *testing.T) {
 	assert.Equal(t, lisp.CondInvalidHexLiteral, parseErrorCondition(t, "#xG"))
 }
 
+// A float literal the lexer accepts but strconv.ParseFloat rejects (out of
+// range) reports invalid-float.  Pinned as a companion to
+// TestCondition_InvalidString: the string path used to report this same
+// condition, so the fix for issue #317 has to leave THIS path alone.
+func TestCondition_InvalidFloat(t *testing.T) {
+	assert.Equal(t, lisp.CondInvalidFloat, parseErrorCondition(t, "1e999"))
+}
+
+// A string literal the lexer accepts but strconv.Unquote rejects (bad escape)
+// reports invalid-string.  Regression test for issue #317: ParseLiteralString
+// raised invalid-float here, copy-pasted from the neighbouring float path.
+//
+// The lexer deliberately defers escape validation to the parser ("Wait until
+// parsing to check the escaped character" in lexer.go), which is what makes
+// this path reachable at all.
+func TestCondition_InvalidString(t *testing.T) {
+	assert.Equal(t, lisp.CondInvalidString, parseErrorCondition(t, `"\q"`))
+}
+
 func TestCondition_ParseError(t *testing.T) {
 	assert.Equal(t, lisp.CondParseError, parseErrorCondition(t, "#!/usr/bin/env elps\n#!/usr/bin/env foo\n"))
 }


### PR DESCRIPTION
Fixes #317.

`rdparser.ParseLiteralString` raised the condition name `invalid-float` when
`strconv.Unquote` rejected a string literal — copy-pasted from the neighbouring
float path. Found by grammar-aware fuzzing (#311) and deliberately left unfixed
there, because condition names are language-visible.

## ⚠️ Release note — behaviour change

> **Condition name change.** A malformed string literal now raises the condition
> `invalid-string` instead of `invalid-float`. Code that selected on the old name
> — `(handler-bind ([invalid-float ...]) ...)`, or a Go embedder comparing
> `ErrorVal.Condition()` — no longer catches malformed *string* literals. It still
> catches malformed float literals, which are unchanged. Catch-all handlers
> (`condition`, `error`) and `ignore-errors` are unaffected.

The perverse case worth flagging to anyone upgrading: a handler that caught
`invalid-float` *specifically to work around this bug* is exactly the code this
fix breaks.

## Why `invalid-string`

The issue suggested the name; checking the surrounding convention confirms it
rather than just accepting it. The parser raises two shapes of `invalid-*`, and
they are not interchangeable:

| Shape | Names | Raised when |
|---|---|---|
| `invalid-<kind>` | `invalid-float`, `invalid-symbol` | Token was **accepted**, but its text would not convert |
| `invalid-<kind>-literal` | `invalid-octal-literal`, `invalid-hex-literal` | The `#o` / `#x` dispatch macro was **not followed by a valid token** |

The string case is a `strconv.Unquote` failure on an already-accepted `STRING`
token, so it belongs to the first family alongside `invalid-float` and
`invalid-symbol`. `invalid-string-literal` would have mis-filed it under the
dispatch-macro family.

Full set of condition names `rdparser` raises, for the record: `parse-error`,
`scan-error`, `unmatched-syntax`, `mismatched-syntax`, `invalid-symbol`,
`invalid-octal-literal`, `invalid-hex-literal`, `invalid-float`,
`integer-overflow-error`, `unbound-expression-error`.

## Also: registered both names as API

`lisp/conditions.go` describes itself as "stable API for programmatic error
classification in LSP and tooling integrations", but `invalid-float` was never
declared there even though every one of its peers was. This adds
`CondInvalidFloat` and `CondInvalidString` and uses them at the two call sites,
so the new name is discoverable rather than a bare string literal in the parser.

The rest of `parser.go` still spells its condition names as raw literals. That
mechanical migration is deliberately **out of scope** — it would bury a
release-note-worthy semantic change under a large no-op diff.

## Reachability

The lexer defers escape validation to the parser (`"Wait until parsing to check
the escaped character"`), which is what makes this path reachable:

```
$ elps run bad.lisp        # (debug-print "\q")
before: error: bad.lisp:1:14: invalid-float:  invalid string literal: "\q"
after:  error: bad.lisp:1:14: invalid-string: invalid string literal: "\q"
```

## Test plan

- `TestCondition_InvalidString` — `"\q"` (bad escape) ⇒ `invalid-string`. Regression test for this issue.
- `TestCondition_InvalidFloat` — `1e999` (out of range) ⇒ `invalid-float`. Pins that the float path is **unchanged**; without it the fix could have renamed both.
- `TestConditionConstants` — extended with the two new constants.

**Mutation-verified.** Reverting the one-line rename (restoring `CondInvalidFloat`
in `ParseLiteralString`) makes `TestCondition_InvalidString` fail with
`expected: "invalid-string"`, while `TestCondition_InvalidFloat` keeps passing —
confirming the two pins are independent and the new test genuinely covers the fix.

Green: `go build ./...`, `go test ./...`, `golangci-lint run ./...` (0 issues),
`elps doc -m`, `elps fmt -l --exclude 'grammar' ./...`, `scripts/ci-gates-test.sh`
(116 passed, 0 failed).

## Downstream impact check

- **`luthersystems/substrate`**: zero source references to `invalid-float` — or to
  any parser condition name — across `.lisp`, `.go`, `.md`, and workflow files. The
  single repo-wide grep hit is `cmd/substratehcp/build/substratehcp-local`, a
  compiled build artifact that merely has the string linked in.
- Substrate's name-selective `handler-bind` specifiers are all domain conditions
  (`set-exception-error`, `csprng-uninitialized`, `missing-dsr`,
  `missing-callback-state`, `json:syntax-error`, `iv-empty`, `key-empty`,
  `missing-mxf`, `other-condition`). Its ~17 uses of the catch-all `condition`
  specifier and 3 of `error` are name-agnostic, so the rename is invisible to them.
- **elps itself**: no test, `docs/lang.md` section, embedded guide, lint analyzer,
  or LSP diagnostic mapping referenced the old name. `docs/lang.md` documents
  `handler-bind` only with user-defined conditions and carries no parser-condition list.
- No conflict with the unimplemented `ErrorCode` taxonomy sketched in
  `docs/plans/lsp-support-enhancements.md` (`invalid-escape` / `invalid-number`) —
  that is a proposed separate type in a not-yet-created `parser/token/errors.go`,
  a different namespace from lisp condition names.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_