### PR TITLE
Bound evaluator recursion depth, not just call-stack frames

### DIFF
--- a/docs/lang.md
+++ b/docs/lang.md
@@ -942,11 +942,17 @@ an embedder can identify the offending Go function.
 
 ## Execution Limits
 
-ELPS bounds evaluation with four independent mechanisms: **context
-cancellation**, **step limits**, **stack height limits** and a
-**tail-iteration limit**.  Context cancellation and step limits are optional
-and impose negligible overhead when not configured; the physical stack limit
-and the tail-iteration limit are on by default.
+ELPS bounds evaluation with five independent mechanisms: **context
+cancellation**, **step limits**, **stack height limits**, an **evaluation
+nesting limit** and a **tail-iteration limit**.  Context cancellation and step
+limits are optional and impose negligible overhead when not configured; the
+physical stack limit, the evaluation nesting limit and the tail-iteration
+limit are on by default.
+
+None of them bound *total* memory: `Runtime.MaxAlloc` caps the output size of
+a single builtin call, not the sum across calls, so a loop that allocates many
+smaller values is bounded only by whatever stops the loop.  A host that must
+bound total memory has to do it outside the interpreter.
 
 ### Context Cancellation
 
@@ -1010,9 +1016,9 @@ inside a builtin.  **Context cancellation with a deadline is the only limit
 here that measures elapsed time**, and it is what you want if the real
 requirement is "give up after N seconds".
 
-### Stack Height and Tail-Call Limits
+### Stack Height, Nesting and Tail-Call Limits
 
-ELPS distinguishes three things that a naive "stack limit" conflates.
+ELPS distinguishes four things that a naive "stack limit" conflates.
 
 **Physical stack height** is the number of frames actually on the call
 stack.  This is the memory guard: unbounded *non-tail* recursion exhausts the
@@ -1023,6 +1029,42 @@ below the measured crash threshold, and exceeding it produces an ordinary,
 catchable ELPS error.  Override with
 `lisp.WithMaximumPhysicalStackHeight(n)`; 0 disables the check, which is not
 recommended.
+
+It bounds *frames*, not evaluation depth — see below.
+
+**Evaluation nesting** is how deeply the evaluator recurses into itself, which
+is the true measure of Go stack consumed.  It is not the same as stack height
+and is not implied by it: a call's arguments are evaluated *before* the call's
+frame is pushed, so
+
+```lisp
+(identity (identity (identity ... 1)))
+```
+
+recurses through the whole evaluator while the physical stack height stays at
+**zero**.  That is the exact shape the physical limit exists to stop and the
+one shape it cannot see.  Nesting does not have to be written out by hand
+either — a recursive macro generates it at expansion time from an integer, so
+neither the parser's depth limit nor the source size bounds it:
+
+```lisp
+(defmacro nest (n)
+  (if (<= n 0) 1 (quasiquote (identity (nest (unquote (- n 1)))))))
+(nest 800000)   ; without the nesting limit: fatal error: stack overflow
+```
+
+Nesting is bounded by default (`DefaultMaxEvalNesting`, 100000), several times
+below the measured crash threshold and well above the nesting an ordinary
+recursion reaches before it hits the 25000-frame physical limit.  Exceeding it
+raises a catchable `eval-nesting-exceeded` condition:
+
+```lisp
+(handler-bind ((eval-nesting-exceeded (lambda (c &rest args) 'too-deep)))
+    (nest 800000))
+```
+
+Override with `lisp.WithMaxEvalNesting(n)`; a negative value disables the
+check, which re-exposes the host process to an unrecoverable stack overflow.
 
 **Tail-call iterations** count the turns of a tail-recursive loop.  Tail
 calls run in constant stack space, so no stack-height limit can bound a

--- a/internal/fuzzseed/evalseed.go
+++ b/internal/fuzzseed/evalseed.go
@@ -48,6 +48,20 @@ func EvalRunaway() map[string]string {
 		"non-tail-recursion-forever": `(defun rec (n) (+ 1 (rec n))) (rec 0)`,
 		"non-tail-mutual":            `(defun p (n) (+ 1 (q n))) (defun q (n) (+ 1 (p n))) (p 0)`,
 
+		// --- unbounded ARGUMENT nesting (MaxEvalNesting).  Same failure
+		// mode as the two above -- Go stack exhaustion -- reached by a
+		// shape no stack-height limit can see: evalSExprCells evaluates a
+		// call's arguments BEFORE pushing the call's frame, so this
+		// recurses through the whole evaluator at physical height zero.
+		//
+		// The nesting is generated during macro expansion from an integer,
+		// so the source is constant-size and rdparser's parse-depth limit
+		// -- which was the only thing incidentally bounding this -- never
+		// sees it.  Measured against the pre-fix tree at stock defaults,
+		// the 800000 form aborted the process with "fatal error: stack
+		// overflow" (issue #316).  MaxEvalNesting is what stops it now. ---
+		"macro-generated-arg-nesting": `(defmacro nest (n) (if (<= n 0) 1 (quasiquote (identity (nest (unquote (- n 1))))))) (nest 800000)`,
+
 		// --- non-recursive infinite loop.  Neither stack limit can see this:
 		// it grows no frames and performs no tail calls.  Only a step budget
 		// or a context deadline stops it. ---

--- a/lisp/conditions.go
+++ b/lisp/conditions.go
@@ -19,6 +19,12 @@ const (
 const (
 	CondContextCancelled  = "context-cancelled"
 	CondStepLimitExceeded = "step-limit-exceeded"
+
+	// CondEvalNestingExceeded reports that the evaluator recursed into
+	// itself more deeply than Runtime.MaxEvalNesting allows.  It is the
+	// recoverable substitute for a Go stack overflow, which is a
+	// runtime.throw that neither recover() nor handler-bind can intercept.
+	CondEvalNestingExceeded = "eval-nesting-exceeded"
 )
 
 // CondInternalPanic is the condition type of an error produced by recovering

--- a/lisp/config.go
+++ b/lisp/config.go
@@ -41,6 +41,27 @@ func WithMaximumPhysicalStackHeight(n int) Config {
 	}
 }
 
+// WithMaxEvalNesting returns a Config that bounds how deeply the evaluator may
+// recurse into itself while evaluating a single expression.
+//
+// This is a distinct quantity from stack height and is not implied by it.  A
+// call's arguments are evaluated before the call's frame is pushed, so
+// ((lambda (x) x) ((lambda (x) x) ... )) recurses through the Go evaluator
+// while the physical stack height stays at zero — the exact shape
+// WithMaximumPhysicalStackHeight exists to stop and the one shape it cannot
+// see (issue #316).  Nesting is bounded here instead.
+//
+// A value of 0 selects DefaultMaxEvalNesting.  A negative value disables the
+// check, which re-exposes the host process to an unrecoverable
+// "fatal error: stack overflow"; do that only when some other bound on
+// expression depth is guaranteed.
+func WithMaxEvalNesting(n int) Config {
+	return func(env *LEnv) *LVal {
+		env.Runtime.MaxEvalNesting = n
+		return Nil()
+	}
+}
+
 // WithMaxTailIterations returns a Config that bounds the number of tail-call
 // iterations a single stack frame may perform.  Tail calls run in constant
 // stack space, so neither stack-height limit can bound a runaway tail loop;

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -937,11 +937,23 @@ func (env *LEnv) Eval(v *LVal) *LVal {
 // evaluation into an LError, preventing panics from crashing the host process
 // when ELPS is embedded.
 //
+// eval also carries the evaluator's recursion-depth guard.  Every nested
+// evaluation passes through here, so incrementing a counter on entry and
+// decrementing it on exit measures the Go stack the evaluator is consuming.
+// This is NOT the same quantity as CallStack height: evalSExprCells evaluates
+// a call's arguments before any frame is pushed, so nested arguments recurse
+// through eval at physical height zero and MaxHeightPhysical never sees them
+// (issue #316).  A counter rather than a frame is deliberate -- a frame here
+// would corrupt the error messages and stack dumps produced while an argument
+// is being evaluated, which is why evalSExprCells pushes none.
+//
 // NOTE:  eval shouldn't unquote v during evaluation -- a difference between
 // Eval and the "eval" builtin function, but it does.  For some reason macros
 // won't work without this unquoting.
 func (env *LEnv) eval(ctx context.Context, v *LVal) (result *LVal) {
+	env.Runtime.evalNesting++
 	defer func() {
+		env.Runtime.evalNesting--
 		if r := recover(); r != nil {
 			// Tag the error with CondInternalPanic so it is distinguishable
 			// from a lisp-level error: a panic is a host-code bug, and
@@ -961,6 +973,14 @@ func (env *LEnv) eval(ctx context.Context, v *LVal) (result *LVal) {
 			}
 		}
 	}()
+	if env.Runtime.evalNestingExceeded() {
+		return env.ErrorConditionf(CondEvalNestingExceeded,
+			"evaluation nesting depth exceeded maximum: %d"+
+				" (expressions nested this deeply consume Go stack without pushing"+
+				" call frames, so the limit stops the Go runtime from aborting the"+
+				" process with an unrecoverable stack overflow; raise or disable it"+
+				" with WithMaxEvalNesting)", env.Runtime.evalNesting)
+	}
 	macroDepth := 0
 eval:
 	if lerr := env.checkLimits(ctx); lerr != nil {

--- a/lisp/eval_fuzz_test.go
+++ b/lisp/eval_fuzz_test.go
@@ -94,6 +94,19 @@ const (
 	fuzzMaxAlloc          = 1_000_000
 	fuzzMacroDepth        = 100
 
+	// fuzzMaxEvalNesting bounds the evaluator's recursion into itself, which
+	// is a different quantity from physical height: a call's arguments are
+	// evaluated before its frame is pushed, so nested arguments recurse
+	// through the evaluator at height zero and fuzzMaxPhysicalHeight cannot
+	// see them (issue #316).  Sized against the physical budget by the
+	// measured ~1.5 eval levels per physical frame, with headroom, so the
+	// physical bound stays the one that fires on ordinary recursion.
+	//
+	// Before this existed, a macro that generates nesting at expansion time
+	// was stopped here only by the 2s context deadline -- i.e. by wall clock,
+	// after hundreds of thousands of Go frames had already been pushed.
+	fuzzMaxEvalNesting = 20_000
+
 	// fuzzDeadline is the context deadline every evaluation runs under.  It
 	// is the only limit that bounds wall-clock time, and it is checked at
 	// each evaluation step.
@@ -128,6 +141,7 @@ func newFuzzEnv() (*lisp.LEnv, *bytes.Buffer, *lisp.LVal) {
 		lisp.WithMaxSteps(fuzzMaxSteps),
 		lisp.WithMaxTailIterations(fuzzMaxTailIterations),
 		lisp.WithMaximumPhysicalStackHeight(fuzzMaxPhysicalHeight),
+		lisp.WithMaxEvalNesting(fuzzMaxEvalNesting),
 		lisp.WithMaxAlloc(fuzzMaxAlloc),
 		lisp.WithMaxMacroExpansionDepth(fuzzMacroDepth),
 	)

--- a/lisp/evalnesting_test.go
+++ b/lisp/evalnesting_test.go
@@ -1,0 +1,321 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Evaluation-nesting limit tests (issue #316).
+//
+// The quantity under test is how deeply LEnv.eval recurses into itself, which
+// is what actually consumes Go stack. It is NOT the call-stack height:
+// evalSExprCells evaluates a call's arguments before pushing the call's frame,
+// so ((identity (identity ... 1))) recurses through the whole evaluator at
+// physical height zero. MaxHeightPhysical -- the limit written to stop
+// unbounded recursion from aborting the process with a Go stack overflow --
+// cannot see that shape at all.
+//
+// Two things make these tests worth their runtime:
+//
+//   - nestedCallGo builds the nesting with no parser involvement, which is the
+//     embedder-facing half of the gap.
+//   - macroNestSrc generates the nesting at macro-expansion time from an
+//     integer, which is the ELPS-facing half: it defeats
+//     rdparser.DefaultMaxParseDepth, the limit that was incidentally
+//     containing this before. Measured on linux/amd64 against the pre-fix
+//     tree, `(nest 800000)` -- about 120 bytes of source, every documented
+//     limit at its default -- reached `fatal error: stack overflow` and took
+//     the process down. That is why the fix is a limit and not a doc note.
+
+// nestedCallGo builds (identity (identity ... 1)) of the given nesting depth
+// directly as an LVal tree. No parser, so rdparser.DefaultMaxParseDepth does
+// not apply.
+func nestedCallGo(depth int) *lisp.LVal {
+	v := lisp.Int(1)
+	for i := 0; i < depth; i++ {
+		v = lisp.SExpr([]*lisp.LVal{lisp.Symbol("identity"), v})
+	}
+	return v
+}
+
+// macroNestSrc returns ELPS source, of constant size regardless of depth, that
+// generates depth levels of argument nesting during macro expansion.
+func macroNestSrc(depth int) string {
+	return fmt.Sprintf(`
+(defmacro nest (n)
+  (if (<= n 0)
+      1
+      (quasiquote (identity (nest (unquote (- n 1)))))))
+(nest %d)
+`, depth)
+}
+
+// TestArgumentNestingIsNotBoundedByStackHeight is the ground truth the issue
+// reports: argument evaluation recurses through the Go evaluator without
+// pushing a single call frame, so no stack-height limit constrains it.
+//
+// A five-frame physical ceiling -- low enough that three levels of ordinary
+// non-tail recursion is refused -- permits 5,000 levels of argument nesting.
+func TestArgumentNestingIsNotBoundedByStackHeight(t *testing.T) {
+	tiny := []lisp.Config{
+		lisp.WithMaximumPhysicalStackHeight(5),
+		lisp.WithMaxEvalNesting(-1), // disabled: isolate what stack height sees
+	}
+
+	// Non-tail recursion is refused almost immediately under this ceiling.
+	env := newLimitTestEnv(t, tiny...)
+	require.NotEqual(t, lisp.LError,
+		env.LoadString("test", `(defun rec (n) (if (= n 0) 0 (+ 1 (rec (- n 1)))))`).Type)
+	res := env.LoadString("test", `(rec 10)`)
+	require.Equal(t, lisp.LError, res.Type,
+		"10 levels of non-tail recursion must exceed a 5-frame ceiling")
+	assert.Contains(t, res.String(), "physical stack height exceeded maximum")
+
+	// The same ceiling permits three orders of magnitude more argument
+	// nesting, because argument evaluation pushes no frames.
+	env = newLimitTestEnv(t, tiny...)
+	res = env.Eval(nestedCallGo(5000))
+	require.NotEqual(t, lisp.LError, res.Type,
+		"5,000 levels of argument nesting must be invisible to a 5-frame ceiling: %v", res)
+	assert.Equal(t, "1", res.String())
+	assert.Empty(t, env.Runtime.Stack.Frames)
+}
+
+// TestEvalNestingLimitBoundsArgumentNesting pins the fix: the nesting limit
+// sees exactly the shape stack height cannot.
+func TestEvalNestingLimitBoundsArgumentNesting(t *testing.T) {
+	env := newLimitTestEnv(t,
+		lisp.WithMaximumPhysicalStackHeight(0), // off: prove nesting is what trips
+		lisp.WithMaxEvalNesting(200))
+	res := env.Eval(nestedCallGo(5000))
+	require.Equal(t, lisp.LError, res.Type, "expected the nesting limit to trip, got %v", res)
+	msg := res.String()
+	assert.Contains(t, msg, "evaluation nesting depth exceeded maximum")
+	assert.Contains(t, msg, "WithMaxEvalNesting",
+		"the error must say which knob raises the limit")
+	assert.Contains(t, msg, lisp.CondEvalNestingExceeded,
+		"the error must carry a distinguishable condition")
+	assert.NotContains(t, msg, "stack height exceeded",
+		"the message must not read like a call-stack overflow -- it is a different quantity")
+}
+
+// TestMacroGeneratedNestingIsBounded is the load-bearing regression test.
+//
+// The nesting here is generated during macro expansion from an integer
+// argument, so the source is a constant ~120 bytes at any depth and
+// rdparser.DefaultMaxParseDepth never sees it. Against the pre-fix tree this
+// program ran to completion at depth 400,000 and killed the process outright
+// at 800,000; the ELPS call stack was empty throughout.
+func TestMacroGeneratedNestingIsBounded(t *testing.T) {
+	env := newLimitTestEnv(t, lisp.WithMaxEvalNesting(500))
+	res := env.LoadString("test", macroNestSrc(20000))
+	require.Equal(t, lisp.LError, res.Type,
+		"macro-generated nesting must be bounded, got %v", res)
+	assert.Contains(t, res.String(), "evaluation nesting depth exceeded maximum")
+
+	// The same program just under the limit still evaluates: the guard bounds
+	// depth, it does not break recursive macros.
+	env = newLimitTestEnv(t, lisp.WithMaxEvalNesting(500))
+	res = env.LoadString("test", macroNestSrc(100))
+	require.NotEqual(t, lisp.LError, res.Type, "100 levels must be permitted: %v", res)
+	assert.Equal(t, "1", res.String())
+}
+
+// TestDefaultLimitsContainFatalNesting runs, at the DEFAULTS an embedder gets
+// from lisp.NewEnv(nil), the exact program that took the pre-fix process down
+// with "fatal error: stack overflow". Every other test here configures a small
+// limit to stay cheap; this one is deliberately expensive, because a default
+// that is merely present but set above the crash point would pass all of them.
+//
+// Cost: reaching the 100,000-level default consumes ~140MB of goroutine stack
+// (measured ~1.4KB per level). That is the price of asserting the default
+// rather than the mechanism.
+func TestDefaultLimitsContainFatalNesting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocates ~140MB of goroutine stack")
+	}
+	for _, tt := range []struct {
+		name string
+		eval func(env *lisp.LEnv) *lisp.LVal
+	}{
+		{
+			// The ELPS-source path: constant-size source, nesting
+			// generated at expansion time, parse depth irrelevant.
+			name: "macro generated",
+			eval: func(env *lisp.LEnv) *lisp.LVal {
+				return env.LoadString("test", macroNestSrc(800000))
+			},
+		},
+		{
+			// The embedder path: an AST built through the Go API, which
+			// never passes the parser at all.
+			name: "go api",
+			eval: func(env *lisp.LEnv) *lisp.LVal {
+				return env.Eval(nestedCallGo(800000))
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newLimitTestEnv(t) // stock defaults, no overrides
+			res := tt.eval(env)
+			require.Equal(t, lisp.LError, res.Type,
+				"800,000 levels must be refused at the defaults, got %v", res)
+			assert.Contains(t, res.String(), "evaluation nesting depth exceeded maximum")
+			assert.Empty(t, env.Runtime.Stack.Frames,
+				"the ELPS call stack was empty the whole time -- which is exactly why"+
+					" MaxHeightPhysical could not see this")
+		})
+	}
+}
+
+// TestEvalNestingLimitBoundary pins the exact off-by-one, so < vs <= cannot
+// drift. env.Eval of an n-deep nesting reaches nesting depth n+1: one level
+// for the outermost expression plus one per nested argument.
+func TestEvalNestingLimitBoundary(t *testing.T) {
+	const limit = 100
+
+	for _, tt := range []struct {
+		depth   int
+		wantErr bool
+	}{
+		{depth: limit - 2, wantErr: false},
+		{depth: limit - 1, wantErr: false},
+		{depth: limit, wantErr: true},
+	} {
+		t.Run(fmt.Sprintf("depth_%d", tt.depth), func(t *testing.T) {
+			env := newLimitTestEnv(t, lisp.WithMaxEvalNesting(limit))
+			res := env.Eval(nestedCallGo(tt.depth))
+			if !tt.wantErr {
+				require.NotEqual(t, lisp.LError, res.Type,
+					"depth %d must be allowed under a %d-level limit: %v", tt.depth, limit, res)
+				return
+			}
+			require.Equal(t, lisp.LError, res.Type,
+				"depth %d must exceed a %d-level limit", tt.depth, limit)
+			assert.Contains(t, res.String(),
+				fmt.Sprintf("evaluation nesting depth exceeded maximum: %d", limit+1),
+				"the error must report the depth that exceeded the limit")
+		})
+	}
+}
+
+// TestEvalNestingDefaults pins the default policy. The guard is on by default
+// for the same reason the physical-height guard is: with it off, the failure
+// mode is an unrecoverable process abort.
+func TestEvalNestingDefaults(t *testing.T) {
+	assert.Equal(t, 100000, lisp.DefaultMaxEvalNesting)
+
+	for _, tt := range []struct {
+		name string
+		rt   *lisp.Runtime
+	}{
+		{"StandardRuntime", lisp.StandardRuntime()},
+		{"NewEnv", lisp.NewEnv(nil).Runtime},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, 0, tt.rt.MaxEvalNesting,
+				"the zero value must mean 'use the default', not 'disabled'")
+			assert.Equal(t, lisp.DefaultMaxEvalNesting, tt.rt.MaxEvalNestingDepth())
+			assert.Equal(t, 0, tt.rt.EvalNesting())
+		})
+	}
+
+	// An explicit value wins; a negative value disables the check.
+	env := newLimitTestEnv(t, lisp.WithMaxEvalNesting(1234))
+	assert.Equal(t, 1234, env.Runtime.MaxEvalNestingDepth())
+	env = newLimitTestEnv(t, lisp.WithMaxEvalNesting(-1))
+	assert.Equal(t, 0, env.Runtime.MaxEvalNestingDepth(),
+		"a negative limit reports as disabled")
+}
+
+// TestEvalNestingLimitCanBeDisabled pins the escape hatch: an embedder that
+// has some other bound on expression depth can turn the check off.
+func TestEvalNestingLimitCanBeDisabled(t *testing.T) {
+	env := newLimitTestEnv(t, lisp.WithMaxEvalNesting(50))
+	require.Equal(t, lisp.LError, env.Eval(nestedCallGo(200)).Type,
+		"the limit must trip when configured")
+
+	env = newLimitTestEnv(t, lisp.WithMaxEvalNesting(-1))
+	res := env.Eval(nestedCallGo(200))
+	require.NotEqual(t, lisp.LError, res.Type, "a negative limit must disable the check: %v", res)
+	assert.Equal(t, "1", res.String())
+}
+
+// TestEvalNestingIsRecoverable is the point of the whole exercise: what was a
+// runtime.throw that no handler-bind and no recover() could intercept is now
+// an ordinary condition an ELPS program can catch.
+func TestEvalNestingIsRecoverable(t *testing.T) {
+	env := newLimitTestEnv(t, lisp.WithMaxEvalNesting(100))
+	res := env.LoadString("test", `
+(defmacro nest (n)
+  (if (<= n 0)
+      1
+      (quasiquote (identity (nest (unquote (- n 1)))))))
+(handler-bind ([eval-nesting-exceeded (lambda (c &rest args) 'caught)])
+  (nest 10000))
+`)
+	require.NotEqual(t, lisp.LError, res.Type, "the condition must be catchable: %v", res)
+	assert.Equal(t, "'caught", res.String())
+}
+
+// TestEvalNestingCounterUnwinds pins that the counter is decremented on every
+// exit path. A counter that leaks on the error path would degrade a long-lived
+// Runtime into one that refuses to evaluate anything -- a far worse failure
+// than the one being guarded against.
+func TestEvalNestingCounterUnwinds(t *testing.T) {
+	env := newLimitTestEnv(t, lisp.WithMaxEvalNesting(100))
+
+	for _, tt := range []struct {
+		name string
+		src  string
+	}{
+		{"success", `(+ 1 (+ 1 (+ 1 1)))`},
+		{"lisp error", `(error 'boom "x")`},
+		{"caught error", `(ignore-errors (error 'boom "x"))`},
+		{"nesting limit", `(defun f (n) (+ 1 (f n))) (f 0)`},
+		{"undefined symbol", `(no-such-function 1 2 3)`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			env.LoadString("test", tt.src)
+			assert.Equal(t, 0, env.Runtime.EvalNesting(),
+				"the nesting counter must return to zero after evaluation")
+			assert.Empty(t, env.Runtime.Stack.Frames,
+				"the call stack must unwind too")
+		})
+	}
+
+	// And the runtime is still usable afterwards.
+	res := env.LoadString("test", `(+ 1 2)`)
+	require.NotEqual(t, lisp.LError, res.Type, "the runtime must survive: %v", res)
+	assert.Equal(t, "3", res.String())
+}
+
+// TestEvalNestingErrorReportsSource pins the reason the guard is a counter and
+// not a stack frame. evalSExprCells pushes nothing while evaluating arguments
+// precisely so that an error raised there reports the argument's own location
+// and an uncluttered stack; a frame pushed per nesting level would have
+// rewritten both. The error must still point at real source.
+func TestEvalNestingErrorReportsSource(t *testing.T) {
+	env := newLimitTestEnv(t, lisp.WithMaxEvalNesting(100))
+	res := env.LoadString("nesting.lisp", macroNestSrc(1000))
+	require.Equal(t, lisp.LError, res.Type)
+	assert.Contains(t, res.String(), "nesting.lisp:",
+		"the error must carry the source location of the expression that overflowed")
+
+	// An ordinary error raised while evaluating a nested argument is
+	// unaffected by the guard: same location, same short stack.
+	env = newLimitTestEnv(t)
+	res = env.LoadString("argerr.lisp", "(identity (identity (error 'boom \"deep\")))")
+	require.Equal(t, lisp.LError, res.Type)
+	msg := res.String()
+	assert.Contains(t, msg, "argerr.lisp:1:")
+	assert.Contains(t, msg, "boom")
+	assert.NotContains(t, strings.ToLower(msg), "nesting depth")
+}

--- a/lisp/evalnesting_test.go
+++ b/lisp/evalnesting_test.go
@@ -39,7 +39,7 @@ import (
 // not apply.
 func nestedCallGo(depth int) *lisp.LVal {
 	v := lisp.Int(1)
-	for i := 0; i < depth; i++ {
+	for range depth {
 		v = lisp.SExpr([]*lisp.LVal{lisp.Symbol("identity"), v})
 	}
 	return v

--- a/lisp/runtime.go
+++ b/lisp/runtime.go
@@ -101,13 +101,13 @@ func (r *Runtime) EvalNesting() int {
 // counter the caller has already incremented, with no function call in the
 // common case (it inlines).
 func (r *Runtime) evalNestingExceeded() bool {
-	max := r.MaxEvalNesting
-	if max == 0 {
-		max = DefaultMaxEvalNesting
-	} else if max < 0 {
+	limit := r.MaxEvalNesting
+	if limit == 0 {
+		limit = DefaultMaxEvalNesting
+	} else if limit < 0 {
 		return false
 	}
-	return r.evalNesting > max
+	return r.evalNesting > limit
 }
 
 // CheckAlloc returns a non-empty error message if n exceeds the per-operation

--- a/lisp/runtime.go
+++ b/lisp/runtime.go
@@ -44,7 +44,9 @@ type Runtime struct {
 	conditionStack         []*LVal
 	MaxAlloc               int   // Per-operation allocation size cap (0 = use default). Not cumulative.
 	MaxMacroExpansionDepth int   // Maximum macro expansion iterations (0 = use default).
+	MaxEvalNesting         int   // Evaluator recursion depth cap (0 = use default, negative = disabled).
 	evalDepth              int   // Re-entrancy depth of top-level evaluation entry points.
+	evalNesting            int   // Current recursion depth of LEnv.eval (the Go-stack guard).
 	maxSteps               int64 // Per-evaluation step limit (0 = unlimited).
 	steps                  int64 // Steps consumed by the current top-level evaluation.
 	totalSteps             int64 // Steps consumed by all completed top-level evaluations.
@@ -71,6 +73,41 @@ func (r *Runtime) MaxMacroExpansions() int {
 		return r.MaxMacroExpansionDepth
 	}
 	return DefaultMaxMacroExpansionDepth
+}
+
+// MaxEvalNestingDepth returns the effective evaluator recursion-depth cap.
+// Zero means "use DefaultMaxEvalNesting"; a negative value disables the check
+// and is reported as zero.
+func (r *Runtime) MaxEvalNestingDepth() int {
+	if r.MaxEvalNesting == 0 {
+		return DefaultMaxEvalNesting
+	}
+	if r.MaxEvalNesting < 0 {
+		return 0
+	}
+	return r.MaxEvalNesting
+}
+
+// EvalNesting reports how deeply LEnv.eval is currently recursed into itself.
+// It is zero outside of an evaluation.  See DefaultMaxEvalNesting for what the
+// quantity measures and why it is bounded separately from stack height.
+func (r *Runtime) EvalNesting() int {
+	return r.evalNesting
+}
+
+// evalNestingExceeded reports whether the evaluator has recursed past its
+// depth cap.  It runs once per LEnv.eval call -- the interpreter's hottest
+// path -- so it is deliberately a couple of loads and compares against a
+// counter the caller has already incremented, with no function call in the
+// common case (it inlines).
+func (r *Runtime) evalNestingExceeded() bool {
+	max := r.MaxEvalNesting
+	if max == 0 {
+		max = DefaultMaxEvalNesting
+	} else if max < 0 {
+		return false
+	}
+	return r.evalNesting > max
 }
 
 // CheckAlloc returns a non-empty error message if n exceeds the per-operation
@@ -192,6 +229,48 @@ const DefaultMaxMacroExpansionDepth = 1000
 // tail-recursive loop runs at constant physical height no matter how many
 // iterations it performs.
 //
+// It bounds FRAMES, not evaluation depth. A frame is pushed when a function is
+// invoked, and LEnv.evalSExprCells deliberately evaluates a call's arguments
+// BEFORE pushing anything (pushing there would corrupt the error messages and
+// stack dumps produced while an argument is being evaluated). Nested arguments
+// therefore recurse through the Go evaluator at physical height zero, which is
+// exactly the shape this limit exists to stop and exactly the shape it cannot
+// see. DefaultMaxEvalNesting covers that path; see issue #316.
+//
+// # DefaultMaxEvalNesting — the same memory guard, on the evaluator's own recursion
+//
+// This bounds how deeply LEnv.eval may recurse into itself, which is the true
+// measure of Go stack consumed by the evaluator. Every nested evaluation
+// passes through eval — a call's arguments, a special operator's subforms, a
+// builtin re-entering via env.Eval — so a single counter incremented on entry
+// and decremented on exit bounds all of them, and unlike a stack frame it
+// costs no allocation and does not appear in a stack trace.
+//
+// Measured on linux/amd64 against the 1GB default goroutine stack:
+// argument-nesting depth 700,000 completes, 800,000 aborts the process with
+// "fatal error: stack overflow" (~1.4KB of Go stack per level). 100,000 sits
+// 7-8x below that, matching the margin DefaultMaxPhysicalStackHeight keeps.
+//
+// It also sits comfortably above ordinary recursion. Measured with
+// (defun sum (n) (if (<= n 0) 0 (+ n (sum (- n 1))))), the physical limit
+// binds first for any MaxEvalNesting of 38,000 or more: that recursion costs
+// ~1.5 eval levels per physical frame, so it reaches physical height 25,001
+// at nesting ~38,000. Only code whose body nests expressions more than ~4
+// deep per recursion level can reach 100,000 nesting before 25,000 frames,
+// and such code really is consuming ~4x the Go stack per frame.
+//
+// The two limits bound different quantities and neither implies the other.
+// Deeply nested arguments raise nesting at constant height; a long chain of
+// tail-position calls raises neither.
+//
+// Before this limit existed the only thing bounding evaluator recursion was
+// rdparser.DefaultMaxParseDepth (10,000) — incidentally, because nesting had
+// to be parsed before it could be evaluated. That bound was never sound: a
+// recursive macro generates nesting at expansion time from an integer
+// argument, so ~120 bytes of source reached the fatal overflow with every
+// documented limit at its default. Parse depth is no longer load-bearing for
+// stack safety.
+//
 // # DefaultMaxTailIterations — the runaway-loop backstop
 //
 // This bounds how many turns a single tail-recursive loop may take. Its unit
@@ -233,10 +312,23 @@ const DefaultMaxMacroExpansionDepth = 1000
 // single step may perform an arbitrary amount of work inside a builtin. A
 // context deadline is the only real time bound; see WithContext and the
 // *Context methods on LEnv.
+//
+// # Bounding total memory
+//
+// Runtime.MaxAlloc is PER-OPERATION, not cumulative: each builtin checks its
+// own output size against it, so a program that allocates a thousand buffers
+// of MaxAlloc-1 bytes passes every check. Nothing here tracks total heap. The
+// incidental bound is whatever limit stops the loop doing the allocating —
+// MaxTailIterations for a tail loop, MaxSteps for a stepped one — multiplied
+// by MaxAlloc, which is not a memory budget in any useful sense. A host that
+// must bound total memory has to do it outside the interpreter (a cgroup, a
+// container limit, or Go's GOMEMLIMIT plus a watchdog); see Runtime.MaxAlloc
+// and CheckAlloc.
 const (
 	DefaultMaxLogicalStackHeight  = 0
 	DefaultMaxPhysicalStackHeight = 25000
 	DefaultMaxTailIterations      = 1000000
+	DefaultMaxEvalNesting         = 100000
 )
 
 // StandardRuntime returns a new Runtime with an empty package registry and

--- a/lisp/runtime.go
+++ b/lisp/runtime.go
@@ -256,8 +256,9 @@ const DefaultMaxMacroExpansionDepth = 1000
 // binds first for any MaxEvalNesting of 38,000 or more: that recursion costs
 // ~1.5 eval levels per physical frame, so it reaches physical height 25,001
 // at nesting ~38,000. Only code whose body nests expressions more than ~4
-// deep per recursion level can reach 100,000 nesting before 25,000 frames,
-// and such code really is consuming ~4x the Go stack per frame.
+// deep per recursion level can reach 100,000 nesting before 25,000 frames --
+// such code costs 4 eval levels per frame, ~2.6x what ordinary recursion
+// costs, so it really is consuming that much more Go stack per frame.
 //
 // The two limits bound different quantities and neither implies the other.
 // Deeply nested arguments raise nesting at constant height; a long chain of

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -39,6 +39,14 @@ func (*reader) ReadLocation(name string, loc string, r io.Reader) ([]*lisp.LVal,
 // Deeply nested input (e.g. 50K+ unmatched parens) can overflow the Go
 // goroutine stack with a fatal crash that recover() cannot catch.  This
 // limit converts the fatal crash into a parse error.
+//
+// It bounds the PARSER's recursion only.  It used to be, incidentally, the
+// only thing bounding the EVALUATOR's recursion as well -- nesting had to be
+// parsed before it could be evaluated -- but that composition was never
+// sound: a recursive macro generates nesting at expansion time and never
+// passes through here, as does any embedder building an AST through the Go
+// API.  lisp.DefaultMaxEvalNesting is the limit that bounds evaluation depth
+// (issue #316); this one is not load-bearing for it.
 const DefaultMaxParseDepth = 10000
 
 // Parser is a lisp parser.


### PR DESCRIPTION
Closes #316.

## Direction: (1), the counter — and the gap is live, not latent

The issue offered two directions: count Go-recursion depth against a limit, or
document that `MaxHeightPhysical` bounds frames rather than evaluation depth.
This PR does (1), because establishing the ground truth first turned the
finding from "latent gap" into "live defect".

### Ground truth (measured, linux/amd64, Go 1.25, 1GB default goroutine stack)

**1. `MaxHeightPhysical` really does not see argument-evaluation depth.**
With the stock default of 25,000, argument nesting of 400,000 levels evaluates
to completion and the ELPS call stack is *empty* throughout. Under a
deliberately tiny 5-frame ceiling — low enough that 10 levels of ordinary
non-tail recursion is refused — 5,000 levels of argument nesting still
evaluate fine. Pinned by `TestArgumentNestingIsNotBoundedByStackHeight`.

**2. The real Go crash point, and where `DefaultMaxParseDepth` sits.**
Bisected in subprocesses: 700,000 levels of argument nesting completes,
800,000 aborts with `fatal error: stack overflow` (`goroutine stack exceeds
1000000000-byte limit`), i.e. ~1.4KB of Go stack per level. `DefaultMaxParseDepth`
(10,000) is ~75x below that, so the issue's account of the two limits
composing by accident is correct as far as it goes.

**3. Deep nesting IS reachable without the parser — two ways. This is the
headline, and it changes the priority.**

The issue reports the author could not construct a deeper case from ELPS at
runtime, because list builders return quoted values that `eval` returns
unchanged. That observation is correct — I reproduced it, `(eval (build N 1))`
via `list` fails with `first element of expression is not a function:
'identity` at every depth, because `builtinEval` shallow-unquotes only the
outermost level. But it does not close the door:

* **A recursive macro does it.** Macro arguments are passed *unevaluated and
  unquoted*, and a macro expansion is re-evaluated by `eval`. So a macro can
  emit one level of nesting per expansion and recurse on an integer:

  ```lisp
  (defmacro nest (n)
    (if (<= n 0) 1 (quasiquote (identity (nest (unquote (- n 1)))))))
  (nest 800000)
  ```

  ~120 bytes of source, constant size at any depth, no parse nesting at all.
  Against `main`, at the defaults an embedder gets from `lisp.NewEnv(nil)`,
  **that program kills the host process with `fatal error: stack overflow`.**
  It also slips past `MaxMacroExpansionDepth` (1,000), because each expansion
  happens at a *different* `eval` frame, so the per-frame `macroDepth` counter
  never exceeds 1.

* **The Go API does it**, as the issue anticipated: `lisp.SExpr` nested
  800,000 deep, evaluated with `env.Eval`, same fatal abort.

So this is not two limits composing by accident. It is one limit that a
constant-size ELPS program walks straight past. That is why this PR ships the
guard rather than the doc note.

## The fix

Count `eval`'s own recursion depth. Every nested evaluation passes through
`LEnv.eval` — a call's arguments, a special operator's subforms, a builtin
re-entering via `env.Eval` — so a single counter incremented on entry and
decremented in the `defer` that is already there bounds all of them.

Deliberately a counter and **not** a stack frame, which is what
`evalSExprCells` is avoiding when it says *"We don't want to push anything on
the stack here because that would cause improper error messages/stack-dumps"*.
I tested that claim rather than trusting it: pushing a frame per argument
evaluation instead of counting fails **13 tests** —

* `TestStack`: the reported function name changes, `recursive: physical stack
  height exceeded` becomes `argeval: physical stack height exceeded`;
* `TestSpecialOp`: `debug-stack` gains a phantom `argeval` frame
  (`Stack Trace [4 frames]` → `[5 frames]`);
* 7 debugger tests across `x/debugger`, `dapserver` and `debugrepl`:
  step-into resolves to the wrong line, because stepping is keyed off stack
  depth.

The comment is accurate; a counter threads the needle.

New API: `Runtime.MaxEvalNesting` / `lisp.WithMaxEvalNesting(n)` /
`lisp.DefaultMaxEvalNesting` (100,000) / condition `eval-nesting-exceeded` /
`Runtime.EvalNesting()`. Zero means "use the default" (so a hand-built
`Runtime` is guarded, not unguarded); negative disables.

### Why 100,000

* 7-8x below the measured 700k–800k crash band — the same order of margin
  `DefaultMaxPhysicalStackHeight` keeps (8-16x), and the margin matters because
  the crash point moves with Go's stack settings, per-frame size and
  architecture.
* Above ordinary recursion, so `MaxHeightPhysical` stays the binding
  constraint for ordinary recursive code. Measured with
  `(defun sum (n) (if (<= n 0) 0 (+ n (sum (- n 1)))))`: the physical limit
  wins for any `MaxEvalNesting` >= 38,000, i.e. that recursion costs ~1.5 eval
  levels per physical frame and reaches height 25,001 at nesting ~38,000. Code
  must nest expressions more than ~4 deep per recursion level to reach 100,000
  nesting before 25,000 frames — 4 eval levels per frame is ~2.6x what ordinary
  recursion costs, so such code really is using that much more Go stack.

## Benchmarks

`eval` is the hottest path in the interpreter, so the cost is one increment,
one compare and one decrement per `eval` call, with no allocation and no new
`defer` (the decrement goes inside the recover handler that already exists).

Measured exactly as CI does — two trees, interleaved round-robin so
time-varying machine load hits both arms equally, `benchstat` over the pair:

**Full suite, `-benchmem -benchtime=100ms -count=1` x 10 rounds, all packages
(142 rows):**

| metric | geomean delta | significant bad-direction moves |
|---|---|---|
| sec/op (`lisp`) | +1.03% | 0 |
| B/op (`lisp`) | -0.00% | 0 |
| allocs/op (`lisp`) | +0.00% | 0 |

`scripts/benchstat-gate.sh` verdict: *interpreted 11 delta rows + 131
no-change rows; 0 significant moves in the bad direction; 0 at or above the
gate.* Every per-benchmark row is `~` (p > 0.05). Allocation counts are
byte-identical — the guard allocates nothing.

**Focused re-run on the eval-heavy benchmarks (`EnvGet`, the seven
`EnvFunCall*`, `MacroDefun`), `-benchtime=200ms -count=1` x 20 interleaved
rounds:**

| benchmark | base sec/op | PR sec/op | verdict |
|---|---|---|---|
| `EnvGet` | 16.41m ± 18% | 16.82m ± 11% | ~ (p=0.820, n=20) |
| `EnvFunCallBuiltin` | 932.6µ ± 3% | 959.4µ ± 7% | ~ (p=0.478, n=20) |
| `EnvFunCallRecursion` | 11.33m ± 5% | 11.15m ± 5% | ~ (p=0.841, n=20) |
| `EnvFunCallTailRec` | 5.517m ± 10% | 5.452m ± 5% | ~ (p=0.820, n=20) |
| `EnvFunCallPos` | 2.519m ± 8% | 2.580m ± 7% | ~ (p=0.620, n=20) |
| `EnvFunCallKey` | 2.975m ± 8% | 2.905m ± 8% | ~ (p=0.355, n=20) |
| `EnvFunCallOpt` | 2.514m ± 9% | 2.590m ± 7% | ~ (p=0.758, n=20) |
| `EnvFunCallVar` | 3.303m ± 10% | 3.190m ± 5% | ~ (p=0.253, n=20) |
| `MacroDefun` | 44.00µ ± 5% | 43.97µ ± 4% | ~ (p=0.659, n=20) |
| **geomean** | 2.398m | 2.403m | **+0.21%** |

`B/op` and `allocs/op` geomeans: -0.00% / +0.00%, every row `~`, seven of nine
`allocs/op` rows flagged "all samples are equal".

This sandbox is noisy (per-row variance ±10-40%, versus ~1.5% on the CI
fleet), so treat these as an upper bound rather than a precise figure: the
measurement can exclude a large regression, and it does, but it cannot resolve
a sub-1% one. What it can settle exactly is the allocation metrics, which are
deterministic and unchanged.

## Mutation verification

Each new guard was reverted in place and the suite re-run, to confirm the
tests actually fail without it:

| mutation | result |
|---|---|
| delete the `evalNestingExceeded` check in `eval` (keep the counter) | 6 tests fail; `TestDefaultLimitsContainFatalNesting` does not merely fail — **the test binary dies with `runtime: goroutine stack exceeds 1000000000-byte limit` / `fatal error: stack overflow`**, which is the defect itself, reproduced on demand |
| `>` → `>=` in the limit comparison (off-by-one) | `TestEvalNestingLimitBoundary/depth_99` and `/depth_100` fail |
| delete the `evalNesting--` decrement (counter leaks) | 4 tests fail, including every `TestEvalNestingCounterUnwinds` subtest — a leaked counter degrades a long-lived `Runtime` into one that refuses to evaluate anything |

The naive alternative — a stack frame instead of a counter — was mutation-tested
the same way and fails 13 tests; see above.

## Also addressed: `Runtime.MaxAlloc` is per-operation

Documented rather than changed, and I think that is the right call. Making it
cumulative would mean tracking every allocation and every release across the
interpreter — a real allocator — and it still would not bound memory the host
does not route through `CheckAlloc` (Go's own map growth, the `LVal` tree
itself). The honest statement is that ELPS has no total-memory bound and the
host must supply one: a cgroup, a container limit, or `GOMEMLIMIT` plus a
watchdog. That now appears in the `DefaultMax*` block in `lisp/runtime.go`
under "Bounding total memory" and in the execution-limits section of
`docs/lang.md`, alongside the existing "none of these bound elapsed time"
note, so the two holes in the containment model are stated in the same place.

## Test Plan

- [x] `make test` passes
- [x] `make static-checks` (`golangci-lint run ./...`) passes
- [x] `./elps fmt -l ./...` reports no changes
- [x] `./elps lint ./...` unchanged from `main` (byte-identical output)
- [x] `./elps doc -m` reports no missing docs
- [x] `make race`, `make test-elpscheck`, `bash scripts/ci-gates-test.sh` pass
- [x] new guard mutation-verified three ways

Base for the diff is `da347a6` (rebased onto current `main`, which moved during
the work). All run in the sandbox, all clean:

| check | result |
|---|---|
| `go build ./...` | pass |
| `go test ./...` | pass |
| `make test` (Go tests + `_examples` lisp) | pass |
| `make race` | pass, no data races |
| `make test-elpscheck` | pass |
| `golangci-lint run ./...` | 0 issues |
| `./elps fmt -l ./...` | no files listed |
| `./elps doc -m` | all documented |
| `bash scripts/ci-gates-test.sh` | 116 passed, 0 failed |
| `make bench-gate` on the benchstat output | 0 significant moves in the bad direction |

`./elps lint ./...` exits 1 on both `main` and this branch with byte-identical
output (44 lines, pre-existing diagnostics in example/test lisp sources), so it
is unchanged by this PR.

## Files

* `lisp/env.go` — the counter and the check in `eval`.
* `lisp/runtime.go` — `MaxEvalNesting`, `DefaultMaxEvalNesting`, accessors,
  and the measurement record in the `DefaultMax*` doc block.
* `lisp/config.go` — `WithMaxEvalNesting`.
* `lisp/conditions.go` — `CondEvalNestingExceeded`.
* `lisp/evalnesting_test.go` — new.
* `lisp/eval_fuzz_test.go`, `internal/fuzzseed/evalseed.go` — the
  macro-generated shape as a runaway seed, plus an explicit nesting budget for
  the harness. Against `main` that seed was stopped only by the harness's 2s
  wall-clock deadline, after hundreds of thousands of Go frames had already
  been pushed; it now trips the nesting limit deterministically in ~250ms.
* `docs/lang.md`, `parser/rdparser/parser.go` — documentation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_