### PR TITLE
Add a daily scheduled govulncheck run, and lint every script in scripts/

### DIFF
--- a/.github/workflows/govulncheck-scheduled.yml
+++ b/.github/workflows/govulncheck-scheduled.yml
@@ -1,0 +1,117 @@
+name: govulncheck (scheduled)
+
+# Scheduled companion to the govulncheck gate that already runs on pull
+# requests in .github/workflows/govulncheck.yml. That workflow is NOT modified
+# and NOT duplicated here: it fires on `pull_request`, this one only on
+# `schedule` / `workflow_dispatch`, so the two never scan the same event.
+#
+# Why a schedule: a PR-triggered gate only re-scans when someone opens a PR,
+# but the Go vulnerability database updates continuously -- a repo nobody has
+# touched for a month can go from clean to vulnerable with no code change at
+# all. Pinning the toolchain to `stable` also means this picks up Go stdlib
+# advisories, which track toolchain patch releases rather than any dependency.
+#
+# A finding opens (and later auto-closes) a `govulncheck-drift` issue, so it
+# is visible without anyone subscribing to cron failures. The issue logic
+# lives in scripts/govulncheck-drift.cjs, not inline here.
+#
+# The cron minute/hour is staggered against the other luthersystems repos
+# running this same workflow (06:10 reliable, 06:20 ui-core, 06:30 mars,
+# 06:40 sandbox, 06:50 insideout-terraform-presets, 07:00 svc, 07:10
+# lutherauth, 07:20 lutherauth-sdk-go, 07:30 insideout-mcp) so they do not all
+# hit the vulndb and the Actions queue in the same minute.
+
+on:
+  schedule:
+    - cron: "40 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # SHA-pinned, and reusing SHAs already present elsewhere in this tree, so
+      # the pin is verifiable from the repository itself. scripts/ci-gates-test.sh
+      # hard-fails any new workflow that uses a floating action tag.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
+        with:
+          go-version: "stable"
+          cache: true
+
+      # Do not fold this into the scan step. A refactor elsewhere in the fleet
+      # dropped it and the scripts below then ran against a govulncheck binary
+      # that was never installed.
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        id: scan
+        run: bash scripts/govulncheck-scan.sh
+
+      # Second, ADDITIVE pass over the built binaries. NOT a substitute for the
+      # source scan above and must not become one: source mode reports
+      # vulnerabilities in imported packages even when the linker dropped the
+      # code, which binary mode cannot see. Run together, neither loses
+      # coverage.
+      #
+      # What binary mode adds: reflection-reached code. Per the govulncheck
+      # docs, calls made via package reflect "will not be reported in source
+      # scan mode" -- binary mode keys off symbol presence instead. It also
+      # scans the stdlib at the version the binary was BUILT with rather than
+      # the version the scanner runs under.
+      #
+      # Library modules have no main packages; there the step is a no-op.
+      # elps has exactly one (the root `elps` CLI), so this pass does apply.
+      #
+      # This pass has to `go build` each main package before it has anything to
+      # scan, so it goes red for two unrelated reasons: a compile error, or an
+      # actual finding. Both still FAIL -- a package that did not compile was
+      # not scanned, and an unscanned package is not a clean one -- but the
+      # script reports them as separate outputs (`build_failed` /
+      # `vulns_found`) and emits a distinct `::error::` for each, so the check
+      # name "govulncheck" stops turning a build break into a phantom security
+      # finding.
+      #
+      # The script exits NON-ZERO on either condition, which is why the two
+      # steps below carry `!cancelled()` guards -- without them a failure here
+      # would skip the tracking-issue writer.
+      - name: Run govulncheck (binary mode)
+        id: binscan
+        run: bash scripts/govulncheck-binary-scan.sh
+
+      # `!cancelled()` + the outcome guard keeps this reachable now that the
+      # binary pass can exit non-zero, while preserving the behaviour that a
+      # setup failure (checkout / install) skips the writer entirely -- a
+      # skipped scan must never be read as "clean" and auto-close the issue.
+      - name: Open, refresh or close the tracking issue
+        if: ${{ !cancelled() && steps.binscan.outcome != 'skipped' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        env:
+          FOUND: ${{ steps.scan.outputs.exit != '0' || steps.binscan.outputs.exit != '0' }}
+          # Split out so the issue does not describe a compile error as a
+          # "reachable vulnerability" and send its reader hunting a CVE that
+          # does not exist.
+          VULN_FOUND: ${{ steps.scan.outputs.exit != '0' || steps.binscan.outputs.vulns_found == '1' }}
+          BUILD_FAILED: ${{ steps.binscan.outputs.build_failed == '1' }}
+          REPORT_PATH: /tmp/govulncheck.txt
+        with:
+          script: |
+            const run = require('./scripts/govulncheck-drift.cjs');
+            await run({ github, context, core });
+
+      # Named for what it actually gates: a finding OR a build break. The
+      # script only reports which condition tripped (log + job summary) and
+      # then fails; it never decides whether to fail.
+      - name: Fail if govulncheck reported a finding or a build break
+        if: ${{ !cancelled() && (steps.scan.outputs.exit != '0' || steps.binscan.outputs.exit != '0') }}
+        env:
+          SOURCE_SCAN_EXIT: ${{ steps.scan.outputs.exit }}
+          BINARY_BUILD_FAILED: ${{ steps.binscan.outputs.build_failed }}
+          BINARY_VULNS_FOUND: ${{ steps.binscan.outputs.vulns_found }}
+        run: bash scripts/govulncheck-fail-summary.sh

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -1130,15 +1130,29 @@ case "$req_out" in
 esac
 
 echo
-echo "== shell lint on the scripts this suite owns ============================="
+echo "== shell lint on every script in scripts/ ================================"
 
-OWNED_SCRIPTS=(
-	"${SCRIPT_DIR}/bench-arms-check.sh"
-	"${SCRIPT_DIR}/benchstat-gate.sh"
-	"${SCRIPT_DIR}/ci-gates-test.sh"
-	"${SCRIPT_DIR}/fuzz-budget-check.sh"
-	"${SCRIPT_DIR}/fuzz.sh"
-)
+# DISCOVERED, not enumerated. This was a hardcoded five-entry array, and the
+# consequence was exactly what a hardcoded list always produces: scripts landed
+# in scripts/ and were never linted by anything. scripts/fuzz-classify-test.sh
+# sat unlinted from the day it was added, and the four govulncheck-* scripts
+# would have joined it. A lint list that has to be edited by hand is a lint
+# list that silently shrinks in relative terms every time the directory grows.
+#
+# The floor below is the other half of the guard: a glob that matches nothing
+# (wrong SCRIPT_DIR, a `set -f` somewhere above, a rename of the directory)
+# would otherwise report "clean on all 0 scripts" and pass.
+OWNED_SCRIPTS=()
+while IFS= read -r s; do
+	OWNED_SCRIPTS+=("$s")
+done < <(find "$SCRIPT_DIR" -maxdepth 1 -name '*.sh' -type f | LC_ALL=C sort)
+
+SCRIPT_FLOOR=5
+if [ "${#OWNED_SCRIPTS[@]}" -ge "$SCRIPT_FLOOR" ]; then
+	ok "discovered ${#OWNED_SCRIPTS[@]} shell scripts in scripts/ (floor ${SCRIPT_FLOOR})"
+else
+	bad "discovered only ${#OWNED_SCRIPTS[@]} shell scripts in scripts/, expected >= ${SCRIPT_FLOOR} — the glob is broken, not the tree"
+fi
 
 for s in "${OWNED_SCRIPTS[@]}"; do
 	if bash -n "$s" 2>/dev/null; then
@@ -1158,6 +1172,29 @@ if command -v shellcheck >/dev/null 2>&1; then
 	fi
 else
 	echo "SKIP  shellcheck not installed"
+fi
+
+# Same treatment for the .cjs helpers. ci-queue-watchdog.cjs already had a
+# node --check above as part of its own workflow-wiring assertions; this covers
+# every .cjs in the directory, including any added later with no wiring test.
+OWNED_CJS=()
+while IFS= read -r s; do
+	OWNED_CJS+=("$s")
+done < <(find "$SCRIPT_DIR" -maxdepth 1 -name '*.cjs' -type f | LC_ALL=C sort)
+
+if [ "${#OWNED_CJS[@]}" -eq 0 ]; then
+	bad "no .cjs helpers discovered in scripts/ — the glob is broken, not the tree"
+elif command -v node >/dev/null 2>&1; then
+	for s in "${OWNED_CJS[@]}"; do
+		if node --check "$s" 2>/dev/null; then
+			ok "node --check $(basename "$s")"
+		else
+			bad "node --check $(basename "$s")"
+			node --check "$s" 2>&1 | sed 's/^/        | /'
+		fi
+	done
+else
+	echo "SKIP  node not installed (${#OWNED_CJS[@]} .cjs helpers unchecked)"
 fi
 
 echo

--- a/scripts/govulncheck-binary-scan.sh
+++ b/scripts/govulncheck-binary-scan.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Binary-mode govulncheck pass for the scheduled workflow.
+#
+# Extracted from .github/workflows/govulncheck-scheduled.yml. Run locally as:
+#
+#   GITHUB_OUTPUT=/dev/stdout scripts/govulncheck-binary-scan.sh
+#
+# ADDITIVE to the source scan, never a replacement: source mode reports
+# vulnerabilities in imported packages even when the linker dropped the code,
+# which binary mode cannot see. What binary mode adds is reflection-reached code
+# (the govulncheck docs state such calls are not reported in source scan mode)
+# and the standard library at the version the binary was BUILT with rather than
+# the version the scanner runs under.
+#
+# Library modules have no main packages; there this is a no-op, not an error.
+#
+# ---------------------------------------------------------------------------
+# BUILD FAILURE vs VULNERABILITY FINDING
+# ---------------------------------------------------------------------------
+# This pass has to `go build` every main package before it has an artifact to
+# scan, so there are two independent ways for it to go red and they call for
+# completely different responses:
+#
+#   build_failed=1   the tree did not compile. NOT a security finding.
+#   vulns_found=1    the binary built, and govulncheck reported against it.
+#
+# BOTH still fail, and that is deliberate: a package that does not compile has
+# not been scanned, so calling it clean would open a hole in the gate. What
+# changes here is only diagnosability -- each condition gets its own loud
+# ::error::, its own line in the job summary, and its own step output, so a
+# reader (and scripts/govulncheck-drift.cjs, which files the tracking issue)
+# can tell them apart.
+#
+# The triggering example: ui-core run 31232762542 was red under the check name
+# "govulncheck" with ZERO vulnerabilities in every tree -- argo-workflows
+# v4.0.8 had stopped compiling against a bumped k8s.io/api. Every reader of
+# that check concluded "security finding" and was wrong.
+#
+# `set -o pipefail` below is load-bearing and really is set (it is the `o` in
+# `set -uo pipefail`): without it the `govulncheck | tee` pipeline would report
+# tee's status, which always succeeds, and every finding would be swallowed.
+# Statuses are captured with `|| status=$?` on the command/pipeline itself,
+# never via ${PIPESTATUS[0]} -- PIPESTATUS is clobbered by ANY subsequent
+# command, including `|| true`, and reading it late silently passes the gate.
+set -uo pipefail
+
+REPORT_PATH="${REPORT_PATH:-/tmp/govulncheck.txt}"
+BIN_DIR="${BIN_DIR:-/tmp/gv-bins}"
+OUT_FILE="${GITHUB_OUTPUT:-/dev/null}"
+SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+# emit_outputs <build_failed> <vulns_found>
+#
+# `exit` is the pre-existing aggregate output the workflows already gate on;
+# build_failed / vulns_found are the new, separately-readable conditions.
+emit_outputs() {
+  local aggregate=0
+  if [ "$1" != "0" ] || [ "$2" != "0" ]; then
+    aggregate=1
+  fi
+  {
+    echo "build_failed=$1"
+    echo "vulns_found=$2"
+    echo "exit=${aggregate}"
+  } >>"$OUT_FILE"
+}
+
+# `go list` failing is itself a build-level failure (a syntax error anywhere in
+# the module makes it non-zero), and its stdout is empty in that case -- so it
+# must NOT be mistaken for "this module has no main packages".
+#
+# `gt (len .GoFiles) 0` excludes TEST-ONLY main packages -- a directory whose
+# only Go files are `*_test.go` declaring `package main`. `go list` reports
+# .Name=main for those, but `go build` cannot produce a binary from one and
+# fails with "no non-test Go files in ...". That is not a build break to
+# report; there is simply no binary to scan. This is NOT a softening of the
+# build-failure rule: any package that has non-test Go files is still built,
+# and any failure to build it still fails the check.
+# Triggering example: luthersystems/substrate cmd/substratehcp/stresstest
+# (mockstress_test.go, package main, no non-test sources).
+if ! mains_raw="$(go list -f '{{if and (eq .Name "main") (gt (len .GoFiles) 0)}}{{.ImportPath}}{{end}}' ./...)"; then
+  echo "::error title=govulncheck binary pass: BUILD FAILURE (not a vulnerability)::\`go list ./...\` failed, so no package could be built or scanned. This is a build/module error, NOT a govulncheck finding."
+  {
+    echo "=== BUILD FAILURE: go list ./... failed ==="
+    echo "No package could be enumerated, so binary-mode govulncheck scanned"
+    echo "nothing. This is a build error, NOT a vulnerability finding."
+  } >>"$REPORT_PATH"
+  {
+    echo "### govulncheck binary pass: BUILD FAILURE (not a vulnerability)"
+    echo
+    echo '`go list ./...` failed — nothing was built, nothing was scanned.'
+  } >>"$SUMMARY_FILE"
+  emit_outputs 1 0
+  exit 1
+fi
+
+mains="$(printf '%s\n' "$mains_raw" | grep -v '^$' || true)"
+if [ -z "$mains" ]; then
+  echo "No main packages in this module — binary mode does not apply."
+  emit_outputs 0 0
+  exit 0
+fi
+
+mkdir -p "$BIN_DIR"
+build_failed=0
+vulns_found=0
+failed_builds=""
+found_pkgs=""
+
+for pkg in $mains; do
+  out="${BIN_DIR}/$(echo "$pkg" | tr '/' '_')"
+
+  echo "::group::go build ${pkg}"
+  build_status=0
+  go build -o "$out" "$pkg" || build_status=$?
+  echo "::endgroup::"
+
+  if [ "$build_status" -ne 0 ]; then
+    build_failed=1
+    failed_builds="${failed_builds}${failed_builds:+ }${pkg}"
+    rm -f "$out"
+    echo "::error title=govulncheck binary pass: BUILD FAILURE (not a vulnerability)::\`go build ${pkg}\` exited ${build_status}. This is a COMPILE ERROR in the tree, NOT a govulncheck finding — the package was not scanned at all. Fix the build, then re-read the scan."
+    {
+      echo "=== BUILD FAILURE: ${pkg} (go build exit ${build_status}) ==="
+      echo "This package could not be compiled, so binary-mode govulncheck did"
+      echo "not scan it. This is a build error, NOT a vulnerability finding."
+    } >>"$REPORT_PATH"
+    continue
+  fi
+
+  echo "::group::govulncheck -mode=binary ${pkg}"
+  gv_status=0
+  govulncheck -mode=binary "$out" 2>&1 | tee -a "$REPORT_PATH" || gv_status=$?
+  echo "::endgroup::"
+  rm -f "$out"
+
+  if [ "$gv_status" -ne 0 ]; then
+    vulns_found=1
+    found_pkgs="${found_pkgs}${found_pkgs:+ }${pkg}"
+    if [ "$gv_status" -eq 3 ]; then
+      # 3 is govulncheck's documented "vulnerabilities found" exit code.
+      echo "::error title=govulncheck binary pass: vulnerability found::govulncheck -mode=binary reported a finding in the built binary for ${pkg}. The binary compiled fine — this IS a security finding."
+    else
+      echo "::error title=govulncheck binary pass: scanner failure::govulncheck -mode=binary exited ${gv_status} for ${pkg}. The binary compiled fine, but ${gv_status} is not govulncheck's vulnerabilities-found code (3), so this is more likely a scanner error than a finding. Failing either way — an unscanned binary is not a clean binary."
+    fi
+  fi
+done
+
+{
+  if [ "$build_failed" -ne 0 ]; then
+    echo "### govulncheck binary pass: BUILD FAILURE (not a vulnerability)"
+    echo
+    echo "These \`main\` packages did not compile, so they were **not scanned**:"
+    echo
+    for p in $failed_builds; do
+      echo "- \`${p}\`"
+    done
+    echo
+    echo "Fix the compile error. Do not read this as a security finding."
+    echo
+  fi
+  if [ "$vulns_found" -ne 0 ]; then
+    echo "### govulncheck binary pass: findings in built binaries"
+    echo
+    for p in $found_pkgs; do
+      echo "- \`${p}\`"
+    done
+    echo
+  fi
+} >>"$SUMMARY_FILE"
+
+emit_outputs "$build_failed" "$vulns_found"
+
+if [ "$build_failed" -ne 0 ] || [ "$vulns_found" -ne 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/govulncheck-drift.cjs
+++ b/scripts/govulncheck-drift.cjs
@@ -1,0 +1,152 @@
+// Tracking-issue state machine for the daily scheduled govulncheck run.
+//
+// Extracted from .github/workflows/govulncheck-scheduled.yml so the logic
+// lives in a real, lintable, testable file and the workflow step stays a thin
+// shim (mirrors scripts/scout-drift-sla.cjs in luthersystems/buildenv):
+//
+//   uses: actions/github-script@v7
+//   with:
+//     script: |
+//       const run = require('./scripts/govulncheck-drift.cjs');
+//       await run({ github, context, core });
+//
+// Inputs (env):
+//   FOUND         'true' when ANY condition tripped (vulnerability or build break)
+//   VULN_FOUND    'true' when a scan actually reported a vulnerability
+//   BUILD_FAILED  'true' when the binary-mode pass could not BUILD a main package
+//   REPORT_PATH   path to the captured govulncheck output (default /tmp/govulncheck.txt)
+//
+// VULN_FOUND / BUILD_FAILED exist because the binary-mode pass has to compile
+// every main package before it can scan it, so it goes red for two unrelated
+// reasons. Filing "reachable vulnerability on main" for a compile error sends
+// whoever picks up the issue hunting a CVE that does not exist (the triggering
+// case: ui-core run 31232762542, red with zero vulnerabilities because
+// argo-workflows v4.0.8 stopped compiling against a bumped k8s.io/api). Both
+// still open an issue -- an unscanned tree is not a clean tree -- but the
+// issue says which one happened.
+//
+// Behaviour:
+//   - finding + no open issue   -> open one, labelled `govulncheck-drift`
+//   - finding + issue already open -> add a comment (don't spam new issues)
+//   - clean + issue open        -> comment and CLOSE it (auto-resolve on recovery)
+//   - clean + no issue          -> no-op, stays quiet
+//
+// It reports only; it does not attempt a fix. govulncheck findings are
+// reachability findings and the remedy is frequently a major-version migration
+// rather than a version bump, so there is nothing safe to auto-apply.
+
+const LABEL = 'govulncheck-drift';
+const TITLE_VULN = 'govulncheck: reachable vulnerability on main';
+const TITLE_BUILD = 'govulncheck: binary-mode build failure on main';
+const MAX_REPORT_BYTES = 50000;
+
+module.exports = async ({ github, context, core }) => {
+  const fs = require('fs');
+  const found = process.env.FOUND === 'true';
+  const buildFailed = process.env.BUILD_FAILED === 'true';
+  // Fall back to the old single-flag behaviour when a caller has not been
+  // updated to pass VULN_FOUND: anything that is not a known build break is
+  // reported as a vulnerability, exactly as before.
+  const vulnFound = process.env.VULN_FOUND
+    ? process.env.VULN_FOUND === 'true'
+    : found && !buildFailed;
+  const reportPath = process.env.REPORT_PATH || '/tmp/govulncheck.txt';
+  const { owner, repo } = context.repo;
+  const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+  const open = await github.rest.issues.listForRepo({
+    owner,
+    repo,
+    state: 'open',
+    labels: LABEL,
+  });
+  const existing = open.data[0];
+
+  if (!found) {
+    if (!existing) {
+      core.info('govulncheck clean, no open drift issue — nothing to do.');
+      return;
+    }
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: existing.number,
+      body: `Scheduled govulncheck is clean as of ${runUrl} — closing.`,
+    });
+    await github.rest.issues.update({
+      owner,
+      repo,
+      issue_number: existing.number,
+      state: 'closed',
+      state_reason: 'completed',
+    });
+    core.info(`Closed #${existing.number} on recovery.`);
+    return;
+  }
+
+  let report = '';
+  try {
+    report = fs.readFileSync(reportPath, 'utf8').slice(-MAX_REPORT_BYTES);
+  } catch (err) {
+    core.warning(`Could not read ${reportPath}: ${err.message}`);
+  }
+
+  const lead = [];
+  if (buildFailed) {
+    lead.push(
+      'The scheduled `govulncheck` run went red because the binary-mode pass',
+      '**could not build** one or more `main` packages.',
+      '',
+      '**This is a build break, not a vulnerability finding.** The packages that',
+      'failed to compile were not scanned at all, which is why the run still',
+      'fails -- an unscanned tree is not a clean tree. Fix the compile error',
+      'first; look for the `BUILD FAILURE` lines in the report below.',
+      '',
+    );
+  }
+  if (vulnFound) {
+    lead.push(
+      'Scheduled `govulncheck` found a reachable vulnerability on `main`.',
+      '',
+      'This is a **reachability** finding: govulncheck only reports when this',
+      'module actually calls the vulnerable code, so it is not import-only noise.',
+      '',
+    );
+  }
+  if (lead.length === 0) {
+    lead.push('Scheduled `govulncheck` reported a failure on `main`.', '');
+  }
+
+  const body = [
+    ...lead,
+    `Run: ${runUrl}`,
+    '',
+    '<details><summary>Report</summary>',
+    '',
+    '```',
+    report,
+    '```',
+    '',
+    '</details>',
+  ].join('\n');
+
+  if (existing) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: existing.number,
+      body,
+    });
+    core.info(`Refreshed #${existing.number}.`);
+    return;
+  }
+
+  const created = await github.rest.issues.create({
+    owner,
+    repo,
+    title: buildFailed && !vulnFound ? TITLE_BUILD : TITLE_VULN,
+    body,
+    labels: [LABEL],
+  });
+  core.info(`Opened #${created.data.number}.`);
+};

--- a/scripts/govulncheck-fail-summary.sh
+++ b/scripts/govulncheck-fail-summary.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Final gate step for the govulncheck workflows.
+#
+# The job goes red for more than one reason and the check name ("govulncheck")
+# reads as "security finding" for all of them. This step exists so the LAST
+# thing in the log, and the top of the job summary, names which condition
+# actually tripped. It never decides anything and never softens anything: it
+# fails whenever any condition is set.
+#
+# Inputs (env, all optional — an unset/empty value counts as "did not trip"):
+#   SOURCE_SCAN_EXIT      steps.scan.outputs.exit      (source-mode pass)
+#   BINARY_BUILD_FAILED   steps.binscan.outputs.build_failed
+#   BINARY_VULNS_FOUND    steps.binscan.outputs.vulns_found
+#
+# Run locally as:
+#   BINARY_BUILD_FAILED=1 scripts/govulncheck-fail-summary.sh
+set -uo pipefail
+
+SOURCE_SCAN_EXIT="${SOURCE_SCAN_EXIT:-0}"
+BINARY_BUILD_FAILED="${BINARY_BUILD_FAILED:-0}"
+BINARY_VULNS_FOUND="${BINARY_VULNS_FOUND:-0}"
+SUMMARY_FILE="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+reasons=()
+if [ "$SOURCE_SCAN_EXIT" != "0" ] && [ -n "$SOURCE_SCAN_EXIT" ]; then
+  reasons+=("VULNERABILITY: the source-mode scan reported a finding.")
+fi
+if [ "$BINARY_BUILD_FAILED" != "0" ] && [ -n "$BINARY_BUILD_FAILED" ]; then
+  reasons+=("BUILD FAILURE: a main package did not compile, so the binary-mode pass could not scan it. This is NOT a vulnerability finding.")
+fi
+if [ "$BINARY_VULNS_FOUND" != "0" ] && [ -n "$BINARY_VULNS_FOUND" ]; then
+  reasons+=("VULNERABILITY: the binary-mode pass reported a finding against a binary that built fine.")
+fi
+
+if [ "${#reasons[@]}" -eq 0 ]; then
+  echo "No govulncheck condition tripped — nothing to fail."
+  exit 0
+fi
+
+{
+  echo "## govulncheck failed"
+  echo
+  for r in "${reasons[@]}"; do
+    echo "- ${r}"
+  done
+  echo
+} >>"$SUMMARY_FILE"
+
+echo "govulncheck failed for the following reason(s):"
+for r in "${reasons[@]}"; do
+  echo "  - ${r}"
+done
+
+exit 1

--- a/scripts/govulncheck-scan.sh
+++ b/scripts/govulncheck-scan.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Source-mode govulncheck scan for the scheduled workflow.
+#
+# Extracted from .github/workflows/govulncheck-scheduled.yml so the logic lives
+# in a real, lintable, runnable file and the workflow step stays a thin shim.
+# Run it locally exactly as CI does:
+#
+#   GITHUB_OUTPUT=/dev/stdout scripts/govulncheck-scan.sh
+#
+# Writes the full report to $REPORT_PATH for the drift-issue body, and the scan's
+# exit status to $GITHUB_OUTPUT as `exit=N`. It deliberately does NOT fail the
+# step itself -- the workflow decides, after the binary pass has also run, so a
+# finding in one mode cannot mask the other.
+set -uo pipefail
+
+REPORT_PATH="${REPORT_PATH:-/tmp/govulncheck.txt}"
+
+# `set +e` around the pipeline, then read PIPESTATUS immediately: the pipeline's
+# own status is tee's, which succeeds regardless, so reading it would silently
+# swallow every finding.
+set +e
+govulncheck ./... 2>&1 | tee "$REPORT_PATH"
+status="${PIPESTATUS[0]}"
+set -e
+
+echo "exit=${status}" >> "${GITHUB_OUTPUT:-/dev/null}"
+exit 0


### PR DESCRIPTION
Replaces #329, which was branched off `1f4a12a` and carried six commits of already-merged work (dependabot bumps, a `main` merge) that conflicted on rebase. This is the same five files, applied cleanly to current `main`, plus one change #329 did not have.

## What

**A daily scheduled `govulncheck` run.** The existing gate only re-scans when someone opens a PR, but the Go vulnerability database updates continuously — a repo nobody touches for a month can go from clean to vulnerable with no code change at all. Pinning the toolchain to `stable` also picks up stdlib advisories, which track Go patch releases rather than any dependency.

The PR-triggered `govulncheck.yml` is **not modified and not duplicated**. It fires on `pull_request`; this one only on `schedule` / `workflow_dispatch`, so no event is scanned twice.

| File | Role |
|---|---|
| `.github/workflows/govulncheck-scheduled.yml` | daily cron (07:40 UTC) + `workflow_dispatch`; `contents: read`, `issues: write` |
| `scripts/govulncheck-scan.sh` | source-mode scan |
| `scripts/govulncheck-binary-scan.sh` | additive binary-mode pass |
| `scripts/govulncheck-drift.cjs` | tracking-issue state machine |
| `scripts/govulncheck-fail-summary.sh` | final gate; names which condition tripped |

A cron failure nobody subscribes to is a failure nobody sees, so a finding also opens a `govulncheck-drift` issue: finding + no issue → open one; finding + issue open → comment (no duplicates); clean + issue open → comment and close; clean + no issue → no-op.

## The one addition over #329: discovery-based script linting

Putting the logic in `scripts/` exposed a gap in the suite that is supposed to police `scripts/`. `ci-gates-test.sh` linted a **hardcoded five-entry array**, so `scripts/fuzz-classify-test.sh` had been sitting unlinted since the day it was added, and the four new `govulncheck-*` scripts would have joined it silently.

Discovery replaces the list. Every `*.sh` gets `bash -n` + `shellcheck -S warning`; every `*.cjs` gets `node --check`. A floor assertion fails the suite if the glob ever matches fewer than five, so a broken glob reports as a failure rather than as "clean on all 0 scripts".

Coverage: **5 scripts → 9, 1 `.cjs` → 2.** All clean.

## Correctness details worth reviewing

- `set -o pipefail` is on (the `o` in `set -uo pipefail`). Without it a `govulncheck | tee` pipeline reports `tee`'s status, which always succeeds, and every finding is swallowed.
- Exit statuses are captured with `|| status=$?` on the pipeline itself, or by reading `${PIPESTATUS[0]}` on the *immediately* following line. `PIPESTATUS` is clobbered by any subsequent command, including `|| true`.
- The `go install golang.org/x/vuln/cmd/govulncheck@latest` step is its own step and must stay — a refactor elsewhere in the fleet dropped it and the scripts then ran against a binary that was never installed.
- **A build failure in the binary pass still fails the check.** A package that did not compile was not scanned, and an unscanned package is not a clean one. It is reported *separately* (`build_failed` vs `vulns_found`, distinct `::error::` lines, distinct issue title) so a compile break is not filed as a phantom CVE. The triggering case was ui-core run 31232762542: red under the check name "govulncheck" with zero vulnerabilities in every tree, because argo-workflows had stopped compiling against a bumped `k8s.io/api`.
- The binary pass skips **test-only `main` packages** (a directory whose only Go files are `*_test.go` declaring `package main`). `go build` cannot produce a binary from one. Any package with non-test sources is still built, and any failure to build it still fails.

## Verification

- `scripts/ci-gates-test.sh` → **123 passed, 0 failed** on this branch.
- `shellcheck -S warning scripts/*.sh` → clean, exit 0.
- `govulncheck ./...` on this tree under go1.26.5 (what `go-version: stable` resolves to) → no vulnerabilities, 0 reachable.
- Each script exercised standalone against a **stubbed `govulncheck`** on `PATH`: finding / clean / no-`main`-packages / test-only-`main` / build-failure, plus the four `govulncheck-drift.cjs` transitions driven through a fake Octokit.
- Every `uses:` is SHA-pinned, reusing SHAs already present elsewhere in this tree (`actions/checkout` ×11, `setup-go` ×7, `github-script` ×3), so each pin is verifiable from the repository itself.

## CI cannot exercise the new workflow

It has no `pull_request` trigger — which is also why it is correctly out of scope for the `Required:` aggregate guard (the guard is scoped to PR-triggered workflows, and the suite confirms `govulncheck.yml`'s own aggregate still covers all its jobs). **Please fire a `workflow_dispatch` run from the Actions tab after merge** and confirm the job is green, or that it correctly opens a `govulncheck-drift` issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_