### PR TITLE
Refuse a sleep that cannot succeed instead of blocking on it (#338)

### DIFF
--- a/docs/lang.md
+++ b/docs/lang.md
@@ -1123,6 +1123,38 @@ depending on the shape of the loop.  It is **disabled by default**
 (`DefaultMaxLogicalStackHeight`, 0).  Callers who specifically want it can
 opt in with `lisp.WithMaximumLogicalStackHeight(n)`.
 
+**Sleep length** is the one limit whose unit is wall clock rather than work.
+Every limit above counts something the interpreter *does* — steps, frames,
+turns, bytes, nesting — and a sleeping goroutine does none of them, so
+`time:sleep` was bounded by none of them at once and
+`"9223372036854775807ns"` blocked for roughly 292 years.
+
+A single sleep is capped at one hour (`lisp.DefaultMaxSleep`).  Over that
+raises `sleep-limit-exceeded` **immediately**, without sleeping:
+
+```lisp
+(time:sleep (time:parse-duration "2h"))
+; sleep-limit-exceeded: sleep of 2h0m0s exceeds the maximum 1h0m0s
+
+(time:sleep (time:parse-duration "2h") :max (time:parse-duration "3h"))
+; sleeps, because the caller said so explicitly
+```
+
+`:max` makes an unusually long sleep visible at the call site instead of
+being an accident of arithmetic.  A host that does not trust the program can
+set a ceiling `:max` cannot exceed with `lisp.WithMaxSleep(d)` — program
+source may relax the default, only the host may relax the ceiling.
+
+A sleep that would outlast the context deadline is also refused immediately,
+with `context-cancelled`, rather than blocking until the deadline first: it
+could not have completed, so waiting would only burn the budget the caller
+has left to react in.  A sleep already under way is still interrupted if the
+context is cancelled.
+
+Note this bounds one call, not their sum — N sleeps just under the cap still
+block for N times the cap.  A context deadline is what bounds total elapsed
+time.
+
 Because tail calls are optimized, a correctly written tail-recursive loop
 runs in constant stack space for an unbounded number of iterations:
 

--- a/lisp/conditions.go
+++ b/lisp/conditions.go
@@ -27,6 +27,13 @@ const (
 	// recoverable substitute for a Go stack overflow, which is a
 	// runtime.throw that neither recover() nor handler-bind can intercept.
 	CondEvalNestingExceeded = "eval-nesting-exceeded"
+
+	// CondSleepLimitExceeded reports that a requested sleep was longer than
+	// the caller is allowed to sleep for, and was refused WITHOUT sleeping.
+	// It is distinct from context-cancelled: nothing was cancelled and no
+	// time passed, the request was rejected on entry.  See
+	// DefaultMaxSleep and Runtime.MaxSleep.
+	CondSleepLimitExceeded = "sleep-limit-exceeded"
 )
 
 // CondInternalPanic is the condition type of an error produced by recovering

--- a/lisp/config.go
+++ b/lisp/config.go
@@ -5,6 +5,7 @@ package lisp
 import (
 	"context"
 	"io"
+	"time"
 )
 
 // Config is a function that configures a root environment or its runtime.
@@ -58,6 +59,33 @@ func WithMaximumPhysicalStackHeight(n int) Config {
 func WithMaxEvalNesting(n int) Config {
 	return func(env *LEnv) *LVal {
 		env.Runtime.MaxEvalNesting = n
+		return Nil()
+	}
+}
+
+// WithMaxSleep returns a Config that sets a HARD CEILING on how long a single
+// (time:sleep d) may block, in the host's hands rather than the program's.
+//
+// This is the containment bound, and it is not the same knob as
+// DefaultMaxSleep. A sleep with no explicit :max is capped at
+// DefaultMaxSleep, which program source may raise per call with
+// (time:sleep d :max m). That is a guard against accidents. The ceiling set
+// here is what :max may not exceed, so a program cannot opt itself out of
+// it — which matters when the program is untrusted, as customer-supplied
+// phylum source is downstream in luthersystems/substrate.
+//
+// Zero or negative means no ceiling: :max may name any duration. That is the
+// default, because the interpreter cannot know what wall-clock budget the
+// host is willing to spend.
+//
+// Note what this does NOT do: it bounds one sleep call, not their sum. A
+// loop of N sleeps each just under the ceiling still blocks for N times the
+// ceiling. Bounding total elapsed time is what a context deadline is for
+// (see WithContext) -- sleep observes that too, and refuses immediately
+// rather than blocking to the deadline.
+func WithMaxSleep(d time.Duration) Config {
+	return func(env *LEnv) *LVal {
+		env.Runtime.MaxSleep = d
 		return Nil()
 	}
 }

--- a/lisp/lisplib/libtime/libtime.go
+++ b/lisp/lisplib/libtime/libtime.go
@@ -115,14 +115,26 @@ var builtins = []*libutil.Builtin{
 		`Returns the number of nanoseconds in the duration as an integer.
 		The argument must be a native duration value. Returns an error
 		if the value overflows an int.`),
-	libutil.FunctionDoc("sleep", lisp.Formals("time-duration"), BuiltinSleep,
+	libutil.FunctionDoc("sleep", lisp.Formals("time-duration", lisp.KeyArgSymbol, "max"), BuiltinSleep,
 		`Pauses execution for the specified duration. The argument must
 		be a native duration value (from parse-duration). Returns nil.
-		The pause is interruptible: if the evaluation's context is
-		cancelled, or its deadline would expire before the duration
-		elapses, sleep wakes at that point and raises a
-		context-cancelled condition instead of returning nil. With no
-		context configured the full duration is always slept.`),
+
+		A sleep that cannot succeed is REFUSED IMMEDIATELY rather than
+		blocked on. Two things refuse it, both before any time passes:
+
+		  1. A duration longer than one hour raises
+		     sleep-limit-exceeded. Pass :max with a longer duration to
+		     allow it -- (time:sleep d :max m) -- which makes an
+		     unusually long sleep explicit at the call site. The host
+		     may set a ceiling that :max cannot exceed.
+		  2. A duration that would outlast the evaluation's context
+		     deadline raises context-cancelled. The sleep could not
+		     have completed, so waiting out the remaining time would
+		     only consume the budget the caller has left to react in.
+
+		Once started, the pause is still interruptible: if the context
+		is cancelled while sleeping, sleep wakes at that point and
+		raises context-cancelled instead of returning nil.`),
 }
 
 func BuiltinUTCNow(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
@@ -340,7 +352,7 @@ func BuiltinDurationNS(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 // wakes early if the context is cancelled, and never sleeps past the
 // context's deadline.  See sleepContext for the full rationale.
 func BuiltinSleep(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
-	lt := args.Cells[0]
+	lt, lmax := args.Cells[0], args.Cells[1]
 	if lt.Type != lisp.LNative {
 		return env.Errorf("argument is not a duration: %v", lt.Type)
 	}
@@ -348,7 +360,61 @@ func BuiltinSleep(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	if !ok {
 		return env.Errorf("argument is not a duration: %v", lt)
 	}
+	limit, lerr := sleepCap(env, lmax)
+	if lerr != nil {
+		return lerr
+	}
+	if limit > 0 && d > limit {
+		return env.ErrorConditionf(lisp.CondSleepLimitExceeded,
+			"sleep of %v exceeds the maximum %v"+
+				" (pass :max to allow a longer sleep, subject to any host ceiling)",
+			d, limit)
+	}
 	return sleepContext(env, d)
+}
+
+// sleepCap resolves the longest sleep this call may request, or 0 for no
+// limit.  It returns a non-nil second value if the :max argument is unusable.
+//
+// Three inputs, in increasing authority:
+//
+//	lisp.DefaultMaxSleep   the cap when :max is absent
+//	:max                   raises it for this call, at the program's discretion
+//	Runtime.MaxSleep       the host's ceiling, which :max may not exceed
+//
+// The last is what makes this a bound rather than a suggestion: program
+// source can relax the default but cannot relax the ceiling, so an untrusted
+// program cannot grant itself an unbounded sleep.  See lisp.WithMaxSleep.
+func sleepCap(env *lisp.LEnv, lmax *lisp.LVal) (time.Duration, *lisp.LVal) {
+	ceiling := env.Runtime.MaxSleepCeiling()
+	if lmax.IsNil() {
+		limit := lisp.DefaultMaxSleep
+		if ceiling > 0 && ceiling < limit {
+			// A host ceiling below the default lowers the default too;
+			// otherwise the default would quietly exceed the ceiling.
+			limit = ceiling
+		}
+		return limit, nil
+	}
+	if lmax.Type != lisp.LNative {
+		return 0, env.Errorf("max is not a duration: %v", lmax.Type)
+	}
+	m, ok := lmax.Native.(time.Duration)
+	if !ok {
+		return 0, env.Errorf("max is not a duration: %v", lmax)
+	}
+	if m <= 0 {
+		// Reject rather than treat as "no limit": a non-positive :max most
+		// likely came from arithmetic that underflowed, and reading it as
+		// "unlimited" would turn a bug into the very unbounded sleep this
+		// exists to prevent.
+		return 0, env.Errorf("max is not a positive duration: %v", m)
+	}
+	if ceiling > 0 && m > ceiling {
+		return 0, env.ErrorConditionf(lisp.CondSleepLimitExceeded,
+			"max %v exceeds the host ceiling %v", m, ceiling)
+	}
+	return m, nil
 }
 
 // sleepContext pauses for d, bounded by env's context.
@@ -396,28 +462,32 @@ func sleepContext(env *lisp.LEnv, d time.Duration) *lisp.LVal {
 	if err := ctx.Err(); err != nil {
 		return errContextCancelled(env, err)
 	}
-	truncated := false
+	// FAIL FAST rather than sleeping out a doomed wait.  When the deadline is
+	// nearer than d the sleep provably cannot complete: the outcome is already
+	// decided on entry, and the only question is whether the caller learns now
+	// or after its remaining budget has been burned.  This used to wait and
+	// then report (issue #338), which spent the caller's last chance to flush a
+	// partial result or run cleanup on a call whose answer was already known.
+	//
+	// The objection to failing fast was that (while true (ignore-errors
+	// (time:sleep 1))) stops being throttled and becomes a busy loop.  That is
+	// real, but it is not this branch's doing: the loop is already unbounded
+	// and MaxSteps is what bounds it.  Trading a caller's usable budget for a
+	// throttle on catch-and-continue code is the wrong way round, and the
+	// throttle was never durable anyway -- it lasted only until the deadline.
 	if hasDeadline {
 		if remaining := time.Until(deadline); remaining < d {
-			d, truncated = remaining, true
+			return errContextCancelled(env, context.DeadlineExceeded)
 		}
 	}
-	if d > 0 {
-		timer := time.NewTimer(d)
-		defer timer.Stop()
-		select {
-		case <-timer.C:
-		case <-done:
-		}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-done:
 	}
 	if err := ctx.Err(); err != nil {
 		return errContextCancelled(env, err)
-	}
-	if truncated {
-		// The wait ended at the deadline but ctx has not observed it yet
-		// (a nil Done channel, or a race with the context's own timer).
-		// Report it anyway: the sleep did not run to completion.
-		return errContextCancelled(env, context.DeadlineExceeded)
 	}
 	return lisp.Nil()
 }

--- a/lisp/lisplib/libtime/sleep_test.go
+++ b/lisp/lisplib/libtime/sleep_test.go
@@ -7,6 +7,7 @@ package libtime_test
 
 import (
 	"context"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -51,11 +52,34 @@ func sleepEnv(t *testing.T, ctx context.Context) *lisp.LEnv {
 	return env
 }
 
-// callSleep invokes the builtin directly with a native duration.  Direct
-// application is what the fuzz sweep does and it keeps the timing assertions
-// free of parser and evaluator noise.
+// callSleep invokes the builtin directly with a native duration and no :max.
+// Direct application is what the fuzz sweep does and it keeps the timing
+// assertions free of parser and evaluator noise.
+//
+// The nil second cell is the unsupplied :max keyword.  BuiltinSleep reads
+// args.Cells[1] unconditionally, as every builtin with a keyword formal in
+// this repo does (see builtinLoadString) -- the formals machinery guarantees
+// the cell exists, so a direct caller has to supply it too.
 func callSleep(env *lisp.LEnv, d time.Duration) *lisp.LVal {
-	return libtime.BuiltinSleep(env, lisp.SExpr([]*lisp.LVal{libtime.Duration(d)}))
+	return callSleepMax(env, d, lisp.Nil())
+}
+
+// callSleepMax is callSleep with an explicit :max argument.  Pass lisp.Nil()
+// for "not supplied".
+func callSleepMax(env *lisp.LEnv, d time.Duration, maxArg *lisp.LVal) *lisp.LVal {
+	return libtime.BuiltinSleep(env, lisp.SExpr([]*lisp.LVal{libtime.Duration(d), maxArg}))
+}
+
+// requireSleepLimit asserts v is the sleep-limit-exceeded condition, i.e. the
+// sleep was refused on entry rather than attempted.
+func requireSleepLimit(t *testing.T, v *lisp.LVal) {
+	t.Helper()
+	if v.Type != lisp.LError {
+		t.Fatalf("expected an error, got %v (%v)", v.Type, v)
+	}
+	if v.Str != lisp.CondSleepLimitExceeded {
+		t.Fatalf("expected condition %q, got %q (%v)", lisp.CondSleepLimitExceeded, v.Str, v)
+	}
 }
 
 // requireCancelled asserts v is the context-cancelled condition.  Any other
@@ -148,9 +172,42 @@ func TestSleepInterruptedThroughEval(t *testing.T) {
 		return env.LoadStringContext(ctx, "sleep_test.lisp",
 			`(time:sleep (time:parse-duration "9223372036854775807ns"))`)
 	})
-	requireCancelled(t, v)
+	// sleep-limit-exceeded, not context-cancelled: the 292-year duration is
+	// refused by the length cap, which is checked before the context is
+	// consulted at all.  Reporting the cap is the more useful of the two --
+	// it names the thing the caller can act on (:max) rather than the
+	// deadline that merely happened to be nearer.
+	requireSleepLimit(t, v)
 	if elapsed >= slack {
-		t.Fatalf("slept %v, expected to wake at the deadline", elapsed)
+		t.Fatalf("slept %v, expected an immediate refusal", elapsed)
+	}
+}
+
+// TestSleepPastDeadlineFailsFast pins issue #338: a sleep the deadline will
+// outlast is refused on entry, NOT slept out to the deadline first.
+//
+// The distinction is invisible to a pass/fail check on the condition alone --
+// the old behaviour raised the same context-cancelled -- so the assertion
+// that carries the meaning is the elapsed time.  A sleep well under the cap
+// (so the length check cannot be what fires) with a deadline much nearer must
+// return in far less than the remaining budget.
+func TestSleepPastDeadlineFailsFast(t *testing.T) {
+	t.Parallel()
+	const remaining = 750 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), remaining)
+	defer cancel()
+	env := sleepEnv(t, ctx)
+
+	v, elapsed := runBounded(t, remaining+slack, func() *lisp.LVal {
+		// A minute is far below DefaultMaxSleep, so only the deadline can
+		// refuse it.
+		return callSleep(env, time.Minute)
+	})
+	requireCancelled(t, v)
+	if elapsed > remaining/2 {
+		t.Fatalf("took %v to refuse a doomed sleep with %v remaining;"+
+			" expected an immediate refusal, not a wait to the deadline",
+			elapsed, remaining)
 	}
 }
 
@@ -243,7 +300,7 @@ func TestSleepRejectsNonDuration(t *testing.T) {
 	t.Parallel()
 	env := sleepEnv(t, nil)
 	for _, arg := range []*lisp.LVal{lisp.Int(5), lisp.Native("not-a-duration")} {
-		v := libtime.BuiltinSleep(env, lisp.SExpr([]*lisp.LVal{arg}))
+		v := libtime.BuiltinSleep(env, lisp.SExpr([]*lisp.LVal{arg, lisp.Nil()}))
 		if v.Type != lisp.LError {
 			t.Errorf("sleep(%v) = %v, want an error", arg, v)
 			continue
@@ -251,5 +308,149 @@ func TestSleepRejectsNonDuration(t *testing.T) {
 		if !strings.Contains(v.String(), "not a duration") {
 			t.Errorf("sleep(%v) error = %v, want a duration type error", arg, v)
 		}
+	}
+}
+
+// TestSleepLengthCapRefusesImmediately covers the length cap itself, with no
+// context involved: a duration over DefaultMaxSleep is refused on entry.
+//
+// The elapsed assertion is the load-bearing one. A cap that errored only
+// AFTER sleeping would satisfy a condition-only check while leaving the
+// unbounded-block defect entirely in place.
+func TestSleepLengthCapRefusesImmediately(t *testing.T) {
+	t.Parallel()
+	env := sleepEnv(t, nil)
+	v, elapsed := runBounded(t, slack, func() *lisp.LVal {
+		return callSleep(env, lisp.DefaultMaxSleep+time.Second)
+	})
+	requireSleepLimit(t, v)
+	if elapsed > time.Second {
+		t.Fatalf("took %v to refuse an over-cap sleep, expected immediate", elapsed)
+	}
+}
+
+// TestSleepUnderCapStillSleeps is the negative control for the test above.
+// Without it, an implementation that refused EVERY sleep would pass the cap
+// tests and look correct.
+func TestSleepUnderCapStillSleeps(t *testing.T) {
+	t.Parallel()
+	env := sleepEnv(t, nil)
+	v, elapsed := runBounded(t, slack, func() *lisp.LVal {
+		return callSleep(env, 20*time.Millisecond)
+	})
+	if v.Type == lisp.LError || !v.IsNil() {
+		t.Fatalf("sleep under the cap = %v, want nil", v)
+	}
+	if elapsed < 10*time.Millisecond {
+		t.Fatalf("returned in %v; the sleep did not actually happen", elapsed)
+	}
+}
+
+// TestSleepMaxRaisesTheCap: :max is what a caller who really means it uses.
+// A duration over the default but under :max must actually sleep.
+func TestSleepMaxRaisesTheCap(t *testing.T) {
+	t.Parallel()
+	// Over DefaultMaxSleep would take an hour to observe, so instead pin the
+	// decision rather than the wait: an over-default duration with a large
+	// enough :max must NOT be refused by the cap. A context deadline stops
+	// the test from actually waiting an hour.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	envCtx := sleepEnv(t, ctx)
+
+	v, _ := runBounded(t, slack, func() *lisp.LVal {
+		return callSleepMax(envCtx, 2*lisp.DefaultMaxSleep,
+			libtime.Duration(3*lisp.DefaultMaxSleep))
+	})
+	// The deadline refuses it, not the cap -- which is the point: with :max
+	// supplied, the length is no longer what stops it.
+	requireCancelled(t, v)
+}
+
+// TestSleepMaxCannotExceedHostCeiling is the containment property. Program
+// source may raise the default cap, but not past a ceiling the host set --
+// otherwise untrusted source could grant itself an unbounded sleep and the
+// bound would be decorative.
+func TestSleepMaxCannotExceedHostCeiling(t *testing.T) {
+	t.Parallel()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env, lisp.WithMaxSleep(time.Second)); rc.Type == lisp.LError {
+		t.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := libtime.LoadPackage(env); rc.Type == lisp.LError {
+		t.Fatalf("load time package: %v", rc)
+	}
+
+	v, elapsed := runBounded(t, slack, func() *lisp.LVal {
+		return callSleepMax(env, time.Hour, libtime.Duration(time.Hour))
+	})
+	requireSleepLimit(t, v)
+	if elapsed > time.Second {
+		t.Fatalf("took %v to refuse, expected immediate", elapsed)
+	}
+
+	// And the ceiling lowers the no-:max default too, so the default cannot
+	// quietly exceed it.
+	v2, _ := runBounded(t, slack, func() *lisp.LVal {
+		return callSleep(env, 2*time.Second)
+	})
+	requireSleepLimit(t, v2)
+}
+
+// TestSleepRejectsNonPositiveMax: a negative :max is a bug in the caller's
+// arithmetic, and reading it as "unlimited" would convert that bug into the
+// unbounded sleep this whole mechanism exists to prevent.
+func TestSleepRejectsNonPositiveMax(t *testing.T) {
+	t.Parallel()
+	env := sleepEnv(t, nil)
+	for _, m := range []time.Duration{0, -time.Second, time.Duration(math.MinInt64)} {
+		v := callSleepMax(env, time.Second, libtime.Duration(m))
+		if v.Type != lisp.LError {
+			t.Errorf("sleep with :max %v = %v, want an error", m, v)
+			continue
+		}
+		if !strings.Contains(v.String(), "positive duration") {
+			t.Errorf("sleep with :max %v error = %v, want a positive-duration error", m, v)
+		}
+	}
+}
+
+// TestSleepRejectsNonDurationMax keeps the :max type check honest.
+func TestSleepRejectsNonDurationMax(t *testing.T) {
+	t.Parallel()
+	env := sleepEnv(t, nil)
+	for _, m := range []*lisp.LVal{lisp.Int(5), lisp.Native("nope")} {
+		v := callSleepMax(env, time.Second, m)
+		if v.Type != lisp.LError {
+			t.Errorf("sleep with :max %v = %v, want an error", m, v)
+			continue
+		}
+		if !strings.Contains(v.String(), "max is not a duration") {
+			t.Errorf("sleep with :max %v error = %v, want a duration type error", m, v)
+		}
+	}
+}
+
+// TestSleepMaxThroughEval proves the keyword reaches the builtin through the
+// formals machinery, not just through a hand-built args list. The direct
+// callers above would all still pass if the formal were misdeclared.
+func TestSleepMaxThroughEval(t *testing.T) {
+	t.Parallel()
+	env := sleepEnv(t, nil)
+	v, elapsed := runBounded(t, slack, func() *lisp.LVal {
+		return env.LoadString("sleep_max_test.lisp",
+			`(time:sleep (time:parse-duration "2h") :max (time:parse-duration "1s"))`)
+	})
+	// 2h is over the 1s :max, so this must be refused -- and refused by the
+	// cap, which proves :max was read rather than ignored. Were the keyword
+	// dropped, 2h would be measured against DefaultMaxSleep instead and this
+	// would still error, so the message is checked too.
+	requireSleepLimit(t, v)
+	if !strings.Contains(v.String(), "maximum 1s") {
+		t.Fatalf("error = %v, want the 1s :max to be the reported maximum", v)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("took %v to refuse, expected immediate", elapsed)
 	}
 }

--- a/lisp/runtime.go
+++ b/lisp/runtime.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"sync/atomic"
+	"time"
 )
 
 // Runtime is an object underlying a family of tree of LEnv values.  It is
@@ -42,14 +43,15 @@ type Runtime struct {
 	Profiler               Profiler
 	Debugger               Debugger // nil = disabled (zero overhead on hot path)
 	conditionStack         []*LVal
-	MaxAlloc               int   // Per-operation allocation size cap (0 = use default). Not cumulative.
-	MaxMacroExpansionDepth int   // Maximum macro expansion iterations (0 = use default).
-	MaxEvalNesting         int   // Evaluator recursion depth cap (0 = use default, negative = disabled).
-	evalDepth              int   // Re-entrancy depth of top-level evaluation entry points.
-	evalNesting            int   // Current recursion depth of LEnv.eval (the Go-stack guard).
-	maxSteps               int64 // Per-evaluation step limit (0 = unlimited).
-	steps                  int64 // Steps consumed by the current top-level evaluation.
-	totalSteps             int64 // Steps consumed by all completed top-level evaluations.
+	MaxAlloc               int           // Per-operation allocation size cap (0 = use default). Not cumulative.
+	MaxMacroExpansionDepth int           // Maximum macro expansion iterations (0 = use default).
+	MaxEvalNesting         int           // Evaluator recursion depth cap (0 = use default, negative = disabled).
+	MaxSleep               time.Duration // Hard ceiling on a single time:sleep (0 or negative = none). See MaxSleepCeiling.
+	evalDepth              int           // Re-entrancy depth of top-level evaluation entry points.
+	evalNesting            int           // Current recursion depth of LEnv.eval (the Go-stack guard).
+	maxSteps               int64         // Per-evaluation step limit (0 = unlimited).
+	steps                  int64         // Steps consumed by the current top-level evaluation.
+	totalSteps             int64         // Steps consumed by all completed top-level evaluations.
 	numenv                 atomicCounter
 	numsym                 atomicCounter
 	macroExpSeq            int64 // monotonic counter for MacroExpansionInfo.ID
@@ -331,6 +333,47 @@ const (
 	DefaultMaxTailIterations      = 1000000
 	DefaultMaxEvalNesting         = 100000
 )
+
+// DefaultMaxSleep bounds a single (time:sleep d) that does not pass an
+// explicit :max, and is the last of the execution limits because it bounds
+// WALL CLOCK rather than work.
+//
+// Every other limit here counts something the interpreter does — steps,
+// frames, iterations, bytes, nesting. A sleeping goroutine does none of
+// them, which is why time:sleep was unbounded by all of them at once and
+// "9223372036854775807ns" blocked for ~292 years (issue #314). Bounding it
+// needs a wall-clock number, and there is no work-based limit that implies
+// one.
+//
+// One hour is chosen to be far above any plausible legitimate sleep in an
+// embedded interpreter — a backoff, a poll interval, a test delay are all
+// orders of magnitude below it — while still refusing the 292-year shape
+// immediately rather than after 292 years. A caller who genuinely wants
+// longer says so with :max, which is the point: the length becomes explicit
+// at the call site instead of being an accident of arithmetic.
+//
+// :max raises the per-call cap but CANNOT exceed Runtime.MaxSleep when the
+// embedder has set one. That split is deliberate. Program source and the
+// embedder are different trust domains: downstream (luthersystems/substrate)
+// the program is customer-supplied phylum running as chaincode, so a cap
+// that program source could raise would be decorative. DefaultMaxSleep is a
+// guard against accidents, which the program may relax; Runtime.MaxSleep is
+// a containment bound, which only the host may relax.
+const DefaultMaxSleep = time.Hour
+
+// MaxSleepCeiling returns the hard upper bound on a single sleep, or 0 when
+// the embedder has set none.  A negative Runtime.MaxSleep disables the bound
+// explicitly and is also reported as 0.
+//
+// This is the ceiling on what (time:sleep d :max m) may request, NOT the cap
+// applied when :max is absent — that is DefaultMaxSleep. See its doc comment
+// for why the two are separate.
+func (r *Runtime) MaxSleepCeiling() time.Duration {
+	if r.MaxSleep <= 0 {
+		return 0
+	}
+	return r.MaxSleep
+}
 
 // StandardRuntime returns a new Runtime with an empty package registry and
 // Stderr set to os.Stderr.


### PR DESCRIPTION
Closes #338.

`time:sleep` had two ways to waste a caller's time, both ending in an error it could have been given on entry.

## 1. Fail fast past the deadline (#338)

A sleep longer than the context's remaining time was truncated to the deadline, **slept out**, and only then reported as `context-cancelled`. The outcome was decided the moment the truncation was computed — the sleep provably could not complete — so the wait bought nothing and cost the caller the entire budget it had left to flush a partial result or run cleanup in. It now returns immediately.

The argument against, which I raised when filing #338: `(while true (ignore-errors (time:sleep 1)))` stops being throttled and becomes a busy loop. That's real, but the loop is already unbounded and `MaxSteps` is what bounds it. Trading a caller's usable budget for a throttle on catch-and-continue code is the wrong way round — and the throttle only lasted until the deadline anyway.

## 2. Cap the length

With no deadline configured — the default for every embedder using `Eval` rather than `EvalContext` — nothing bounded the duration at all. That's how `"9223372036854775807ns"` blocked for ~292 years (#314). A single sleep is now capped at `DefaultMaxSleep` (one hour); anything longer raises the new `sleep-limit-exceeded` **without sleeping**.

This is a **behaviour change** for programs that legitimately sleep longer, which is why the cap is raisable per call:

```lisp
(time:sleep (time:parse-duration "2h"))
; sleep-limit-exceeded: sleep of 2h0m0s exceeds the maximum 1h0m0s

(time:sleep (time:parse-duration "2h") :max (time:parse-duration "3h"))
; sleeps, because the caller said so explicitly
```

That isn't a loophole — it's the point. An unusually long sleep becomes explicit at the call site instead of an accident of arithmetic.

## 3. Two trust domains — the part worth reviewing

A cap that program source can raise is worthless when **the program is the untrusted party**, which downstream in `luthersystems/substrate` it is: customer-supplied phylum running as chaincode. A `:max` keyword on its own would have made this decorative.

So there are three layers, in increasing authority:

| | What it is | Who may relax it |
|---|---|---|
| `DefaultMaxSleep` (1h) | cap when `:max` is absent | — |
| `:max` | raises it for one call | program source |
| `Runtime.MaxSleep` via `lisp.WithMaxSleep(d)` | ceiling `:max` cannot exceed | host only, unreachable from ELPS |

A ceiling below the default lowers the default too, so the default cannot quietly exceed it.

A **non-positive `:max` is rejected**, not read as "no limit" — it most likely came from arithmetic that underflowed, and the permissive reading would convert that bug into exactly the unbounded sleep this prevents.

## On the overflow concern

I looked for one and **did not find it**, so the cap is not presented as an overflow fix. `time.Duration` is int64 nanoseconds, `time.ParseDuration` rejects out-of-range input, and `Time.Sub` / `time.Until` saturate rather than wrap. What the cap actually buys is refusal of absurd-but-representable durations — which is the real ask.

## Mutation verification

| Mutation | Result |
|---|---|
| fail-fast reverted to truncate-and-wait | `TestSleepPastDeadlineFailsFast` fails on **elapsed time** — 750ms against a 750ms deadline — not on the condition, which is unchanged |
| host ceiling made advisory | `TestSleepMaxCannotExceedHostCeiling` fails |

The first is the one that matters: the old and new behaviour raise the *same* condition, so a condition-only assertion would have passed either way. The timing assertion is what carries the meaning.

`TestSleepUnderCapStillSleeps` is the negative control — without it, an implementation that refused *every* sleep would satisfy every cap test. `TestSleepMaxThroughEval` drives `:max` through the formals machinery and checks the reported maximum, so a misdeclared keyword can't pass by erroring for the wrong reason.

## Verification

`go build ./...`, `go test ./...`, `golangci-lint run ./...` (0 issues), `./elps doc -m`, `./elps fmt -l`. `docs/lang.md` gains a "Sleep length" subsection in the execution-limits chapter, noting that this bounds one call and not their sum — N sleeps just under the cap still block for N times the cap, and a context deadline is what bounds total elapsed time.

## Worth your judgement

**One hour is a guess.** It's far above any plausible backoff, poll interval or test delay, and far below 292 years — but if there's a real workload in the fleet that sleeps longer, say so and I'll raise it or default the cap off.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_