### PR TITLE
Require both halves of a package-qualified symbol to be names (#319)

### DIFF
--- a/docs/lang.md
+++ b/docs/lang.md
@@ -26,6 +26,29 @@ number.
 
 Symbols are currently case sensitive although this may change.
 
+A symbol may also be written in its package-qualified form, `pkg:name` (see
+[Packages](#packages)).  Both halves are identifiers and the rule above applies
+to each of them independently, so `a:1` is not a symbol: the reader rejects it
+with an `invalid-symbol` condition rather than producing a symbol named `1` in
+package `a`, a name no other part of the language can write.  Note that `+1`
+and `.1` *are* identifiers — `+` and `.` are ordinary symbol characters — so
+`a:+1` and `a:.1` are both fine.
+
+### Keywords
+
+A symbol written with a leading colon and no package, `:name`, is a *keyword*.
+
+Keywords are values, not identifiers.  A keyword evaluates to itself, is never
+looked up in a package, and cannot be assigned to — `(set ':k 1)` is an error.
+Because a keyword names no binding, the "identifiers cannot start with a
+number" rule does not apply to it: `:1` is an ordinary keyword whose name is
+`1`, in the same way that `:foo` is one whose name is `foo`.
+
+Keywords are used to label [keyword arguments](#keyword-arguments), and a
+keyword only matches a formal argument spelled the same way.  A keyword whose
+name is not also a legal identifier therefore cannot match any formal argument,
+so `:1` is only useful as data.
+
 ### Numbers
 
 Numbers can be either int or floating point and will be converted between the
@@ -640,6 +663,10 @@ of whether it was exported.
 NOTE:  Qualified access (`pkg:sym`) works for all symbols in a package, not
 just exported ones.  Exports only control what `use-package` imports into the
 caller's namespace — they do not restrict visibility.
+
+NOTE:  Both halves of a qualified symbol must be [identifiers](#symbols).
+Qualified access is another way to spell a name, not a way to introduce one
+that could not be written unqualified, so `a:1` is rejected by the reader.
 
 Scheme-like symbol bindings and assignment are also possible using the `define`
 and `set!` operators.

--- a/internal/fuzzseed/fuzzseed.go
+++ b/internal/fuzzseed/fuzzseed.go
@@ -190,6 +190,13 @@ func Adversarial() [][]byte {
 		"a:",
 		":a",
 		"::",
+		// The local half of a qualified symbol has to be a name; the local
+		// half of a KEYWORD does not (issue #319).  Both spellings reach the
+		// same readSymbol loop, so seed both sides of that split.
+		"a:1",
+		":1",
+		"a:+1",
+		"1:1",
 		strings.Repeat("a", 256),
 
 		// --- comments and hash-bang ---

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -52,6 +52,7 @@ const DefaultMaxParseDepth = 10000
 // Parser is a lisp parser.
 type Parser struct {
 	src             *TokenSource
+	nameReadback    map[string]bool
 	pendingComments []*token.Token
 	depth           int
 	maxDepth        int
@@ -394,7 +395,7 @@ func (p *Parser) ParseFunRef() *lisp.LVal {
 	// wrong layer to ask: "--" and "-a" lex as NEGATIVE, and only become
 	// symbols when ParseNegative merges them. A token-level guard rejects
 	// those valid names; re-reading through the parser gets them right.
-	if !readsBackAsSymbol(name.Str) {
+	if !p.readsBackAsSymbol(name.Str) {
 		return p.errorf("parse-error",
 			"invalid symbol following #': %q does not read back as a symbol", name.Str)
 	}
@@ -598,6 +599,39 @@ func (p *Parser) ParseSymbol() *lisp.LVal {
 	}
 	if len(pieces) == 2 && pieces[1] == "" {
 		return p.errorf("invalid-symbol", "invalid symbol %q", tok.Text)
+	}
+	// A package-qualified symbol NAMES A BINDING: "pkg:name" is the qualified
+	// spelling of the symbol "name" inside package "pkg", so both halves have
+	// to be names the reader gives back as symbols on their own.
+	//
+	// They were not checked, and "a:1" was the result -- the symbol named "1"
+	// in package "a". Nothing else in the language can write that name: a bare
+	// 1 is an INT, and docs/lang.md has said since the beginning that
+	// identifiers cannot start with a number. The binding it creates is
+	// reachable only through the qualified spelling and can never be imported
+	// usefully by use-package, so it is a trap rather than a capability.
+	//
+	// This is the same defect as "#'0", recorded in lexer.readFunRef: isWord
+	// is the CONTINUATION rune class and admits digits, and readSymbol gets
+	// away with using it only because it is entered after isWordStart or ':'
+	// has already matched. Matching ':' is what admits the digit here. The
+	// fix is deliberately the same one ParseFunRef got -- re-read the name and
+	// require a symbol back -- rather than a second, differently-worded rune
+	// test. Re-reading also states the requirement exactly: it accepts "+1"
+	// and ".1", which ARE writable as bare symbols, and it keeps working if
+	// the number syntax changes. Issue #319.
+	//
+	// A LEADING ':' IS NOT COVERED, deliberately: ":1" is a keyword, and a
+	// keyword names no binding. It is a self-evaluating literal that PutGlobal
+	// explicitly refuses to bind, so the rule above has nothing to say about
+	// it. See docs/lang.md, "Keywords".
+	if len(pieces) == 2 && pieces[0] != "" {
+		for _, piece := range pieces {
+			if !p.readsBackAsSymbol(piece) {
+				return p.errorf("invalid-symbol",
+					"invalid symbol %q: %q does not read back as a symbol", tok.Text, piece)
+			}
+		}
 	}
 	return p.Symbol(tok.Text)
 }
@@ -935,19 +969,48 @@ func (p *Parser) PendingComments() []*token.Token {
 	return p.pendingComments
 }
 
+// readsBackAsSymbol memoizes readsBackAsSymbol over the lifetime of p.
+//
+// The predicate is a pure function of the string, and source repeats names:
+// substrate's phylum sources hold thousands of qualified-symbol occurrences
+// drawn from ~200 distinct names, and ParseSymbol asks about both halves of
+// every one of them. Without the cache the check costs +18% on the wall clock
+// of parsing that corpus; with it the sub-parse runs once per distinct name
+// per file.
+func (p *Parser) readsBackAsSymbol(s string) bool {
+	if ok, seen := p.nameReadback[s]; seen {
+		return ok
+	}
+	ok := readsBackAsSymbol(s)
+	if p.nameReadback == nil {
+		p.nameReadback = make(map[string]bool)
+	}
+	p.nameReadback[s] = ok
+	return ok
+}
+
 // readsBackAsSymbol reports whether s, parsed on its own, yields exactly one
 // expression and that expression is a symbol named s.
 //
-// Used to reject #' operands that cannot survive the round trip through the
-// printer. Re-parsing rather than pattern-matching the name states the
-// requirement exactly: an earlier attempt used strconv.ParseInt/ParseFloat and
-// was wrong, because "-1abc" is not a number by either yet still reads back as
-// an INT. Re-parsing also stays correct if the number syntax ever changes.
+// Used by ParseFunRef to reject #' operands that cannot survive the round trip
+// through the printer, and by ParseSymbol to reject either half of a
+// package-qualified symbol that is not a name (issue #319). Re-parsing rather
+// than pattern-matching the name states the requirement exactly: an earlier
+// attempt used strconv.ParseInt/ParseFloat and was wrong, because "-1abc" is
+// not a number by either yet still reads back as an INT. Re-parsing also stays
+// correct if the number syntax ever changes.
+//
+// s never contains a ':' at either call site -- ParseSymbol has already split
+// on it and rejected any symbol with more than one -- so the ParseSymbol call
+// below cannot recurse back into here.
 func readsBackAsSymbol(s string) bool {
 	if s == "" {
 		return false
 	}
-	exprs, err := New(token.NewScanner("", strings.NewReader(s))).ParseProgram()
+	// NewScannerString, not NewScanner: this runs once per #' operand and
+	// twice per package-qualified symbol, and NewScanner charges a 128KiB
+	// sliding window per call regardless of how few bytes it scans.
+	exprs, err := New(token.NewScannerString("", s)).ParseProgram()
 	if err != nil || len(exprs) != 1 {
 		return false
 	}

--- a/parser/rdparser/qualified_symbol_test.go
+++ b/parser/rdparser/qualified_symbol_test.go
@@ -1,0 +1,145 @@
+// Copyright © 2026 The ELPS authors
+
+package rdparser_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/rdparser"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// TestQualifiedSymbolHalvesMustBeNames pins the accept/reject table for
+// package-qualified symbols (issue #319).
+//
+// "pkg:name" is the qualified spelling of the symbol "name" inside package
+// "pkg", so both halves have to be names the reader gives back as symbols on
+// their own. They were not checked, and "a:1" got through -- the symbol named
+// "1", which a bare 1 cannot spell and which docs/lang.md has always forbidden
+// ("Identifiers cannot start with a number").
+//
+// Root cause is the one recorded in lexer.readFunRef for "#'0": isWord is the
+// CONTINUATION rune class and admits digits, and readSymbol relies on having
+// been entered after isWordStart or ':' already matched. Matching ':' is what
+// admits the digit here.
+func TestQualifiedSymbolHalvesMustBeNames(t *testing.T) {
+	t.Parallel()
+
+	// Rejected: the local half is not a name. Every one of these is a symbol
+	// nothing else in the language can write.
+	//
+	// "a:1abc" and "a:0x10" are the ones a naive check misses: neither is a
+	// number by strconv, but both start with a digit, so the reader gives them
+	// back as an INT followed by a separate symbol rather than as one symbol.
+	for _, src := range []string{
+		"a:1", "a:1b", "a:-1", "a:1.5", "a:1e5", "a:0x10", "a:1abc", "a:1_",
+		"a:9", "(a:1)", "'a:1", "#'a:1", "[a:1]", "(f a:1 b)",
+	} {
+		t.Run("rejected/"+src, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseOne(t, src)
+			require.Error(t, err, "%q must be refused: its local part is not a name", src)
+			assert.Equal(t, lisp.CondInvalidSymbol, parseCondition(t, src),
+				"rejection of %q should report the invalid-symbol condition", src)
+		})
+	}
+
+	// Accepted: both halves are names. This half of the table is the guard
+	// against over-tightening.
+	//
+	//   "a:+1" / "a:.1" / "a:*1"  -- '+', '.' and '*' are ordinary symbol
+	//                                characters, so these ARE writable bare.
+	//   "-a:b" / "a:-" / "a:--"   -- these lex as NEGATIVE and only become
+	//                                symbols once ParseNegative merges them,
+	//                                so a token-level check rejects them
+	//                                wrongly.
+	for _, src := range []string{
+		"a:b", "lisp:set", "xyz:abc?", "a:+1", "a:.1", "a:*1", "a:_1",
+		"a:true", "a:-", "a:--", "a:-a", "-a:b", "a:<=", "a:set!", "a:->",
+	} {
+		t.Run("accepted/"+src, func(t *testing.T) {
+			t.Parallel()
+			expr, err := parseOne(t, src)
+			require.NoError(t, err, "%q is a valid qualified symbol", src)
+			require.Equal(t, lisp.LSymbol, expr.Type)
+			assert.Equal(t, src, expr.Str)
+
+			// And it still round trips: printing and re-reading gives the
+			// same symbol back.
+			rt, err := parseOne(t, expr.String())
+			require.NoError(t, err, "printed form %q must re-parse", expr.String())
+			assert.Equal(t, lisp.LSymbol, rt.Type)
+			assert.Equal(t, expr.Str, rt.Str)
+		})
+	}
+}
+
+// TestKeywordNamesAreNotIdentifiers pins the deliberate exemption for
+// keywords, the other half of issue #319.
+//
+// ":1" is admitted by the same rune-class reuse as "a:1", but it is NOT the
+// same thing. A leading ':' with no package yields a keyword: a self-evaluating
+// literal that names no binding and that PutGlobal explicitly refuses to bind.
+// The identifier rule governs names of bindings, so it has nothing to say
+// about a keyword, and keywords are the only interned-literal facility the
+// language has. Rejecting ":1" would remove a usable datum to buy uniformity.
+//
+// The one consequence worth knowing is pinned below: a keyword whose name is
+// not a legal identifier can never match a &key formal, because no formal can
+// be spelled that way.
+func TestKeywordNamesAreNotIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	for _, src := range []string{":1", ":1.5", ":-1", ":+1", ":1a", ":b", ":9"} {
+		t.Run("accepted/"+src, func(t *testing.T) {
+			t.Parallel()
+			expr, err := parseOne(t, src)
+			require.NoError(t, err, "%q is a keyword, not a qualified symbol", src)
+			require.Equal(t, lisp.LSymbol, expr.Type)
+			assert.Equal(t, src, expr.Str)
+		})
+	}
+
+	// An empty name is still not a keyword, and neither is a doubled colon.
+	for _, src := range []string{":", "::", "a:", "a:b:c"} {
+		t.Run("rejected/"+src, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseOne(t, src)
+			assert.Error(t, err, "%q is not a symbol", src)
+		})
+	}
+}
+
+// TestDigitBeforeColonSplitsTokens records that "1:1" was never one symbol to
+// begin with: the lexer stops the number at the ':' and starts a fresh token,
+// so it reads as the INT 1 followed by the keyword :1. Pinned because it looks
+// like a qualified symbol and is not one -- tightening the qualified-symbol
+// rule does not (and should not) change it.
+func TestDigitBeforeColonSplitsTokens(t *testing.T) {
+	t.Parallel()
+
+	exprs, err := rdparser.New(token.NewScannerString("test", "1:1")).ParseProgram()
+	require.NoError(t, err)
+	require.Len(t, exprs, 2)
+	assert.Equal(t, lisp.LInt, exprs[0].Type)
+	assert.Equal(t, 1, exprs[0].Int)
+	assert.Equal(t, lisp.LSymbol, exprs[1].Type)
+	assert.Equal(t, ":1", exprs[1].Str)
+}
+
+// parseCondition returns the lisp condition reported by the parse error for
+// src, or "" when src parses cleanly.
+func parseCondition(t *testing.T, src string) string {
+	t.Helper()
+	_, err := rdparser.New(token.NewScannerString("test", src)).ParseProgram()
+	if err == nil {
+		return ""
+	}
+	var ev *lisp.ErrorVal
+	require.ErrorAs(t, err, &ev)
+	return ev.Condition()
+}

--- a/parser/rdparser/qualified_symbol_test.go
+++ b/parser/rdparser/qualified_symbol_test.go
@@ -131,6 +131,30 @@ func TestDigitBeforeColonSplitsTokens(t *testing.T) {
 	assert.Equal(t, ":1", exprs[1].Str)
 }
 
+// TestQualifiedSymbolCheckIsMemoizedPerName guards the cache behind the check.
+//
+// Parser.readsBackAsSymbol memoizes per NAME, and both halves of every
+// qualified symbol go through it, so a program that mentions a package
+// repeatedly seeds the cache with entries that must not be mistaken for a
+// verdict on the local half. "(a:b a:1)" is the shape that would break if the
+// cache were keyed on the whole symbol, or consulted once per symbol rather
+// than once per half: "a" is already cached as good when "a:1" is reached.
+func TestQualifiedSymbolCheckIsMemoizedPerName(t *testing.T) {
+	t.Parallel()
+
+	_, err := rdparser.New(token.NewScannerString("test", "(a:b a:1)")).ParseProgram()
+	require.Error(t, err, "a cached verdict for the package half must not excuse the local half")
+	assert.Contains(t, err.Error(), `"1" does not read back as a symbol`)
+
+	// ...and the mirror: a name cached as BAD must not condemn a later good
+	// one that merely shares a package.
+	exprs, err := rdparser.New(token.NewScannerString("test", "(a:b a:b a:c)")).ParseProgram()
+	require.NoError(t, err)
+	require.Len(t, exprs, 1)
+	require.Len(t, exprs[0].Cells, 3)
+	assert.Equal(t, "a:c", exprs[0].Cells[2].Str)
+}
+
 // parseCondition returns the lisp condition reported by the parse error for
 // src, or "" when src parses cleanly.
 func parseCondition(t *testing.T, src string) string {

--- a/parser/token/scanner.go
+++ b/parser/token/scanner.go
@@ -45,10 +45,34 @@ func newScannerBuf(file string, r io.Reader, buf []byte) *Scanner {
 	return s
 }
 
-// NewScanner initializes and returns a new Scanner.
+// DefaultBufSize is the size of the sliding window NewScanner allocates.  It
+// is also the largest single token NewScanner can scan: the window never
+// grows, so a token that fills it fails with "token exceeds maximum allowable
+// size".
+const DefaultBufSize = 128 << 10
+
+// NewScanner initializes and returns a new Scanner reading through a
+// DefaultBufSize sliding window.
 func NewScanner(file string, r io.Reader) *Scanner {
-	buf := make([]byte, 128<<10)
+	buf := make([]byte, DefaultBufSize)
 	return newScannerBuf(file, r, buf)
+}
+
+// NewScannerString initializes and returns a new Scanner reading src, sizing
+// the sliding window to src rather than allocating the DefaultBufSize window
+// NewScanner uses.  src is already in memory, so the window costs nothing
+// extra and no token can overrun it.
+//
+// This exists because the fixed window is charged per SCANNER, not per byte
+// scanned, and the parser re-reads short strings: readsBackAsSymbol scans each
+// #' operand and each half of every package-qualified symbol to check that it
+// reads back as a symbol (issue #319).  Through NewScanner that is 128KiB per
+// check -- 2.6GB and 1.7s to parse 10k qualified symbols, which is both a
+// pointless cost on ordinary source and an allocation amplification an
+// attacker controls, in a parser whose job is to survive untrusted phylum
+// source.
+func NewScannerString(file string, src string) *Scanner {
+	return newScannerBuf(file, strings.NewReader(src), make([]byte, len(src)))
 }
 
 // SetPath associates a physical location (e.g. filesystem path) with s to aid

--- a/parser/token/scanner.go
+++ b/parser/token/scanner.go
@@ -71,7 +71,7 @@ func NewScanner(file string, r io.Reader) *Scanner {
 // pointless cost on ordinary source and an allocation amplification an
 // attacker controls, in a parser whose job is to survive untrusted phylum
 // source.
-func NewScannerString(file string, src string) *Scanner {
+func NewScannerString(file, src string) *Scanner {
 	return newScannerBuf(file, strings.NewReader(src), make([]byte, len(src)))
 }
 

--- a/parser/token/scanner_test.go
+++ b/parser/token/scanner_test.go
@@ -5,6 +5,7 @@ package token
 import (
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -211,4 +212,41 @@ func TestSeqFiller(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, "xxxxxxxxx\nxxxxxxxxx\nxxxx", string(buf1)+string(buf2))
+}
+
+// TestNewScannerString pins that sizing the window to the source changes
+// nothing about what the scanner does.
+//
+// NewScanner allocates its 128KiB window per SCANNER, not per byte scanned,
+// and rdparser.readsBackAsSymbol builds one scanner per #' operand and two per
+// package-qualified symbol.  NewScannerString exists to make those re-reads
+// cheap (issue #319); it is only safe because a window the size of the whole
+// source cannot be overrun by a token drawn from that source, so the two
+// constructors must agree rune for rune.
+func TestNewScannerString(t *testing.T) {
+	srcs := []string{
+		"", "a", "ab", "abc", "a:b", "1", "-1", "  x  ", "a\nb\n",
+		"(defun f (x) (+ x 1))", "\xff", "\xe4\xb8", "日本語",
+	}
+	for _, src := range srcs {
+		t.Run(src, func(t *testing.T) {
+			big := NewScanner("test", strings.NewReader(src))
+			small := NewScannerString("test", src)
+			for i := 0; ; i++ {
+				errBig := big.ScanRune()
+				errSmall := small.ScanRune()
+				assert.Equal(t, errBig == nil, errSmall == nil,
+					"rune %d: error disagreement: %v vs %v", i, errBig, errSmall)
+				assert.Equal(t, big.Rune(), small.Rune(), "rune %d", i)
+				assert.Equal(t, big.EOF(), small.EOF(), "rune %d: EOF", i)
+				assert.Equal(t, big.Text(), small.Text(), "rune %d: text", i)
+				if errBig != nil || errSmall != nil {
+					break
+				}
+				if i > len(src)+4 {
+					t.Fatal("scanner did not terminate")
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes #319.

`rdparser` accepted `a:1` — a package-qualified symbol whose local part is a bare digit. Same root cause as the `#'0` defect recorded in `lexer.readFunRef`: `isWord` is the CONTINUATION rune class and admits digits, and `readSymbol` gets away with it only because it is entered after `isWordStart` or `':'` has already matched. Matching `':'` is what admits the digit. The `#'` path was fixed by requiring the operand to read back as a symbol; the `pkg:name` path had the same shape and was left alone.

## Current behaviour, measured before deciding anything

Every row observed against `ParseProgram` on `main`:

| Input | Before | After | Note |
|---|---|---|---|
| `a:1` | symbol `a:1` | **rejected** | the reported case |
| `a:1b` | symbol `a:1b` | **rejected** | |
| `a:1abc` | symbol `a:1abc` | **rejected** | not a number by `strconv`, still reads back as INT + symbol |
| `a:0x10` | symbol `a:0x10` | **rejected** | reads back as INT `0` + symbol `x10` |
| `a:-1` | symbol `a:-1` | **rejected** | reads back as INT |
| `a:1.5`, `a:1e5` | symbol | **rejected** | read back as FLOAT |
| `a:1_`, `a:9` | symbol | **rejected** | |
| `a:b`, `lisp:set`, `xyz:abc?` | symbol | symbol | unchanged |
| `a:+1`, `a:.1`, `a:*1`, `a:_1` | symbol | symbol | `+ . * _` are ordinary symbol characters, so these *are* writable bare |
| `a:-`, `a:--`, `a:-a`, `-a:b` | symbol | symbol | lex as NEGATIVE, only become symbols once `ParseNegative` merges — a token-level guard would wrongly reject them |
| `a:true`, `a:<=`, `a:set!`, `a:->` | symbol | symbol | unchanged |
| `:1`, `:1.5`, `:-1`, `:+1`, `:1a` | keyword | **keyword (unchanged)** | deliberate — see below |
| `:b` | keyword | keyword | unchanged |
| `1:1` | INT `1` + keyword `:1` | same | never one symbol: the lexer stops the number at `':'` |
| `-1:b` | INT `-1` + keyword `:b` | same | |
| `1a:b` | INT `1` + symbol `a:b` | same | |
| `a:`, `:`, `::`, `a::b`, `a:b:c` | rejected | rejected | pre-existing |
| `#'a:1` | `(lisp:function a:1)` | **rejected** | `readsBackAsSymbol("a:1")` was true, so the funref guard did not catch it |
| `#'a:b` | `(lisp:function a:b)` | unchanged | |

The guard is exactly "the local part must not start with a digit": a digit start always routes to `readNumber`, which can only emit INT/FLOAT or an INT followed by a separate token, never a single symbol.

## Decision

**Tighten `pkg:name`. Leave `:name` (keywords) alone. Document both.**

`pkg:name` is the qualified *spelling of a binding's name*. `docs/lang.md` has always said identifiers cannot start with a number, and ELPS has no `|...|`-style escape, so `a:1` is the only way to write the symbol named `1` — a binding reachable only through the qualified spelling, never importable usefully by `use-package`. That is a trap, not a capability, and qualified access should be another way to spell a name rather than a way to introduce one that cannot be written unqualified.

`:1` is a different thing and is **not** tightened. A leading `':'` with no package yields a keyword: a self-evaluating literal that names no binding and that `PutGlobal` explicitly refuses to bind (`(set ':k 1)` errors). The identifier rule governs names of bindings, so it has nothing to say about a keyword. Keywords are the language's only interned-literal facility and `:1` is usable data — verified: it evaluates to itself and works as a sorted-map key, `(sorted-map :1 "x")` → `(sorted-map ':1 "x")`. The one consequence worth knowing is that a keyword whose name is not a legal identifier can never match a `&key` formal (no formal can be spelled that way), so `(f :1 2)` is always "unrecognized keyword argument: 1". That is now documented and pinned rather than left implicit.

Round-trip stability was the reason this was lower severity than `#'0`, and it remains true — `a:1` printed and re-read stably, so nothing here fixes a formatter corruption. It is fixed because it is a name the language otherwise forbids, reachable from source.

## Implementation

Same treatment `readFunRef` got — re-read and require a symbol back — rather than a second, differently-worded rune test. `ParseSymbol` checks **both** halves, not just the local one: the package half is provably safe today only because of the lexer's entry conditions, and relying on that reasoning is exactly what produced the bug.

Two supporting changes fell out of it:

- **`token.NewScannerString`** sizes the scanner window to the source instead of allocating the fixed 128KiB window per scanner. `readsBackAsSymbol` builds one scanner per call, so through `NewScanner` the check cost **2.6GB and 1.7s** to parse 10k qualified symbols. That amplification already existed for every `#'` operand; this removes it there too.
- **`Parser.readsBackAsSymbol` memoizes** per name. Real source repeats names, so the sub-parse runs once per distinct name per file.

Cost, `benchstat` over substrate's `shirocore` + `e2e` corpus (667KB, n=8):

| | sec/op | B/op | allocs/op |
|---|---|---|---|
| with cache | ~ (p=0.645) | +2.02% | +1.78% |
| without cache | +17.76% (p=0.001) | +6.61% | +5.97% |

Adversarial worst case (10k *distinct* qualified names) is 3.7x time / 3.2x memory — a bounded constant, linear in input, versus the 2.6GB the un-right-sized scanner would have cost.

## Substrate check — before tightening

Token-level scan of every `.lisp` file for SYMBOL tokens containing `':'`:

- **`luthersystems/substrate`: 93 files, 207 distinct qualified symbols, ZERO with a digit-leading local part.**
- 78 more files across `ui-core`, `elps` and `reliable`: 128 distinct, zero.
- All 171 files still parse clean with the guard in place.
- The minifier cannot produce one either: `newName` is always `fmt.Sprintf("x%d", …)`.

No existing phylum source is affected.

## Mutation verification

- Guard disabled (`if false && …`): all **14** `rejected/` subtests fail; every `accepted/` subtest, the keyword table, the token-split test and the pre-existing `#'` test still pass — the tests are sensitive to the guard and nothing else. Restored, all green.
- Cache key mutated to `strconv.Itoa(len(s))` (collides `"a"` with `"1"`): `TestQualifiedSymbolCheckIsMemoizedPerName` fails with `a cached verdict for the package half must not excuse the local half`, i.e. the parser accepts `a:1` again. Restored, all green.

## Test plan

- `go build ./...`, `go test ./...` — green
- `golangci-lint run ./...` and the `elpscheck`-tagged pass — 0 issues
- `./elps doc -m` — all documented
- `./elps fmt -l --exclude 'grammar' ./...` — clean
- `./elps lint --workspace=. --exclude 'grammar' --include '_examples' ./...` — 9 warnings, identical to `main`
- `bash scripts/ci-gates-test.sh` — 116 passed, 0 failed

`a:1`, `:1`, `a:+1` and `1:1` are added to the adversarial fuzz seed corpus so both sides of the split stay exercised.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_