### PR TITLE
Make swallowed macro-expansion panics observable, and fuzz analysis and lint directly

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -61,7 +61,7 @@ permissions:
 
 jobs:
   fuzz:
-    name: Fuzz shard ${{ matrix.shard }}/5
+    name: Fuzz shard ${{ matrix.shard }}/6
     runs-on: ubuntu-latest
     strategy:
       # Sharded so wall clock is set by the LARGEST shard rather than by the
@@ -81,19 +81,21 @@ jobs:
       # or a single failure costs the whole night's coverage.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5]
+        shard: [1, 2, 3, 4, 5, 6]
     # DERIVED, not remembered. scripts/fuzz-budget-check.sh asserts
     #
     #     ceil(targets / shards) x FUZZTIME + overhead <= timeout-minutes
     #
     # on every PR, so this number cannot silently stop covering the sweep. At
-    # 20 targets over 5 shards that is 4 x 10m + 10m = 50; 60 leaves a shard's
-    # worth of headroom for a target being added before anyone reshards. That
-    # ceiling is now fully consumed: 20 targets is exactly ceil(20/5) = 4, so
-    # the NEXT target added is the one that runs out. ceil(21/5) = 5 puts
-    # `needed` at exactly 60, which the gate passes while describing a
-    # truncated sweep -- so the 21st target must arrive together with a sixth
-    # shard, not after it.
+    # 23 targets over 6 shards that is 4 x 10m + 10m = 50; 60 leaves a shard's
+    # worth of headroom for a target being added before anyone reshards.
+    #
+    # This branch is what consumed the previous ceiling. Five shards held to
+    # exactly 20 targets; the three targets added here take it to 23, and
+    # ceil(23/5) = 5 puts `needed` at exactly 60 -- which the gate PASSES while
+    # describing a truncated sweep. So the sixth shard arrives HERE, in the
+    # same change as the targets that need it, rather than being left for
+    # whoever next notices. ceil(23/6) = 4 restores the 10 minutes.
     #
     # THE HEADROOM IS THE POINT, NOT THE GREEN TICK. The gate's condition is
     # `needed > timeout`, so a sweep sized at exactly timeout-minutes PASSES --
@@ -170,7 +172,7 @@ jobs:
         run: ./scripts/fuzz-budget-check.sh
 
       - name: Fuzz
-        run: ./scripts/fuzz.sh --shard ${{ matrix.shard }}/5
+        run: ./scripts/fuzz.sh --shard ${{ matrix.shard }}/6
 
       # Only from main/schedule: a corpus grown from an unmerged branch would
       # otherwise be handed to every other PR.

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ editors/vscode/bin/
 # rather than the whole committed corpus. Regenerated per run; never committed
 # (the crasher itself belongs in <package>/testdata/fuzz/<Target>/).
 fuzz-crashers/
+
+# scripts/ci-gates-test.sh synthesises a throwaway package here for its
+# empty-discovery control and deletes it again. Ignored so an interrupted run
+# cannot leave the tree looking dirty.
+internal/citest-emptyfuzz.*/

--- a/analysis/analysis_fuzz_guard_test.go
+++ b/analysis/analysis_fuzz_guard_test.go
@@ -1,0 +1,177 @@
+// Copyright © 2026 The ELPS authors
+
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Guards for the two analysis fuzz targets.
+//
+// These exist because of what PR #348 found by measuring rather than reading:
+// three separate harness bugs where every operation "ran", every test passed,
+// and whole functions sat at 0% because the harness was quietly starving them.
+// A fuzz target cannot report that it is covering less than it thinks. These
+// tests assert the specific reachability claims the harness comments make, so
+// that a future change which breaks one fails CI instead of silently reducing
+// what the nightly sweep explores.
+
+// TestAnalyzeFuzzSeedsExpandMacros is the sharpest of these guards.
+//
+// Setting cfg.MacroExpander looks sufficient for the analysis-time evaluation
+// path to be covered, and is not: the analyser consults the expander only for a
+// head symbol it does not already know, so a stdlib macro (known) and a macro
+// defined in the file under analysis (not in the env) both miss. Only a macro
+// that came from ANOTHER file is both present in the env and unknown to the
+// analyser. If macroSeeds ever stops producing that shape, env.MacroCall is
+// never reached, ExpandMacro returns nil every time for the boring reason, and
+// the target's ExpansionPanics assertion becomes vacuous while still passing.
+func TestAnalyzeFuzzSeedsExpandMacros(t *testing.T) {
+	// Exactly the cross product the seed corpus contains, so this guard is
+	// about the CORPUS rather than about a script invented here.
+	totalAsked, totalExpanded := 0, 0
+	for i, ms := range macroSeeds {
+		for j, sc := range analyzeScripts {
+			stats, err := runAnalyze([]byte(ms[0]), []byte(ms[1]), sc)
+			require.NoError(t, err, "macroSeeds[%d] with analyzeScripts[%d] failed", i, j)
+			totalAsked += stats.asked
+			totalExpanded += stats.expanded
+		}
+	}
+	assert.Positive(t, totalAsked,
+		"the analyser never consulted the macro expander at all")
+	assert.Positive(t, totalExpanded,
+		"no seed reached a SUCCESSFUL expansion, so env.MacroCall never ran and the"+
+			" analysis-time evaluation path this target claims to cover is covered by"+
+			" nothing. The shape that reaches it is a macro defined in the NEIGHBOURING"+
+			" file (so LoadWorkspaceMacros put it in the env) and called from the file"+
+			" under analysis (so the analyser does not already know it)")
+}
+
+// TestFuzzPreambleHeadsMatchScan pins the harness's copy of the preamble head
+// list to the switch it was copied from. If workspace.go starts collecting a
+// new form and this list does not, the harness replays a SUBSET of what
+// production replays and the difference is invisible.
+func TestFuzzPreambleHeadsMatchScan(t *testing.T) {
+	src, err := os.ReadFile("workspace.go")
+	require.NoError(t, err)
+
+	// The `case "in-package", "use-package", ...:` arm inside scanFileFull.
+	re := regexp.MustCompile(`(?s)switch astutil\.HeadSymbol\(expr\) \{\s*case ([^:]+):\s*preamble = append`)
+	m := re.FindSubmatch(src)
+	require.NotNil(t, m, "could not locate scanFileFull's preamble switch in workspace.go;"+
+		" this guard has gone stale and must be repointed, not deleted")
+
+	found := map[string]bool{}
+	for _, lit := range strings.Split(string(m[1]), ",") {
+		if s := strings.Trim(strings.TrimSpace(lit), `"`); s != "" {
+			found[s] = true
+		}
+	}
+	assert.Equal(t, found, preambleHeads,
+		"the fuzz harness's preambleHeads no longer matches scanFileFull's switch;"+
+			" the harness would replay a different preamble than production does")
+}
+
+// TestAnalyzeFuzzSeedsBuildScopes checks the seeds are not all degenerate: at
+// least one produces a Result with symbols and references. A corpus that parses
+// to nothing exercises the analyser's early returns and nothing else, which is
+// exactly how #348's didChange bug hid.
+func TestAnalyzeFuzzSeedsBuildScopes(t *testing.T) {
+	stats, err := runAnalyze([]byte(fuzzSeedUses), []byte(fuzzSeedDefs), []byte{4, 1, 2, 3, 1, 0, 1, 2})
+	require.NoError(t, err)
+	assert.Positive(t, stats.symbols, "the primary seed produced no symbols")
+	assert.Positive(t, stats.refs, "the primary seed produced no references")
+}
+
+// TestWorkspaceFuzzSeedsCollectFiles checks the workspace harness actually
+// materialises and collects a tree. A bug in writeWorkspace would leave the
+// scan looking at an empty directory: every call would return promptly, every
+// seed would pass, and the whole of workspace.go past collectLispFiles would be
+// unreached.
+func TestWorkspaceFuzzSeedsCollectFiles(t *testing.T) {
+	// Script with MaxFiles unconstrained and main.lisp written.
+	sc := []byte{1, 3, 1, 2, 0, 1, 1, 0, 1, 0, 1, 1, 1}
+	const defs = `(in-package 'wsdemo)
+(defun add (a b) (+ a b))
+(defmacro defthing (name args &rest body) (quasiquote (defun (unquote name) (unquote args) (unquote-splicing body))))
+(export 'add)`
+	stats, err := runWorkspaceScan(t.TempDir(), []byte(defs), []byte("(in-package 'user)\n(use-package 'wsdemo)\n(defun main () (add 1 2))"), sc)
+	require.NoError(t, err)
+	assert.Positive(t, stats.files, "the scan collected no files at all")
+	assert.Positive(t, stats.defs, "the scan found no definitions")
+	assert.Positive(t, stats.preamble,
+		"the scan collected no preamble forms, so LoadWorkspaceMacros had nothing to"+
+			" evaluate and the macro-loading path is unreached")
+	assert.Positive(t, stats.defForms,
+		"no DefFormSpec was derived from a def*-prefixed macro; extractDefFormSpecs"+
+			" and the whole def-like analysis path are unreached")
+}
+
+// TestWorkspaceFuzzContainsLoadFile is the containment claim as a test.
+//
+// walkLoadFile joins a load-file argument to the containing directory and
+// recurses, so `(load-file "../../../etc/passwd")` in a fuzzer-derived file
+// would make this target a file-read primitive pointed at the machine running
+// it. The harness strips the token; this proves the strip works, that it
+// preserves byte offsets, and that the only load edges that survive are the
+// harness's own.
+func TestWorkspaceFuzzContainsLoadFile(t *testing.T) {
+	hostile := []byte(`(in-package 'user)
+(load-file "../../../etc/passwd")
+(load-file "/etc/shadow")
+(defun f () 1)`)
+
+	safe := neutraliseLoadFile(hostile)
+	assert.Len(t, safe, len(hostile),
+		"the substitution changed the length, so every token.Location downstream"+
+			" of it now differs from what the original bytes would have produced")
+	assert.NotContains(t, string(safe), "load-file",
+		"a load edge survived neutralisation")
+
+	// End to end: run the harness on the hostile input and check every file the
+	// scan reports is inside the temp root.
+	root := t.TempDir()
+	stats, err := runWorkspaceScan(root, hostile, hostile, []byte{1, 3, 1, 2, 0, 1, 1, 0})
+	require.NoError(t, err)
+	assert.Positive(t, stats.files)
+
+	// And that the neutralised token is what is actually on disk.
+	for _, name := range []string{wsPlainFile, wsSubFile} {
+		b, readErr := os.ReadFile(filepath.Join(root, filepath.FromSlash(name))) //nolint:gosec // fixed name under t.TempDir()
+		require.NoError(t, readErr)
+		assert.NotContains(t, string(b), "load-file",
+			"%s went to disk with a live load edge in it", name)
+	}
+}
+
+// TestWorkspaceFuzzLoadTreeIsExercised checks the harness's own load edges
+// actually build a load tree, including the self-cycle that is the only thing
+// testing walkLoadFile's `visited` guard. Without this, main.lisp could quietly
+// stop being written and buildLoadTree would go to 0% with every seed passing.
+func TestWorkspaceFuzzLoadTreeIsExercised(t *testing.T) {
+	root := t.TempDir()
+	sc := &script{b: []byte{1, 3, 1, 2, 0, 1, 1, 0, 1, 0, 1, 1, 1}}
+	require.NoError(t, writeWorkspace(root, sc, []byte("(defun a () 1)"), []byte("(defun b () 2)")))
+
+	main, err := os.ReadFile(filepath.Join(root, wsMainFile)) //nolint:gosec // fixed name under t.TempDir()
+	require.NoError(t, err, "main.lisp was not written, so buildLoadTree never runs")
+	assert.Contains(t, string(main), "(load-file ",
+		"main.lisp carries no load edge, so walkLoadFile's recursion is unreached")
+
+	pkgMap, order := buildLoadTree(filepath.Join(root, wsMainFile))
+	assert.NotEmpty(t, order, "the load walk visited nothing")
+	for path := range pkgMap {
+		rel, relErr := filepath.Rel(root, path)
+		require.NoError(t, relErr)
+		assert.False(t, rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)),
+			"the load tree escaped the workspace root: %q", path)
+	}
+}

--- a/analysis/analysis_fuzz_test.go
+++ b/analysis/analysis_fuzz_test.go
@@ -1,0 +1,722 @@
+// Copyright © 2026 The ELPS authors
+
+package analysis
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/astutil"
+	"github.com/luthersystems/elps/internal/fuzzseed"
+	"github.com/luthersystems/elps/internal/fuzzwatch"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser/rdparser"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// Fuzzing the ANALYSER on its own API, rather than through the language server.
+//
+// # Why a dedicated target, when FuzzLSPSession already reaches this package
+//
+// Issue #318 lists analysis/ as unfuzzed. FuzzLSPSession (PR #348) softened
+// that: driving didOpen runs parse -> analysis -> lint synchronously, and the
+// seed corpus alone measured 33.7% mean per-function coverage of this package.
+// That is a downgrade, not a close, for three separate reasons.
+//
+//  1. THE LSP IS NOT THE ONLY CALLER. luthersystems/substrate imports
+//     github.com/luthersystems/elps/analysis directly, as does lint/, the
+//     minifier and the MCP server. Whatever the language server happens not to
+//     construct is still constructible by those callers.
+//
+//  2. THE LSP CONSTRUCTS ONLY ONE SHAPE OF Config. Every field of
+//     analysis.Config is attacker-influenced in production -- ExtraGlobals and
+//     PackageSymbols come off disk, DefForms are DERIVED FROM MACRO NAMES in
+//     workspace source (extractDefFormSpecs), PackageImports and
+//     DefaultPackage from cross-file scans. The LSP builds them all from one
+//     workspace scan, so the fuzzer never varies them independently and never
+//     produces the combinations a caller with its own index would. DefForms is
+//     the sharpest of these: FormalsIndex and NameIndex are INTEGER INDICES
+//     into a fuzzer-chosen form's Cells, which is where an out-of-range slice
+//     lives, and no LSP-driven input can set them to an arbitrary value.
+//
+//  3. THE POSITION QUERIES ARE THIS PACKAGE'S, NOT THE SERVER'S.
+//     ScopeAtPosition and FindEnclosingFunction do their own line/column
+//     arithmetic on a scope tree, and are exported for embedders.
+//
+// # The assertion with teeth: ExpansionPanics
+//
+// The analyser evaluates code. When Config.MacroExpander is set -- which the
+// LSP, lint and the MCP server all do -- analysing a document CALLS
+// env.MacroCall on macros loaded from the workspace, so a macro body runs
+// while a file is merely being looked at. EnvMacroExpander.ExpandMacro wraps
+// that in a blanket recover() whose recovery sets result = nil.
+//
+// nil is also the ordinary answer for "not a macro", and the analyser asks the
+// expander about EVERY unknown head symbol, so nil is overwhelmingly the common
+// return. #348 called this out and left it open: a panic in analysis-time macro
+// expansion was invisible to any fuzzer, because there was no marker to key
+// off, and closing it needed a change in this package rather than in the
+// harness.
+//
+// EnvMacroExpander.ExpansionPanics is that change. It counts calls that failed
+// to complete, keyed off a local variable in ExpandMacro's own frame that only
+// a normal return can set -- non-forgeable in the same sense lisp.IsInternalPanic
+// and the LSP harness's checkIndexBuilt are non-forgeable. This target asserts
+// the count is zero after every input, which is the whole reason the target can
+// claim to cover analysis-time evaluation at all.
+//
+// # What is deliberately kept out of reach
+//
+// NO FILESYSTEM. Filename is a fixed constant and Runtime.Library stays nil, so
+// load-file cannot reach the disk while the preamble is being evaluated -- the
+// same principle FuzzEval and FuzzLSPSession apply. The workspace-scanning half
+// of this package needs real files and is fuzzed separately by
+// FuzzWorkspaceScan, which owns the containment argument for that.
+//
+// SINGLE GOROUTINE. Nothing here spawns one, so a crasher reproduces from its
+// own testdata file.
+const (
+	// Budgets for the injected LEnv. Analysis-time macro expansion evaluates
+	// macro bodies, so this is arbitrary evaluation reachable from a source
+	// file and needs FuzzEval's budgets. Same values as FuzzLSPSession's.
+	analysisEnvMaxSteps          = 200_000
+	analysisEnvMaxTailIterations = 10_000
+	analysisEnvMaxPhysHeight     = 2_000
+	analysisEnvMaxAlloc          = 1_000_000
+	analysisEnvMacroDepth        = 100
+	analysisEnvMaxEvalNesting    = 20_000
+
+	// Fixed filenames. Never fuzzer-derived: they end up in token.Location and
+	// in SymbolKey strings, and a fuzzer-chosen path is a step towards a
+	// filesystem primitive for no coverage gain.
+	fuzzAnalysisFile  = "fuzz-a.lisp"
+	fuzzWorkspaceFile = "fuzz-b.lisp"
+
+	// maxProbes bounds the position queries run against one result. Each walks
+	// the scope tree, so an unbounded count would let one input spend the
+	// deadline in the harness rather than in the code under test.
+	maxProbes = 32
+
+	// maxDefForms bounds how many DefFormSpecs are synthesised per input.
+	maxDefForms = 4
+
+	// watchdogTimeout is scheduled time, not wall clock (see internal/fuzzwatch).
+	analysisWatchdogTimeout = 30 * time.Second
+)
+
+// ---------------------------------------------------------------------------
+// harness
+// ---------------------------------------------------------------------------
+
+// discardWriter drops everything. The analyser may evaluate a macro body that
+// prints; that must not spam the fuzzing log.
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// countingExpander wraps EnvMacroExpander so the harness can tell how many
+// expansions actually SUCCEEDED.
+//
+// This exists because of the lesson #348 recorded the hard way: setting
+// cfg.MacroExpander looks sufficient for the macro-evaluation path to be
+// covered, and is not. The analyser consults the expander only for a head
+// symbol it does not already know, and a macro defined in the file under
+// analysis is not in the env while a stdlib macro is not unknown -- so the only
+// macro that reaches env.MacroCall is one that came from ANOTHER file. Without
+// a count, a harness that never reaches MacroCall passes every test and looks
+// identical to one that does. TestAnalyzeFuzzSeedsExpandMacros asserts the
+// seeds reach it.
+//
+// It also forwards ExpansionPanics, so the target's assertion goes through the
+// exported PanicReporter interface exactly as an embedder's would.
+type countingExpander struct {
+	inner    *EnvMacroExpander
+	expanded int
+	asked    int
+}
+
+func (c *countingExpander) ExpandMacro(form *lisp.LVal, pkg string) *lisp.LVal {
+	c.asked++
+	v := c.inner.ExpandMacro(form, pkg)
+	if v != nil {
+		c.expanded++
+	}
+	return v
+}
+
+func (c *countingExpander) ExpansionPanics() uint64 { return c.inner.ExpansionPanics() }
+
+// newFuzzEnv builds the environment the expander runs in and replays preamble
+// into it, mirroring what buildWorkspaceIndex and lint.BuildAnalysisConfig do:
+// LoadWorkspaceMacros first, then the expander over the resulting env.
+//
+// Runtime.Library stays nil so load-file cannot reach the disk while the
+// fuzzer-derived preamble is being EVALUATED.
+func newFuzzEnv(preamble []*lisp.LVal) (*lisp.LEnv, error) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = rdparser.NewReader()
+	if rc := lisp.InitializeUserEnv(env,
+		lisp.WithStderr(discardWriter{}),
+		lisp.WithMaxSteps(analysisEnvMaxSteps),
+		lisp.WithMaxTailIterations(analysisEnvMaxTailIterations),
+		lisp.WithMaximumPhysicalStackHeight(analysisEnvMaxPhysHeight),
+		lisp.WithMaxAlloc(analysisEnvMaxAlloc),
+		lisp.WithMaxMacroExpansionDepth(analysisEnvMacroDepth),
+		lisp.WithMaxEvalNesting(analysisEnvMaxEvalNesting),
+	); rc.Type == lisp.LError {
+		return nil, fmt.Errorf("InitializeUserEnv: %v", rc)
+	}
+	if rc := lisplib.LoadLibrary(env); rc.Type == lisp.LError {
+		return nil, fmt.Errorf("LoadLibrary: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		return nil, fmt.Errorf("InPackage: %v", rc)
+	}
+	// Evaluates fuzzer-derived forms, which is what production does with a
+	// workspace preamble and the reason the env is budgeted.
+	_ = LoadWorkspaceMacros(env, preamble)
+	return env, nil
+}
+
+// preambleHeads are the top-level forms scanFileFull collects into
+// Prescan.Preamble and LoadWorkspaceMacros then evaluates. Kept in step with
+// the switch in workspace.go; TestFuzzPreambleHeadsMatchScan asserts it.
+var preambleHeads = map[string]bool{
+	"in-package": true, "use-package": true, "export": true,
+	"defmacro": true, "defun": true, "set": true,
+}
+
+// fuzzPreamble extracts from src the forms a workspace scan would have
+// collected out of a neighbouring file.
+func fuzzPreamble(src []byte) []*lisp.LVal {
+	sc := token.NewScanner(fuzzWorkspaceFile, bytes.NewReader(src))
+	res := rdparser.New(sc).ParseProgramFaultTolerant()
+	var preamble []*lisp.LVal
+	for _, expr := range res.Exprs {
+		if expr == nil || expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
+			continue
+		}
+		if preambleHeads[astutil.HeadSymbol(expr)] {
+			preamble = append(preamble, expr)
+		}
+	}
+	return preamble
+}
+
+// script is the fuzzer's third input, read as a byte stream so that the same
+// input always produces the same configuration.
+type script struct {
+	b []byte
+	i int
+}
+
+func (s *script) next() byte {
+	if len(s.b) == 0 {
+		return 0
+	}
+	v := s.b[s.i%len(s.b)]
+	s.i++
+	return v
+}
+
+func (s *script) intn(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	return int(s.next()) % n
+}
+
+func (s *script) bit() bool { return s.next()&1 == 1 }
+
+// headSymbols collects the head symbol of every s-expression in exprs, at any
+// depth, so that a synthesised DefFormSpec can name a form that is ACTUALLY
+// PRESENT in the input. Specs naming a head that never occurs are free to
+// generate and worthless: defLikeMatch returns false and analyzeDefLike is
+// never entered. Measured, not assumed -- with a fixed vocabulary of heads the
+// whole def-like surface stayed at 0%.
+func headSymbols(exprs []*lisp.LVal) []string {
+	var out []string
+	seen := map[string]bool{}
+	var walk func(v *lisp.LVal, depth int)
+	walk = func(v *lisp.LVal, depth int) {
+		if v == nil || depth > 32 || len(out) > 64 {
+			return
+		}
+		if v.Type == lisp.LSExpr && len(v.Cells) > 0 {
+			if h := astutil.HeadSymbol(v); h != "" && !seen[h] {
+				seen[h] = true
+				out = append(out, h)
+			}
+		}
+		for _, c := range v.Cells {
+			walk(c, depth+1)
+		}
+	}
+	for _, e := range exprs {
+		walk(e, 0)
+	}
+	return out
+}
+
+// buildDefForms synthesises DefFormSpecs from the script.
+//
+// FormalsIndex and NameIndex are the point of this: they are indices into a
+// form's Cells that reach validDefFormSpec and analyzeDefLike, and production
+// derives them from macro FORMALS found in workspace source
+// (extractDefFormSpecs), so an embedder's index is as untrusted as the source
+// it came from. Negative and past-the-end values are generated deliberately.
+func buildDefForms(sc *script, heads []string) []DefFormSpec {
+	n := sc.intn(maxDefForms + 1)
+	specs := make([]DefFormSpec, 0, n)
+	for range n {
+		var head string
+		if len(heads) > 0 && !sc.bit() {
+			head = heads[sc.intn(len(heads))]
+		} else {
+			// A head that is probably absent, so the "no match" path is
+			// exercised too.
+			head = fmt.Sprintf("defthing%d", sc.intn(4))
+		}
+		specs = append(specs, DefFormSpec{
+			Head: head,
+			// -2..4: below, at and above the guard boundaries.
+			FormalsIndex: sc.intn(7) - 2,
+			BindsName:    sc.bit(),
+			NameIndex:    sc.intn(7) - 2,
+			NameKind:     SymbolKind(sc.intn(8)),
+		})
+	}
+	return specs
+}
+
+// groupByPackage turns a flat symbol list into the package-keyed maps
+// Config.PackageExports and Config.PackageSymbols expect.
+func groupByPackage(syms []ExternalSymbol) map[string][]ExternalSymbol {
+	m := map[string][]ExternalSymbol{}
+	for _, s := range syms {
+		m[s.Package] = append(m[s.Package], s)
+	}
+	return m
+}
+
+// analyzeResult is what one harness run reports back for the guard tests.
+type analyzeResult struct {
+	asked    int
+	expanded int
+	symbols  int
+	refs     int
+}
+
+// runAnalyze is the body of FuzzAnalyzeSource. It returns an error rather than
+// calling t.Fatalf so the guard tests can drive it too.
+func runAnalyze(src, wsSrc, scriptBytes []byte) (analyzeResult, error) {
+	var stats analyzeResult
+	sc := &script{b: scriptBytes}
+
+	env, err := newFuzzEnv(fuzzPreamble(wsSrc))
+	if err != nil {
+		return stats, fmt.Errorf("harness: %w", err)
+	}
+	exp := &countingExpander{inner: &EnvMacroExpander{Env: env}}
+	if sc.bit() {
+		// What an embedder does after loading more macros into a reused env.
+		// Also proves Reset does not clear the abort record.
+		exp.inner.Reset()
+	}
+
+	// The neighbouring file supplies the cross-file half of the config, the
+	// way a workspace scan would. ExtractFileDefinitions runs the same
+	// scanFileFull path the scanner uses.
+	wsDefs := ExtractFileDefinitions(wsSrc, fuzzWorkspaceFile)
+
+	// Parse the file under analysis fault-tolerantly, so malformed input still
+	// produces the partial and half-built ASTs the analyser has to survive.
+	// (AnalyzeFile, exercised below, takes the strict parser instead and
+	// returns nil on a parse error, so on its own it would never see them.)
+	res := rdparser.New(token.NewScanner(fuzzAnalysisFile, bytes.NewReader(src))).ParseProgramFaultTolerant()
+	exprs := res.Exprs
+	heads := headSymbols(exprs)
+
+	pkgExports := ExtractPackageExports(env.Runtime.Registry)
+	for pkg, syms := range groupByPackage(wsDefs) {
+		pkgExports[pkg] = append(pkgExports[pkg], syms...)
+	}
+
+	defaultPkg := ""
+	switch sc.intn(4) {
+	case 1:
+		defaultPkg = lisp.DefaultUserPackage
+	case 2:
+		defaultPkg = "demo"
+	case 3:
+		if len(wsDefs) > 0 {
+			defaultPkg = wsDefs[sc.intn(len(wsDefs))].Package
+		}
+	}
+
+	pkgImports := map[string][]string{}
+	if sc.bit() {
+		for _, s := range wsDefs {
+			pkgImports[s.Package] = appendUnique(pkgImports[s.Package], lisp.DefaultUserPackage, "demo")
+		}
+		pkgImports[lisp.DefaultUserPackage] = appendUnique(pkgImports[lisp.DefaultUserPackage], "demo")
+	}
+
+	cfg := &Config{
+		ExtraGlobals:   wsDefs,
+		PackageExports: pkgExports,
+		PackageSymbols: groupByPackage(wsDefs),
+		DefForms:       buildDefForms(sc, heads),
+		PackageImports: pkgImports,
+		DefaultPackage: defaultPkg,
+		Filename:       fuzzAnalysisFile,
+	}
+	if sc.intn(8) != 0 {
+		// Usually on -- 7 inputs in 8. This is the path that EVALUATES macro
+		// bodies and the one the ExpansionPanics assertion exists for, so it
+		// must not be a coin flip; the off case exists only to keep the
+		// no-expander branch of analyzeCall alive.
+		cfg.MacroExpander = exp
+	}
+
+	// Cross-file references, built from the neighbouring file the same way
+	// ScanWorkspaceRefs builds them.
+	if sc.bit() {
+		wsRes := Analyze(fuzzPreambleExprs(wsSrc), &Config{
+			ExtraGlobals:   wsDefs,
+			PackageExports: pkgExports,
+			Filename:       fuzzWorkspaceFile,
+		})
+		refs := ExtractFileRefs(wsRes, fuzzWorkspaceFile)
+		wsRefs := map[string][]FileReference{}
+		for _, r := range refs {
+			key := r.SymbolKey.String()
+			wsRefs[key] = append(wsRefs[key], r)
+		}
+		cfg.WorkspaceRefs = wsRefs
+	}
+
+	result := Analyze(exprs, cfg)
+	if result == nil {
+		return stats, errors.New("Analyze returned nil; it has a single return and always builds a Result")
+	}
+	if result.RootScope == nil {
+		return stats, errors.New("Analyze returned a Result with no RootScope")
+	}
+
+	// AnalyzeFile on the same bytes: a different entry point with its own
+	// config copy and the strict parser.
+	_ = AnalyzeFile(src, fuzzAnalysisFile, cfg)
+
+	stats.asked, stats.expanded = exp.asked, exp.expanded
+	stats.symbols, stats.refs = len(result.Symbols), len(result.References)
+
+	probeResult(sc, result, src)
+
+	// THE ASSERTION THIS TARGET EXISTS FOR. Reached through the exported
+	// PanicReporter interface, as an embedder would.
+	var reporter PanicReporter = exp
+	if n := reporter.ExpansionPanics(); n > 0 {
+		rec := exp.inner.LastExpansionPanic()
+		return stats, fmt.Errorf(
+			"EnvMacroExpander swallowed %d panic(s) during analysis-time macro expansion."+
+				" ExpandMacro's recover() returns nil, which is also the ordinary"+
+				" \"not a macro\" answer, so this is a Go panic in host code that no"+
+				" return value could have reported.\n  macro:   %s\n  package: %s\n"+
+				"  value:   %v\n  stack:\n%s",
+			n, rec.Macro, rec.Package, rec.Value, rec.GoStack)
+	}
+	return stats, nil
+}
+
+// fuzzPreambleExprs parses the neighbouring file in full (not just its
+// preamble) for the cross-file reference pass.
+func fuzzPreambleExprs(src []byte) []*lisp.LVal {
+	return rdparser.New(token.NewScanner(fuzzWorkspaceFile, bytes.NewReader(src))).
+		ParseProgramFaultTolerant().Exprs
+}
+
+// probeResult runs the position and lookup queries an embedder makes against a
+// Result. These have their own arithmetic over the scope tree and are exported
+// for callers that never touch the LSP.
+func probeResult(sc *script, result *Result, src []byte) {
+	lines := bytes.Split(src, []byte("\n"))
+	width := 1
+	for _, ln := range lines {
+		if len(ln) > width {
+			width = len(ln)
+		}
+	}
+
+	for range maxProbes {
+		var line, col int
+		switch sc.intn(4) {
+		case 0:
+			// Absurd but legal: an embedder converting from a 32-bit client
+			// position can hand these straight through.
+			line, col = 1<<20+int(sc.next()), 1<<20+int(sc.next())
+		case 1:
+			// Zero and negative: 1-based APIs called with 0-based values, the
+			// single most common embedder mistake.
+			line, col = sc.intn(3)-1, sc.intn(3)-1
+		case 2:
+			line, col = int(sc.next()), int(sc.next())
+		default:
+			// Mostly inside the document, so the queries resolve to real
+			// scopes and reach the interesting branches.
+			line = sc.intn(len(lines)+2) + 1
+			col = sc.intn(width+2) + 1
+		}
+
+		scope := ScopeAtPosition(result.RootScope, line, col)
+		_ = FindEnclosingFunction(result.RootScope, line, col)
+		if scope == nil {
+			continue
+		}
+		_ = scope.Kind.String()
+
+		name := ""
+		if len(result.Symbols) > 0 {
+			name = result.Symbols[sc.intn(len(result.Symbols))].Name
+		}
+		pkg := lisp.DefaultUserPackage
+		if len(result.ExtraGlobals) > 0 {
+			pkg = result.ExtraGlobals[sc.intn(len(result.ExtraGlobals))].Package
+		}
+		_ = scope.Lookup(name)
+		_ = scope.LookupLocal(name)
+		_ = scope.LookupAllLocal(name)
+		_ = scope.LookupInPackage(name, pkg)
+		_ = scope.LookupLocalInPackage(name, pkg)
+		_ = scope.LookupLocalVisible(name, pkg)
+	}
+
+	// Result consumers: everything a caller does with what it got back.
+	for _, ref := range ExtractFileRefs(result, fuzzAnalysisFile) {
+		_ = ref.SymbolKey.String()
+	}
+	for _, sym := range result.Symbols {
+		_ = SymbolToKey(sym).String()
+		_ = SymbolKeyFromNameKind(sym.Name, sym.Kind.String()).String()
+		if sym.Signature != nil {
+			_ = sym.Signature.MinArity()
+			_ = sym.Signature.MaxArity()
+		}
+	}
+	for _, u := range result.Unresolved {
+		_ = u.Name
+	}
+	if len(result.ExtraGlobals) > 0 {
+		_ = PreferredDefinition(result.ExtraGlobals)
+		dup := append([]ExternalSymbol(nil), result.ExtraGlobals...)
+		SortDefinitions(dup)
+		_ = FindExternalSymbol(groupByPackage(dup), dup[0].Package, dup[0].Name)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// seeds
+// ---------------------------------------------------------------------------
+
+// Real lisp, so analysis runs on well-formed input as well as on noise.
+const (
+	fuzzSeedDefs = `(in-package 'demo)
+(use-package 'lisp)
+(defun add (a b) "add two" (+ a b))
+(defmacro twice (x) (quasiquote (+ (unquote x) (unquote x))))
+(defmacro defthing (name args &rest body)
+  (quasiquote (defun (unquote name) (unquote args) (unquote-splicing body))))
+(defun caller (n) (add n (twice n)))
+(export 'add)
+(export 'twice)`
+
+	fuzzSeedUses = `(in-package 'user)
+(use-package 'demo)
+(defun main () (add 1 2))
+(defthing helper (x) (+ x 1))
+(let ([a 1] [b 2]) (+ a b))
+(labels ([f (x) (g x)] [g (x) x]) (f 1))`
+)
+
+// macroSeeds are the inputs whose whole job is to reach env.MacroCall: a macro
+// that is in the env (because the neighbouring file defined it and
+// LoadWorkspaceMacros replayed it) but unknown to the analyser. Nothing else
+// gets there. See countingExpander.
+var macroSeeds = [][2]string{
+	{"(in-package 'demo)\n(twice (twice 3))",
+		"(in-package 'demo)\n(defmacro twice (x) (quasiquote (+ (unquote x) (unquote x))))"},
+	// Expands to a call to itself; bounded by the env's macro-expansion depth.
+	{"(in-package 'demo)\n(loopy 1)",
+		"(in-package 'demo)\n(defmacro loopy (x) (quasiquote (loopy (unquote x))))"},
+	// Macro body raises a lisp error while being expanded during analysis.
+	{"(in-package 'demo)\n(boom 1)",
+		"(in-package 'demo)\n(defmacro boom (x) (error 'macro-boom \"x\"))"},
+	// Macro body loops; the env's step budget is what stops it.
+	{"(in-package 'demo)\n(spin 1)",
+		"(in-package 'demo)\n(defmacro spin (x) (foldl (lambda (a b) (+ a b)) 0 (range 0 1000000)))"},
+	// Macro expanding to a binding form, so the analyser resolves symbols the
+	// macro introduced rather than treating the call as opaque.
+	{"(in-package 'demo)\n(with-x 5 (+ x 1))",
+		"(in-package 'demo)\n(defmacro with-x (v &rest body) (quasiquote (let ([x (unquote v)]) (unquote-splicing body))))"},
+	// A preamble whose defmacro FAILS to evaluate. LoadWorkspaceMacros then
+	// takes its error branch and names the macro (preambleDefName), which no
+	// well-formed preamble reaches.
+	{"(in-package 'demo)\n(broken 1)",
+		"(in-package 'demo)\n(defmacro broken 1 2)\n(defmacro)\n(set)\n(use-package 'no-such-package)"},
+}
+
+// analyzeScripts are the seed configurations. Chosen to hit distinct Config
+// shapes rather than to be pretty: the first byte drives the DefForm count and
+// later bytes the flags. Package-level so the guard tests can drive the same
+// set the seeds use -- a guard that invents its own script proves nothing about
+// the corpus.
+var analyzeScripts = [][]byte{
+	{0, 0, 0, 0, 0, 0, 0, 0},
+	{4, 1, 2, 3, 1, 0, 1, 2, 3, 4, 1, 1, 0, 0, 1, 1},
+	{2, 3, 0, 1, 255, 254, 7, 9, 3, 3, 3, 3},
+	{1, 0, 3, 1, 1, 1, 1, 1, 2, 2, 2, 2, 128, 64, 32, 16},
+	{255, 255, 255, 255, 255, 255, 255, 255},
+}
+
+// FuzzAnalyzeSource analyses fuzzer-chosen source against a fuzzer-chosen
+// Config, with a neighbouring file supplying the cross-file symbols and the
+// macros that analysis-time expansion evaluates.
+//
+// Asserted, and only this:
+//
+//  1. No Go panic escapes Analyze, AnalyzeFile, or any of the result queries.
+//     Nothing recovers between them and the fuzz function, so this is an
+//     ordinary crash the engine attributes to its input.
+//  2. EnvMacroExpander did not swallow a panic (ExpansionPanics). This is the
+//     one that needs a marker, because that recover's nil is indistinguishable
+//     from the routine answer.
+//  3. Analyze returns a Result with a RootScope. It has a single return
+//     statement and always builds one, so a nil means control left another way.
+//  4. The run terminates (the watchdog). Interpreter budgets bound the macro
+//     bodies; nothing bounds a loop in the analyser itself.
+//
+// NOT asserted: that any symbol resolves, that Unresolved is empty, or that a
+// position query finds anything. Malformed source with nothing resolvable is
+// the normal case for a fuzzer and the right answer is an empty result.
+func FuzzAnalyzeSource(f *testing.F) {
+	add := func(src, ws string, sc []byte) { f.Add([]byte(src), []byte(ws), sc) }
+
+	scripts := analyzeScripts
+	for _, sc := range scripts {
+		add(fuzzSeedUses, fuzzSeedDefs, sc)
+		add(fuzzSeedDefs, fuzzSeedUses, sc)
+	}
+
+	for _, ms := range macroSeeds {
+		for _, sc := range scripts {
+			add(ms[0], ms[1], sc)
+		}
+	}
+
+	// Position-arithmetic shapes: no trailing newline, CRLF, a lone CR, tabs
+	// and multi-byte runes. ScopeAtPosition indexes by line and column, so a
+	// rune boundary is where that arithmetic goes wrong.
+	for _, src := range []string{
+		"", "\n\n\n", "(defun f (x) x)", "(defun f (x) x)\r\n(f 1)\r\n",
+		"(defun f (x) x)\r(f 1)", "(defun éèê (x) x)\n(éèê 1)",
+		"\t\t(defun f (x)\n\t\tx)", "(defun f (x", ";; only a comment",
+		"(deftype point (x y) x)", "(set 'g 1)\n(set! g 2)",
+		"(cond ((true) 1) (:else 2))", "(flet ([h (x) x]) (h 1))",
+		"(dotimes (i 3) i)", "(macrolet ([m (x) x]) (m 1))",
+		"(handler-bind ((condition (lambda (c) c))) (error 'x \"y\"))",
+		"(defun f (x) x) ; nolint:unused-variable",
+		"a:b\nfoo:bar\n:kw\n", "(lisp:car '(1 2))",
+		// One per remaining arm of analyzeSExpr's head switch. Every one of
+		// these was added because MEASUREMENT said the arm was at 0% from the
+		// seeds, not because reading the switch suggested it -- the same way
+		// #348 found its three silent harness bugs. The arms are keyed on exact
+		// head symbols, so a seed corpus without the literal spelling never
+		// enters them however much lisp it contains.
+		"(test \"name\" (assert true))",
+		"(test-let ([a 1]) a)",
+		"(test-let* ([a 1] [b a]) b)",
+		"(function car)",
+		"(qualified-symbol 'demo 'add)",
+		"(s:deftype \"my-type\" (or 'a 'b))",
+		"(expr (+ % 1))",
+		"(thread-first 1 (+ 2) (* 3))",
+		"(thread-last 1 (+ 2))",
+		"(defthing empty () 1)", // empty formals, for isEmptyFormals
+		"(let* ([a 1] [b a]) b)",
+	} {
+		add(src, fuzzSeedDefs, scripts[1])
+	}
+
+	// Parser-adversarial text: a fault-tolerant parse of these yields the
+	// partial and malformed ASTs the analyser then has to survive. Small by
+	// construction, so they do not throttle the generations descended from
+	// them. LispSources() is deliberately not used, for the same reason.
+	for _, seed := range fuzzseed.Adversarial() {
+		add(string(seed), fuzzSeedDefs, scripts[0])
+		add(fuzzSeedUses, string(seed), scripts[2])
+	}
+
+	f.Fuzz(func(t *testing.T, src, wsSrc, scriptBytes []byte) {
+		runAnalyzeBudgeted(t, src, wsSrc, scriptBytes)
+	})
+}
+
+// fatalf is the subset of *testing.T the budgeted runners use, so the guard
+// tests can pass something else.
+type fatalf interface {
+	Helper()
+	Fatalf(format string, args ...interface{})
+	Skipf(format string, args ...interface{})
+}
+
+// runAnalyzeBudgeted runs one analysis on its own goroutine under the
+// watchdog. A hang is a real possibility: the interpreter budgets bound macro
+// bodies, but nothing bounds a loop in the analyser itself.
+func runAnalyzeBudgeted(t fatalf, src, wsSrc, scriptBytes []byte) {
+	t.Helper()
+
+	type outcome struct {
+		err error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		_, err := runAnalyze(src, wsSrc, scriptBytes)
+		done <- outcome{err}
+	}()
+
+	budget := fuzzwatch.New(analysisWatchdogTimeout)
+	wait := budget.Total()
+	for {
+		select {
+		case o := <-done:
+			if o.err != nil {
+				t.Fatalf("%v\n--- src (%d bytes) ---\n%q\n--- workspace (%d bytes) ---\n%q"+
+					"\n--- script (%d bytes) ---\n%q",
+					o.err, len(src), src, len(wsSrc), wsSrc, len(scriptBytes), scriptBytes)
+			}
+			return
+		case <-time.After(wait):
+			verdict, more, report := budget.Check()
+			switch verdict {
+			case fuzzwatch.Continue:
+				wait = more
+			case fuzzwatch.Inconclusive:
+				t.Skipf("no verdict: the process was starved throughout (%s)", report)
+				return
+			default:
+				t.Fatalf("analysis did not terminate within %s of SCHEDULED time (%s)."+
+					" Macro bodies run under interpreter budgets, but nothing bounds a"+
+					" loop in the analyser itself"+
+					"\n--- src (%d bytes) ---\n%q\n--- workspace (%d bytes) ---\n%q"+
+					"\n--- script (%d bytes) ---\n%q",
+					budget.Total(), report, len(src), src, len(wsSrc), wsSrc,
+					len(scriptBytes), scriptBytes)
+				return
+			}
+		}
+	}
+}

--- a/analysis/expander.go
+++ b/analysis/expander.go
@@ -4,7 +4,9 @@ package analysis
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
+	"sync/atomic"
 
 	"github.com/luthersystems/elps/astutil"
 	"github.com/luthersystems/elps/lisp"
@@ -22,6 +24,53 @@ type MacroExpander interface {
 	ExpandMacro(form *lisp.LVal, pkg string) *lisp.LVal
 }
 
+// PanicReporter is implemented by a MacroExpander that recovers Go panics
+// internally and can report having done so.
+//
+// The problem it solves is that MacroExpander's contract makes a swallowed
+// panic INDISTINGUISHABLE from ordinary failure: an implementation that
+// recovers can only report that recovery by returning nil, and nil is also the
+// answer for "not a macro", "wrong arity" and "expansion errored" — the
+// overwhelmingly common cases. A caller that wants to know whether analysis-time
+// macro expansion crashed cannot learn it from the return value, ever.
+//
+// So the signal is carried out of band. Callers that need it (tests, fuzz
+// targets, an embedder that wants to log host-code bugs) should type-assert:
+//
+//	if pr, ok := cfg.MacroExpander.(analysis.PanicReporter); ok {
+//	        if n := pr.ExpansionPanics(); n > 0 { ... }
+//	}
+//
+// ExpansionPanics must be monotonic and must never be resettable through this
+// interface: a count that can go back down is a count that can be cleared by
+// the very code whose bugs it is recording.
+type PanicReporter interface {
+	// ExpansionPanics returns the number of ExpandMacro calls that did not
+	// complete normally over the lifetime of the expander.
+	ExpansionPanics() uint64
+}
+
+// ExpansionPanic describes one ExpandMacro call that did not complete.
+type ExpansionPanic struct {
+	// Value is what recover() returned at the aborted call. It is nil in the
+	// one case that is not a panic at all: runtime.Goexit unwinding through
+	// ExpandMacro (a macro body that reached t.Fatal, say). The abort is
+	// counted either way — see EnvMacroExpander.ExpansionPanics.
+	Value any
+
+	// GoStack is the Go stack captured inside the recover handler. That
+	// handler runs before the panic unwind completes, so the stack points at
+	// the panic site rather than at the handler — the same property
+	// lisp.(*LEnv).eval relies on when it fills CallStack.GoStack.
+	GoStack []byte
+
+	// Macro is the head symbol of the form being expanded and Package the
+	// package context it was expanded in, when they could be read. Both are
+	// best-effort diagnostics: the form itself may be what was malformed.
+	Macro   string
+	Package string
+}
+
 // EnvMacroExpander uses a live LEnv to expand user-defined macros.
 // Expansion errors and panics are caught — the analyzer falls back to
 // opaque analysis when ExpandMacro returns nil.
@@ -29,6 +78,9 @@ type MacroExpander interface {
 // Thread-safe: a mutex serializes expansion calls since MacroCall mutates
 // shared Runtime state (call stack, package pointer). The mutex is only
 // contended when multiple LSP handlers trigger concurrent analyses.
+//
+// A recovered panic is COUNTED as well as swallowed; see ExpansionPanics for
+// why the count exists and why nothing outside this file can fake it.
 type EnvMacroExpander struct {
 	Env *lisp.LEnv
 
@@ -38,14 +90,122 @@ type EnvMacroExpander struct {
 	// expander's lifetime. If macros are added to the env after creation
 	// (e.g. LoadWorkspaceMacros), create a new EnvMacroExpander or call
 	// Reset() to clear the cache.
+
+	// aborted counts ExpandMacro calls that left the function without
+	// reaching the statement after expand() returned. Monotonic, and there
+	// is deliberately no way to decrement or clear it.
+	aborted atomic.Uint64
+
+	lastMu    sync.Mutex
+	lastPanic *ExpansionPanic
 }
 
 // Reset clears the not-a-macro cache. Call this after loading new macros
 // into the env (e.g. via LoadWorkspaceMacros) if the expander is reused.
+//
+// Reset does NOT clear the abort count or the last recorded panic. Evidence
+// that host code crashed during analysis outlives a cache invalidation, and a
+// reset that wiped it would give the caller a way to lose the only record of a
+// swallowed panic.
 func (e *EnvMacroExpander) Reset() {
 	e.mu.Lock()
 	e.notMacro = nil
 	e.mu.Unlock()
+}
+
+// ExpansionPanics returns how many ExpandMacro calls on this expander did not
+// complete normally — a Go panic that the blanket recover swallowed, or a
+// runtime.Goexit that unwound through it.
+//
+// # Why this is here at all
+//
+// ExpandMacro's recover sets result = nil, and nil is ALSO the ordinary answer
+// for "that head symbol is not a macro" — by far the most common outcome, since
+// the analyzer consults the expander for every unknown head symbol in the file.
+// A panic in analysis-time macro expansion was therefore not merely unreported,
+// it was unreportABLE: no caller, and no test or fuzz target, could tell the
+// crash apart from the routine case. Merely opening a document runs this code
+// over attacker-chosen source (lsp/), and luthersystems/substrate reaches it
+// through lint/ as well, so the silent class is a real one.
+//
+// # Why the marker cannot be forged
+//
+// This is the same trick lisp.IsInternalPanic uses, and the same one the LSP
+// fuzz harness uses on buildWorkspaceIndex: key off something only the
+// non-panicking path can produce, rather than off a value the code under test
+// chose.
+//
+// The marker is `completed`, a bool local to ExpandMacro's own stack frame. It
+// is set by exactly one statement, placed immediately after the call to
+// expand() returns, so it runs if and only if control came back from expand
+// normally. A panic anywhere inside expand — including inside a macro BODY that
+// env.MacroCall evaluates — skips that statement, and the deferred handler
+// observes completed == false and counts the abort.
+//
+// Nothing reachable from lisp can touch a Go local. A macro cannot expand to a
+// value that sets it, an expansion result cannot be shaped to imitate it, and
+// an embedder cannot set it either: it does not exist outside the frame. The
+// counter it feeds is unexported, is only ever incremented, and the package
+// exports no way to lower it — deliberately, so that the code whose bugs it
+// records cannot clear its own record. That is the difference between this and
+// a `Panicked bool` field, which any holder of the expander could set to
+// either value at any time.
+//
+// The count is monotonic over the expander's lifetime, so callers that want a
+// per-operation answer should take a snapshot before and compare after.
+func (e *EnvMacroExpander) ExpansionPanics() uint64 {
+	return e.aborted.Load()
+}
+
+// LastExpansionPanic returns the most recently recorded abort, or nil if there
+// has been none. The returned value is a copy; the GoStack slice is shared and
+// must not be mutated.
+func (e *EnvMacroExpander) LastExpansionPanic() *ExpansionPanic {
+	e.lastMu.Lock()
+	defer e.lastMu.Unlock()
+	if e.lastPanic == nil {
+		return nil
+	}
+	cp := *e.lastPanic
+	return &cp
+}
+
+// recordAbort is called only from ExpandMacro's deferred handler, only when
+// that call failed to complete.
+func (e *EnvMacroExpander) recordAbort(r any, form *lisp.LVal, pkg string) {
+	e.aborted.Add(1)
+
+	// Captured here, in the deferred handler, so runtime.Stack still reflects
+	// the panic site: the unwind is not finished until this function returns.
+	buf := make([]byte, 16*1024)
+	n := runtime.Stack(buf, false)
+
+	rec := &ExpansionPanic{
+		Value:   r,
+		GoStack: buf[:n],
+		Macro:   safeHeadSymbol(form),
+		Package: pkg,
+	}
+	e.lastMu.Lock()
+	e.lastPanic = rec
+	e.lastMu.Unlock()
+}
+
+// safeHeadSymbol reads the head symbol of form without assuming form is
+// well-formed. It runs while recovering from a panic that a malformed form may
+// itself have caused, so a second panic here would replace the original with a
+// far less useful one.
+func safeHeadSymbol(form *lisp.LVal) (name string) {
+	defer func() {
+		if recover() != nil {
+			name = "<unreadable>"
+		}
+	}()
+	if form == nil || len(form.Cells) == 0 || form.Cells[0] == nil ||
+		form.Cells[0].Type != lisp.LSymbol {
+		return "<unknown>"
+	}
+	return form.Cells[0].Str
 }
 
 // ExpandMacro looks up the head symbol in the environment relative to
@@ -53,13 +213,41 @@ func (e *EnvMacroExpander) Reset() {
 // expand it. The env is temporarily switched to pkg so that unqualified
 // symbol resolution matches the file's package context — the same way
 // the runtime resolves symbols during eval.
+//
+// A recovered panic still yields nil — the analyzer's fallback to opaque macro
+// handling is the right behaviour and does not change — but it is now also
+// COUNTED, so the crash is observable even though the return value cannot carry
+// it. See ExpansionPanics.
 func (e *EnvMacroExpander) ExpandMacro(form *lisp.LVal, pkg string) (result *lisp.LVal) {
+	// completed is the non-forgeable marker. It lives in this frame and is set
+	// by exactly one statement, below, that only a normal return from expand
+	// can reach. Read ExpansionPanics before changing anything here: moving
+	// this assignment, or adding a return between expand() and it, breaks the
+	// only detector this package has for a swallowed panic.
+	completed := false
 	defer func() {
-		if r := recover(); r != nil {
-			result = nil
+		r := recover()
+		if completed {
+			return
 		}
+		// Control is leaving ExpandMacro without expand having returned. Either
+		// r != nil (a Go panic, which this recover has just swallowed) or
+		// r == nil (runtime.Goexit unwinding through here). Both are aborts and
+		// both are recorded; only the first is a panic.
+		e.recordAbort(r, form, pkg)
+		result = nil
 	}()
 
+	result = e.expand(form, pkg)
+	completed = true
+	return result
+}
+
+// expand is ExpandMacro's body. It is split out so that ExpandMacro's deferred
+// handler can distinguish "expand returned" from "control escaped expand",
+// which a single function with several return statements cannot do without a
+// flag at every one of them.
+func (e *EnvMacroExpander) expand(form *lisp.LVal, pkg string) *lisp.LVal {
 	if e.Env == nil || len(form.Cells) == 0 || form.Cells[0].Type != lisp.LSymbol {
 		return nil
 	}

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -541,3 +541,99 @@ func TestEnvMacroExpander_Reset_ClearsCache(t *testing.T) {
 	require.NotNil(t, expanded, "after Reset, newly-defined macro should expand")
 	assert.Equal(t, "if", expanded.Cells[0].Str)
 }
+
+// ---------------------------------------------------------------------------
+// Swallowed-panic detection
+//
+// ExpandMacro's blanket recover sets result = nil, which is ALSO the answer for
+// "not a macro" — the overwhelmingly common case. Before ExpansionPanics there
+// was no way for any caller, test or fuzz target to tell the two apart, so a
+// panic in analysis-time macro expansion was a silent class of defect. These
+// tests are the two halves of that claim: the detector fires on a real panic,
+// and it does not fire on anything a lisp program can arrange.
+// ---------------------------------------------------------------------------
+
+// TestExpandMacroPanicIsCounted drives a real nil-pointer dereference through
+// ExpandMacro's own code (a nil form reaches `len(form.Cells)`) rather than
+// through a test-only hook, and checks that the recover leaves a record.
+func TestExpandMacroPanicIsCounted(t *testing.T) {
+	env := newTestEnv(t)
+	expander := &EnvMacroExpander{Env: env}
+
+	require.Equal(t, uint64(0), expander.ExpansionPanics())
+	require.Nil(t, expander.LastExpansionPanic())
+
+	// A nil form panics inside ExpandMacro. Env is non-nil so the
+	// short-circuit in the guard does not save it.
+	result := expander.ExpandMacro(nil, "user")
+
+	assert.Nil(t, result, "a recovered panic must still yield the nil the analyzer expects")
+	assert.Equal(t, uint64(1), expander.ExpansionPanics(),
+		"the recovered panic was not counted; it is invisible again")
+
+	rec := expander.LastExpansionPanic()
+	require.NotNil(t, rec)
+	assert.NotNil(t, rec.Value, "recover() returned nil for a genuine panic?")
+	assert.Contains(t, string(rec.GoStack), "goroutine ",
+		"GoStack should be a runtime.Stack dump")
+	assert.Contains(t, string(rec.GoStack), "ExpandMacro",
+		"GoStack should have been captured before the unwind completed")
+	assert.Equal(t, "user", rec.Package)
+
+	// Monotonic, and Reset does not erase the evidence.
+	expander.Reset()
+	assert.Equal(t, uint64(1), expander.ExpansionPanics(),
+		"Reset cleared the abort count; the code being watched must not be able"+
+			" to clear its own record")
+}
+
+// TestExpandMacroNoPanicNotCounted is the false-positive half. Every one of
+// these returns nil, and none of them is a panic — if any bumped the counter
+// the signal would be useless, since nil is what ExpandMacro almost always
+// returns.
+func TestExpandMacroNoPanicNotCounted(t *testing.T) {
+	env := newTestEnv(t)
+	evalSource(t, env, `
+(defmacro good (x) (quasiquote (+ (unquote x) 1)))
+(defmacro boom (x) (error 'macro-boom "deliberate lisp-level error"))
+(defmacro deep (x) (quasiquote (deep (unquote x))))
+(defun notmac (x) x)`)
+
+	expander := &EnvMacroExpander{Env: env}
+
+	sexpr := func(cells ...*lisp.LVal) *lisp.LVal { return lisp.SExpr(cells) }
+
+	cases := []struct {
+		name string
+		form *lisp.LVal
+	}{
+		{"successful expansion", sexpr(lisp.Symbol("good"), lisp.Int(1))},
+		{"not a macro", sexpr(lisp.Symbol("notmac"), lisp.Int(1))},
+		{"unbound symbol", sexpr(lisp.Symbol("no-such-symbol-anywhere"), lisp.Int(1))},
+		{"head is not a symbol", sexpr(lisp.Int(1), lisp.Int(2))},
+		{"empty form", sexpr()},
+		{"macro body raises a lisp error", sexpr(lisp.Symbol("boom"), lisp.Int(1))},
+		{"macro expands to itself forever", sexpr(lisp.Symbol("deep"), lisp.Int(1))},
+		{"wrong arity", sexpr(lisp.Symbol("good"))},
+		{"too many args", sexpr(lisp.Symbol("good"), lisp.Int(1), lisp.Int(2), lisp.Int(3))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expander.ExpandMacro(tc.form, "user")
+		})
+	}
+
+	assert.Equal(t, uint64(0), expander.ExpansionPanics(),
+		"a lisp-reachable outcome was counted as a swallowed panic (last: %+v)",
+		expander.LastExpansionPanic())
+}
+
+// TestEnvMacroExpanderIsPanicReporter pins the optional interface, which is how
+// callers holding a MacroExpander (lint's LintConfig, the LSP's analysis.Config)
+// reach the count without knowing the concrete type.
+func TestEnvMacroExpanderIsPanicReporter(t *testing.T) {
+	var expander MacroExpander = &EnvMacroExpander{Env: newTestEnv(t)}
+	pr, ok := expander.(PanicReporter)
+	require.True(t, ok, "EnvMacroExpander must satisfy PanicReporter")
+	assert.Equal(t, uint64(0), pr.ExpansionPanics())
+}

--- a/analysis/workspace_fuzz_test.go
+++ b/analysis/workspace_fuzz_test.go
@@ -1,0 +1,412 @@
+// Copyright © 2026 The ELPS authors
+
+package analysis
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/internal/fuzzseed"
+	"github.com/luthersystems/elps/internal/fuzzwatch"
+)
+
+// Fuzzing the WORKSPACE SCANNER: the half of analysis/ that reads a directory
+// tree off disk.
+//
+// # Why this is separate from FuzzAnalyzeSource
+//
+// workspace.go is 1221 of this package's lines and roughly half its functions,
+// and none of it is reachable without real files. FuzzLSPSession cannot reach
+// any of it -- it initializes with RootURI and RootPath unset precisely so that
+// a fuzz target does not walk the machine it is running on, and says so. From
+// the LSP seed corpus every one of PrescanWorkspace, ScanWorkspaceRefs,
+// scanFileFull, buildLoadTree, walkLoadFile, collectLispFilesWithConfig,
+// extractDefFormSpecs and the six ScanWorkspace* entry points measured 0%.
+//
+// They are not obscure. lint.BuildAnalysisConfig calls PrescanWorkspace and
+// ScanWorkspaceRefs on every `elps lint --workspace` run, the LSP calls them on
+// every editor session that has a root, and luthersystems/substrate imports
+// this package directly. The input is a checkout, which is to say: whatever
+// source someone asked the tool to look at.
+//
+// # Containment, which is the whole design problem here
+//
+// A scanner that follows references between files is a file-read primitive if
+// the fuzzer controls where it points. walkLoadFile is exactly that: it reads a
+// file, finds `(load-file "...")`, joins the string to the file's directory and
+// RECURSES. `filepath.Join(dir, "../../../etc/passwd")` escapes the workspace,
+// and the recursion means one escape in one file is enough.
+//
+// So the harness draws a line that the fuzzer cannot cross:
+//
+//	the TREE SHAPE is the harness's        every path, every filename and every
+//	                                       directory is a fixed constant below;
+//	                                       nothing the fuzzer produces is ever
+//	                                       used as a path.
+//
+//	the FILE CONTENTS are the fuzzer's     with one substitution: `load-file` is
+//	                                       rewritten to `load-filx` in every
+//	                                       fuzzer-derived file (same length, so
+//	                                       every token.Location is unchanged).
+//	                                       After that no fuzzer-derived file can
+//	                                       introduce a load edge at all.
+//
+//	the LOAD GRAPH is the harness's        main.lisp gets harness-written
+//	                                       load-file forms, selected by the
+//	                                       fuzzer from a fixed table: a real
+//	                                       file, a file in a subdirectory, a
+//	                                       missing file, and main.lisp itself
+//	                                       (the cycle that tests walkLoadFile's
+//	                                       `visited` guard). Every target is
+//	                                       inside the temp root.
+//
+// The result is that walkLoadFile is fully exercised -- recursion, cycles,
+// missing files, package inheritance through the tree -- while the set of
+// files it can possibly open is a fixed, four-element list under t.TempDir().
+// Stripping one token is a smaller cost than the alternative, which is what
+// FuzzLSPSession had to do: not fuzz this code at all.
+//
+// # What the fuzzer does get to steer
+//
+// ScanConfig is attacker-adjacent in its own right: Excludes and IncludeDirs
+// come from a config file or CLI flags in production, and Excludes are
+// filepath.Match patterns, where a malformed pattern (`[`) returns
+// ErrBadPattern and MatchesExclude discards the error. MaxFiles and
+// MaxFileBytes decide whether a scan is truncated, and Truncated is a
+// user-visible warning in the LSP.
+const (
+	// The tree. Fixed, and the only paths this target can ever touch.
+	wsMainFile   = "main.lisp"
+	wsPlainFile  = "plain.lisp"
+	wsSubFile    = "sub/nested.lisp"
+	wsSkipFile   = "_skipped/hidden.lisp" // under a ShouldSkipDir directory
+	wsDotFile    = ".dot/dotted.lisp"     // under a hidden directory
+	wsNonLisp    = "notes.txt"            // wrong extension, never collected
+	wsMissingRef = "absent.lisp"          // referenced by main, never created
+
+	wsWatchdogTimeout = 30 * time.Second
+
+	// Cap on total bytes written per input. A scan is O(bytes) across several
+	// passes, so an unbounded corpus entry would spend the deadline in I/O.
+	wsMaxFileBytes = 64 << 10
+)
+
+// loadFileToken is neutralised in every fuzzer-derived file. The replacement is
+// the SAME LENGTH, so byte offsets, line lengths and every token.Location the
+// scanner computes are identical to what the original bytes would have
+// produced -- the substitution removes an edge from the load graph and changes
+// nothing else.
+var (
+	loadFileToken = []byte("load-file")
+	loadFileSafe  = []byte("load-filx")
+)
+
+func neutraliseLoadFile(src []byte) []byte {
+	return bytes.ReplaceAll(src, loadFileToken, loadFileSafe)
+}
+
+// wsLoadTargets is the fixed set of load-file arguments main.lisp may be given.
+// Every entry resolves inside the temp root; the last two are the missing-file
+// and self-cycle cases.
+var wsLoadTargets = []string{wsPlainFile, wsSubFile, wsMissingRef, wsMainFile}
+
+// wsFileByteLimits straddle the sizes the harness actually writes, so that the
+// skip-oversize branch is reachable without being universal.
+var wsFileByteLimits = []int64{0, 0, 0, 16, 256, 4096, 1 << 20}
+
+// wsExcludePatterns are the fixed exclude patterns, including two that
+// filepath.Match rejects outright.
+var wsExcludePatterns = []string{
+	"*.lisp", "plain.lisp", "sub", "_*", "*", "[", "a[b", "**/*.lisp", "",
+}
+
+// writeWorkspace materialises the tree under root and returns the root.
+func writeWorkspace(root string, sc *script, a, b []byte) error {
+	if len(a) > wsMaxFileBytes {
+		a = a[:wsMaxFileBytes]
+	}
+	if len(b) > wsMaxFileBytes {
+		b = b[:wsMaxFileBytes]
+	}
+
+	// main.lisp: fuzzer-derived content (load-file neutralised) followed by
+	// harness-written load edges the fuzzer only gets to SELECT.
+	var main bytes.Buffer
+	main.Write(neutraliseLoadFile(a))
+	main.WriteByte('\n')
+	if sc.bit() {
+		main.WriteString("(in-package 'wsdemo)\n")
+	}
+	for range sc.intn(len(wsLoadTargets) + 1) {
+		fmt.Fprintf(&main, "(load-file %q)\n", wsLoadTargets[sc.intn(len(wsLoadTargets))])
+	}
+
+	files := map[string][]byte{
+		wsPlainFile: neutraliseLoadFile(b),
+		wsSubFile:   neutraliseLoadFile(a),
+		wsSkipFile:  neutraliseLoadFile(b),
+		wsDotFile:   neutraliseLoadFile(a),
+		wsNonLisp:   neutraliseLoadFile(b),
+	}
+	if sc.bit() {
+		files[wsMainFile] = main.Bytes()
+	}
+
+	for name, content := range files {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+			return err
+		}
+		if err := os.WriteFile(path, content, 0o600); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// buildScanConfig draws a ScanConfig from the script.
+func buildScanConfig(sc *script) *ScanConfig {
+	if sc.intn(8) == 0 {
+		// nil is a supported argument -- every effective* accessor has a nil
+		// receiver branch, and the four-arg ScanWorkspace* wrappers pass nil.
+		return nil
+	}
+	cfg := &ScanConfig{
+		// 0 means "use the default"; small values make Truncated reachable.
+		MaxFiles: sc.intn(5),
+		// Drawn from a table rather than computed, because the first version
+		// of this line was `intn(4) * 16` and every value it could produce was
+		// smaller than every file the harness writes. The scan collected ZERO
+		// files, every seed passed, and all of workspace.go past
+		// collectLispFilesWithConfig sat at 0% -- caught by
+		// TestWorkspaceFuzzSeedsCollectFiles, not by reading. The entries now
+		// straddle the sizes actually written: 0 (default), tiny (everything
+		// skipped), around the seed size (some skipped), and large.
+		MaxFileBytes: wsFileByteLimits[sc.intn(len(wsFileByteLimits))],
+	}
+	for range sc.intn(3) {
+		cfg.Excludes = append(cfg.Excludes, wsExcludePatterns[sc.intn(len(wsExcludePatterns))])
+	}
+	for _, dir := range []string{"_skipped", ".dot", "sub"} {
+		if sc.bit() {
+			cfg.IncludeDirs = append(cfg.IncludeDirs, dir)
+		}
+	}
+	return cfg
+}
+
+// scanStats is what one workspace run reports back, for the guard tests.
+type scanStats struct {
+	files     int
+	defs      int
+	preamble  int
+	defForms  int
+	refKeys   int
+	truncated bool
+}
+
+func runWorkspaceScan(root string, a, b, scriptBytes []byte) (scanStats, error) {
+	var stats scanStats
+	sc := &script{b: scriptBytes}
+
+	if err := writeWorkspace(root, sc, a, b); err != nil {
+		return stats, fmt.Errorf("harness: writing workspace: %w", err)
+	}
+	scanCfg := buildScanConfig(sc)
+
+	prescan, err := PrescanWorkspace(root, scanCfg)
+	if err != nil {
+		// A walk error is a legitimate outcome, not a finding: the scanner is
+		// meant to report an unreadable tree rather than panic on one.
+		return stats, nil //nolint:nilerr // an error return here is the code under test behaving
+	}
+	if prescan == nil {
+		return stats, errors.New("PrescanWorkspace returned (nil, nil);" +
+			" it has a single success return and always builds a WorkspacePrescan")
+	}
+	stats.files = len(prescan.Files)
+	stats.defs = len(prescan.AllDefs)
+	stats.preamble = len(prescan.Preamble)
+	stats.defForms = len(prescan.DefForms)
+	stats.truncated = prescan.Truncated
+
+	// Every file the scan reports must be one the harness wrote. This is the
+	// containment claim as an ASSERTION rather than as a comment: if a future
+	// change to the scanner (or to this harness) let a fuzzer-derived string
+	// become a path, the escape shows up here rather than in someone's logs.
+	for _, p := range prescan.Files {
+		rel, relErr := filepath.Rel(root, p)
+		if relErr != nil || rel == ".." || bytes.HasPrefix([]byte(rel), []byte(".."+string(filepath.Separator))) {
+			return stats, fmt.Errorf("scan collected a path outside the workspace root: %q (root %q)", p, root)
+		}
+	}
+
+	// The remaining entry points, all of which are exported and used by
+	// different callers (the CLI, the LSP, substrate).
+	_, _ = ScanWorkspace(root)
+	_, _ = ScanWorkspacePackages(root)
+	_, _ = ScanWorkspaceDefinitions(root)
+	_, _, _ = ScanWorkspaceFull(root)
+	_, _, _, _ = ScanWorkspaceAll(root)
+	_, _, _, _, _ = ScanWorkspaceAllWithConfig(root, scanCfg)
+
+	// The config a workspace-aware caller builds out of a prescan, then the
+	// cross-file reference scan that reads every file again through
+	// AnalyzeFile.
+	env, err := newFuzzEnv(prescan.Preamble)
+	if err != nil {
+		return stats, fmt.Errorf("harness: %w", err)
+	}
+	exp := &countingExpander{inner: &EnvMacroExpander{Env: env}}
+	cfg := &Config{
+		ExtraGlobals:   prescan.AllDefs,
+		PackageExports: prescan.PkgExports,
+		PackageSymbols: prescan.PkgAllSymbols,
+		DefForms:       prescan.DefForms,
+		PackageImports: prescan.PackageImports,
+		DefaultPackage: prescan.DefaultPackage,
+		MacroExpander:  exp,
+	}
+	refs := ScanWorkspaceRefs(root, cfg, scanCfg)
+	stats.refKeys = len(refs)
+
+	// Path helpers, on the paths the scan produced rather than on invented
+	// strings. absent.lisp is included on purpose: NormalizePath has a whole
+	// fallback for a path that does not exist, and every path a successful scan
+	// returns does exist, so nothing else reaches it. A load-file naming a
+	// missing file is how production gets there.
+	_ = NormalizePath(filepath.Join(root, wsMissingRef))
+	_ = NormalizePath(filepath.Join(root, wsMissingRef, "deeper", "still"))
+	for _, p := range prescan.Files {
+		_ = NormalizePath(p)
+		_ = MatchesExclude(p, wsExcludePatterns)
+		_ = ShouldSkipDir(filepath.Base(filepath.Dir(p)))
+		_ = ExtractFileDefinitions([]byte(filepath.Base(p)), p)
+	}
+
+	if n := exp.ExpansionPanics(); n > 0 {
+		rec := exp.inner.LastExpansionPanic()
+		return stats, fmt.Errorf(
+			"EnvMacroExpander swallowed %d panic(s) during the workspace scan"+
+				"\n  macro:   %s\n  package: %s\n  value:   %v\n  stack:\n%s",
+			n, rec.Macro, rec.Package, rec.Value, rec.GoStack)
+	}
+	return stats, nil
+}
+
+// FuzzWorkspaceScan scans a fuzzer-written .lisp tree with a fuzzer-chosen
+// ScanConfig.
+//
+// Asserted, and only this:
+//
+//  1. No Go panic escapes the scan or the reference pass. Nothing recovers
+//     between them and the fuzz function.
+//  2. PrescanWorkspace never returns (nil, nil).
+//  3. Every collected path is inside the temp root -- the containment
+//     invariant, asserted rather than assumed.
+//  4. The macro expander swallowed no panic (ExpansionPanics).
+//  5. The scan terminates (the watchdog). walkLoadFile is recursive over a
+//     graph the load edges describe, and `visited` is the only thing stopping
+//     a cycle.
+//
+// NOT asserted: which files are collected, how many definitions are found, or
+// that anything resolves. A tree of garbage yielding nothing is correct.
+func FuzzWorkspaceScan(f *testing.F) {
+	add := func(a, b string, sc []byte) { f.Add([]byte(a), []byte(b), sc) }
+
+	scripts := [][]byte{
+		{0, 0, 0, 0, 0, 0, 0, 0},
+		{1, 3, 1, 2, 0, 1, 1, 0, 1, 0, 1, 1, 1},
+		{1, 4, 3, 3, 2, 5, 6, 1, 1, 1, 0, 0, 2, 2},
+		{1, 2, 1, 1, 3, 1, 2, 3, 4, 5, 6, 7, 8},
+		{255, 255, 255, 255, 255, 255, 255, 255},
+		{1, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // MaxFiles small -> Truncated
+	}
+
+	const defs = `(in-package 'wsdemo)
+(use-package 'lisp)
+(defun add (a b) "add two" (+ a b))
+(defmacro defthing (name args &rest body)
+  (quasiquote (defun (unquote name) (unquote args) (unquote-splicing body))))
+(deftype point (x y) x)
+(set 'answer 42)
+(export 'add)
+(export 'defthing)`
+
+	const uses = `(in-package 'user)
+(use-package 'wsdemo)
+(defun main () (add 1 2))
+(defthing helper (x) (+ x 1))`
+
+	for _, sc := range scripts {
+		add(defs, uses, sc)
+		add(uses, defs, sc)
+		add("", "", sc)
+	}
+
+	// A bare file (no in-package) is what makes the load tree load-bearing:
+	// its package is inherited through main.lisp's load edges, which is the
+	// only thing buildLoadTree exists for.
+	add("(defun bare () 1)", defs, scripts[1])
+	add(defs, "(defun bare () 1)\n(bare)", scripts[1])
+
+	// The token the harness strips, present in the input, so the neutralising
+	// substitution itself is on the seeded path.
+	add("(load-file \"../../../etc/passwd\")\n(defun f () 1)", defs, scripts[1])
+
+	for _, seed := range fuzzseed.Adversarial() {
+		add(string(seed), defs, scripts[0])
+		add(defs, string(seed), scripts[2])
+	}
+
+	f.Fuzz(func(t *testing.T, a, b, scriptBytes []byte) {
+		runWorkspaceScanBudgeted(t, t.TempDir(), a, b, scriptBytes)
+	})
+}
+
+func runWorkspaceScanBudgeted(t fatalf, root string, a, b, scriptBytes []byte) {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := runWorkspaceScan(root, a, b, scriptBytes)
+		done <- err
+	}()
+
+	budget := fuzzwatch.New(wsWatchdogTimeout)
+	wait := budget.Total()
+	for {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("%v\n--- a (%d bytes) ---\n%q\n--- b (%d bytes) ---\n%q"+
+					"\n--- script (%d bytes) ---\n%q",
+					err, len(a), a, len(b), b, len(scriptBytes), scriptBytes)
+			}
+			return
+		case <-time.After(wait):
+			verdict, more, report := budget.Check()
+			switch verdict {
+			case fuzzwatch.Continue:
+				wait = more
+			case fuzzwatch.Inconclusive:
+				t.Skipf("no verdict: the process was starved throughout (%s)", report)
+				return
+			default:
+				t.Fatalf("the workspace scan did not terminate within %s of SCHEDULED"+
+					" time (%s). walkLoadFile recurses over the load graph and only"+
+					" `visited` bounds it"+
+					"\n--- a (%d bytes) ---\n%q\n--- b (%d bytes) ---\n%q"+
+					"\n--- script (%d bytes) ---\n%q",
+					budget.Total(), report, len(a), a, len(b), b,
+					len(scriptBytes), scriptBytes)
+				return
+			}
+		}
+	}
+}

--- a/lint/lint_fuzz_guard_test.go
+++ b/lint/lint_fuzz_guard_test.go
@@ -1,0 +1,127 @@
+// Copyright © 2026 The ELPS authors
+
+package lint
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/rdparser"
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Guards for FuzzLintSource.
+//
+// PR #348 found three harness bugs by measuring per-function coverage from the
+// seed corpus, in each case where every operation "ran", every test passed, and
+// whole functions sat at 0%. A fuzz target cannot report that it is covering
+// less than it thinks, so the reachability claims in the harness comments are
+// asserted here instead.
+
+// TestLintFuzzSeedsProduceDiagnostics checks the primary seeds actually make
+// the analyzers FIRE. A corpus that lints clean exercises each analyzer's walk
+// and none of its reporting, which is most of the interesting code -- and it
+// would pass every test while doing so.
+func TestLintFuzzSeedsProduceDiagnostics(t *testing.T) {
+	stats, err := runLint(t.TempDir(), []byte(lintSeedUses), []byte(lintSeedDefs), lintScripts[0])
+	require.NoError(t, err)
+	assert.Positive(t, stats.analyzers, "buildLinter produced a Linter with no analyzers")
+	assert.Positive(t, stats.syntactic,
+		"the primary seed produced no syntactic diagnostics, so the reporting half of"+
+			" every analyzer is unreached")
+	assert.Positive(t, stats.semantic,
+		"the primary seed produced no semantic diagnostics, so the analyzers that"+
+			" require an analysis.Result never report")
+	assert.Positive(t, stats.workspace,
+		"LintFiles over the temp workspace produced nothing, so BuildAnalysisConfig's"+
+			" output is never actually used")
+}
+
+// TestLintFuzzSeedsCoverEveryAnalyzer checks the corpus is not quietly linting
+// against a one-analyzer Linter.
+//
+// buildLinter draws a SUBSET from the script, and a script whose bytes happen
+// to clear every bit yields all[:1]. That is a legitimate configuration, but if
+// no seed ever ran the full set, most of analyzers.go would be unreached from
+// the corpus while the target still looked healthy.
+func TestLintFuzzSeedsCoverEveryAnalyzer(t *testing.T) {
+	want := len(DefaultAnalyzers())
+	require.Greater(t, want, 1, "DefaultAnalyzers is degenerate")
+
+	best := 0
+	for i, sc := range lintScripts {
+		stats, err := runLint(t.TempDir(), []byte(lintSeedUses), []byte(lintSeedDefs), sc)
+		require.NoError(t, err, "lintScripts[%d] failed", i)
+		if stats.analyzers > best {
+			best = stats.analyzers
+		}
+	}
+	assert.GreaterOrEqual(t, best, want,
+		"no seed script ran the full analyzer set (best was %d of %d), so most of"+
+			" analyzers.go is unreachable from the seed corpus", best, want)
+}
+
+// TestLintFuzzEmbedderAnalyzerReports checks the embedder-registered analyzer
+// actually reports through every Pass method.
+//
+// Pass.ReportNode and Pass.ReportWithNotes have NO caller anywhere in this
+// repository -- they exist for embedders such as luthersystems/substrate. That
+// makes them exactly the kind of exported function a target can leave at 0%
+// while reporting a healthy overall number, so the harness registers an
+// analyzer that uses them and this test asserts the registration works.
+func TestLintFuzzEmbedderAnalyzerReports(t *testing.T) {
+	a := embedderAnalyzer(&script{b: []byte{1, 1, 1, 1}})
+	pass := &Pass{
+		Analyzer: a,
+		Filename: lintFileA,
+		Exprs:    parseForGuard(t, "(defun f (x) (+ x 1))\n(f 1)"),
+	}
+	require.NoError(t, a.Run(pass))
+	require.NotEmpty(t, pass.diagnostics,
+		"the embedder analyzer reported nothing, so ReportNode and ReportWithNotes"+
+			" stay at 0% however long the sweep runs")
+
+	seen := map[string]bool{}
+	for _, d := range pass.diagnostics {
+		for _, m := range []string{msgReport, msgReportWithNotes, msgReportNode, msgReportf} {
+			if strings.HasPrefix(d.Message, m) {
+				seen[m] = true
+			}
+		}
+		assert.Equal(t, "fuzz-embedder", d.Analyzer,
+			"Report* must stamp the analyzer name onto every diagnostic")
+		assert.NotEqual(t, severityUnset, d.Severity,
+			"Report* must fill an unset severity from the analyzer default")
+	}
+	for _, m := range []string{msgReport, msgReportWithNotes, msgReportNode, msgReportf} {
+		assert.True(t, seen[m],
+			"no diagnostic came from %q, so that Pass method stays at 0%% however"+
+				" long the sweep runs", m)
+	}
+}
+
+// TestLintFuzzDeterminismCheckIsLive guards the determinism assertion itself:
+// if runLint ever stopped calling LintFile twice, the check would pass
+// vacuously and the property would silently stop being tested.
+func TestLintFuzzDeterminismCheckIsLive(t *testing.T) {
+	linter := &Linter{Analyzers: DefaultAnalyzers()}
+	src := []byte(lintSeedUses)
+	first, err := linter.LintFile(src, lintFileA)
+	require.NoError(t, err)
+	require.NotEmpty(t, first,
+		"the determinism check compares two empty slices unless the seed produces"+
+			" diagnostics")
+	second, err := linter.LintFile(src, lintFileA)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+}
+
+func parseForGuard(t *testing.T, src string) []*lisp.LVal {
+	t.Helper()
+	return rdparser.New(token.NewScanner(lintFileA, bytes.NewReader([]byte(src)))).
+		ParseProgramFaultTolerant().Exprs
+}

--- a/lint/lint_fuzz_test.go
+++ b/lint/lint_fuzz_test.go
@@ -315,9 +315,10 @@ func runLint(root string, src, wsSrc, scriptBytes []byte) (lintStats, error) {
 	exp := &analysis.EnvMacroExpander{Env: env}
 
 	wsDefs := analysis.ExtractFileDefinitions(wsSrc, lintFileB)
+	stdlibExports := analysis.ExtractPackageExports(env.Runtime.Registry)
 	acfg := &analysis.Config{
 		ExtraGlobals:   wsDefs,
-		PackageExports: analysis.ExtractPackageExports(env.Runtime.Registry),
+		PackageExports: stdlibExports,
 		PackageSymbols: groupByPackage(wsDefs),
 		MacroExpander:  exp,
 	}
@@ -372,7 +373,7 @@ func runLint(root string, src, wsSrc, scriptBytes []byte) (lintStats, error) {
 	if sc.bit() {
 		// Skips defaultStdlibExports' fresh env boot, which is the reason the
 		// field exists.
-		lcfg.StdlibExports = analysis.ExtractPackageExports(env.Runtime.Registry)
+		lcfg.StdlibExports = stdlibExports
 	}
 
 	files := []string{pathA, pathB}[:1+sc.intn(2)]
@@ -383,8 +384,16 @@ func runLint(root string, src, wsSrc, scriptBytes []byte) (lintStats, error) {
 			return stats, err
 		}
 	}
-	if _, err := BuildAnalysisConfig(lcfg); err != nil {
-		_ = err // a workspace that cannot be scanned is a legitimate outcome
+	// The CLI's stdin path calls BuildAnalysisConfig directly rather than
+	// through LintFiles. Only occasionally: LintFiles has already called it
+	// once, and a second call re-walks the workspace and re-runs
+	// ScanWorkspaceRefs over every file. Measured on the first campaign, that
+	// doubled cost put this target at ~65 exec/sec against FuzzAnalyzeSource's
+	// ~280, and the second call reaches no branch the first did not.
+	if sc.intn(4) == 0 {
+		if _, err := BuildAnalysisConfig(lcfg); err != nil {
+			_ = err // a workspace that cannot be scanned is a legitimate outcome
+		}
 	}
 
 	// --- output, severity and the AST helpers -------------------------------

--- a/lint/lint_fuzz_test.go
+++ b/lint/lint_fuzz_test.go
@@ -1,0 +1,706 @@
+// Copyright © 2026 The ELPS authors
+
+package lint
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/analysis"
+	"github.com/luthersystems/elps/internal/fuzzseed"
+	"github.com/luthersystems/elps/internal/fuzzwatch"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser/rdparser"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// Fuzzing the LINTER on its own API, rather than through the language server.
+//
+// # Why a dedicated target, when FuzzLSPSession already reaches this package
+//
+// Issue #318 lists lint/ as unfuzzed. FuzzLSPSession (PR #348) reaches it
+// transitively -- didOpen runs every registered analyzer synchronously -- and
+// measured 38.7% mean per-function coverage of this package from its seed
+// corpus. What that path does NOT reach is most of the package's public
+// surface, and the gap is not incidental:
+//
+//   - THE LSP RUNS ONE FIXED ANALYZER SET. It builds a Linter from
+//     DefaultAnalyzers() and never narrows it. But `elps lint --checks=a,b`
+//     does, and narrowing turns on a whole block of logic in
+//     LintFileWithContext: `narrowedRun`, the conditional staleness rules that
+//     govern suppression directives, and the unknown-analyzer message. From
+//     the LSP seeds that block is dead code.
+//
+//   - THE LSP NEVER CALLS THE CLI ENTRY POINTS. LintFiles, BuildAnalysisConfig
+//     and defaultStdlibExports measured 0%, as did every output and severity
+//     function -- FormatText, FormatJSON, ParseSeverity, MaxSeverity,
+//     ShouldFail, Severity.MarshalJSON/UnmarshalJSON. Those decide the exit
+//     code of `elps lint` and the bytes a CI job parses.
+//
+//   - luthersystems/substrate IMPORTS THIS PACKAGE DIRECTLY. The linter runs
+//     over customer-supplied phylum source, not only over a file someone opened
+//     in an editor.
+//
+// # The assertions
+//
+// Panics are the primary one and need no marker: nothing recovers between an
+// analyzer's Run and the fuzz function. Two more are worth the cost.
+//
+// SERIALISABILITY. Diagnostics are on their way out as JSON -- `elps lint
+// --format=json` is what a CI job reads, and the LSP converts the same structs
+// into protocol.Diagnostic. A diagnostic that cannot be marshalled is a broken
+// run reported as a clean one, so FormatJSON's error is checked rather than
+// discarded.
+//
+// DETERMINISM. LintFileWithContext builds its unused-nolint diagnostics by
+// RANGING OVER A MAP (nolintMap) and then sorts the combined slice with
+// sort.Slice -- which is not stable -- on (file, line) alone. Two diagnostics
+// on one line therefore have no defined order. Linting the same bytes twice and
+// comparing is a cheap, honest test of a property the CLI's output contract
+// depends on, and it is exactly the sort of thing no unit test with a
+// hand-written fixture would notice.
+const (
+	// Budgets for the injected LEnv, from FuzzLSPSession. LintFileWithAnalysis
+	// runs semantic analysis, which with a MacroExpander set EVALUATES macro
+	// bodies loaded from the workspace.
+	lintEnvMaxSteps          = 200_000
+	lintEnvMaxTailIterations = 10_000
+	lintEnvMaxPhysHeight     = 2_000
+	lintEnvMaxAlloc          = 1_000_000
+	lintEnvMacroDepth        = 100
+	lintEnvMaxEvalNesting    = 20_000
+
+	// Fixed names. Never fuzzer-derived: filenames reach os.ReadFile in
+	// LintFiles, and a fuzzer-chosen path there is a file-read primitive
+	// pointed at the machine running the tests.
+	lintFileA = "fuzz-a.lisp"
+	lintFileB = "fuzz-b.lisp"
+
+	// Cap on bytes written into the temp workspace per input.
+	lintMaxFileBytes = 64 << 10
+
+	lintWatchdogTimeout = 30 * time.Second
+)
+
+// discardWriter drops everything a macro body prints during analysis.
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// script reads the fuzzer's third input as a byte stream, so one input always
+// produces one configuration.
+type script struct {
+	b []byte
+	i int
+}
+
+func (s *script) next() byte {
+	if len(s.b) == 0 {
+		return 0
+	}
+	v := s.b[s.i%len(s.b)]
+	s.i++
+	return v
+}
+
+func (s *script) intn(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	return int(s.next()) % n
+}
+
+func (s *script) bit() bool { return s.next()&1 == 1 }
+
+// newLintEnv builds the environment semantic analysis expands macros in.
+// Runtime.Library stays nil so load-file cannot reach the disk.
+func newLintEnv() (*lisp.LEnv, error) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = rdparser.NewReader()
+	if rc := lisp.InitializeUserEnv(env,
+		lisp.WithStderr(discardWriter{}),
+		lisp.WithMaxSteps(lintEnvMaxSteps),
+		lisp.WithMaxTailIterations(lintEnvMaxTailIterations),
+		lisp.WithMaximumPhysicalStackHeight(lintEnvMaxPhysHeight),
+		lisp.WithMaxAlloc(lintEnvMaxAlloc),
+		lisp.WithMaxMacroExpansionDepth(lintEnvMacroDepth),
+		lisp.WithMaxEvalNesting(lintEnvMaxEvalNesting),
+	); rc.Type == lisp.LError {
+		return nil, fmt.Errorf("InitializeUserEnv: %v", rc)
+	}
+	if rc := lisplib.LoadLibrary(env); rc.Type == lisp.LError {
+		return nil, fmt.Errorf("LoadLibrary: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		return nil, fmt.Errorf("InPackage: %v", rc)
+	}
+	return env, nil
+}
+
+// buildLinter draws an analyzer subset from the script.
+//
+// The subset is the point: `elps lint --checks=...` narrows the set, and
+// narrowing is what turns on LintFileWithContext's `narrowedRun` branch and the
+// conditional nolint-staleness rules. The full set and the empty set are both
+// reachable (an empty --checks is a user error the CLI passes straight
+// through), and so is a Linter with a nil Run, which is what a
+// half-constructed embedder Analyzer looks like.
+func buildLinter(sc *script) *Linter {
+	all := DefaultAnalyzers()
+	var chosen []*Analyzer
+	switch sc.intn(8) {
+	case 0:
+		chosen = nil
+	case 1:
+		chosen = all
+	default:
+		for _, a := range all {
+			if sc.bit() {
+				chosen = append(chosen, a)
+			}
+		}
+		if len(chosen) == 0 {
+			chosen = all[:1]
+		}
+	}
+	// An EMBEDDER-REGISTERED analyzer, which is the case substrate is. It is
+	// also the only way Pass.ReportNode and Pass.ReportWithNotes get called at
+	// all: measurement said both sat at 0%, and grepping the repository
+	// explained why -- nothing in elps calls either one. They are exported API
+	// that exists solely for callers outside this module, so a target that
+	// covers only elps' own analyzers leaves two public functions unfuzzed
+	// while reporting a healthy number.
+	//
+	// Registering one also exercises the Linter's handling of a name that is
+	// NOT in DefaultAnalyzers(): the knownAnalyzers merge, enabledAnalyzers,
+	// and the narrowedRun computation all read both lists.
+	switch sc.intn(4) {
+	case 0:
+		chosen = append(chosen, embedderAnalyzer(sc))
+	case 1:
+		chosen = append(chosen, failingAnalyzer())
+	}
+	return &Linter{Analyzers: chosen}
+}
+
+// embedderAnalyzer reports through every Pass.Report* method, at nodes the
+// script chooses.
+func embedderAnalyzer(sc *script) *Analyzer {
+	stride := 1 + sc.intn(7)
+	sev := []Severity{severityUnset, SeverityError, SeverityWarning, SeverityInfo}[sc.intn(4)]
+	return &Analyzer{
+		Name:     "fuzz-embedder",
+		Doc:      "reports through every Pass method, so all four are fuzzed",
+		Severity: SeverityWarning,
+		Run: func(pass *Pass) error {
+			n := 0
+			WalkSExprs(pass.Exprs, func(sexpr *lisp.LVal, depth int) {
+				n++
+				if n%stride != 0 {
+					return
+				}
+				// The message prefixes are load-bearing: they are how
+				// TestLintFuzzEmbedderAnalyzerReports tells which Pass method
+				// produced a diagnostic, and therefore how it can assert that
+				// all four were actually used.
+				switch n % 3 {
+				case 0:
+					pass.ReportNode(sexpr, msgReportNode+" on %s/%d", HeadSymbol(sexpr), depth)
+				case 1:
+					pass.ReportWithNotes(Diagnostic{
+						Message:  msgReportWithNotes,
+						Pos:      posFromSource(SourceOf(sexpr).Source),
+						Severity: sev,
+					}, "first note", "")
+				default:
+					pass.Reportf(SourceOf(sexpr).Source, msgReportf+" at depth %d", depth)
+				}
+			})
+			// A node with no source at all, which is what a synthesised or
+			// macro-expanded form looks like to an embedder.
+			pass.ReportNode(nil, msgReportNode+" with no node")
+			pass.ReportNode(lisp.Symbol("synthetic"), msgReportNode+" on a sourceless symbol")
+			pass.Reportf(nil, msgReportf+" with no location")
+			pass.Report(Diagnostic{Message: msgReport})
+			return nil
+		},
+	}
+}
+
+// failingAnalyzer returns an error, which is what a half-configured embedder
+// check does. LintFileWithContext wraps and returns it, abandoning the run.
+func failingAnalyzer() *Analyzer {
+	return &Analyzer{
+		Name:     "fuzz-failing",
+		Doc:      "always fails",
+		Severity: SeverityError,
+		Run:      func(*Pass) error { return errAnalyzerFailed },
+	}
+}
+
+var errAnalyzerFailed = errors.New("deliberate analyzer failure")
+
+// Message prefixes identifying which Pass method produced a diagnostic.
+const (
+	msgReport          = "embedder Report"
+	msgReportWithNotes = "embedder ReportWithNotes"
+	msgReportNode      = "embedder ReportNode"
+	msgReportf         = "embedder Reportf"
+)
+
+// severityStrings feed ParseSeverity, which parses a --fail-on flag.
+var severityStrings = []string{
+	"error", "warning", "info", "hint", "ERROR", "Warning", "", "none",
+	"warn", "0", "-1", "9999",
+}
+
+// lintStats is what one run reports back, for the guard tests.
+type lintStats struct {
+	syntactic int
+	semantic  int
+	workspace int
+	analyzers int
+}
+
+func runLint(root string, src, wsSrc, scriptBytes []byte) (lintStats, error) {
+	var stats lintStats
+	sc := &script{b: scriptBytes}
+
+	if len(src) > lintMaxFileBytes {
+		src = src[:lintMaxFileBytes]
+	}
+	if len(wsSrc) > lintMaxFileBytes {
+		wsSrc = wsSrc[:lintMaxFileBytes]
+	}
+
+	linter := buildLinter(sc)
+	stats.analyzers = len(linter.Analyzers)
+
+	// --- syntactic: what `elps lint` does without --workspace ---------------
+	diags, err := linter.LintFile(src, lintFileA)
+	if err == nil {
+		stats.syntactic = len(diags)
+		if err := checkDiagnostics(diags, "LintFile"); err != nil {
+			return stats, err
+		}
+		// Determinism. Same bytes, same linter, same answer -- see the header.
+		again, err2 := linter.LintFile(src, lintFileA)
+		if err2 != nil {
+			return stats, fmt.Errorf("LintFile succeeded then failed on the same input: %w", err2)
+		}
+		if !reflect.DeepEqual(diags, again) {
+			return stats, fmt.Errorf(
+				"LintFile is not deterministic: two runs over identical bytes with an"+
+					" identical analyzer set produced different diagnostics.\n first: %v\nsecond: %v",
+				diags, again)
+		}
+	}
+
+	// --- semantic: what `elps lint --workspace` does per file ---------------
+	env, err := newLintEnv()
+	if err != nil {
+		return stats, fmt.Errorf("harness: %w", err)
+	}
+	preamble := lintPreamble(wsSrc)
+	_ = analysis.LoadWorkspaceMacros(env, preamble)
+	exp := &analysis.EnvMacroExpander{Env: env}
+
+	wsDefs := analysis.ExtractFileDefinitions(wsSrc, lintFileB)
+	acfg := &analysis.Config{
+		ExtraGlobals:   wsDefs,
+		PackageExports: analysis.ExtractPackageExports(env.Runtime.Registry),
+		PackageSymbols: groupByPackage(wsDefs),
+		MacroExpander:  exp,
+	}
+	if sc.bit() {
+		acfg.DefaultPackage = lisp.DefaultUserPackage
+	}
+
+	semDiags, err := linter.LintFileWithAnalysis(src, lintFileA, acfg)
+	if err == nil {
+		stats.semantic = len(semDiags)
+		if err := checkDiagnostics(semDiags, "LintFileWithAnalysis"); err != nil {
+			return stats, err
+		}
+	}
+
+	// LintFileWithContext with an explicitly nil Result, which is the
+	// "semantic analyzers are no-ops" contract, and with one built here.
+	if _, err := linter.LintFileWithContext(src, lintFileA, nil); err != nil {
+		_ = err // a parse failure is a legitimate outcome
+	}
+
+	// --- CLI entry points: LintFiles over a real (temp) workspace -----------
+	//
+	// Filenames are fixed constants; only the CONTENTS come from the fuzzer.
+	// LintFiles calls os.ReadFile on every path it is handed and
+	// BuildAnalysisConfig walks the workspace root, so a fuzzer-chosen path
+	// here would be a file-read primitive.
+	pathA := filepath.Join(root, lintFileA)
+	pathB := filepath.Join(root, lintFileB)
+	if err := os.WriteFile(pathA, src, 0o600); err != nil {
+		return stats, fmt.Errorf("harness: %w", err)
+	}
+	if err := os.WriteFile(pathB, wsSrc, 0o600); err != nil {
+		return stats, fmt.Errorf("harness: %w", err)
+	}
+
+	lcfg := &LintConfig{
+		Workspace: root,
+		Excludes:  []string{"*.txt", "[", "nothing.lisp"}[:sc.intn(4)],
+	}
+	if sc.bit() {
+		lcfg.Registry = env.Runtime.Registry
+	}
+	switch sc.intn(3) {
+	case 0:
+		// Env set, MacroExpander not: BuildAnalysisConfig loads workspace
+		// macros and constructs the expander itself.
+		lcfg.Env = env
+	case 1:
+		lcfg.MacroExpander = exp
+	}
+	if sc.bit() {
+		// Skips defaultStdlibExports' fresh env boot, which is the reason the
+		// field exists.
+		lcfg.StdlibExports = analysis.ExtractPackageExports(env.Runtime.Registry)
+	}
+
+	files := []string{pathA, pathB}[:1+sc.intn(2)]
+	wsDiags, err := linter.LintFiles(lcfg, files)
+	if err == nil {
+		stats.workspace = len(wsDiags)
+		if err := checkDiagnostics(wsDiags, "LintFiles"); err != nil {
+			return stats, err
+		}
+	}
+	if _, err := BuildAnalysisConfig(lcfg); err != nil {
+		_ = err // a workspace that cannot be scanned is a legitimate outcome
+	}
+
+	// --- output, severity and the AST helpers -------------------------------
+	all := append(append(append([]Diagnostic{}, diags...), semDiags...), wsDiags...)
+	if err := reportSurface(sc, all); err != nil {
+		return stats, err
+	}
+	walkSurface(src)
+
+	// The macro expander must not have swallowed a panic while semantic
+	// analysis evaluated macro bodies. ExpandMacro's recover returns nil, which
+	// is also its ordinary answer, so nothing in the diagnostics could ever
+	// have shown this.
+	if n := exp.ExpansionPanics(); n > 0 {
+		rec := exp.LastExpansionPanic()
+		return stats, fmt.Errorf(
+			"EnvMacroExpander swallowed %d panic(s) while lint ran semantic analysis"+
+				"\n  macro:   %s\n  package: %s\n  value:   %v\n  stack:\n%s",
+			n, rec.Macro, rec.Package, rec.Value, rec.GoStack)
+	}
+	return stats, nil
+}
+
+// checkDiagnostics asserts the invariants every returned diagnostic must hold,
+// whichever entry point produced it.
+func checkDiagnostics(diags []Diagnostic, from string) error {
+	for i, d := range diags {
+		if d.Analyzer == "" {
+			return fmt.Errorf("%s returned diagnostic %d with no Analyzer name: %+v", from, i, d)
+		}
+		if d.Pos.File == "" {
+			return fmt.Errorf("%s returned diagnostic %d with no file; every entry point"+
+				" backfills it from its filename argument: %+v", from, i, d)
+		}
+		if d.Severity < SeverityError || d.Severity > SeverityInfo {
+			return fmt.Errorf("%s returned diagnostic %d with severity %d, outside"+
+				" [%d,%d]. Report and ReportWithNotes fill an unset severity from the"+
+				" analyzer's default, so a value outside the range means an analyzer set"+
+				" one by hand: %+v",
+				from, i, int(d.Severity), int(SeverityError), int(SeverityInfo), d)
+		}
+		if _, err := json.Marshal(d); err != nil {
+			return fmt.Errorf("%s returned a diagnostic that will not marshal to JSON"+
+				" (--format=json is what CI reads): %v: %+v", from, err, d)
+		}
+	}
+	return nil
+}
+
+// reportSurface drives the severity and output functions -- the ones that
+// decide `elps lint`'s exit code and the bytes a CI job parses.
+func reportSurface(sc *script, diags []Diagnostic) error {
+	_ = MaxSeverity(diags)
+	for _, s := range []Severity{SeverityError, SeverityWarning, SeverityInfo} {
+		_ = ShouldFail(diags, s)
+		_ = s.String()
+		b, err := s.MarshalJSON()
+		if err != nil {
+			return fmt.Errorf("Severity(%d).MarshalJSON: %w", int(s), err)
+		}
+		var back Severity
+		if err := back.UnmarshalJSON(b); err != nil {
+			return fmt.Errorf("Severity(%d) does not round-trip through JSON: %w", int(s), err)
+		}
+		if back != s {
+			return fmt.Errorf("Severity round-trip changed the value: %d -> %s -> %d",
+				int(s), b, int(back))
+		}
+	}
+	for range 4 {
+		_, _ = ParseSeverity(severityStrings[sc.intn(len(severityStrings))])
+	}
+	for _, d := range diags {
+		_ = d.String()
+		_ = d.Pos.String()
+	}
+	FormatText(io.Discard, diags)
+	if err := FormatJSON(io.Discard, diags); err != nil {
+		return fmt.Errorf("FormatJSON failed on diagnostics the linter itself produced"+
+			" (--format=json is what CI reads): %v", err)
+	}
+	_ = AnalyzerNames()
+	_ = AnalyzerDoc()
+	return nil
+}
+
+// walkSurface drives the exported AST helpers, which embedders writing their
+// own analyzers call directly.
+func walkSurface(src []byte) {
+	res := rdparser.New(token.NewScanner(lintFileA, bytes.NewReader(src))).ParseProgramFaultTolerant()
+	Walk(res.Exprs, func(node, parent *lisp.LVal, depth int) {
+		_ = SourceOf(node)
+		// NOT SourceOf(parent). Walk documents "parent is nil for top-level
+		// expressions" and SourceOf dereferences its argument unconditionally,
+		// so the obvious pairing of the two segfaults. That is a real (if
+		// minor) contract defect in astutil.SourceOf rather than something this
+		// target should keep re-finding on every input; see the report
+		// accompanying this branch. Guarded here so the finding is recorded
+		// once instead of masking everything downstream of it.
+		if parent != nil {
+			_ = SourceOf(parent)
+		}
+	})
+	WalkSExprs(res.Exprs, func(sexpr *lisp.LVal, depth int) {
+		_ = HeadSymbol(sexpr)
+		_ = ArgCount(sexpr)
+		defs := map[string]bool{}
+		if len(sexpr.Cells) > 1 {
+			CollectFormals(sexpr.Cells[1], defs)
+		}
+	})
+	_ = UserDefined(res.Exprs)
+}
+
+// lintPreamble extracts the forms a workspace scan would replay into the env.
+func lintPreamble(src []byte) []*lisp.LVal {
+	res := rdparser.New(token.NewScanner(lintFileB, bytes.NewReader(src))).ParseProgramFaultTolerant()
+	heads := map[string]bool{
+		"in-package": true, "use-package": true, "export": true,
+		"defmacro": true, "defun": true, "set": true,
+	}
+	var out []*lisp.LVal
+	for _, expr := range res.Exprs {
+		if expr == nil || expr.Type != lisp.LSExpr || expr.Quoted || len(expr.Cells) == 0 {
+			continue
+		}
+		if heads[HeadSymbol(expr)] {
+			out = append(out, expr)
+		}
+	}
+	return out
+}
+
+func groupByPackage(syms []analysis.ExternalSymbol) map[string][]analysis.ExternalSymbol {
+	m := map[string][]analysis.ExternalSymbol{}
+	for _, s := range syms {
+		m[s.Package] = append(m[s.Package], s)
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// the target
+// ---------------------------------------------------------------------------
+
+const (
+	lintSeedDefs = `(in-package 'demo)
+(use-package 'lisp)
+(defun add (a b) "add two" (+ a b))
+(defmacro twice (x) (quasiquote (+ (unquote x) (unquote x))))
+(defmacro defthing (name args &rest body)
+  (quasiquote (defun (unquote name) (unquote args) (unquote-splicing body))))
+(export 'add)
+(export 'twice)`
+
+	lintSeedUses = `(in-package 'user)
+(use-package 'demo)
+(defun main () (add 1 2))
+(defun unused-arg (x y) x)
+(defthing helper (q) (+ q 1))
+(let ([shadow 1]) (let ([shadow 2]) shadow))
+(set 'global 1)
+(if true 1)`
+)
+
+// nolintSeeds exist because the nolint machinery -- filterSuppressed,
+// walkForNolint, checkNolintToken and the whole unused-nolint block -- is
+// driven entirely by COMMENTS, and a corpus of well-formed lisp contains none.
+// The conditional-staleness rules also depend on whether the run was narrowed,
+// which is what buildLinter's subset draw supplies.
+var nolintSeeds = []string{
+	"(defun f (x) x) ; nolint",
+	"(defun f (x) x) ; nolint:unused-variable",
+	"(defun f (x) x) ; nolint:no-such-analyzer",
+	"(defun f (x) x) ; nolint:unused-variable,no-such-analyzer",
+	"(defun f (x) x) ; nolint:unused-nolint",
+	"; nolint\n(defun f (x) x)",
+	"(defun f (x) x) ;nolint:undefined-symbol",
+	"(defun f (x) x) ; nolint: ,, ,",
+	"(defun f (x) x) ; nolint:" + "a,b,c,d,e,f",
+	";; nolint\n;; nolint:x\n(defun f () 1)",
+}
+
+// lintScripts are the seed configurations. Package-level so the guard tests
+// drive the same set the corpus does -- a guard that invents its own script
+// proves nothing about the corpus.
+var lintScripts = [][]byte{
+	{1, 0, 0, 0, 0, 0, 0, 0},       // full analyzer set
+	{0, 0, 0, 0, 0, 0, 0, 0},       // empty Linter
+	{2, 1, 0, 1, 0, 1, 0, 1, 1, 1}, // narrowed: alternating subset
+	{3, 255, 255, 0, 0, 1, 2, 3, 1, 0, 1},
+	{7, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2},
+	{5, 0, 1, 0, 1, 0, 1, 0, 3, 3, 3},
+}
+
+// FuzzLintSource lints fuzzer-chosen source with a fuzzer-chosen analyzer set,
+// through all four entry points the CLI, the LSP and embedders use.
+//
+// Asserted, and only this:
+//
+//  1. No Go panic escapes an analyzer, the nolint machinery or the output
+//     functions. Nothing recovers in between.
+//  2. Every diagnostic returned by every entry point has an analyzer name, a
+//     file, an in-range severity, and marshals to JSON.
+//  3. LintFile is deterministic over identical bytes.
+//  4. Semantic analysis' macro expander swallowed no panic.
+//  5. The run terminates (the watchdog). Nothing bounds a loop in an analyzer.
+//
+// NOT asserted: that any particular diagnostic is or is not produced. A linter
+// finding nothing in garbage is correct, and so is finding a hundred things.
+func FuzzLintSource(f *testing.F) {
+	add := func(src, ws string, sc []byte) { f.Add([]byte(src), []byte(ws), sc) }
+
+	scripts := lintScripts
+	for _, sc := range scripts {
+		add(lintSeedUses, lintSeedDefs, sc)
+		add(lintSeedDefs, lintSeedUses, sc)
+		add("", "", sc)
+	}
+	for _, s := range nolintSeeds {
+		add(s, lintSeedDefs, scripts[0])
+		add(s, lintSeedDefs, scripts[2]) // narrowed run: different staleness rules
+	}
+
+	// Semantic findings that need a RESOLVED user symbol with a signature:
+	// arity violations against a function defined in the same file, and
+	// duplicate definitions. These reach the Notes/Related-building helpers,
+	// which measurement put at 0% from everything above.
+	add("(in-package 'user)\n(defun add (a b) (+ a b))\n(add 1)\n(add 1 2 3)\n(add)",
+		lintSeedDefs, scripts[0])
+	add("(in-package 'user)\n(defun dup () 1)\n(defun dup () 2)\n(defmacro dup (x) x)",
+		lintSeedDefs, scripts[0])
+	add("(in-package 'demo)\n(defun add (a b) 1)", lintSeedDefs, scripts[0])
+
+	// Shapes chosen for what breaks the analyzers rather than the parser:
+	// arity errors, shadowing, rethrow patterns, dead branches, deep nesting.
+	for _, s := range []string{
+		"(car)", "(car 1 2 3)", "(+)", "(lambda)", "(defun)", "(defun f)",
+		"(handler-bind ((condition (lambda (c) (error c)))) 1)",
+		"(cond)", "(cond (true))", "(if)", "(if true)",
+		"(let ())", "(let)", "(let ([a]) a)", "(let ([] 1) 1)",
+		"(deftype)", "(deftype t)", "(set)", "(set!)",
+		"(defun f (x &optional y &rest z) (list x y z))",
+		"(defun f (&rest) 1)", "(defun f (a a) a)",
+		"(progn (progn (progn (progn 1))))",
+		"(defun f () (f))",
+		"(in-package)", "(use-package)", "(export)",
+	} {
+		add(s, lintSeedDefs, scripts[0])
+	}
+
+	// A macro defined next door and called here: the only shape that makes
+	// semantic analysis EVALUATE a macro body, which is what the
+	// ExpansionPanics assertion guards.
+	add("(in-package 'demo)\n(twice (twice 3))",
+		"(in-package 'demo)\n(defmacro twice (x) (quasiquote (+ (unquote x) (unquote x))))",
+		scripts[0])
+	add("(in-package 'demo)\n(boom 1)",
+		"(in-package 'demo)\n(defmacro boom (x) (error 'macro-boom \"x\"))", scripts[0])
+
+	for _, seed := range fuzzseed.Adversarial() {
+		add(string(seed), lintSeedDefs, scripts[0])
+		add(lintSeedUses, string(seed), scripts[2])
+	}
+
+	f.Fuzz(func(t *testing.T, src, wsSrc, scriptBytes []byte) {
+		runLintBudgeted(t, t.TempDir(), src, wsSrc, scriptBytes)
+	})
+}
+
+// fatalf is the subset of *testing.T the budgeted runner uses, so the guard
+// tests can pass something else.
+type fatalf interface {
+	Helper()
+	Fatalf(format string, args ...interface{})
+	Skipf(format string, args ...interface{})
+}
+
+func runLintBudgeted(t fatalf, root string, src, wsSrc, scriptBytes []byte) {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := runLint(root, src, wsSrc, scriptBytes)
+		done <- err
+	}()
+
+	budget := fuzzwatch.New(lintWatchdogTimeout)
+	wait := budget.Total()
+	for {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("%v\n--- src (%d bytes) ---\n%q\n--- workspace (%d bytes) ---\n%q"+
+					"\n--- script (%d bytes) ---\n%q",
+					err, len(src), src, len(wsSrc), wsSrc, len(scriptBytes), scriptBytes)
+			}
+			return
+		case <-time.After(wait):
+			verdict, more, report := budget.Check()
+			switch verdict {
+			case fuzzwatch.Continue:
+				wait = more
+			case fuzzwatch.Inconclusive:
+				t.Skipf("no verdict: the process was starved throughout (%s)", report)
+				return
+			default:
+				t.Fatalf("lint did not terminate within %s of SCHEDULED time (%s)."+
+					" Macro bodies run under interpreter budgets; nothing bounds an"+
+					" analyzer's own walk"+
+					"\n--- src (%d bytes) ---\n%q\n--- workspace (%d bytes) ---\n%q"+
+					"\n--- script (%d bytes) ---\n%q",
+					budget.Total(), report, len(src), src, len(wsSrc), wsSrc,
+					len(scriptBytes), scriptBytes)
+				return
+			}
+		}
+	}
+}

--- a/lsp/lsp_fuzz_test.go
+++ b/lsp/lsp_fuzz_test.go
@@ -93,13 +93,21 @@ import (
 //	                                       lsp_test.go already guards this way,
 //	                                       "fail fast if index build silently
 //	                                       panicked".
-//	EnvMacroExpander.ExpandMacro           NOT COVERED. Its recover sets
-//	  (analysis/expander.go)               result = nil, which is also the
-//	                                       ordinary "not a macro" answer, so
-//	                                       there is no marker to key off. A
-//	                                       panic in macro expansion at analysis
-//	                                       time is invisible to this target.
-//	                                       Stated rather than papered over.
+//	EnvMacroExpander.ExpandMacro           DETECTED, since analysis/ grew the
+//	  (analysis/expander.go)               marker this row used to say it
+//	                                       lacked. Its recover still sets
+//	                                       result = nil -- also the ordinary
+//	                                       "not a macro" answer, so the RETURN
+//	                                       VALUE still cannot carry the fact --
+//	                                       but the expander now counts calls
+//	                                       that failed to complete, keyed off a
+//	                                       local in ExpandMacro's own frame that
+//	                                       only a normal return sets.
+//	                                       checkExpansionPanics reads that count
+//	                                       through analysis.PanicReporter. Same
+//	                                       family of non-forgeable marker as
+//	                                       IsInternalPanic and the analysisCfg
+//	                                       check above.
 //
 // Everything else runs with no recover between the handler body and the fuzz
 // function, because the harness calls the server's handler methods directly
@@ -428,6 +436,49 @@ func (s *session) checkIndexBuilt() error {
 			" swallowed the panic")
 	}
 	return nil
+}
+
+// checkExpansionPanics is the swallowed-panic detector for analysis-time macro
+// expansion, which the table above used to list as NOT COVERED.
+//
+// Analysing a document CALLS env.MacroCall on macros that came off disk, so a
+// macro body is evaluated while a file is merely open in an editor. The recover
+// around that returns nil, and nil is also the answer for "not a macro" -- the
+// answer the analyser gets for almost every head symbol it asks about -- so no
+// return value could ever have distinguished the two.
+//
+// analysis.EnvMacroExpander now counts calls that did not complete, keyed off a
+// local variable in ExpandMacro's own frame. Nothing reachable from lisp, and
+// nothing an embedder holds, can set that local; the count is unexported and
+// only ever increases. Reading it here is the same move as asserting
+// analysisCfg != nil after ensureWorkspaceIndex, one layer down.
+func (s *session) checkExpansionPanics() error {
+	s.srv.analysisCfgMu.RLock()
+	cfg := s.srv.analysisCfg
+	s.srv.analysisCfgMu.RUnlock()
+	if cfg == nil {
+		return nil // already reported by checkIndexBuilt
+	}
+	reporter, ok := cfg.MacroExpander.(analysis.PanicReporter)
+	if !ok {
+		return nil
+	}
+	n := reporter.ExpansionPanics()
+	if n == 0 {
+		return nil
+	}
+	detail := ""
+	if exp, ok := cfg.MacroExpander.(*analysis.EnvMacroExpander); ok {
+		if rec := exp.LastExpansionPanic(); rec != nil {
+			detail = fmt.Sprintf("\n  macro:   %s\n  package: %s\n  value:   %v\n  stack:\n%s",
+				rec.Macro, rec.Package, rec.Value, rec.GoStack)
+		}
+	}
+	return fmt.Errorf(
+		"EnvMacroExpander swallowed %d panic(s) during analysis-time macro expansion."+
+			" A document merely being open evaluated a macro body that crashed host"+
+			" code, and ExpandMacro's recover() turned that into the same nil it"+
+			" returns for \"not a macro\"%s", n, detail)
 }
 
 func (s *session) checkMarshal(what string, v any) {
@@ -871,7 +922,10 @@ func runSession(srcA, srcB, script []byte) error {
 	// Any timer still armed would fire after the session is over, on a
 	// goroutine belonging to no input.
 	_ = s.srv.shutdown(s.ctx)
-	return s.checkIndexBuilt()
+	if err := s.checkIndexBuilt(); err != nil {
+		return err
+	}
+	return s.checkExpansionPanics()
 }
 
 // fatalf is the subset of *testing.T the harness needs, so the same driver
@@ -1226,5 +1280,54 @@ func TestLSPFuzzSeedsTerminate(t *testing.T) {
 			t.Parallel()
 			runSessionBudgeted(t, seed, seed, allOpsScript())
 		})
+	}
+}
+
+// TestLSPFuzzDetectsSwallowedExpansionPanic proves checkExpansionPanics is
+// wired to the object the analyser actually uses, and that it fires.
+//
+// The detector is worth exactly nothing if it reads a different expander from
+// the one buildWorkspaceIndex installed, and that mistake is invisible: the
+// check would return nil forever and every input would pass. So this reaches
+// into the built config, makes THAT expander swallow a real panic (a nil form
+// dereferences inside ExpandMacro), and requires the session-level check to
+// report it.
+func TestLSPFuzzDetectsSwallowedExpansionPanic(t *testing.T) {
+	s, err := newSession(nil)
+	if err != nil {
+		t.Fatalf("newSession: %v", err)
+	}
+
+	s.srv.analysisCfgMu.RLock()
+	cfg := s.srv.analysisCfg
+	s.srv.analysisCfgMu.RUnlock()
+	if cfg == nil {
+		t.Fatal("no analysis config after ensureWorkspaceIndex")
+	}
+	exp, ok := cfg.MacroExpander.(*analysis.EnvMacroExpander)
+	if !ok {
+		t.Fatalf("buildWorkspaceIndex installed a %T, not an *analysis.EnvMacroExpander;"+
+			" checkExpansionPanics reads analysis.PanicReporter, so if the new"+
+			" expander does not implement it this target silently stops detecting"+
+			" swallowed panics", cfg.MacroExpander)
+	}
+
+	if err := s.checkExpansionPanics(); err != nil {
+		t.Fatalf("a fresh session already reports a swallowed panic: %v", err)
+	}
+
+	// A nil form panics inside ExpandMacro. The recover swallows it and returns
+	// nil -- exactly what "not a macro" returns -- so only the count shows it.
+	if v := exp.ExpandMacro(nil, "user"); v != nil {
+		t.Fatalf("ExpandMacro(nil) returned %v, expected the recovered nil", v)
+	}
+	err = s.checkExpansionPanics()
+	if err == nil {
+		t.Fatal("checkExpansionPanics did not report a swallowed panic in the very" +
+			" expander buildWorkspaceIndex installed; the detector is not wired to" +
+			" the object the analyser uses")
+	}
+	if !strings.Contains(err.Error(), "swallowed") {
+		t.Errorf("unexpected error text: %v", err)
 	}
 }

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -295,7 +295,14 @@ echo "== bench-arms-check: the two arms must be comparable =====================
 ARMS="${SCRIPT_DIR}/bench-arms-check.sh"
 
 ARMS_TMP="$(mktemp -d)"
-trap 'rm -rf "$ARMS_TMP"' EXIT
+
+# Set by the empty-discovery control far below, which synthesises a throwaway
+# Go package INSIDE the module (it has to be inside for `go list` to match it).
+# Cleaned up on every exit path so an interrupted run cannot leave a stray
+# package sitting in the tree.
+EMPTY_PKG_DIR=""
+
+trap 'rm -rf "$ARMS_TMP" ${EMPTY_PKG_DIR:+"$EMPTY_PKG_DIR"}' EXIT
 
 # Six samples so the "need >= 6" advisory does not fire in the clean case.
 arms_fixture() { # <file> <cpu> <suffix> [extra-benchmark-name]
@@ -1048,10 +1055,52 @@ else
 
 	# Discovery is dynamic, so it can silently discover nothing -- which would
 	# look exactly like a clean run.
+	#
+	# This control needs a package set that MATCHES at least one package (so it
+	# reaches fuzz.sh's zero-TARGET error rather than its "no packages matched"
+	# one) while defining no fuzz target. It used to name ./lint/... -- a real
+	# package that merely happened to have none -- and the moment FuzzLintSource
+	# landed in lint/ the control quietly stopped being a control: the assertion
+	# still ran, it just no longer exercised the empty path. A self-test whose
+	# entire purpose is proving the gate CAN fail is the last place that should
+	# depend on a real package staying empty by luck.
+	#
+	# So the empty package is synthesised here, fresh, on every run. It is empty
+	# by construction: nobody can add a fuzz target to a directory that exists
+	# only for the length of these three assertions, and it stays empty no
+	# matter what lands anywhere in the real tree. It carries an ordinary Test
+	# function so this also proves discovery selects on the Fuzz* prefix rather
+	# than merely finding a package with no tests at all.
+	EMPTY_PKG_DIR="$(mktemp -d "${REPO_ROOT}/internal/citest-emptyfuzz.XXXXXX")"
+	cat >"${EMPTY_PKG_DIR}/empty.go" <<-'EOF'
+		// Package emptyfuzz is synthesised by scripts/ci-gates-test.sh and
+		// deleted again as soon as the empty-discovery control has run. It
+		// deliberately defines no fuzz target.
+		package emptyfuzz
+	EOF
+	cat >"${EMPTY_PKG_DIR}/empty_test.go" <<-'EOF'
+		package emptyfuzz
+
+		import "testing"
+
+		// A test, but NOT a fuzz target: discovery must select on the Fuzz
+		// prefix, so an ordinary Test must not read as something to fuzz.
+		func TestNotAFuzzTarget(t *testing.T) {}
+	EOF
+	empty_pkg_pat="./internal/$(basename "$EMPTY_PKG_DIR")/..."
 	assert_exit 2 "discovering ZERO targets is an error, not a clean run" \
-		env FUZZTIME=1s "$FUZZ" ./lint/...
+		env FUZZTIME=1s "$FUZZ" "$empty_pkg_pat"
 	assert_contains "cannot fail" "the empty-discovery error explains itself" \
-		env FUZZTIME=1s "$FUZZ" ./lint/...
+		env FUZZTIME=1s "$FUZZ" "$empty_pkg_pat"
+	# ...and the control is honestly a control. A synthetic package introduces a
+	# second way to exit 2 -- the pattern matching nothing at all -- which would
+	# satisfy the assertion above for entirely the wrong reason, leaving the
+	# zero-target path as unexercised as ./lint/... left it.
+	assert_not_contains "no packages matched" \
+		"the empty case reaches zero-target discovery, not an unmatched pattern" \
+		env FUZZTIME=1s "$FUZZ" "$empty_pkg_pat"
+	rm -rf "$EMPTY_PKG_DIR"
+	EMPTY_PKG_DIR=""
 
 	# The targets really are found. Listed once and asserted against, so the
 	# package set is only compiled a single extra time.


### PR DESCRIPTION
Closes the `analysis/` and `lint/` bullets on #318, and the `EnvMacroExpander.ExpandMacro` gap #348 identified. Targeted at v1.50.0, not the v1.49.1 patch.

## The blind spot #348 named

`EnvMacroExpander.ExpandMacro` had a blanket `recover()` whose recovery sets `result = nil` — which is *also* the ordinary "not a macro" answer. A panic in analysis-time macro expansion was invisible to any fuzzer, with no marker to key off. #348 said closing it needed a change in `analysis/`, not in the harness.

`ExpandMacro`'s body moved into an unexported `expand()`, and the wrapper holds one local:

```go
completed := false
defer func() {
    r := recover()
    if completed { return }
    e.recordAbort(r, form, pkg)   // atomic counter + Go stack + macro name
    result = nil
}()
result = e.expand(form, pkg)
completed = true
```

**Why it is non-forgeable.** `completed` is a Go local in `ExpandMacro`'s own frame, set by one statement reachable only via a normal return from `expand`. Nothing in lisp can touch a Go local, no expansion *result* can imitate it, and no embedder holds it because it does not exist outside the frame. The counter it feeds is unexported and only ever incremented, and `Reset()` deliberately does **not** clear it, so the code being watched cannot erase its own record.

This is the same family as `lisp.IsInternalPanic` and #348's `analysisCfg != nil` post-condition: a property only the non-panicking path can produce, not a flag. A `Panicked bool` field is the obvious alternative and is exactly what this avoids — any holder of the expander could set it either way.

Side catch: `runtime.Goexit` unwinding through `ExpandMacro` is counted too. `recover()` returns nil there, so a "did we recover?" flag would miss it.

Behaviour is unchanged — a recovered panic still returns nil and the analyser still falls back to opaque handling. The `NOT COVERED` row in `lsp/lsp_fuzz_test.go`'s recover-site table becomes `DETECTED`.

## Three new targets

| target | drives |
|---|---|
| `analysis.FuzzAnalyzeSource` | `Analyze`/`AnalyzeFile` over a fuzzer-built `Config`. The point is `DefForms`: `FormalsIndex`/`NameIndex` are integer indices into a fuzzer-chosen form, production derives them from workspace macro names, and no LSP-driven input can vary them. |
| `analysis.FuzzWorkspaceScan` | `PrescanWorkspace`, the six `ScanWorkspace*`, `ScanWorkspaceRefs`, `buildLoadTree`/`walkLoadFile`. Closes #318's "`ScanWorkspaceRefs` is never exercised". |
| `lint.FuzzLintSource` | `LintFile`/`LintFileWithAnalysis`/`LintFileWithContext`/`LintFiles` + `BuildAnalysisConfig`, with a fuzzer-drawn analyzer subset and an embedder-registered analyzer. |

**Containment for the workspace target is the load-bearing design decision.** `walkLoadFile` reads a file, finds `(load-file "…")`, joins to the containing dir and *recurses* — `../../../etc/passwd` escapes, and one escape in one file is enough. So every path, filename and dir is a harness constant; `load-file` is rewritten to `load-filx` (same length, so every `token.Location` is unchanged) in every fuzzer-derived file; and the load graph is harness-written from a fixed table. Asserted rather than commented: every collected path must resolve inside the temp root, and `TestWorkspaceFuzzContainsLoadFile` runs a hostile input end to end.

## Coverage against #318's baseline

Mean per-function, seed corpus alone, baseline measured on a stashed pristine tree:

| | transitive via `FuzzLSPSession` | dedicated |
|---|---|---|
| `analysis/` | **34.1%**, 67 of 125 funcs at 0% | **85.4%**, 3 of 130 at 0% |
| `lint/` | **38.7%**, 24 of 46 funcs at 0% | **90.1%**, 0 of 46 at 0% |

The three remaining zeroes are `recordAbort`, `safeHeadSymbol`, `LastExpansionPanic` — the panic-recording path, which by construction runs only when a defect is found. Unit tests cover them.

## Measuring first found two silent harness bugs

Same class #348 documented, and both invisible to a passing test:

- `ScanConfig.MaxFileBytes` was drawn as `intn(4)*16`, smaller than every file the harness writes. The scan collected **zero files**; everything past `collectLispFilesWithConfig` sat at 0% while every seed passed.
- `cfg.MacroExpander` was set on a coin flip and the guard's script cleared it, so `env.MacroCall` was never reached and the `ExpansionPanics` assertion was **vacuous**.

Both are now pinned by guard tests, along with requirements that the corpus reach a *successful* expansion, collect files/defs/preamble/DefFormSpecs, run the full analyzer set, and exercise all four `Pass.Report*` methods.

## Defects found, filed separately, not fixed here

- **#353** — `analysis.AnalyzeFile` silently drops `Config.MacroExpander`, so `ScanWorkspaceRefs` and the LSP's `updateFileRefs` compute cross-file references without macro expansion while per-document analysis uses it.
- **#354** — `astutil.SourceOf` nil-derefs on the nil parent `Walk` documents it will pass.

Both are judgement calls about intended behaviour, so they are in flight as their own change rather than bundled here.

## Campaign

~1.25M executions across two sweeps per target, `fuzz.sh` reporting 0 failures both times. **No crashers — verified on the filesystem**: `analysis/testdata` and `lint/testdata` do not exist after either sweep.

Weak evidence, and should be read as such: corpora were still growing steadily at the 10-minute mark (431 and 419 new interesting inputs still arriving at the end). Nowhere near saturated.

## Reviewer note: shard budget — resolved here, in `5ccc6d4`

*This section previously predicted 22 targets across the three in-flight #318 branches and asked whichever merged last to add a sixth shard. Reality has overtaken it; the numbers below are measured on this tree rather than projected.*

Two of the three siblings landed on `main` — #357 (`claude/fuzz-elpsutil`) and #356 (`claude/fuzz-core`, which also carried `lisp.FuzzCyclicValueWalks` forward from #391). That puts `main` at **20 targets — exactly the five-shard ceiling**, not the 22 the prediction assumed. The three targets added here take the sweep to **23**.

At 5 shards, `ceil(23/5) = 5` puts `needed` at 5 × 10m + 10m = **60 against a 60-minute timeout**. `fuzz-budget-check.sh` tests `needed > timeout`, so it goes **green at zero headroom** — the truncated sweep its own error text warns about, with observed shard durations already varying from 4m25s to 5m42s.

So this branch is the one that adds the **sixth shard**, in the same change as the targets that consume the fifth. Verified on this tree:

```
targets discovered      23
shards                  6
largest shard           4 target(s)
required                50 min
timeout-minutes         60 min
headroom                10 min
```

Checked rather than assumed:

- **Partition** — round-robin assignment measured per shard: `4 + 4 + 4 + 4 + 4 + 3 = 23`, every target assigned exactly once, nothing dropped.
- **Required checks** — the per-shard jobs are not required status checks by name; the aggregate `Required: fuzz` is. Renaming `Fuzz shard i/5` → `i/6` therefore strands nothing.
- `scripts/ci-gates-test.sh` — 127 passed, 0 failed with the new matrix. `scripts/confidentiality-guard.sh` — clean.

## Verification

Full `go test ./...` green; `golangci-lint run ./analysis/... ./lint/...` reports 0 issues. There is a pre-existing `gofmt` diff in `analysis/analyzer.go` on `main` which is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_