### PR TITLE
Give tree-sitter-elps dependabot coverage, and enforce that every manifest has it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,21 @@
 version: 2
+
+# EVERY dependency manifest in the repository must have an entry here.
+#
+# Dependabot only looks where it is told. A manifest with no matching
+# `directory:` gets no security updates and no version bumps, and nothing
+# anywhere reports that — the dashboard shows green because it is not looking,
+# which is indistinguishable from green because there is nothing to find.
+#
+# That is not hypothetical here: tree-sitter-elps/ is a separate Go module AND
+# an npm package with a lockfile, it is built and tested on every PR by
+# .github/workflows/tree-sitter.yml, and it had no entry at all. Its
+# go-tree-sitter, node-addon-api and tree-sitter-cli dependencies were frozen
+# at whatever they were when they were added.
+#
+# scripts/ci-gates-test.sh enforces the rule: it walks the tree for go.mod and
+# package.json (ignoring vendor/ and node_modules/) and fails if any of them
+# lacks a matching entry below. Adding a module means adding an entry here.
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -18,6 +35,18 @@ updates:
     groups:
       go-deps:
         patterns: ["*"]
+  # Separate Go module (`github.com/luthersystems/elps/tree-sitter-elps`), so
+  # the root entry above does not reach it — `./...` from the repo root does
+  # not descend into a nested module, and neither does Dependabot.
+  - package-ecosystem: "gomod"
+    directory: "/tree-sitter-elps"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      tree-sitter-go-deps:
+        patterns: ["*"]
   - package-ecosystem: "npm"
     directory: "/editors/vscode"
     schedule:
@@ -26,4 +55,15 @@ updates:
     open-pull-requests-limit: 5
     groups:
       vscode-deps:
+        patterns: ["*"]
+  # The grammar's npm side (node-addon-api, node-gyp-build, prebuildify,
+  # tree-sitter-cli), with a committed package-lock.json.
+  - package-ecosystem: "npm"
+    directory: "/tree-sitter-elps"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      tree-sitter-npm-deps:
         patterns: ["*"]

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -755,6 +755,116 @@ else
 fi
 
 echo
+echo "== dependabot covers every dependency manifest ==========================="
+
+# Dependabot only looks where it is told, and says nothing about where it does
+# not. A manifest with no matching `directory:` gets no version bumps and no
+# security updates, and the only symptom is an absence -- the dashboard is
+# green because it is not looking, which reads exactly like green because
+# there is nothing to find.
+#
+# Triggering example: tree-sitter-elps/ is a separate Go module AND an npm
+# package with a committed lockfile, built and tested on every PR by
+# .github/workflows/tree-sitter.yml, and it had no entry at all. Its
+# go-tree-sitter / node-addon-api / tree-sitter-cli pins were frozen from the
+# day they were written.
+#
+# This walks the tree rather than reading a list, so a module added later is
+# covered by construction.
+dep_out="$(python3 - "$REPO_ROOT" <<'PY'
+import os, sys
+try:
+    import yaml
+except ImportError:
+    print("__SKIP__ PyYAML not installed")
+    sys.exit(0)
+
+root = sys.argv[1]
+passes, failures = [], []
+
+cfg_path = os.path.join(root, ".github", "dependabot.yml")
+if not os.path.exists(cfg_path):
+    print("FAIL  .github/dependabot.yml is missing")
+    print("__COUNTS__ 0 1")
+    sys.exit(0)
+
+with open(cfg_path) as fh:
+    cfg = yaml.safe_load(fh)
+
+# (ecosystem, normalised directory) pairs the config declares. `directories:`
+# is the newer plural spelling; accept both so switching to it does not read
+# as a regression.
+def norm(d):
+    d = "/" + str(d).strip().strip("/")
+    return "/" if d == "/" else d
+
+declared = set()
+for u in (cfg.get("updates") or []):
+    eco = u.get("package-ecosystem")
+    dirs = u.get("directories") or ([u.get("directory")] if u.get("directory") else [])
+    for d in dirs:
+        declared.add((eco, norm(d)))
+
+# Manifests actually present, excluding vendored and installed trees.
+IGNORE = {"node_modules", "vendor", ".git", "testdata", "build"}
+MANIFESTS = {"go.mod": "gomod", "package.json": "npm"}
+found = set()
+for dirpath, dirnames, filenames in os.walk(root):
+    dirnames[:] = [d for d in dirnames if d not in IGNORE]
+    for fn in filenames:
+        eco = MANIFESTS.get(fn)
+        if eco is None:
+            continue
+        rel = os.path.relpath(dirpath, root)
+        found.add((eco, "/" if rel == "." else "/" + rel.replace(os.sep, "/")))
+
+missing = sorted(m for m in found if m not in declared)
+for eco, d in missing:
+    failures.append(
+        f"{eco} manifest at {d} has no dependabot entry — it gets no version "
+        f"bumps and no security updates, silently"
+    )
+if not missing:
+    passes.append(
+        f"every dependency manifest has a dependabot entry "
+        f"({len(found)} manifests: " +
+        ", ".join(f"{e}{d}" for e, d in sorted(found)) + ")"
+    )
+
+# A `directory:` pointing at nothing is the same failure seen from the other
+# side: the entry looks like coverage and provides none.
+stale = sorted(
+    (e, d) for (e, d) in declared
+    if e in MANIFESTS.values() and (e, d) not in found
+)
+for eco, d in stale:
+    failures.append(f"dependabot declares {eco} at {d}, but no such manifest exists")
+if not stale:
+    passes.append("no dependabot entry points at a manifest that does not exist")
+
+for p in passes:
+    print(f"PASS  {p}")
+for f_ in failures:
+    print(f"FAIL  {f_}")
+print(f"__COUNTS__ {len(passes)} {len(failures)}")
+PY
+)"
+
+if echo "$dep_out" | grep -q '^__SKIP__'; then
+	echo "SKIP  $(echo "$dep_out" | sed -n 's/^__SKIP__ //p')"
+else
+	echo "$dep_out" | grep -v '^__COUNTS__' || true
+	dep_counts="$(echo "$dep_out" | sed -n 's/^__COUNTS__ //p')"
+	if [ -n "$dep_counts" ]; then
+		read -r dep_pass dep_fail <<<"$dep_counts"
+		pass=$((pass + dep_pass))
+		fail=$((fail + dep_fail))
+	else
+		bad "dependabot coverage guard did not run"
+	fi
+fi
+
+echo
 echo "== fuzz gate: time bounding =============================================="
 
 FUZZ="${SCRIPT_DIR}/fuzz.sh"


### PR DESCRIPTION
## The gap

`tree-sitter-elps/` is a separate Go module **and** an npm package with a committed `package-lock.json`. It is built and tested on every pull request by `.github/workflows/tree-sitter.yml`. It had **no dependabot entry at all**.

`.github/dependabot.yml` listed `gomod` at `/` and `npm` at `/editors/vscode`. Neither reaches a nested module — `go list ./...` from the repo root does not descend into `tree-sitter-elps`, and neither does Dependabot. So these were frozen at whatever they were when they were written, receiving neither version bumps nor security updates:

| Manifest | Dependencies left unwatched |
|---|---|
| `tree-sitter-elps/go.mod` | `go-tree-sitter v0.25.0`, `testify v1.11.1` (+ 4 indirect) |
| `tree-sitter-elps/package.json` | `node-addon-api ^8.3.0`, `node-gyp-build ^4.8.4`, `prebuildify ^6.0.1`, `tree-sitter-cli ^0.24.0`, `tree-sitter ^0.22.4` |

Two entries added, each in its own update group so a tree-sitter bump does not arrive mixed into the root `go-deps` PR.

## The guard, which is the point

This failure mode has **no symptom**. The dependabot dashboard is green because it is not looking, which is indistinguishable from green because there is nothing to find. Nobody notices until a CVE lands in a dependency nobody is watching. The fix for the instance is two YAML entries; the fix for the *class* is that adding a module and forgetting the entry has to fail CI.

`scripts/ci-gates-test.sh` now walks the tree for `go.mod` and `package.json` (skipping `node_modules/`, `vendor/`, `testdata/`, `build/`) and fails if any manifest lacks a matching entry. **Discovery, not a second hardcoded list** that could fall out of date the same way the first one did. It accepts both the `directory:` and the newer plural `directories:` spelling, so switching to the latter will not read as a regression.

It checks the converse too: an entry whose directory holds no manifest is the same failure seen from the other side, since it looks like coverage and provides none.

## Verification

The guard was mutation-tested against synthetic trees, not just observed to pass on a tree that already satisfies it:

| Case | Result |
|---|---|
| the **pre-change** config against this repo's real manifest layout | **2 FAIL**, naming `gomod /tree-sitter-elps` and `npm /tree-sitter-elps` exactly |
| an entry pointing at a directory with no manifest | **1 FAIL**, naming the stale entry |
| `package.json` planted under `node_modules/` at two different depths | still clean — the walk cannot be tripped into demanding entries for installed packages |

On the real tree it reports 4 manifests, all covered. `bash -n` and `shellcheck -S warning` clean. PyYAML is already a hard dependency of the existing workflow-shape guards in the same script, so the new check adds no new requirement — and it degrades to `SKIP` rather than a false pass if it is ever absent.

## Note on overlap

#339 also touches `scripts/ci-gates-test.sh`, in the shell-lint section near the end of the file; this change inserts a new section in the middle. Whichever lands second I will rebase.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_