### PR TITLE
Say that the nesting default's margin is pointer-size dependent

### DIFF
--- a/lisp/runtime.go
+++ b/lisp/runtime.go
@@ -253,6 +253,15 @@ const DefaultMaxMacroExpansionDepth = 1000
 // "fatal error: stack overflow" (~1.4KB of Go stack per level). 100,000 sits
 // 7-8x below that, matching the margin DefaultMaxPhysicalStackHeight keeps.
 //
+// THAT MARGIN IS POINTER-SIZE DEPENDENT. Go caps a goroutine stack at 1GB on
+// 64-bit but 250MB on 32-bit (runtime/proc.go: maxstacksize). At ~1.4KB per
+// level the default costs ~140MB, so the same 100,000 is a 7-8x margin on
+// amd64 and roughly 1.8x on a 32-bit build -- and an embedder whose own call
+// stack is already deep when it enters Eval eats into what is left. Nothing
+// here is exercised on 32-bit: CI builds ubuntu-latest and windows-latest,
+// both amd64. A 32-bit embedder should lower this with WithMaxEvalNesting
+// rather than trust the default.
+//
 // It also sits comfortably above ordinary recursion. Measured with
 // (defun sum (n) (if (<= n 0) 0 (+ n (sum (- n 1))))), the physical limit
 // binds first for any MaxEvalNesting of 38,000 or more: that recursion costs


### PR DESCRIPTION
Documentation only. The `DefaultMaxEvalNesting` constant is unchanged.

## The gap

The rationale for the 100,000 default argues it sits "7-8x below the measured crash point", gives the measurement as **linux/amd64 against the 1GB default goroutine stack**, and stops there. A reader on another target has no way to tell whether that margin transfers.

It doesn't. From `runtime/proc.go` in the Go source on this machine:

```go
// Max stack size is 1 GB on 64-bit, 250 MB on 32-bit.
if goarch.PtrSize == 8 {
    maxstacksize = 1000000000
} else {
    maxstacksize = 250000000
}
```

At the measured ~1.4KB of Go stack per nesting level, the default costs ~140MB regardless of pointer size:

| Build | Stack cap | Cost at 100,000 | Margin |
|---|---|---|---|
| 64-bit | 1GB | ~140MB | **7-8x** |
| 32-bit | 250MB | ~140MB | **~1.8x** |

And an embedder already several frames deep when it calls `Eval` eats into what's left of the 32-bit case.

## Why it's a note and not a fix

Nothing in CI builds 32-bit — `ubuntu-latest` and `windows-latest` are both amd64 — and nothing in the fleet ships it. So this isn't a live defect and I haven't changed the constant or added a build-tagged default, either of which would be speculative.

It is, though, a **public API default whose safety argument silently assumed a pointer size**, and `WithMaxEvalNesting` is the knob to reach for. That's worth a sentence in the doc comment rather than only in #342's commit message, which is where it currently lives.

Raised during the review of #342 and deferred rather than bundled.

## Verification

`go build ./...`, `go test ./lisp/`, `./elps doc -m`, `gofmt` — all clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PotMjAgqXqttCidgjH78xi)_