### PR TITLE
Check that builtins do not mutate their arguments, and give the thin stdlib packages a budget

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -87,8 +87,10 @@ jobs:
     #     ceil(targets / shards) x FUZZTIME + overhead <= timeout-minutes
     #
     # on every PR, so this number cannot silently stop covering the sweep. At
-    # 17 targets over 5 shards that is 4 x 10m + 10m = 50; 60 leaves a shard's
-    # worth of headroom for a target being added before anyone reshards.
+    # 18 targets over 5 shards that is 4 x 10m + 10m = 50; 60 leaves a shard's
+    # worth of headroom for a target being added before anyone reshards. The
+    # 21st target is where that runs out: ceil(21/5) = 5 puts `needed` at
+    # exactly 60, which the gate passes while describing a truncated sweep.
     #
     # THE HEADROOM IS THE POINT, NOT THE GREEN TICK. The gate's condition is
     # `needed > timeout`, so a sweep sized at exactly timeout-minutes PASSES --

--- a/internal/fuzzfp/fuzzfp.go
+++ b/internal/fuzzfp/fuzzfp.go
@@ -1,0 +1,482 @@
+// Copyright © 2026 The ELPS authors
+
+// Package fuzzfp watches the arguments a fuzz target hands to a builtin and
+// reports the two mutations that no builtin may ever perform: rewriting a
+// value's source location, and reaching inside an LNative to change the Go
+// value a host handed in.
+//
+// # Why only those two
+//
+// A blanket "the arguments came back unchanged" assertion is not available
+// here, because several callables mutate an argument BY DESIGN -- `append!`
+// grows a vector in place, `assoc!` writes a sorted-map, and MacroCall writes
+// to the nodes a macro returns. A guard that fired on those would be turned
+// off within a week. So this package asserts only properties that hold for
+// every callable in the library, and says so in one place rather than leaving
+// each target to decide.
+//
+// # Source
+//
+// LVal.Source documents itself as shared: "Programs should not modify the
+// contents of Source as the reference may be shared by multiple LVals." Every
+// value the interpreter builds without a parser behind it points at ONE
+// process-wide token.Location (lisp.nativeSource), so a builtin that writes
+// through a Source pointer relocates a large fraction of every value alive in
+// the process.
+//
+// One write to Source is legitimate, and it is the reason the tracker
+// (issue #318) recorded Source as unwatchable: stampMacroExpansion replaces a
+// SYNTHETIC location with the macro call site. Its guard is exactly
+//
+//	if v.Source == nil || v.Source.Pos < 0 { v.Source = callSite }
+//
+// so the legitimate transition is precisely "nil-or-synthetic pointer replaced
+// by a real one".
+//
+// That is worth stating as the interpreter's invariant rather than as a macro
+// special case, because it is not one site. LEnv.errorSource (lisp/env.go)
+// stamps an error's location under the SAME condition -- "All objects are
+// given a source which may be a nativeSource() value which does not correspond
+// to a file and has an invalid position (-1)", says the comment there -- and
+// those are the only two places in lisp/ that write Source onto a value they
+// did not just allocate. Neither writes over a real location.
+//
+// [Guard] permits that transition and watches everything else:
+//
+//   - the pointer is unchanged, so the Location VALUE must be unchanged. This
+//     is the case that matters most, because it is the shared one: an in-place
+//     edit of lisp.nativeSource's Location is invisible to
+//     lisp.SingletonSnapshot (which compares Source by pointer) and would
+//     otherwise be reported by nothing at all.
+//   - a REAL location (Pos >= 0) is never replaced, in any direction.
+//
+// And nothing at all is asserted about what a nil-or-synthetic Source becomes.
+// That is deliberately as permissive as the interpreter, not one step
+// stricter: LEnv.errorSource assigns env.Loc, env.Loc is assigned from an
+// evaluated node's Source, and a hand-built LVal may have a nil Source -- so a
+// synthetic location legitimately becoming nil is reachable. A rule that
+// reported it would fire on correct code at a rate low enough to look like an
+// intermittent defect, and a gate that does that gets switched off. The cost
+// is that a builtin which nils a synthetic Source is not reported; the two
+// rules above are the ones with teeth.
+//
+// # LNative
+//
+// The tracker's stated reason for recording only an LNative's dynamic type was
+// that formatting an arbitrary Go value can traverse a randomised map. That is
+// true of fmt, and it is a property of fmt rather than of the values: a walk
+// that sorts map entries by their own fingerprint is deterministic over
+// exactly the same inputs. [fingerprintGo] is that walk. It reads unexported
+// fields through reflect without ever calling Value.Interface (which would
+// panic on them), so it sees inside time.Time and *regexp.Regexp, and it
+// breaks cycles on pointer identity so a self-referential native terminates.
+//
+// Deterministic here means "twice in one process gives the same answer", which
+// is what a before/after comparison needs and is also the strong form: Go
+// randomises map iteration per range statement per run, so two ranges in one
+// process already disagree. TestFingerprintIsDeterministic exercises that
+// directly, and TestGuardIsDeterministicOverGeneratedValues does it over the
+// whole generated corpus.
+//
+// # What is deliberately NOT watched
+//
+//   - Cells, Str, Int, Float, Quoted, Spliced. Legitimately mutated; see
+//     above.
+//   - The Native of an LFun (an *LFunData, holding an *LEnv), an LError (a
+//     call stack) or an LBytes (a *[]byte). Only nodes whose Type is LNative
+//     have their Native fingerprinted, which is what keeps the walk away from
+//     an entire environment and from the deliberately-mutable byte slice.
+//   - Meta. Only populated in format-preserving mode, which no builtin target
+//     runs in.
+package fuzzfp
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// maxNodes caps how many LVal nodes one Guard watches. internal/fuzzval's own
+// Budget is 512 values, and the only way past that is descending into a
+// function value's body, so this is generous. A cap exists at all so that a
+// builtin which builds a huge structure in place cannot turn the guard into
+// the slowest part of the target.
+const maxNodes = 8192
+
+// maxGoNodes caps one native's fingerprint walk. *regexp.Regexp reaches a
+// compiled program of a few hundred nodes; a host is free to hand in something
+// far larger, and an unbounded walk would be a denial of service on the target
+// rather than a check on the builtin.
+const maxGoNodes = 4096
+
+// maxGoDepth bounds nesting independently of maxGoNodes: a linked list a
+// million long is caught by the node cap, but a deeply nested value would
+// still recurse a million frames before reaching it.
+const maxGoDepth = 32
+
+// watched is one LVal node and the properties of it that must survive a call.
+type watched struct {
+	v *lisp.LVal
+	// srcPtr is the Source pointer as it was. Kept alongside srcVal so the
+	// guard can tell "the pointer was replaced" from "the shared Location was
+	// edited in place" -- two different defects with two different blast
+	// radii.
+	srcPtr *token.Location
+	srcVal token.Location
+	// native is the structural fingerprint of v.Native, recorded only when
+	// typ is LNative.
+	native string
+	path   string
+	typ    lisp.LType
+}
+
+// Guard is a set of watched nodes. Create one with [Watch] before the call and
+// call [Guard.Check] after it.
+type Guard struct {
+	nodes []watched
+}
+
+// Watch records every LVal reachable from v.
+//
+// Nodes are recorded BY POINTER, not by position, so a builtin that
+// legitimately reshapes the tree -- appends a cell, replaces one, sorts in
+// place -- does not knock the before and after records out of alignment and
+// produce a spurious report. A node that is dropped from the tree entirely is
+// still watched: whoever dropped it may still be holding it.
+func Watch(v *lisp.LVal) *Guard {
+	g := &Guard{}
+	seen := make(map[*lisp.LVal]bool)
+	g.walk(v, "arg", seen)
+	return g
+}
+
+func (g *Guard) walk(v *lisp.LVal, path string, seen map[*lisp.LVal]bool) {
+	if v == nil || seen[v] || len(g.nodes) >= maxNodes {
+		return
+	}
+	seen[v] = true
+
+	w := watched{v: v, path: path, typ: v.Type, srcPtr: v.Source}
+	if v.Source != nil {
+		w.srcVal = *v.Source
+	}
+	if v.Type == lisp.LNative {
+		w.native = fingerprintGo(v.Native)
+	}
+	g.nodes = append(g.nodes, w)
+
+	for i, c := range v.Cells {
+		g.walk(c, path+"["+strconv.Itoa(i)+"]", seen)
+	}
+	if v.Type == lisp.LSortMap {
+		m := v.Map()
+		if m == nil || m.Map == nil {
+			return
+		}
+		// Keys() is documented sorted, so the traversal order is stable and a
+		// report names the same cell on every run.
+		keys := m.Keys()
+		if keys == nil || keys.Type == lisp.LError {
+			return
+		}
+		for _, k := range keys.Cells {
+			g.walk(k, path+".key("+k.Str+")", seen)
+			val, ok := m.Get(k)
+			if !ok || val == nil {
+				continue
+			}
+			g.walk(val, path+"["+k.Str+"]", seen)
+		}
+	}
+}
+
+// Check re-derives every watched property and reports the first violation, or
+// "" when there is none.
+//
+// One violation rather than all of them: a fuzz failure is read by a human
+// looking for the smallest reproducer, and a builtin that relocates one node
+// has almost always relocated a thousand.
+func (g *Guard) Check() string {
+	for i := range g.nodes {
+		if msg := g.nodes[i].check(); msg != "" {
+			return msg
+		}
+	}
+	return ""
+}
+
+func (w *watched) check() string {
+	if msg := w.checkSource(); msg != "" {
+		return msg
+	}
+	return w.checkNative()
+}
+
+// checkSource implements the three rules in the package doc.
+func (w *watched) checkSource() string {
+	now := w.v.Source
+	switch {
+	case w.srcPtr == nil && now == nil:
+		return ""
+	case w.srcPtr == now:
+		// Same pointer: the Location itself must not have been edited. This is
+		// the shared-object case -- nearly every value in the process points
+		// at lisp.nativeSource's single Location.
+		if *now == w.srcVal {
+			return ""
+		}
+		return fmt.Sprintf("%s: the token.Location at %p was edited IN PLACE, which relocates every value sharing it"+
+			"\n  before: %+v\n  after:  %+v", w.path, now, w.srcVal, *now)
+	case w.srcPtr == nil || w.srcVal.Pos < 0:
+		// A synthetic (or absent) location may be replaced by anything. Both
+		// sites in lisp/ that write a Source they did not allocate are guarded
+		// by exactly this condition, and neither constrains what it writes.
+		// See the package doc for why matching that rather than tightening it
+		// is the right call.
+		return ""
+	default:
+		// A real location. Nothing in the interpreter rewrites one.
+		return fmt.Sprintf("%s: a REAL source location was replaced; stampMacroExpansion only ever replaces a"+
+			" synthetic one (Pos < 0)\n  before: %s\n  after:  %s",
+			w.path, describeLoc(w.srcPtr), describeLoc(now))
+	}
+}
+
+func (w *watched) checkNative() string {
+	if w.typ != lisp.LNative {
+		return ""
+	}
+	if w.v.Type != lisp.LNative {
+		return fmt.Sprintf("%s: an LNative's Type was changed to %s in place", w.path, w.v.Type)
+	}
+	if now := fingerprintGo(w.v.Native); now != w.native {
+		return fmt.Sprintf("%s: the Go value inside an LNative was mutated"+
+			"\n  before: %s\n  after:  %s", w.path, w.native, now)
+	}
+	return ""
+}
+
+func describeLoc(l *token.Location) string {
+	if l == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%p%+v", l, *l)
+}
+
+// Fingerprint returns the structural fingerprint of a Go value. Exported for
+// the determinism tests; the guard itself uses it internally.
+func Fingerprint(v any) string { return fingerprintGo(v) }
+
+// fingerprintGo renders v deterministically.
+//
+// Determinism is the whole point, so every source of ordering nondeterminism
+// is handled explicitly:
+//
+//   - map entries are rendered and then SORTED, so Go's per-range randomised
+//     iteration order cannot reach the output;
+//   - pointer identity is rendered as a small dense index into the set of
+//     pointers seen during THIS walk, never as an address, so ASLR and the
+//     allocator cannot reach it either;
+//   - cycles terminate at the first repeat of a pointer.
+//
+// Unexported fields are read through kind-specific accessors (Int, String,
+// Len, Pointer, MapRange). Value.Interface is never called: it panics on a
+// value obtained from an unexported field, and calling it is the usual reason
+// a reflective walk cannot see inside a stdlib type.
+func fingerprintGo(v any) string {
+	var b strings.Builder
+	s := &goWalk{seen: map[uintptr]int{}, budget: maxGoNodes}
+	s.value(&b, reflect.ValueOf(v), 0)
+	return b.String()
+}
+
+type goWalk struct {
+	// seen maps a pointer to the order in which this walk first met it, so the
+	// rendering of shared structure is stable without ever printing an
+	// address.
+	seen   map[uintptr]int
+	budget int
+}
+
+func (s *goWalk) value(b *strings.Builder, v reflect.Value, depth int) {
+	if s.budget <= 0 {
+		b.WriteString("...")
+		return
+	}
+	s.budget--
+	if depth > maxGoDepth {
+		b.WriteString("<deep>")
+		return
+	}
+	if !v.IsValid() {
+		b.WriteString("nil")
+		return
+	}
+	b.WriteString(v.Type().String())
+	b.WriteByte('(')
+	defer b.WriteByte(')')
+
+	switch v.Kind() {
+	case reflect.Bool:
+		b.WriteString(strconv.FormatBool(v.Bool()))
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		b.WriteString(strconv.FormatInt(v.Int(), 10))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		b.WriteString(strconv.FormatUint(v.Uint(), 10))
+	case reflect.Float32, reflect.Float64:
+		b.WriteString(formatFloat(v.Float()))
+	case reflect.Complex64, reflect.Complex128:
+		c := v.Complex()
+		b.WriteString(formatFloat(real(c)))
+		b.WriteByte('+')
+		b.WriteString(formatFloat(imag(c)))
+	case reflect.String:
+		b.WriteString(strconv.Quote(v.String()))
+	case reflect.Pointer, reflect.Interface:
+		s.indirect(b, v, depth)
+	case reflect.Slice:
+		if v.IsNil() {
+			b.WriteString("nil")
+			return
+		}
+		// A slice header is (ptr, len, cap). Two slices over one array are
+		// distinguishable, so the identity of the backing array is part of the
+		// fingerprint -- a builtin that reslices in place has changed the
+		// value even when the elements read the same.
+		id, repeat := s.mark(v.Pointer())
+		if repeat {
+			fmt.Fprintf(b, "@%d/%d", id, v.Len())
+			return
+		}
+		fmt.Fprintf(b, "@%d len=%d cap=%d", id, v.Len(), v.Cap())
+		s.elements(b, v, depth)
+	case reflect.Array:
+		s.elements(b, v, depth)
+	case reflect.Struct:
+		for i := range v.NumField() {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteString(v.Type().Field(i).Name)
+			b.WriteByte('=')
+			s.value(b, v.Field(i), depth+1)
+		}
+	case reflect.Map:
+		s.mapValue(b, v, depth)
+	case reflect.Func, reflect.Chan, reflect.UnsafePointer:
+		// Not walkable and not comparable by value. The pointer is stable for
+		// the lifetime of the process, which is all a before/after comparison
+		// needs, and it is rendered through mark() so no address is printed.
+		if v.IsNil() {
+			b.WriteString("nil")
+			return
+		}
+		id, _ := s.mark(v.Pointer())
+		fmt.Fprintf(b, "@%d", id)
+	default:
+		b.WriteString("<unsupported>")
+	}
+}
+
+func (s *goWalk) indirect(b *strings.Builder, v reflect.Value, depth int) {
+	if v.IsNil() {
+		b.WriteString("nil")
+		return
+	}
+	if v.Kind() == reflect.Pointer {
+		id, repeat := s.mark(v.Pointer())
+		if repeat {
+			// A cycle, or ordinary sharing. Either way the target has already
+			// been rendered once; rendering it again would not terminate.
+			fmt.Fprintf(b, "@%d", id)
+			return
+		}
+		fmt.Fprintf(b, "@%d ", id)
+	}
+	s.value(b, v.Elem(), depth+1)
+}
+
+func (s *goWalk) elements(b *strings.Builder, v reflect.Value, depth int) {
+	n := v.Len()
+	for i := range n {
+		if s.budget <= 0 {
+			b.WriteString(" ...")
+			return
+		}
+		b.WriteByte(' ')
+		s.value(b, v.Index(i), depth+1)
+	}
+}
+
+// mapValue renders a map with its entries sorted by their own rendering.
+//
+// This is the case the tracker recorded as unfixable. It is fixable: Go
+// randomises the ORDER a range yields entries, not the entries themselves, so
+// rendering each entry independently and sorting the renderings removes the
+// randomness completely. The sort key is the whole "k=v" string rather than
+// just the key, so two entries whose keys render identically (possible for
+// NaN keys, and for keys past the depth cap) still order deterministically.
+func (s *goWalk) mapValue(b *strings.Builder, v reflect.Value, depth int) {
+	if v.IsNil() {
+		b.WriteString("nil")
+		return
+	}
+	fmt.Fprintf(b, "len=%d", v.Len())
+	entries := make([]string, 0, v.Len())
+	it := v.MapRange()
+	for it.Next() {
+		if s.budget <= 0 {
+			entries = append(entries, "...")
+			break
+		}
+		// Each entry gets a FRESH pointer-identity table. Sharing one across
+		// entries would make an entry's rendering depend on which entries were
+		// rendered before it -- i.e. on the very iteration order being sorted
+		// away.
+		sub := &goWalk{seen: map[uintptr]int{}, budget: min(s.budget, maxGoNodes/4)}
+		var eb strings.Builder
+		sub.value(&eb, it.Key(), depth+1)
+		eb.WriteByte('=')
+		sub.value(&eb, it.Value(), depth+1)
+		s.budget -= maxGoNodes/4 - sub.budget
+		entries = append(entries, eb.String())
+	}
+	sort.Strings(entries)
+	for _, e := range entries {
+		b.WriteByte(' ')
+		b.WriteString(e)
+	}
+}
+
+// mark returns a stable small index for p and whether it had been seen before.
+func (s *goWalk) mark(p uintptr) (int, bool) {
+	if id, ok := s.seen[p]; ok {
+		return id, true
+	}
+	id := len(s.seen)
+	s.seen[p] = id
+	return id, false
+}
+
+// formatFloat renders a float so that NaN compares equal to NaN and the two
+// zeros compare unequal.
+//
+// Both directions matter. A fingerprint in which NaN != NaN would report every
+// native holding a NaN as mutated on every call, and one in which -0 == +0
+// would miss a sign flip -- which is a real mutation, observable from lisp
+// through (/ 1 x).
+func formatFloat(f float64) string {
+	switch {
+	case math.IsNaN(f):
+		return "NaN"
+	case math.Signbit(f) && f == 0:
+		return "-0"
+	}
+	return strconv.FormatFloat(f, 'x', -1, 64)
+}

--- a/internal/fuzzfp/fuzzfp_test.go
+++ b/internal/fuzzfp/fuzzfp_test.go
@@ -296,8 +296,26 @@ func TestGuardDetectsSourceCorruption(t *testing.T) {
 		},
 		{
 			name: "shared synthetic edited in place",
-			make: func() *lisp.LVal { return lisp.Int(1) },
-			mut:  func(v *lisp.LVal) { v.Source.Pos = 7 },
+			// The value gets its OWN synthetic location rather than the one
+			// lisp.Int hands it. nativeSource() returns defaultSourceLocation,
+			// a package-level singleton shared by every value constructed
+			// anywhere in this binary -- editing it in place here corrupted it
+			// for every other test, and TestGuardPermitsEveryReplacementOfA-
+			// SyntheticLocation then failed its own precondition whenever it
+			// happened to run afterwards. With t.Parallel() that is a race:
+			// measured at 2 failures in 8 runs of this package.
+			//
+			// The guard's rule is about the POINTER being unchanged while the
+			// pointee is edited, so a location this test owns exercises it
+			// identically. Which particular synthetic location it is does not
+			// matter to the guard, and mutating a shared one is precisely the
+			// defect class this package exists to detect.
+			make: func() *lisp.LVal {
+				v := lisp.Int(1)
+				v.Source = &token.Location{File: "<native code>", Pos: -1}
+				return v
+			},
+			mut: func(v *lisp.LVal) { v.Source.Pos = 7 },
 		},
 		{
 			name: "real location edited in place",

--- a/internal/fuzzfp/fuzzfp_test.go
+++ b/internal/fuzzfp/fuzzfp_test.go
@@ -1,0 +1,486 @@
+// Copyright © 2026 The ELPS authors
+
+package fuzzfp_test
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/luthersystems/elps/internal/fuzzfp"
+	"github.com/luthersystems/elps/internal/fuzzval"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// cyclic is a Go value that points at itself. A native is an arbitrary host
+// value, so nothing stops a host handing one in, and a naive reflective walk
+// would recurse until the stack ran out.
+type cyclic struct {
+	Name string
+	Self *cyclic
+	Peer *cyclic
+}
+
+// unexportedFields exists to pin that the walk reads fields reflect refuses to
+// hand out through Interface(). If it ever stops doing so, time.Time and
+// *regexp.Regexp become opaque and this package's entire claim about LNative
+// evaporates -- silently, because an opaque value still fingerprints
+// consistently and so still passes every before/after comparison.
+type unexportedFields struct {
+	n int
+	s string
+	m map[string]int
+}
+
+// TestFingerprintIsDeterministic is the assertion the narrowed LNative
+// exclusion rests on.
+//
+// The tracker (issue #318) excluded LNative contents because "formatting
+// arbitrary Go values can traverse a randomised map". Go randomises map
+// iteration order PER RANGE STATEMENT PER RUN, so two ranges over one map in a
+// single process already disagree -- which is what makes an in-process repeat
+// the strong test rather than a weak one. 2000 repetitions over maps large
+// enough that a chance agreement is negligible (8! = 40320 orders for the
+// smallest of them).
+//
+// A flaky fingerprint is worse than an honest exclusion: it would report
+// perfectly correct builtins as corrupting their arguments, at a rate low
+// enough to look like a real intermittent defect.
+func TestFingerprintIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		// Not fatal: a stripped container may have no tzdata. The other cases
+		// still carry the test.
+		loc = time.UTC
+	}
+	self := &cyclic{Name: "a"}
+	self.Self = self
+	self.Peer = &cyclic{Name: "b", Self: self}
+
+	shared := []byte("0123456789")
+
+	values := map[string]any{
+		"nil":            nil,
+		"int":            42,
+		"string":         "a\xffb",
+		"bytes":          []byte{0, 1, 2},
+		"empty-map":      map[string]int{},
+		"small-map":      map[string]int{"a": 1},
+		"map-8":          map[string]int{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6, "g": 7, "h": 8},
+		"map-nested":     map[string]map[string]int{"x": {"a": 1, "b": 2, "c": 3}, "y": {"d": 4, "e": 5, "f": 6}},
+		"map-iface-key":  map[any]any{1: "a", "b": 2, 3.5: []int{1, 2}, true: nil},
+		"map-struct-val": map[string]unexportedFields{"k": {n: 1, s: "x", m: map[string]int{"p": 1, "q": 2}}},
+		// Pointer-bearing map VALUES. These are what pin the fresh
+		// pointer-identity table per entry: with one table shared across the
+		// range, an entry's "@N" index depends on how many entries were
+		// rendered before it, i.e. on the very iteration order being sorted
+		// away, and sorting stable strings would not save it.
+		"map-slice-val": map[string][]byte{"a": {1}, "b": {2}, "c": {3}, "d": {4}, "e": {5}, "f": {6}},
+		"map-ptr-val": map[string]*cyclic{
+			"a": {Name: "a"}, "b": {Name: "b"}, "c": {Name: "c"}, "d": {Name: "d"},
+		},
+		"unexported":    unexportedFields{n: 7, s: "s", m: map[string]int{"a": 1, "b": 2, "c": 3, "d": 4}},
+		"time":          time.Date(2026, 8, 10, 1, 2, 3, 4, loc),
+		"duration":      3 * time.Hour,
+		"regexp":        regexp.MustCompile(`^(a|b)+[0-9]{2,3}\p{L}$`),
+		"regexp-simple": regexp.MustCompile(`abc`),
+		"cyclic":        self,
+		"shared-slices": [][]byte{shared, shared[2:5], shared},
+		"func":          strings.ToUpper,
+		"chan":          make(chan int, 1),
+		"unsafe":        unsafe.Pointer(&shared), //nolint:gosec // G103: an embedder may hand in any Go value, including this one
+		"nan":           math.NaN(),
+		"negzero":       math.Copysign(0, -1),
+		"deep":          deepNest(64),
+		"wide-slice":    makeWide(1000),
+	}
+
+	for name, v := range values {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			want := fuzzfp.Fingerprint(v)
+			for i := range 2000 {
+				if got := fuzzfp.Fingerprint(v); got != want {
+					t.Fatalf("fingerprint of %s is not deterministic; repetition %d differs\n want: %s\n  got: %s",
+						name, i, want, got)
+				}
+			}
+			if want == "" {
+				t.Fatalf("fingerprint of %s is empty; an empty fingerprint compares equal to everything", name)
+			}
+		})
+	}
+}
+
+// TestFingerprintSeesInsideUnexportedFields is the counterweight to the
+// determinism test.
+//
+// "Deterministic" is trivially satisfied by a fingerprint that records
+// nothing, and a walk that gave up at the first unexported field would do
+// exactly that for time.Time and *regexp.Regexp -- the two native types the
+// stdlib actually produces. So the fingerprint must also be SENSITIVE: two
+// values that differ only in unexported state must fingerprint differently.
+func TestFingerprintSeesInsideUnexportedFields(t *testing.T) {
+	t.Parallel()
+
+	pairs := []struct {
+		name string
+		a, b any
+	}{
+		{"time-instant", time.Unix(0, 0).UTC(), time.Unix(1, 0).UTC()},
+		{"time-monotonic-vs-not", time.Unix(0, 0).UTC(), time.Unix(0, 0)},
+		{"duration", time.Second, 2 * time.Second},
+		{"regexp-pattern", regexp.MustCompile(`a`), regexp.MustCompile(`b`)},
+		{"regexp-longest", regexp.MustCompile(`a|ab`), longest(regexp.MustCompile(`a|ab`))},
+		{"unexported-int", unexportedFields{n: 1}, unexportedFields{n: 2}},
+		{"unexported-map", unexportedFields{m: map[string]int{"a": 1}}, unexportedFields{m: map[string]int{"a": 2}}},
+		{"nil-vs-empty-map", map[string]int(nil), map[string]int{}},
+		{"nil-vs-empty-slice", []byte(nil), []byte{}},
+		{"zero-signs", 0.0, math.Copysign(0, -1)},
+		{"slice-cap", makeCap(1, 1), makeCap(1, 2)},
+	}
+	for _, p := range pairs {
+		t.Run(p.name, func(t *testing.T) {
+			t.Parallel()
+			fa, fb := fuzzfp.Fingerprint(p.a), fuzzfp.Fingerprint(p.b)
+			if fa == fb {
+				t.Fatalf("two different values fingerprint identically, so a mutation between them"+
+					" would be invisible:\n  %s", fa)
+			}
+		})
+	}
+}
+
+// TestFingerprintIsInsensitiveToMapInsertionOrder pins the property that makes
+// the sort meaningful rather than merely stabilising: a map built in a
+// different order is the SAME map and must fingerprint the same. Without this,
+// the fingerprint would be stable per-value but would still report a builtin
+// that rebuilt an equal map as having mutated it.
+func TestFingerprintIsInsensitiveToMapInsertionOrder(t *testing.T) {
+	t.Parallel()
+	forward := map[string]int{}
+	backward := map[string]int{}
+	keys := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
+	for i, k := range keys {
+		forward[k] = i
+	}
+	for i := len(keys) - 1; i >= 0; i-- {
+		backward[keys[i]] = i
+	}
+	if a, b := fuzzfp.Fingerprint(forward), fuzzfp.Fingerprint(backward); a != b {
+		t.Fatalf("insertion order reached the fingerprint:\n  %s\n  %s", a, b)
+	}
+}
+
+// TestGuardDetectsNativeMutation is the (b) half of the gate: a builtin that
+// reaches inside a native must be reported.
+func TestGuardDetectsNativeMutation(t *testing.T) {
+	t.Parallel()
+
+	m := map[string]int{"a": 1, "b": 2, "c": 3}
+	buf := []byte("abc")
+	tm := time.Unix(0, 0).UTC()
+
+	cases := []struct {
+		name  string
+		v     *lisp.LVal
+		mutTe func()
+	}{
+		{"map-entry", lisp.Native(m), func() { m["a"] = 99 }},
+		{"map-grow", lisp.Native(m), func() { m["z"] = 1 }},
+		{"slice-element", lisp.Native(buf), func() { buf[0] = 'z' }},
+		{"pointer-target", lisp.Native(&tm), func() { tm = tm.Add(time.Second) }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// NOT parallel: the cases share the mutable values on purpose, so
+			// that each mutation is observed against the state its own Watch
+			// recorded.
+			g := fuzzfp.Watch(c.v)
+			if msg := g.Check(); msg != "" {
+				t.Fatalf("clean check reported a violation: %s", msg)
+			}
+			c.mutTe()
+			if msg := g.Check(); msg == "" {
+				t.Fatalf("mutating the Go value inside an LNative was NOT reported;"+
+					" the LNative half of the guard is blind (%s)", c.name)
+			}
+		})
+	}
+}
+
+// TestGuardDetectsNestedNativeMutation pins that the walk reaches natives that
+// are not the top-level argument. A guard that only checked the argument
+// itself would miss every native inside a list, a map, an array or a
+// tagged-value -- which is how fuzzval hands most of them over.
+func TestGuardDetectsNestedNativeMutation(t *testing.T) {
+	t.Parallel()
+
+	env := newEnv(t)
+	for _, c := range []struct {
+		name string
+		wrap func(native *lisp.LVal) *lisp.LVal
+	}{
+		{"list", func(n *lisp.LVal) *lisp.LVal { return lisp.SExpr([]*lisp.LVal{lisp.Int(1), n}) }},
+		{"vector", func(n *lisp.LVal) *lisp.LVal { return lisp.Vector([]*lisp.LVal{n}) }},
+		{"quote", func(n *lisp.LVal) *lisp.LVal { return lisp.Quote(lisp.Quote(n)) }},
+		{"tagged", func(n *lisp.LVal) *lisp.LVal { return env.TaggedValue(lisp.Symbol("user:t"), n) }},
+		{"sortmap-value", func(n *lisp.LVal) *lisp.LVal {
+			m := lisp.SortedMap()
+			m.Map().Set(lisp.String("k"), n)
+			return m
+		}},
+		{"deep", func(n *lisp.LVal) *lisp.LVal {
+			v := n
+			for range 5 {
+				v = lisp.SExpr([]*lisp.LVal{lisp.Int(0), v})
+			}
+			return v
+		}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			m := map[string]int{"a": 1}
+			g := fuzzfp.Watch(c.wrap(lisp.Native(m)))
+			if msg := g.Check(); msg != "" {
+				t.Fatalf("clean check reported a violation: %s", msg)
+			}
+			m["a"] = 2
+			if msg := g.Check(); msg == "" {
+				t.Fatalf("a native nested in a %s was not watched", c.name)
+			}
+		})
+	}
+}
+
+// TestGuardDetectsSourceCorruption is the (c) half.
+//
+// Each case is a write the interpreter must never perform, and the last two
+// are the ones the tracker's blanket exclusion was hiding: an in-place edit of
+// the shared synthetic Location relocates every value in the process and is
+// invisible to lisp.SingletonSnapshot, which compares Source by pointer.
+func TestGuardDetectsSourceCorruption(t *testing.T) {
+	t.Parallel()
+
+	real1 := &token.Location{File: "a.lisp", Pos: 10, Line: 2, Col: 3}
+	real2 := &token.Location{File: "b.lisp", Pos: 20, Line: 4, Col: 5}
+
+	for _, c := range []struct {
+		name string
+		mut  func(v *lisp.LVal)
+		make func() *lisp.LVal
+	}{
+		{
+			name: "real replaced by real",
+			make: func() *lisp.LVal { v := lisp.Int(1); v.Source = real1; return v },
+			mut:  func(v *lisp.LVal) { v.Source = real2 },
+		},
+		{
+			name: "real replaced by nil",
+			make: func() *lisp.LVal { v := lisp.Int(1); v.Source = real1; return v },
+			mut:  func(v *lisp.LVal) { v.Source = nil },
+		},
+		{
+			name: "real replaced by synthetic",
+			make: func() *lisp.LVal { v := lisp.Int(1); v.Source = real1; return v },
+			mut:  func(v *lisp.LVal) { v.Source = &token.Location{Pos: -1} },
+		},
+		{
+			name: "shared synthetic edited in place",
+			make: func() *lisp.LVal { return lisp.Int(1) },
+			mut:  func(v *lisp.LVal) { v.Source.Pos = 7 },
+		},
+		{
+			name: "real location edited in place",
+			make: func() *lisp.LVal {
+				v := lisp.Int(1)
+				v.Source = &token.Location{File: "c.lisp", Pos: 1, Line: 1, Col: 1}
+				return v
+			},
+			mut: func(v *lisp.LVal) { v.Source.Line = 99 },
+		},
+		{
+			name: "nested cell relocated",
+			make: func() *lisp.LVal {
+				inner := lisp.Int(1)
+				inner.Source = real1
+				return lisp.SExpr([]*lisp.LVal{lisp.Symbol("f"), inner})
+			},
+			mut: func(v *lisp.LVal) { v.Cells[1].Source = real2 },
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			// NOT parallel: the "shared synthetic" case mutates a
+			// process-wide Location and puts it back.
+			v := c.make()
+			g := fuzzfp.Watch(v)
+			if msg := g.Check(); msg != "" {
+				t.Fatalf("clean check reported a violation: %s", msg)
+			}
+			before := *v.Source
+			c.mut(v)
+			msg := g.Check()
+			if v.Source != nil && *v.Source != before {
+				*v.Source = before // restore the shared Location, if that is what was hit
+			}
+			if msg == "" {
+				t.Fatalf("%s was not reported; the Source half of the guard is blind", c.name)
+			}
+		})
+	}
+}
+
+// TestGuardPermitsTheMacroExpansionStamp is the false-positive half, and it is
+// the reason the tracker excluded Source in the first place.
+//
+// stampMacroExpansion replaces a synthetic location with the macro call site
+// on every node of an expansion, and it is correct to do so. A guard that
+// reported it would be off within a week, so the exact transition it performs
+// is permitted -- and only that one, which the test above pins in the other
+// direction.
+func TestGuardPermitsTheMacroExpansionStamp(t *testing.T) {
+	t.Parallel()
+
+	callSite := &token.Location{File: "caller.lisp", Pos: 100, Line: 9, Col: 1}
+
+	// A synthetic node, exactly as every constructor in lisp/ produces.
+	v := lisp.SExpr([]*lisp.LVal{lisp.Symbol("f"), lisp.Int(1)})
+	if v.Source == nil || v.Source.Pos >= 0 {
+		t.Fatalf("expected a synthetic Source on a constructed value, got %+v; the premise of"+
+			" the Source rule (stamping only ever overwrites Pos < 0) no longer holds", v.Source)
+	}
+	g := fuzzfp.Watch(v)
+	// What stampMacroExpansion does, with its own guard.
+	var stamp func(*lisp.LVal)
+	stamp = func(n *lisp.LVal) {
+		if n == lisp.Nil() || n == lisp.Bool(true) || n == lisp.Bool(false) {
+			return
+		}
+		if n.Source == nil || n.Source.Pos < 0 {
+			n.Source = callSite
+		}
+		for _, c := range n.Cells {
+			stamp(c)
+		}
+	}
+	stamp(v)
+	if msg := g.Check(); msg != "" {
+		t.Fatalf("the macro-expansion stamp was reported as corruption, which would make the"+
+			" guard unusable on every macro in the library: %s", msg)
+	}
+}
+
+// TestGuardIsDeterministicOverGeneratedValues runs the guard over the whole
+// generated corpus -- every shape internal/fuzzval can produce, from every
+// seed -- and asserts that Watch/Check on an untouched value is clean.
+//
+// This is the measurement that decides whether the guard can be switched on at
+// all. Any nondeterminism in the fingerprint, and any value shape whose Source
+// legitimately moves without a builtin being involved, shows up here as a
+// violation on a value nothing has touched.
+func TestGuardIsDeterministicOverGeneratedValues(t *testing.T) {
+	t.Parallel()
+	env := newEnv(t)
+	checked := 0
+	for i, seed := range fuzzval.Seeds() {
+		for rep := range 8 {
+			gen := fuzzval.New(seed, env)
+			for range 4 {
+				v := gen.Value()
+				g := fuzzfp.Watch(v)
+				if msg := g.Check(); msg != "" {
+					t.Fatalf("seed %d (repetition %d) reported a violation on a value NOTHING touched"+
+						"\n%s\n--- value ---\n%s", i, rep, msg, v)
+				}
+				checked++
+			}
+		}
+	}
+	if checked < 1000 {
+		t.Fatalf("only %d values checked; the corpus this test claims to cover is not being generated", checked)
+	}
+	t.Logf("clean over %d generated values", checked)
+}
+
+func newEnv(tb testing.TB) *lisp.LEnv {
+	tb.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); rc.Type == lisp.LError {
+		tb.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := lisplib.LoadLibrary(env); rc.Type == lisp.LError {
+		tb.Fatalf("load-library: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		tb.Fatalf("in-package: %v", rc)
+	}
+	return env
+}
+
+func deepNest(n int) any {
+	var v any = 0
+	for range n {
+		v = []any{v}
+	}
+	return v
+}
+
+func makeWide(n int) any {
+	m := make(map[string]int, n)
+	for i := range n {
+		m[fmt.Sprintf("k%04d", i)] = i
+	}
+	return m
+}
+
+func makeCap(l, c int) []int { return make([]int, l, c) }
+
+func longest(re *regexp.Regexp) *regexp.Regexp {
+	cp := re.Copy()
+	cp.Longest()
+	return cp
+}
+
+// TestGuardPermitsEveryReplacementOfASyntheticLocation is the other
+// false-positive guard, and it is why the Source rule stops where it does.
+//
+// LEnv.errorSource stamps an error's location under the same
+// `Source == nil || Source.Pos < 0` condition stampMacroExpansion uses, and it
+// assigns env.Loc -- which is itself assigned from an evaluated node's Source
+// and can therefore be nil. Every transition below is reachable from correct
+// interpreter code, so reporting any of them would make the gate flaky rather
+// than strict.
+func TestGuardPermitsEveryReplacementOfASyntheticLocation(t *testing.T) {
+	t.Parallel()
+	for _, c := range []struct {
+		name string
+		to   *token.Location
+	}{
+		{"to a real location", &token.Location{File: "x.lisp", Pos: 3, Line: 1, Col: 4}},
+		{"to nil", nil},
+		{"to another synthetic location", &token.Location{File: "<native code>", Pos: -1}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			v := lisp.Int(1)
+			if v.Source == nil || v.Source.Pos >= 0 {
+				t.Fatalf("expected a synthetic Source on a constructed value, got %+v", v.Source)
+			}
+			g := fuzzfp.Watch(v)
+			v.Source = c.to
+			if msg := g.Check(); msg != "" {
+				t.Fatalf("a transition the interpreter itself performs was reported: %s", msg)
+			}
+		})
+	}
+}

--- a/internal/fuzzval/fuzzval.go
+++ b/internal/fuzzval/fuzzval.go
@@ -30,9 +30,13 @@
 package fuzzval
 
 import (
+	"encoding/json"
 	"math"
+	"regexp"
+	"time"
 
 	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/token"
 )
 
 // Budget caps how many LVals one Gen will construct across all calls.  The
@@ -60,6 +64,9 @@ type Gen struct {
 	b      []byte
 	i      int
 	budget int
+	// nloc counts the real source locations handed out, so each is distinct
+	// and so the whole assignment stays a pure function of the input bytes.
+	nloc int
 }
 
 // New returns a Gen driven by data.
@@ -195,7 +202,18 @@ func (g *Gen) value(depth int) *lisp.LVal {
 	}
 	g.budget--
 
-	kind := g.Intn(kindNumKinds)
+	// One byte carries two independent decisions. The kind comes from it
+	// modulo the number of kinds, and the source-location decision from its
+	// top bit -- which that modulo leaves essentially unused, and every kind
+	// is reachable with the bit both set and clear.
+	//
+	// Two decisions from one byte rather than two bytes so that adding the
+	// second decision does not shift the byte stream: a saved crasher keeps
+	// selecting the values it selected when it was saved. A regression corpus
+	// that silently starts testing something else is worse than no regression
+	// corpus.
+	sel := g.Byte()
+	kind := int(sel) % kindNumKinds
 	// Past the depth limit, collapse every compound shape onto a scalar
 	// rather than truncating mid-structure: a half-built array with a
 	// dimension header that disagrees with its cell count is not a value any
@@ -205,6 +223,72 @@ func (g *Gen) value(depth int) *lisp.LVal {
 		kind = g.Intn(kindQuote)
 	}
 
+	return g.locate(g.construct(kind, depth), sel)
+}
+
+// locate gives a generated value a REAL source location about half the time.
+//
+// WHY.  Before this, every generated value carried lisp.nativeSource's shared
+// synthetic Location (Pos < 0), and the only write the interpreter makes to
+// Source -- stampMacroExpansion -- is guarded by `Source == nil || Source.Pos
+// < 0`.  A corpus of exclusively synthetic values therefore never presents the
+// case that a corrupting builtin would have to be caught on, and
+// internal/fuzzfp's Source rule has nothing to bite on.
+//
+// It is also the more faithful model, not merely the more testable one.  Every
+// callable that receives an UNEVALUATED fragment -- every special operator,
+// every macro -- receives it straight from the reader, so in production those
+// nodes all carry real, distinct, per-node locations.  Synthetic locations are
+// what a computed value has.  Generating a mix covers both.
+//
+// Locations come from a fixed process-wide pool rather than being allocated
+// per node, for two reasons.
+//
+//   - Reproducibility.  LVal.String() renders an LQSymbol with %#v, which
+//     prints the Source POINTER.  A freshly allocated Location per node would
+//     therefore make the rendering of a generated value depend on the
+//     allocator, and TestGeneratorIsDeterministic -- the property every saved
+//     crasher rests on -- would fail.
+//   - Fidelity.  LVal.Source documents itself as shared: "the reference may be
+//     shared by multiple LVals".  A pool models that, and it is the sharing
+//     that gives an in-place edit of a Location its real blast radius.
+//
+// NOT applied to the singletons (mutating one corrupts every holder -- see
+// issue #274) or to LFun values (kinds 2 and 3 of fun() return the
+// environment's own global function objects; writing to one would corrupt the
+// environment rather than test a builtin).
+func (g *Gen) locate(v *lisp.LVal, sel byte) *lisp.LVal {
+	if sel&0x80 == 0 || v == nil {
+		return v
+	}
+	if v.Type == lisp.LFun || v == lisp.Nil() || v == lisp.Bool(true) || v == lisp.Bool(false) {
+		return v
+	}
+	v.Source = realLocations[g.nloc%len(realLocations)]
+	g.nloc++
+	return v
+}
+
+// realLocations is the pool locate draws from: distinct, REAL (Pos >= 0)
+// locations of the shape the reader produces.
+//
+// Shared across iterations on purpose, in the same spirit as feeding the
+// singletons in: if a builtin writes through a Source pointer, the value it
+// wrote is visible to the guard that recorded it.
+var realLocations = func() []*token.Location {
+	const n = 64
+	locs := make([]*token.Location, n)
+	for i := range locs {
+		locs[i] = &token.Location{
+			File: "fuzz", Path: "fuzz",
+			Pos: i, Line: 1 + i/16, Col: 1 + i%16,
+			EndPos: i + 1, EndLine: 1 + i/16, EndCol: 2 + i%16,
+		}
+	}
+	return locs
+}()
+
+func (g *Gen) construct(kind, depth int) *lisp.LVal {
 	switch kind {
 	case kindNil:
 		return lisp.Nil()
@@ -448,12 +532,61 @@ func (g *Gen) tagged(depth int) *lisp.LVal {
 	return v
 }
 
-// nativeValues are the Go values an LNative can wrap.  Host applications
-// embed ELPS and hand natives across the boundary, so a builtin that type
-// switches on Native without a default is reachable from real code even
-// though no lisp source can spell these.
+// fuzzDurations are the durations handed to time:sleep and the rest of
+// libtime.
+//
+// Bounded deliberately.  BuiltinSleep refuses a duration over an hour and one
+// that would outlast the evaluation deadline, both instantly -- but anything
+// in between it actually sleeps for, and the fuzz environment's deadline is 5
+// seconds.  A generated 4-second duration would therefore cost four seconds of
+// the target's budget for one input.  The values here cover the refusal paths
+// (negative, over-the-hour, saturated) at zero cost and the SLEEPING path at a
+// worst case of two milliseconds, which is what the tracker recorded as
+// missing: "fuzzval has no time.Duration among its nativeValues, so generated
+// arguments reach the builtin's type check and stop there".
+var fuzzDurations = []time.Duration{
+	0,
+	1,
+	-1,
+	time.Millisecond,
+	2 * time.Millisecond,
+	-time.Hour,
+	2 * time.Hour, // over BuiltinSleep's ceiling: refused, no wait
+	math.MaxInt64,
+	math.MinInt64,
+}
+
+// fuzzPatterns are compiled to *regexp.Regexp, which is what libregexp hands
+// back to lisp and therefore what a later builtin can receive.
+var fuzzPatterns = []string{
+	``, `a`, `(a|b)+`, `^$`, `\p{L}{2,3}`, `(?i)x(y)?z`, `.*`, `[^\x00-\x7f]`,
+}
+
+// native returns an LNative.
+//
+// TWO POPULATIONS, for two different reasons.
+//
+// The first is the embedder's: nil, an empty struct, a string, an int, a byte
+// slice, a map.  Host applications embed ELPS and hand natives across the
+// boundary, so a builtin that type switches on Native without a default is
+// reachable from real code even though no lisp source can spell these.
+//
+// The second is the standard library's own: time.Time, time.Duration,
+// *regexp.Regexp and json.RawMessage are all produced by libtime, libregexp
+// and libjson and handed straight back to lisp, so a phylum can obtain one
+// from one builtin and pass it to any other.  Before these were here, the only
+// natives in the corpus were shapes no stdlib function had a branch for, so
+// every one of them stopped at a type check.  They are also what gives
+// internal/fuzzfp's LNative rule something to guard: a *regexp.Regexp is a
+// compiled program a few hundred nodes deep and a time.Time carries a pointer
+// to a shared *time.Location, so "a builtin mutated a native's internals" is a
+// reachable defect rather than a hypothetical one.
+// nativeNumKinds is the number of shapes native() can build. Named so the
+// seed corpus and the switch cannot drift apart silently.
+const nativeNumKinds = 10
+
 func (g *Gen) native() *lisp.LVal {
-	switch g.Intn(6) {
+	switch g.Intn(nativeNumKinds) {
 	case 0:
 		return lisp.Native(nil)
 	case 1:
@@ -464,9 +597,81 @@ func (g *Gen) native() *lisp.LVal {
 		return lisp.Native(g.pickInt())
 	case 4:
 		return lisp.Native([]byte(g.pickString()))
-	default:
+	case 5:
 		return lisp.Native(map[string]int{"a": 1})
+	case 6:
+		// Deterministic instants only: time.Now() would make a saved crasher
+		// irreproducible, which is the one property a regression corpus has to
+		// have.  UTC for the same reason -- the process's local zone is not an
+		// input to the fuzzer.
+		return lisp.Native(time.Unix(int64(g.pickInt()), int64(g.Intn(1000))).UTC())
+	case 7:
+		return lisp.Native(fuzzDurations[g.Intn(len(fuzzDurations))])
+	case 8:
+		// Compiled fresh rather than shared from a package-level table: a
+		// builtin that mutated a shared *regexp.Regexp would corrupt every
+		// LATER iteration instead of failing the one that did it, and a
+		// crasher that only reproduces after its predecessors is not a
+		// crasher.
+		re, err := regexp.Compile(fuzzPatterns[g.Intn(len(fuzzPatterns))])
+		if err != nil {
+			return lisp.Native(nil)
+		}
+		return lisp.Native(re)
+	default:
+		return lisp.Native(json.RawMessage(g.pickString()))
 	}
+}
+
+// KindSeeds returns exactly one seed per value kind.
+//
+// Seeds() is a grab-bag sized for the mutator to descend from; this is the
+// smaller, structural list a caller uses when it needs the GUARANTEE that
+// every value shape is represented -- for instance a target crossing seeds
+// against callables, which must not leave a builtin having seen only six of
+// the nineteen shapes because six was the sample size.
+//
+// It is derived from kindNumKinds rather than written out, so a kind added to
+// value() is covered by every such caller without anyone remembering to
+// update a list.
+func KindSeeds() [][]byte {
+	seeds := make([][]byte, 0, kindNumKinds)
+	for k := range byte(kindNumKinds) {
+		seeds = append(seeds, []byte{k, 1, 2, 3, 4, 5, 6, 7})
+	}
+	return seeds
+}
+
+// LocatedKindSeeds is KindSeeds with the real-source-location bit set: one
+// seed per kind, each producing a value carrying a REAL token.Location rather
+// than the shared synthetic one.
+//
+// Kept separate from KindSeeds because the two populations cost the same and
+// buy different things. Measured, crossing the located population against
+// every callable moved statement coverage of lisp/lisplib not at all -- a
+// location does not steer control flow -- while roughly doubling what the seed
+// corpus costs on every `go test`. What it buys instead is the ONLY population
+// internal/fuzzfp's "a real location is never replaced" rule can bite on, so a
+// caller should spend it where that matters rather than everywhere.
+func LocatedKindSeeds() [][]byte {
+	seeds := make([][]byte, 0, kindNumKinds)
+	for k := range byte(kindNumKinds) {
+		seeds = append(seeds, []byte{stamped(k), 1, 2, 3, 4, 5, 6, 7})
+	}
+	return seeds
+}
+
+// stamped returns a selector byte that chooses kind k AND sets the
+// real-source-location bit -- the smallest byte >= 0x80 congruent to k modulo
+// kindNumKinds. Setting the top bit of k directly would not do: the bit is
+// part of the value the modulus is taken of, so `k | 0x80` selects a different
+// kind entirely.
+func stamped(k byte) byte {
+	b := int(k)
+	for b < 0x80 {
+		b += kindNumKinds
+	}
+	return byte(b)
 }
 
 // Seeds returns the shared seed corpus for the value-driven targets.
@@ -488,6 +693,13 @@ func Seeds() [][]byte {
 			[]byte{k, 0, 0, 0, 0, 0, 0, 0},
 			[]byte{k, 1, 2, 3, 4, 5, 6, 7},
 			[]byte{k, 0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9},
+			// The same kind with a REAL source location (see Gen.locate: the
+			// selector's top bit). Reaching the located population by mutation
+			// means flipping one specific bit of one specific byte, which for
+			// a 19-way modulus is a needle the mutator has no reason to look
+			// for.
+			[]byte{stamped(k), 0, 0, 0, 0, 0, 0, 0},
+			[]byte{stamped(k), 1, 2, 3, 4, 5, 6, 7},
 		)
 	}
 	// Deep and wide shapes: repeated compound tags nest, repeated scalar
@@ -497,11 +709,23 @@ func Seeds() [][]byte {
 		[]byte{kindArrayND, 3, 2, 2, 2, kindInt, 0, 1},
 		[]byte{kindSortMap, 8, 0, kindString, 0, 1, 0, kindSymbol, 0, 1},
 		[]byte{kindTagged, 0, 0, kindTagged, 0, 0, kindTagged, 0, 0},
-		[]byte{kindNative, 0}, []byte{kindNative, 5},
 		[]byte{kindFun, 0}, []byte{kindFun, 1}, []byte{kindFun, 2}, []byte{kindFun, 3},
 		[]byte{kindInt, 0, 7},   // math.MaxInt
 		[]byte{kindInt, 0, 8},   // math.MinInt
 		[]byte{kindFloat, 0, 6}, // NaN
 	)
+	// One seed per NATIVE shape. The kind tag alone is not enough: native()
+	// switches again on its own byte, so a corpus carrying only
+	// {kindNative, 0} and {kindNative, 5} reached two of ten shapes and left
+	// the rest -- including every type the standard library itself produces --
+	// to be found by mutation. TestGeneratorProducesStdlibNativeTypes fails if
+	// this drifts out of step with native().
+	for k := range byte(nativeNumKinds) {
+		seeds = append(seeds,
+			[]byte{kindNative, k},
+			[]byte{kindNative, k, 1, 2, 3, 4},
+			[]byte{stamped(kindNative), k, 1, 2, 3, 4},
+		)
+	}
 	return seeds
 }

--- a/internal/fuzzval/fuzzval_test.go
+++ b/internal/fuzzval/fuzzval_test.go
@@ -3,6 +3,7 @@
 package fuzzval_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -152,5 +153,112 @@ func TestSeedsAreDistinct(t *testing.T) {
 			t.Errorf("seed %d duplicates seed %d (%v)", i, prev, s)
 		}
 		seen[string(s)] = i
+	}
+}
+
+// TestGeneratorProducesRealSourceLocations pins the other half of the corpus
+// the Source rule in internal/fuzzfp depends on.
+//
+// stampMacroExpansion is guarded by `Source == nil || Source.Pos < 0`, so a
+// corpus in which EVERY value carries the shared synthetic location presents
+// only the case where stamping is legal, and a guard on Source has nothing to
+// catch a corrupting builtin with. Both populations must be present.
+func TestGeneratorProducesRealSourceLocations(t *testing.T) {
+	env := genEnv(t)
+	var located, synthetic int
+	for _, seed := range fuzzval.Seeds() {
+		g := fuzzval.New(seed, env)
+		for range 40 {
+			v := g.Value()
+			if v.Type == lisp.LFun || v == lisp.Nil() || v == lisp.Bool(true) || v == lisp.Bool(false) {
+				continue
+			}
+			if v.Source != nil && v.Source.Pos >= 0 {
+				located++
+			} else {
+				synthetic++
+			}
+		}
+	}
+	if located == 0 {
+		t.Errorf("no generated value carried a REAL source location; internal/fuzzfp's rule that a"+
+			" real location is never replaced has nothing to bite on (%d synthetic)", synthetic)
+	}
+	if synthetic == 0 {
+		t.Errorf("every generated value carried a real source location; the legitimate"+
+			" stampMacroExpansion transition is no longer covered (%d located)", located)
+	}
+}
+
+// TestGeneratorNeverRelocatesSharedValues is the safety half of the same
+// change. Writing Source onto a singleton is issue #274, and writing it onto
+// an LFun drawn from the environment corrupts the environment's own function
+// object -- either would make the generator, not the builtin, the defect.
+func TestGeneratorNeverRelocatesSharedValues(t *testing.T) {
+	env := genEnv(t)
+	nilSrc := lisp.Nil().Source
+	trueSrc := lisp.Bool(true).Source
+	falseSrc := lisp.Bool(false).Source
+	for _, seed := range fuzzval.Seeds() {
+		g := fuzzval.New(seed, env)
+		for range 40 {
+			v := g.Value()
+			if v.Type == lisp.LFun && v.Source != nil && v.Source.Pos >= 0 {
+				t.Fatalf("the generator wrote a real location onto a function value (%s)", v.Str)
+			}
+		}
+	}
+	if lisp.Nil().Source != nilSrc || lisp.Bool(true).Source != trueSrc || lisp.Bool(false).Source != falseSrc {
+		t.Fatalf("the generator relocated a shared singleton")
+	}
+}
+
+// TestGeneratorProducesStdlibNativeTypes pins that the natives the standard
+// library itself hands back to lisp are in the corpus. Without them the only
+// LNative shapes generated are ones no stdlib function has a branch for, so
+// every one stops at a type check and the whole LNative surface is covered
+// only in its rejection path.
+func TestGeneratorProducesStdlibNativeTypes(t *testing.T) {
+	env := genEnv(t)
+	seen := map[string]bool{}
+	for _, seed := range fuzzval.Seeds() {
+		g := fuzzval.New(seed, env)
+		for range 200 {
+			if v := g.Value(); v.Type == lisp.LNative {
+				seen[fmt.Sprintf("%T", v.Native)] = true
+			}
+		}
+	}
+	for _, want := range []string{
+		"time.Time", "time.Duration", "*regexp.Regexp", "json.RawMessage",
+		"string", "int", "[]uint8", "map[string]int", "struct {}", "<nil>",
+	} {
+		if !seen[want] {
+			t.Errorf("the corpus never produced an LNative wrapping %s (saw %v)", want, seen)
+		}
+	}
+}
+
+// TestKindSeedsCoverEveryKind pins KindSeeds' contract. Callers use it because
+// it GUARANTEES every value shape is present -- lisp/lisplib's seed cross
+// applies every callable to one value of every kind on the strength of it --
+// so a KindSeeds that quietly stopped reaching a kind would shrink that cross
+// without shrinking any assertion.
+func TestKindSeedsCoverEveryKind(t *testing.T) {
+	env := genEnv(t)
+	seen := map[lisp.LType]bool{}
+	for _, seed := range fuzzval.KindSeeds() {
+		seen[fuzzval.New(seed, env).Value().Type] = true
+	}
+	want := []lisp.LType{
+		lisp.LInt, lisp.LFloat, lisp.LString, lisp.LSymbol, lisp.LQSymbol,
+		lisp.LBytes, lisp.LError, lisp.LSExpr, lisp.LArray, lisp.LSortMap,
+		lisp.LTaggedVal, lisp.LNative, lisp.LFun, lisp.LQuote,
+	}
+	for _, ty := range want {
+		if !seen[ty] {
+			t.Errorf("KindSeeds' FIRST value never has type %v; the per-kind guarantee it exists"+
+				" to make does not hold", ty)
+		}
 	}
 }

--- a/lisp/lisplib/fuzz_test.go
+++ b/lisp/lisplib/fuzz_test.go
@@ -4,16 +4,21 @@ package lisplib_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/luthersystems/elps/elpsutil"
+	"github.com/luthersystems/elps/internal/fuzzfp"
 	"github.com/luthersystems/elps/internal/fuzzval"
 	"github.com/luthersystems/elps/internal/fuzzwatch"
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/lisplib"
 	"github.com/luthersystems/elps/parser"
+	"github.com/luthersystems/elps/parser/token"
 )
 
 // FuzzApplyStdlib applies every callable the standard library registers -- the
@@ -61,6 +66,14 @@ import (
 //     elpscheck` the same corruption is additionally caught at the next
 //     Bool()/Nil() read, which localises it far better -- run
 //     `make test-elpscheck` for that.
+//     4a. No argument's source location was rewritten, and no LNative's contents
+//     were changed.  See internal/fuzzfp for why those two and not "the
+//     arguments are unchanged": several callables mutate an argument by
+//     design.  Issue #318 recorded both of these as unwatchable; they are not,
+//     and until now NOTHING about an argument was checked at all -- only the
+//     three singletons were, so a builtin that relocated every node of a
+//     parsed fragment, or reached into a host's native, produced no signal
+//     whatsoever.
 //  5. The call terminates.  Bounded by a context deadline, a step limit and,
 //     because neither of those can see a loop that evaluates nothing, an
 //     out-of-band watchdog.  Two of the three defects this target found were
@@ -90,58 +103,175 @@ func FuzzApplyStdlib(f *testing.F) {
 		f.Fatalf("enumerated only %d callables; the stdlib surface should be far larger", len(names))
 	}
 
-	// The seed corpus is the cross of two axes, sampled rather than fully
-	// crossed. A full cross is 240 callables x 57 value seeds = 13,680 entries,
-	// and each entry builds a fresh environment (measured 1.08ms), so the full
-	// cross would add ~15s to every `make test`. The sampled cross is ~890
-	// entries (~1s) and still guarantees that every callable and every value
-	// shape appears at least once in the corpus the fuzzer descends from.
-	valueSeeds := fuzzval.Seeds()
-	for i := range names {
-		idx := uint16(i) //nolint:gosec // G115: i < len(names), a few hundred
-		for _, j := range []int{0, len(valueSeeds) / 2, len(valueSeeds) - 1} {
-			f.Add(idx, valueSeeds[j])
+	seedCross(f, names)
+	f.Fuzz(func(t *testing.T, idx uint16, data []byte) {
+		applyOne(t, names, idx, data)
+	})
+}
+
+// thinPackages are the three standard-library packages that had no budget of
+// their own.
+//
+// Issue #318 recorded them as the sharpest of the thin-coverage cases:
+// libtesting, libhelp and libgolang shared FuzzApplyStdlib's budget with
+// libtime, libregexp, libbase64, libjson, libschema, libmath and libstring, so
+// "nothing found" for them meant "nothing found in whatever fraction of 400k
+// executions the mutator happened to spend on their index range".
+//
+// They are also the three with the most host-side surface per callable, which
+// is what makes a shared budget worst for them specifically: libgolang
+// reflects over arbitrary Go values, libhelp walks the package registry and
+// renders docstrings, and libtesting reaches into the Go testing runner.
+var thinPackages = []string{"testing:", "help:", "golang:"}
+
+// FuzzApplyThinStdlib is FuzzApplyStdlib restricted to thinPackages.
+//
+// Same harness, same assertions, same generator -- the ONLY difference is the
+// callable set, and therefore the budget. A separate target rather than a
+// weighting inside the existing one because the fuzzing engine allocates
+// -fuzztime per target: a weighting would still be spending one budget, which
+// is the thing being fixed.
+//
+// The broad target still covers these packages. This is additive: a dedicated
+// budget on top, not a partition.
+func FuzzApplyThinStdlib(f *testing.F) {
+	names := thinCallables(f)
+	// Per package rather than a single total. The three are very unevenly
+	// sized -- testing registers 11 callables, help and golang 4 each -- so a
+	// total floor generous enough not to be brittle would not notice help or
+	// golang vanishing from LoadLibrary entirely, and this target would stay
+	// green while covering a third less than it claims to.
+	for _, pkg := range thinPackages {
+		n := 0
+		for _, name := range names {
+			if strings.HasPrefix(name, pkg) {
+				n++
+			}
+		}
+		if n == 0 {
+			f.Fatalf("package %q registered no callables; it has been dropped from LoadLibrary"+
+				" and this target would silently cover only %v", pkg, thinPackages)
 		}
 	}
+	if len(names) < 15 {
+		// 19 today. The floor is one package's worth below that.
+		f.Fatalf("enumerated only %d callables across %v", len(names), thinPackages)
+	}
+	seedCross(f, names)
+	f.Fuzz(func(t *testing.T, idx uint16, data []byte) {
+		applyOne(t, names, idx, data)
+	})
+}
+
+// thinCallables is callableNames filtered to thinPackages.
+func thinCallables(tb fuzzT) []string {
+	tb.Helper()
+	var out []string
+	for _, name := range callableNames(tb) {
+		for _, pkg := range thinPackages {
+			if strings.HasPrefix(name, pkg) {
+				out = append(out, name)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// seedCross builds the seed corpus as the cross of two axes, sampled rather
+// than fully crossed. A full cross is 240 callables x 132 value seeds =
+// 31,680 entries, and each entry builds a fresh environment (measured 1.08ms),
+// so the full cross would add ~34s to every `make test`. The sampled cross is
+// ~1100 entries and still guarantees that every callable and every value shape
+// appears at least once in the corpus the fuzzer descends from.
+func seedCross(f *testing.F, names []string) {
+	f.Helper()
+	valueSeeds := fuzzval.Seeds()
+
+	// Every callable is applied to at least one value of EVERY shape.
+	//
+	// This replaced sampling three fixed offsets (0, len/2, len-1) into the
+	// seed list, and the replacement is not cosmetic. fuzzval.Seeds() is
+	// ordered by kind tag, so a fixed offset names a kind -- and growing the
+	// seed list slid those offsets onto different kinds, silently changing
+	// what the entire corpus tests. Measured, the slide took libmath from
+	// 73.8% to 47.5% mean per-function coverage with libmath.toFloat at zero
+	// (not one math builtin received a number any more); re-sampling six
+	// spread offsets instead fixed libmath and took four libjson builtins to
+	// zero in exchange.
+	//
+	// A sampled cross always starves someone, and which someone is decided by
+	// arithmetic nobody is looking at. fuzzval.KindSeeds() is the small
+	// structural list that makes the guarantee explicit instead, and it is
+	// derived from the kind count, so a value shape added to the generator is
+	// crossed against every callable without anyone remembering to.
+	kindSeeds := fuzzval.KindSeeds()
+	located := fuzzval.LocatedKindSeeds()
+	for i := range names {
+		idx := uint16(i) //nolint:gosec // G115: i < len(names), a few hundred
+		for _, seed := range kindSeeds {
+			f.Add(idx, seed)
+		}
+		// Plus ONE value carrying a real source location, with the kind
+		// rotating by callable index. Every callable therefore meets the
+		// population that internal/fuzzfp's "a real location is never
+		// replaced" rule needs, and across the name list every kind appears
+		// located -- at one extra seed per callable rather than nineteen,
+		// which measured as a doubling of the whole corpus's cost for no
+		// statement-coverage gain at all.
+		f.Add(idx, located[i%len(located)])
+	}
+	// And every value seed appears at least once, against callables spread
+	// through the name list.
 	for i, seed := range valueSeeds {
 		for _, j := range []int{0, len(names) / 2, len(names) - 1} {
 			f.Add(uint16((i+j)%len(names)), seed) //nolint:gosec // G115: modulo len(names)
 		}
 	}
+}
 
-	f.Fuzz(func(t *testing.T, idx uint16, data []byte) {
-		name := names[int(idx)%len(names)]
-		if skipCallable(name) {
-			return
-		}
+// applyOne is the body both targets share.
+func applyOne(t fuzzT, names []string, idx uint16, data []byte) {
+	t.Helper()
+	name := names[int(idx)%len(names)]
+	if skipCallable(name) {
+		return
+	}
 
-		before := lisp.TakeSingletonSnapshot()
+	before := lisp.TakeSingletonSnapshot()
 
-		ctx, cancel := context.WithTimeout(context.Background(), callDeadline)
-		defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), callDeadline)
+	defer cancel()
 
-		env := fuzzEnv(t, ctx)
-		fun := env.GetGlobal(lisp.Symbol(name))
-		if fun.Type != lisp.LFun {
-			t.Fatalf("%s: expected a function, got %v", name, fun.Type)
-		}
+	env := fuzzEnv(t, ctx)
+	fun := env.GetGlobal(lisp.Symbol(name))
+	if fun.Type != lisp.LFun {
+		t.Fatalf("%s: expected a function, got %v", name, fun.Type)
+	}
 
-		gen := fuzzval.New(data, env)
-		args := lisp.SExpr(genArgs(gen, fun))
+	gen := fuzzval.New(data, env)
+	args := lisp.SExpr(genArgs(gen, fun))
 
-		result := applyWithWatchdog(t, env, name, fun, args)
+	// Recorded BEFORE the call and while the arguments are still exactly what
+	// the generator built. See internal/fuzzfp for what it watches and, more
+	// importantly, for what it deliberately does not.
+	guard := fuzzfp.Watch(args)
 
-		if result == nil {
-			t.Fatalf("%s returned a nil *LVal", name)
-		}
-		// Rendering the result exercises the same code every error path in the
-		// interpreter runs when it formats an operand.
-		_ = result.String()
+	result := applyWithWatchdog(t, env, name, fun, args)
 
-		if drift := before.Verify(); drift != "" {
-			t.Fatalf("%s mutated the shared singleton %s\n--- args ---\n%s", name, drift, args)
-		}
-	})
+	if result == nil {
+		t.Fatalf("%s returned a nil *LVal", name)
+	}
+	// Rendering the result exercises the same code every error path in the
+	// interpreter runs when it formats an operand.
+	_ = result.String()
+
+	if drift := before.Verify(); drift != "" {
+		t.Fatalf("%s mutated the shared singleton %s\n--- args ---\n%s", name, drift, args)
+	}
+	if damage := guard.Check(); damage != "" {
+		t.Fatalf("%s corrupted an argument\n%s\n--- args ---\n%s", name, damage, args)
+	}
 }
 
 // callDeadline bounds one application.  Generous relative to the work any
@@ -187,7 +317,7 @@ const fuzzMaxSteps = 20000
 // The goroutine is deliberately leaked on timeout: it cannot be interrupted
 // (that is the defect being reported), and a fuzz worker that reports a
 // crasher exits immediately afterwards.
-func applyWithWatchdog(t *testing.T, env *lisp.LEnv, name string, fun, args *lisp.LVal) *lisp.LVal {
+func applyWithWatchdog(t fuzzT, env *lisp.LEnv, name string, fun, args *lisp.LVal) *lisp.LVal {
 	t.Helper()
 	done := make(chan *lisp.LVal, 1)
 	panicked := make(chan any, 1)
@@ -317,7 +447,7 @@ func skipCallable(name string) bool {
 // Sorting matters more than it looks: Go map iteration is randomised, so an
 // unsorted list would make a saved crasher select a DIFFERENT callable on
 // replay, and the regression case would silently stop testing what it caught.
-func callableNames(tb testing.TB) []string {
+func callableNames(tb fuzzT) []string {
 	tb.Helper()
 	env := newStdlibEnv(tb)
 	var names []string
@@ -343,7 +473,7 @@ func callableNames(tb testing.TB) []string {
 // would make iteration N's result depend on iterations 0..N-1, so a saved
 // crasher would not reproduce from a clean start -- which is the one property
 // a regression corpus has to have.
-func fuzzEnv(tb testing.TB, ctx context.Context) *lisp.LEnv {
+func fuzzEnv(tb fuzzT, ctx context.Context) *lisp.LEnv {
 	tb.Helper()
 	env := newStdlibEnv(tb,
 		lisp.WithContext(ctx),
@@ -357,10 +487,23 @@ func fuzzEnv(tb testing.TB, ctx context.Context) *lisp.LEnv {
 	// filesystem read into a clean lisp-level error instead of letting a
 	// generated string name a path on the runner.
 	env.Runtime.Library = nil
+	if fuzzEnvHook != nil {
+		fuzzEnvHook(env)
+	}
 	return env
 }
 
-func newStdlibEnv(tb testing.TB, configs ...lisp.Config) *lisp.LEnv {
+// fuzzEnvHook is nil except while TestArgumentGuardIsWiredIn runs.
+//
+// It exists because "internal/fuzzfp detects a corrupted argument" and "this
+// target would report one" are different claims, and only the first is
+// testable in fuzzfp's own package. A guard constructed AFTER the call, or
+// over a copy of the arguments, or whose result was assigned to _, would pass
+// every test in internal/fuzzfp and catch nothing here. One nil check per
+// input is the price of testing the wiring rather than reading it.
+var fuzzEnvHook func(*lisp.LEnv)
+
+func newStdlibEnv(tb fuzzT, configs ...lisp.Config) *lisp.LEnv {
 	tb.Helper()
 	env := lisp.NewEnv(nil)
 	env.Runtime.Reader = parser.NewReader()
@@ -380,3 +523,149 @@ func newStdlibEnv(tb testing.TB, configs ...lisp.Config) *lisp.LEnv {
 	}
 	return env
 }
+
+// TestArgumentGuardIsWiredIn is the negative control for assertion 4a, in the
+// same spirit as TestInternalPanicMarkerIsNotForgeable in lisp/eval_fuzz_test.go:
+// it installs a builtin that commits each defect the guard claims to catch and
+// asserts the target's own body reports it.
+//
+// Everything FuzzApplyStdlib says about arguments rests on applyOne calling
+// Watch before the call and Check after it. That is four lines that no other
+// test executes, and getting them subtly wrong -- watching a copy, checking
+// before applying, dropping the result -- leaves the target green and blind.
+func TestArgumentGuardIsWiredIn(t *testing.T) {
+	// NOT parallel: fuzzEnvHook is package state.
+	corrupt := []struct {
+		name string
+		fn   lisp.LBuiltin
+	}{{
+		// A builtin that relocates a node it was handed. Nothing in the
+		// interpreter does this; stampMacroExpansion only ever writes over a
+		// SYNTHETIC location, and the generated argument here carries a real
+		// one.
+		name: "corrupt-source",
+		fn: func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+			for _, a := range args.Cells {
+				if a.Source != nil && a.Source.Pos >= 0 {
+					a.Source = &token.Location{File: "elsewhere", Pos: 999, Line: 42, Col: 1}
+					return lisp.Nil()
+				}
+			}
+			return lisp.Nil()
+		},
+	}, {
+		// A builtin that reaches inside a host's native value. This is the
+		// case issue #318 recorded as uncatchable.
+		name: "corrupt-native",
+		fn: func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+			for _, a := range args.Cells {
+				if a.Type == lisp.LNative {
+					if m, ok := a.Native.(map[string]int); ok {
+						m["injected"] = 1
+						return lisp.Nil()
+					}
+				}
+			}
+			return lisp.Nil()
+		},
+	}, {
+		// The shared-Location case: an in-place edit of a Location that many
+		// values in the process point at. lisp.SingletonSnapshot compares
+		// Source by POINTER, so this is invisible to the singleton check that
+		// was previously the only thing guarding an argument at all.
+		//
+		// This leaves internal/fuzzval's location pool perturbed for the rest
+		// of the test binary, which is harmless and unavoidable: undoing it is
+		// what would make the case vacuous, and nothing in this package reads
+		// a generated value's line number.
+		name: "corrupt-shared-location",
+		fn: func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+			for _, a := range args.Cells {
+				if a.Source != nil {
+					a.Source.Line++
+					return lisp.Nil()
+				}
+			}
+			return lisp.Nil()
+		},
+	}}
+
+	for _, c := range corrupt {
+		t.Run(c.name, func(t *testing.T) {
+			name := "user:" + c.name
+			fuzzEnvHook = func(env *lisp.LEnv) {
+				// A FIXED arity of one. genArgs draws the variadic count from
+				// the input before generating anything, so `&rest` would shift
+				// every seed by a byte and the shapes these builtins attack
+				// would mostly not be generated -- which looks exactly like a
+				// guard that does not work.
+				env.AddBuiltins(true, elpsutil.Function(c.name, lisp.Formals("x"), c.fn))
+			}
+			t.Cleanup(func() { fuzzEnvHook = nil })
+
+			// Drive the REAL target body, with the corrupting builtin as the
+			// only callable it can select. Any seed that produces an argument
+			// of the shape this builtin attacks must be reported.
+			var reported, ran int
+			var lastMsg string
+			for _, seed := range fuzzval.Seeds() {
+				st := &spyT{}
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							if _, ok := r.(spyFatal); !ok {
+								panic(r)
+							}
+						}
+					}()
+					applyOne(st, []string{name}, 0, seed)
+				}()
+				ran++
+				if st.failed {
+					reported++
+					lastMsg = st.msg
+				}
+			}
+			if reported == 0 {
+				t.Fatalf("%s corrupted an argument and the target reported nothing across %d seeds;"+
+					" assertion 4a is not wired into applyOne", name, ran)
+			}
+			if !strings.Contains(lastMsg, "corrupted an argument") {
+				t.Fatalf("%s was reported, but not by the argument guard -- the failure was: %s", name, lastMsg)
+			}
+			t.Logf("%s: reported on %d of %d seeds", name, reported, ran)
+		})
+	}
+}
+
+// fuzzT is the subset of *testing.T and *testing.F the harness uses, so the
+// same body serves both fuzz targets AND can be driven by a spy in
+// TestArgumentGuardIsWiredIn. lisp/eval_fuzz_test.go carries the same
+// interface for the same reason.
+type fuzzT interface {
+	Helper()
+	Fatalf(format string, args ...interface{})
+	Skipf(format string, args ...interface{})
+}
+
+// spyT records a Fatalf instead of failing the test, so the wiring test can
+// assert that the harness WOULD have reported a defect.
+//
+// Fatalf panics with a sentinel rather than returning, because every call site
+// in the harness treats Fatalf as terminal (`t.Fatalf(...); return nil` and
+// the like); letting it fall through would exercise paths the real target
+// never takes.
+type spyT struct {
+	msg    string
+	failed bool
+}
+
+type spyFatal struct{}
+
+func (s *spyT) Helper() {}
+func (s *spyT) Fatalf(format string, args ...interface{}) {
+	s.failed = true
+	s.msg = fmt.Sprintf(format, args...)
+	panic(spyFatal{})
+}
+func (s *spyT) Skipf(format string, args ...interface{}) { panic(spyFatal{}) }


### PR DESCRIPTION
Closes part of #318. Targeted at v1.50.0, not the v1.49.1 patch.

## The tracker's premise was wrong

#318 describes `LNative` contents and `LVal.Source` as *excluded from the mutation fingerprint*, with `LBytes` and `LSortMap` "handled specially and caught".

**There is no mutation fingerprint.** Not in the tree, not anywhere in its history. `FuzzApplyStdlib` verified `lisp.SingletonSnapshot` — the three shared singletons — and nothing about the arguments at all. Independently confirmed: the only `fingerprint` occurrences in the repo are in `mcpserver/`, for unrelated workspace hashing.

So it was not a working check with two blind spots. It was no check. That makes the item more urgent than recorded, not less.

## What this adds

An argument-mutation check that actually exists, in `internal/fuzzfp`. It walks reflectively rather than through `fmt`: the stated reason for excluding `LNative` was that formatting arbitrary Go values can traverse a randomised map, which is a property of `fmt`, not of the values. It renders map entries independently and **sorts the renderings**, reads unexported fields through kind-specific accessors so it can see inside `time.Time` and `*regexp.Regexp`, breaks cycles on pointer identity, and renders pointers as dense per-walk indices rather than addresses.

For `Source`, it matches the interpreter's actual invariant. `macroCall`'s guard is exactly `Source == nil || Source.Pos < 0`, and so is `LEnv.errorSource`'s. Two rules survive: a **real** location is never replaced, and an unchanged `Source` pointer must still point at the same `Location` value. The second matters most — nearly every value shares one `token.Location`, and `SingletonSnapshot` compares `Source` by pointer, so in-place corruption of it was invisible to the only check that existed.

The nil-or-synthetic → anything transition is deliberately left free. A stricter rule was written first and rejected: `env.Loc` can legitimately be nil, so it was a latent flake, and a flaky fingerprint is worse than an honest exclusion.

**Determinism is mutation-tested, not asserted.** 2,000 in-process repetitions per value across maps, nested and interface-keyed and pointer-bearing maps, `time.Time`, `*regexp.Regexp`, cyclic and unexported-field values. Deleting the sort fails it; sharing the pointer table across map entries fails it — a case that had to be *added*, because it was not previously pinned.

Also adds `FuzzThinStdlib`, giving `libtesting`/`libhelp`/`libgolang` a dedicated budget instead of sharing one target with six other packages.

## Measuring found a harness bug

The seed cross sampled three fixed offsets into a seed list ordered by kind tag, so an offset names a kind. Growing the list slid all three onto different kinds: libmath fell 73.8% → 47.5% with `toFloat` at **zero** — not one math builtin received a number. A sampled cross always starves someone, invisibly, so the guarantee is now explicit via `fuzzval.KindSeeds()`, derived from the kind count.

Seed-corpus coverage 30.7% → 37.8% overall, no package regressed. libbase64 47.6→89.3, libstring 58.3→82.0, libgolang 56.8→82.8, libregexp 58.9→75.3, libtime 34.4→55.2, libmath 73.8→85.6.

Honest caveat: libtesting and libhelp seed coverage did **not** move (43.5%, 24.3→25.4%). The dedicated target buys campaign budget, not seed coverage.

## Campaign

Four sweeps on a contended 4-core sandbox: **2,261,262 executions, no crashers.** `lisp/lisplib/testdata/fuzz` diffed on the filesystem around every sweep, never changed.

Read against #318's own standing caveat, this is a start and not a verdict — corpora were still growing at every cutoff, and the guard is new.

## Reviewer note: shard budget

This branch alone leaves the sweep at 18 targets, 5 shards, 10 minutes of headroom.

But #318 has three fuzzing branches in flight (this, `claude/fuzz-elpsutil`, `claude/fuzz-analysis`) adding 1, 1 and 3 targets. **Merged together that is 22 targets**, which takes `ceil(22/5)` to 5 per shard and `needed` to exactly 60 against a 60-minute timeout. Because `fuzz-budget-check.sh`'s condition is `needed > timeout`, it goes **green at zero headroom** — precisely the silently-truncated sweep its own error text warns about.

Whichever of the three merges last must add a **sixth shard** in the same change. The gate will not say so.

## Verification

Full `go test ./...`, `golangci-lint run ./...` and the `elpscheck` pass all clean. `lisp/lisplib` package test time 1.1s → 5.9s; suite wall clock unchanged at 46s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_