### PR TITLE
Honour Config.MacroExpander in AnalyzeFile, and stop astutil nil-dereferencing

### DIFF
--- a/analysis/analysis_fuzz_test.go
+++ b/analysis/analysis_fuzz_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -133,17 +134,22 @@ func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
 //
 // It also forwards ExpansionPanics, so the target's assertion goes through the
 // exported PanicReporter interface exactly as an embedder's would.
+// The counters are atomic because ScanWorkspaceRefs analyses files
+// concurrently and shares one Config -- and therefore one expander -- across
+// those goroutines. That only became reachable when AnalyzeFile started
+// honouring Config.MacroExpander; before that this expander was never called
+// from the parallel scan, so plain ints raced with nobody.
 type countingExpander struct {
 	inner    *EnvMacroExpander
-	expanded int
-	asked    int
+	expanded atomic.Int64
+	asked    atomic.Int64
 }
 
 func (c *countingExpander) ExpandMacro(form *lisp.LVal, pkg string) *lisp.LVal {
-	c.asked++
+	c.asked.Add(1)
 	v := c.inner.ExpandMacro(form, pkg)
 	if v != nil {
-		c.expanded++
+		c.expanded.Add(1)
 	}
 	return v
 }
@@ -412,7 +418,7 @@ func runAnalyze(src, wsSrc, scriptBytes []byte) (analyzeResult, error) {
 	// config copy and the strict parser.
 	_ = AnalyzeFile(src, fuzzAnalysisFile, cfg)
 
-	stats.asked, stats.expanded = exp.asked, exp.expanded
+	stats.asked, stats.expanded = int(exp.asked.Load()), int(exp.expanded.Load())
 	stats.symbols, stats.refs = len(result.Symbols), len(result.References)
 
 	probeResult(sc, result, src)

--- a/analysis/samesourcefile_test.go
+++ b/analysis/samesourcefile_test.go
@@ -1,0 +1,70 @@
+package analysis
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sameSourceFile decides whether a reference's text lives in the file being
+// indexed. ExtractFileRefs pairs File (the URI rename edits) with Source (the
+// range rename edits), so a wrong "true" here aims an edit at the wrong file.
+// These cases pin each branch against the two call sites that exist.
+func TestSameSourceFile(t *testing.T) {
+	t.Run("identical is the LSP call site's fast path", func(t *testing.T) {
+		// lsp/server.go passes one filePath to both AnalyzeFile (which sets
+		// Source.File) and ExtractFileRefs, so ordinary nodes compare equal
+		// without ever reaching filepath.Abs.
+		assert.True(t, sameSourceFile("/ws/a.lisp", "/ws/a.lisp"))
+		assert.True(t, sameSourceFile("a.lisp", "a.lisp"))
+	})
+
+	t.Run("Abs carries the workspace-scan call site", func(t *testing.T) {
+		// workspace.go analyses with a possibly-relative path but extracts
+		// against its absolute form. Without normalisation every reference
+		// from a relative path would be dropped and rename would silently
+		// miss those files -- so this is load-bearing, not cosmetic.
+		abs, err := filepath.Abs("a.lisp")
+		require.NoError(t, err)
+		assert.True(t, sameSourceFile("a.lisp", abs))
+		assert.True(t, sameSourceFile(abs, "a.lisp"))
+		assert.True(t, sameSourceFile("./a.lisp", "a.lisp"))
+		assert.True(t, sameSourceFile("b/../a.lisp", "a.lisp"))
+	})
+
+	t.Run("distinct files are rejected", func(t *testing.T) {
+		assert.False(t, sameSourceFile("a.lisp", "b.lisp"))
+		assert.False(t, sameSourceFile("/ws/a.lisp", "/other/a.lisp"))
+		// The macro-expansion case this guard was added for: a node spliced
+		// in from the macro's defining file carries that file's location.
+		assert.False(t, sameSourceFile("macros.lisp", "consumer.lisp"))
+	})
+
+	t.Run("empty source is deliberately permissive", func(t *testing.T) {
+		// FAIL-OPEN, and the only branch that can produce a false positive.
+		// Nodes without a recorded file are attributed to the file being
+		// indexed; failing closed instead would drop them and break rename
+		// for ordinary code. The cost is that if macro expansion ever yields
+		// a node with an EMPTY Source.File rather than the defining file's
+		// path, this guard cannot see it and rename could aim at the wrong
+		// file. Anything that starts populating Source.File differently
+		// should revisit this case first.
+		assert.True(t, sameSourceFile("", "consumer.lisp"))
+		assert.True(t, sameSourceFile("", "/anywhere/at/all.lisp"))
+	})
+
+	t.Run("known limits, recorded rather than asserted as correct", func(t *testing.T) {
+		// Both are false negatives -- they drop a real reference, so rename
+		// under-applies rather than corrupting an unrelated file. Neither is
+		// reachable from the current call sites, because both paths derive
+		// from the same string. They would become reachable if a caller ever
+		// compared an editor-supplied path against an independently resolved
+		// one.
+		assert.False(t, sameSourceFile("/tmp/a.lisp", "/private/tmp/a.lisp"),
+			"symlinked paths to one file are not resolved")
+		assert.False(t, sameSourceFile("A.lisp", "a.lisp"),
+			"comparison is case-sensitive regardless of the filesystem")
+	})
+}

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -575,8 +575,31 @@ func scanUsePackages(exprs []*lisp.LVal) map[string][]string {
 	return result
 }
 
+// ConfigForFile returns a copy of cfg with Filename set to filename, leaving
+// the caller's Config untouched. A nil cfg yields an empty Config.
+//
+// This is a whole-struct copy rather than a field-by-field rebuild on purpose.
+// The rebuild it replaces silently dropped fields twice: DefForms and
+// PackageImports, and then MacroExpander, which did not exist when the
+// rebuild was written and was never added to it (issue #353). Copying carries
+// new Config fields through automatically, so the omission cannot recur.
+// Use this anywhere a workspace-wide Config is specialised for one file.
+func ConfigForFile(cfg *Config, filename string) *Config {
+	fileCfg := &Config{}
+	if cfg != nil {
+		*fileCfg = *cfg
+	}
+	fileCfg.Filename = filename
+	return fileCfg
+}
+
 // AnalyzeFile parses and performs full semantic analysis on a single file.
 // Returns nil if the file fails to parse.
+//
+// Every field of cfg is honoured, including MacroExpander: analysis through
+// AnalyzeFile resolves the same symbols as analysis through Analyze. Callers
+// that scan many files and do not want to pay for macro expansion should leave
+// cfg.MacroExpander nil.
 func AnalyzeFile(source []byte, filename string, cfg *Config) *Result {
 	s := token.NewScanner(filename, bytes.NewReader(source))
 	p := rdparser.New(s)
@@ -586,26 +609,17 @@ func AnalyzeFile(source []byte, filename string, cfg *Config) *Result {
 		return nil
 	}
 
-	fileCfg := cfg
-	if fileCfg == nil {
-		fileCfg = &Config{}
-	}
-	fileCfg = &Config{
-		ExtraGlobals:   fileCfg.ExtraGlobals,
-		PackageExports: fileCfg.PackageExports,
-		PackageSymbols: fileCfg.PackageSymbols,
-		DefForms:       fileCfg.DefForms,
-		PackageImports: fileCfg.PackageImports,
-		DefaultPackage: fileCfg.DefaultPackage,
-		WorkspaceRefs:  fileCfg.WorkspaceRefs,
-		Filename:       filename,
-	}
-	return Analyze(exprs, fileCfg)
+	return Analyze(exprs, ConfigForFile(cfg, filename))
 }
 
 // ExtractFileRefs extracts cross-file-trackable references from an
 // analysis result. Only references to global-scope, non-builtin symbols
 // are included (builtins, special ops, parameters, and locals are skipped).
+//
+// File and Source.File of every returned FileReference denote the same file.
+// The workspace index pairs the two when building document edits (lsp/rename.go
+// takes the URI from File and the range from Source), so a reference whose text
+// lives in a different file must not be recorded under filePath.
 func ExtractFileRefs(result *Result, filePath string) []FileReference {
 	if result == nil {
 		return nil
@@ -618,6 +632,15 @@ func ExtractFileRefs(result *Result, filePath string) []FileReference {
 		}
 		// Skip builtins, special ops, parameters, and locals.
 		if !isGlobalUserSymbol(ref.Symbol) {
+			continue
+		}
+		// Skip references whose text lives in another file. Macro expansion
+		// (Config.MacroExpander) splices nodes from the macro's definition
+		// site into this file's AST, and those nodes carry the *other*
+		// file's location. Recording them under filePath would aim rename
+		// at the wrong file; they are captured correctly when the defining
+		// file is itself scanned.
+		if !sameSourceFile(ref.Source.File, filePath) {
 			continue
 		}
 
@@ -643,6 +666,22 @@ func ExtractFileRefs(result *Result, filePath string) []FileReference {
 		refs = append(refs, fref)
 	}
 	return refs
+}
+
+// sameSourceFile reports whether two file paths denote the same file.
+// Callers mix absolute and relative paths (ScanWorkspaceRefs analyses a
+// possibly-relative path but indexes under the absolute one), and an empty
+// source file is treated as "the file being analysed".
+func sameSourceFile(sourceFile, filePath string) bool {
+	if sourceFile == "" || sourceFile == filePath {
+		return true
+	}
+	a, errA := filepath.Abs(sourceFile)
+	b, errB := filepath.Abs(filePath)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return a == b
 }
 
 // isGlobalUserSymbol returns true if a symbol is a user-defined global
@@ -788,6 +827,11 @@ func scopeContainingAnalysis(scope *Scope, line, col int) *Scope {
 // analysis on each .lisp file, and extracts cross-file references.
 // The cfg should have ExtraGlobals and PackageExports populated from
 // a prior ScanWorkspaceFull call. Parsing is done concurrently.
+//
+// If cfg.MacroExpander is set it is used for every file, so the index agrees
+// with per-document analysis about symbols reachable only through a macro
+// expansion. Expansion is only attempted for heads that are user macros or
+// unresolved, so the added cost is small; leave the field nil to skip it.
 // The optional scanCfg controls file collection limits and excludes.
 //
 // Returns a map from SymbolKey.String() to FileReference slices.

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1865,4 +1866,131 @@ func TestPrescanWorkspace_Preamble(t *testing.T) {
 	assert.Equal(t, 2, heads["defmacro"], "should collect both defmacro forms")
 	assert.Equal(t, 1, heads["defun"], "should collect defun forms")
 	assert.Equal(t, 1, heads["set"], "should collect set forms")
+}
+
+// countingExpander records how many times the analyzer asked it to expand.
+// It never actually expands (returns nil), so it changes no analysis result —
+// it only observes whether Config.MacroExpander reached the analyzer.
+type countingExpander struct {
+	calls int
+}
+
+func (c *countingExpander) ExpandMacro(_ *lisp.LVal, _ string) *lisp.LVal {
+	c.calls++
+	return nil
+}
+
+// TestAnalyzeFile_ForwardsMacroExpander is the issue #353 reproducer:
+// AnalyzeFile must not silently drop Config.MacroExpander. The same source
+// analysed through Analyze and through AnalyzeFile must reach the expander
+// the same number of times.
+func TestAnalyzeFile_ForwardsMacroExpander(t *testing.T) {
+	src := []byte("(in-package 'user)\n(no-such-head 1 2)\n")
+
+	direct := &countingExpander{}
+	exprs, err := rdparser.New(token.NewScanner("x.lisp", strings.NewReader(string(src)))).ParseProgram()
+	require.NoError(t, err)
+	Analyze(exprs, &Config{MacroExpander: direct, Filename: "x.lisp"})
+	require.Positive(t, direct.calls, "sanity: Analyze must consult the expander")
+
+	viaFile := &countingExpander{}
+	require.NotNil(t, AnalyzeFile(src, "x.lisp", &Config{MacroExpander: viaFile}))
+
+	assert.Equal(t, direct.calls, viaFile.calls,
+		"AnalyzeFile must forward Config.MacroExpander to Analyze")
+}
+
+// TestConfigForFile_CarriesEveryField guards the whole class of bug that
+// issue #353 (MacroExpander) and the earlier DefForms/PackageImports drop
+// both belong to: a new Config field added without updating a per-file config.
+// Every field except Filename must survive the copy.
+func TestConfigForFile_CarriesEveryField(t *testing.T) {
+	src := &Config{
+		ExtraGlobals:   []ExternalSymbol{{Name: "g"}},
+		PackageExports: map[string][]ExternalSymbol{"p": {{Name: "e"}}},
+		PackageSymbols: map[string][]ExternalSymbol{"p": {{Name: "s"}}},
+		DefForms:       []DefFormSpec{{Head: "defthing"}},
+		PackageImports: map[string][]string{"p": {"q"}},
+		DefaultPackage: "svc",
+		WorkspaceRefs:  map[string][]FileReference{"k": {{File: "a.lisp"}}},
+		MacroExpander:  &countingExpander{},
+		Filename:       "original.lisp",
+	}
+
+	// Every field must be non-zero above, or the test proves nothing.
+	sv := reflect.ValueOf(*src)
+	for i := range sv.NumField() {
+		require.False(t, sv.Field(i).IsZero(),
+			"test fixture must set Config.%s", sv.Type().Field(i).Name)
+	}
+
+	got := ConfigForFile(src, "other.lisp")
+	require.NotSame(t, src, got, "ConfigForFile must not alias the caller's Config")
+	assert.Equal(t, "other.lisp", got.Filename)
+
+	gv := reflect.ValueOf(*got)
+	for i := range gv.NumField() {
+		name := sv.Type().Field(i).Name
+		if name == "Filename" {
+			continue
+		}
+		assert.Equal(t, sv.Field(i).Interface(), gv.Field(i).Interface(),
+			"ConfigForFile dropped Config.%s", name)
+	}
+}
+
+// TestScanWorkspaceRefs_MacroExpansionKeepsRefsInOwnFile pins the invariant
+// that File and Source.File agree for every workspace reference.
+//
+// Now that AnalyzeFile honours Config.MacroExpander (issue #353),
+// ScanWorkspaceRefs analyses expanded ASTs. Expansion splices nodes from the
+// macro's definition site into the calling file, so those nodes carry the
+// macro file's location. lsp/rename.go takes the edit URI from File and the
+// edit range from Source, so recording such a node under the calling file
+// would aim a rename at coordinates that belong to a different file.
+func TestScanWorkspaceRefs_MacroExpansionKeepsRefsInOwnFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.lisp"), []byte(
+		"(in-package 'user)\n"+
+			"(defun helper-fn (x) (+ x 1))\n"+
+			"(defmacro call-helper (v) (quasiquote (helper-fn (unquote v))))\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.lisp"), []byte(
+		"(in-package 'user)\n"+
+			"(defun use-it (y) (call-helper y))\n"), 0o600))
+
+	pre, err := PrescanWorkspace(dir, nil)
+	require.NoError(t, err)
+
+	env := newTestEnv(t)
+	require.Empty(t, LoadWorkspaceMacros(env, pre.Preamble))
+
+	cfg := &Config{
+		ExtraGlobals:   pre.AllDefs,
+		PackageExports: pre.PkgExports,
+		PackageSymbols: pre.PkgAllSymbols,
+		DefForms:       pre.DefForms,
+		PackageImports: pre.PackageImports,
+		DefaultPackage: pre.DefaultPackage,
+		MacroExpander:  &EnvMacroExpander{Env: env},
+	}
+
+	refs := ScanWorkspaceRefs(dir, cfg, nil)
+	require.NotEmpty(t, refs)
+
+	var checked int
+	for key, list := range refs {
+		for _, ref := range list {
+			require.NotNil(t, ref.Source)
+			assert.Equal(t, filepath.Base(ref.File), filepath.Base(ref.Source.File),
+				"%s: reference recorded in %s but sourced in %s",
+				key, ref.File, ref.Source.File)
+			checked++
+		}
+	}
+	assert.Positive(t, checked)
+
+	// The macro's own body reference to helper-fn stays attributed to a.lisp.
+	helper := refs[SymbolKey{Package: "user", Name: "helper-fn", Kind: SymFunction}.String()]
+	require.Len(t, helper, 1)
+	assert.Equal(t, "a.lisp", filepath.Base(helper[0].File))
 }

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -1868,14 +1868,14 @@ func TestPrescanWorkspace_Preamble(t *testing.T) {
 	assert.Equal(t, 1, heads["set"], "should collect set forms")
 }
 
-// countingExpander records how many times the analyzer asked it to expand.
+// countingStubExpander records how many times the analyzer asked it to expand.
 // It never actually expands (returns nil), so it changes no analysis result —
 // it only observes whether Config.MacroExpander reached the analyzer.
-type countingExpander struct {
+type countingStubExpander struct {
 	calls int
 }
 
-func (c *countingExpander) ExpandMacro(_ *lisp.LVal, _ string) *lisp.LVal {
+func (c *countingStubExpander) ExpandMacro(_ *lisp.LVal, _ string) *lisp.LVal {
 	c.calls++
 	return nil
 }
@@ -1887,13 +1887,13 @@ func (c *countingExpander) ExpandMacro(_ *lisp.LVal, _ string) *lisp.LVal {
 func TestAnalyzeFile_ForwardsMacroExpander(t *testing.T) {
 	src := []byte("(in-package 'user)\n(no-such-head 1 2)\n")
 
-	direct := &countingExpander{}
+	direct := &countingStubExpander{}
 	exprs, err := rdparser.New(token.NewScanner("x.lisp", strings.NewReader(string(src)))).ParseProgram()
 	require.NoError(t, err)
 	Analyze(exprs, &Config{MacroExpander: direct, Filename: "x.lisp"})
 	require.Positive(t, direct.calls, "sanity: Analyze must consult the expander")
 
-	viaFile := &countingExpander{}
+	viaFile := &countingStubExpander{}
 	require.NotNil(t, AnalyzeFile(src, "x.lisp", &Config{MacroExpander: viaFile}))
 
 	assert.Equal(t, direct.calls, viaFile.calls,
@@ -1913,7 +1913,7 @@ func TestConfigForFile_CarriesEveryField(t *testing.T) {
 		PackageImports: map[string][]string{"p": {"q"}},
 		DefaultPackage: "svc",
 		WorkspaceRefs:  map[string][]FileReference{"k": {{File: "a.lisp"}}},
-		MacroExpander:  &countingExpander{},
+		MacroExpander:  &countingStubExpander{},
 		Filename:       "original.lisp",
 	}
 

--- a/astutil/walk.go
+++ b/astutil/walk.go
@@ -44,7 +44,12 @@ func WalkSExprs(exprs []*lisp.LVal, fn func(sexpr *lisp.LVal, depth int)) {
 }
 
 // HeadSymbol returns the symbol name at the head of an s-expression, or "".
+// A nil sexpr yields "", so it is safe to call on the nil parent Walk passes
+// for top-level expressions.
 func HeadSymbol(sexpr *lisp.LVal) string {
+	if sexpr == nil {
+		return ""
+	}
 	if sexpr.Type != lisp.LSExpr || len(sexpr.Cells) == 0 {
 		return ""
 	}
@@ -56,7 +61,12 @@ func HeadSymbol(sexpr *lisp.LVal) string {
 }
 
 // ArgCount returns the number of arguments in an s-expression (excluding the head).
+// A nil sexpr yields 0, so it is safe to call on the nil parent Walk passes for
+// top-level expressions.
 func ArgCount(sexpr *lisp.LVal) int {
+	if sexpr == nil {
+		return 0
+	}
 	if len(sexpr.Cells) <= 1 {
 		return 0
 	}
@@ -129,7 +139,12 @@ func PackageNameArg(arg *lisp.LVal) string {
 
 // SourceOf returns the best source location for a node.
 // Prefers the node's own source, falls back to first child's source.
+// Returns nil for a nil node, so it is safe to call on the nil parent Walk
+// passes for top-level expressions.
 func SourceOf(v *lisp.LVal) *lisp.LVal {
+	if v == nil {
+		return nil
+	}
 	if v.Source != nil && v.Source.Line > 0 {
 		return v
 	}

--- a/astutil/walk_test.go
+++ b/astutil/walk_test.go
@@ -179,3 +179,44 @@ func TestCollectFormals_SkipsMarkers(t *testing.T) {
 	assert.False(t, defs["&optional"])
 	assert.False(t, defs["&rest"])
 }
+
+// TestSourceOf_Nil covers the nil parent that Walk documents it will pass for
+// top-level expressions (issue #354).
+func TestSourceOf_Nil(t *testing.T) {
+	assert.Nil(t, SourceOf(nil))
+}
+
+// TestHeadSymbol_Nil and TestArgCount_Nil cover the same nil-parent shape for
+// the sibling accessors, which are exported alongside Walk from lint/walk.go.
+func TestHeadSymbol_Nil(t *testing.T) {
+	assert.Empty(t, HeadSymbol(nil))
+}
+
+func TestArgCount_Nil(t *testing.T) {
+	assert.Zero(t, ArgCount(nil))
+}
+
+// TestWalk_NilParentAccessors is the issue #354 reproducer: pairing Walk with
+// the astutil accessors on the parent must not panic on top-level forms.
+func TestWalk_NilParentAccessors(t *testing.T) {
+	exprs := []*lisp.LVal{{
+		Type: lisp.LSExpr,
+		Cells: []*lisp.LVal{
+			{Type: lisp.LSymbol, Str: "defun"},
+			{Type: lisp.LSymbol, Str: "f"},
+		},
+	}}
+
+	var sawNilParent bool
+	assert.NotPanics(t, func() {
+		Walk(exprs, func(_ *lisp.LVal, parent *lisp.LVal, _ int) {
+			if parent == nil {
+				sawNilParent = true
+			}
+			_ = SourceOf(parent)
+			_ = HeadSymbol(parent)
+			_ = ArgCount(parent)
+		})
+	})
+	assert.True(t, sawNilParent, "Walk must pass a nil parent for top-level forms")
+}

--- a/lint/walk.go
+++ b/lint/walk.go
@@ -20,11 +20,13 @@ func WalkSExprs(exprs []*lisp.LVal, fn func(sexpr *lisp.LVal, depth int)) {
 }
 
 // HeadSymbol returns the symbol name at the head of an s-expression, or "".
+// A nil sexpr yields "".
 func HeadSymbol(sexpr *lisp.LVal) string {
 	return astutil.HeadSymbol(sexpr)
 }
 
 // ArgCount returns the number of arguments in an s-expression (excluding the head).
+// A nil sexpr yields 0.
 func ArgCount(sexpr *lisp.LVal) int {
 	return astutil.ArgCount(sexpr)
 }
@@ -48,6 +50,7 @@ func CollectFormals(formals *lisp.LVal, defs map[string]bool) {
 
 // SourceOf returns the best source location for a node.
 // Prefers the node's own source, falls back to first child's source.
+// Returns nil for a nil node.
 func SourceOf(v *lisp.LVal) *lisp.LVal {
 	return astutil.SourceOf(v)
 }

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -446,20 +446,7 @@ func (s *Server) getAnalysisConfig(uri string) *analysis.Config {
 	base := s.analysisCfg
 	s.analysisCfgMu.RUnlock()
 
-	cfg := &analysis.Config{
-		Filename: uriToPath(uri),
-	}
-	if base != nil {
-		cfg.ExtraGlobals = base.ExtraGlobals
-		cfg.PackageExports = base.PackageExports
-		cfg.PackageSymbols = base.PackageSymbols
-		cfg.DefForms = base.DefForms
-		cfg.PackageImports = base.PackageImports
-		cfg.DefaultPackage = base.DefaultPackage
-		cfg.WorkspaceRefs = base.WorkspaceRefs
-		cfg.MacroExpander = base.MacroExpander
-	}
-	return cfg
+	return analysis.ConfigForFile(base, uriToPath(uri))
 }
 
 // ensureAnalysis ensures the document has a current analysis result.

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -579,17 +579,7 @@ func (s *service) loadDocument(path string, content *string, workspaceRoot *stri
 	parser := rdparser.New(scanner)
 	parsed := parser.ParseProgramFaultTolerant()
 
-	cfg := &analysis.Config{
-		Filename:       resolvedPath,
-		ExtraGlobals:   state.cfg.ExtraGlobals,
-		PackageExports: state.cfg.PackageExports,
-		PackageSymbols: state.cfg.PackageSymbols,
-		DefForms:       state.cfg.DefForms,
-		PackageImports: state.cfg.PackageImports,
-		DefaultPackage: state.cfg.DefaultPackage,
-		WorkspaceRefs:  state.cfg.WorkspaceRefs,
-		MacroExpander:  state.cfg.MacroExpander,
-	}
+	cfg := analysis.ConfigForFile(state.cfg, resolvedPath)
 	var result *analysis.Result
 	if parsed.Exprs != nil {
 		result = analysis.Analyze(parsed.Exprs, cfg)


### PR DESCRIPTION
Fixes #353 and #354, in two independently revertable commits.

## #354 — `astutil` accessors nil-deref on the nil parent `Walk` documents

`Walk` documents "parent is nil for top-level expressions"; the accessors exported alongside it dereferenced unconditionally. Each SIGSEGV'd before the fix, verified individually.

`SourceOf` was not alone — `HeadSymbol` and `ArgCount` have the same shape and the same natural pairing with `Walk`. All three now return their zero value (`nil`, `""`, `0`) and document it. The remaining helpers (`Walk`, `WalkSExprs`, `UserDefined`, `CollectFormals`, `PackageNameArg`) already guarded.

## #353 — `AnalyzeFile` dropped `Config.MacroExpander`

**Option (a): carry the field through.** The evidence that the omission was never deliberate:

- The field-by-field rebuild was written 2026-02-28 (`c0c6a20`). `MacroExpander` was added to `Config` 2026-04-01 (`e5e6417`), and that commit never touched `analysis/workspace.go`. There is no revision where the field existed and was consciously skipped.
- The twin rebuild in `lsp/server.go:getAnalysisConfig` **does** carry it — same pattern, same author.
- This exact site had already dropped fields once before: `3c6a860` added `DefForms` and `PackageImports` back after they went missing, leaving a regression test behind.

**The cost premise for "skip expansion deliberately" does not hold.** Measured on a synthetic 200-file / 2400-definition workspace running full `ScanWorkspaceRefs`: 350ms with the expander against 395ms without. Expansion is gated on `isMacro || sym == nil`, `EnvMacroExpander` caches negative lookups per (pkg, name), and an expanded form is analysed *instead of* the opaque walk rather than in addition.

The rebuild is now a whole-struct copy (`ConfigForFile`), applied at all three sites that specialise a workspace `Config` for one file — `analysis/workspace.go`, `lsp/server.go`, `mcpserver/service.go`. The latter two were complete but carried the same latent risk. A reflection-based test asserts every `Config` field except `Filename` survives the copy, so the next field added cannot go missing here again.

## The part reviewers should look at: wiring it through naively would have corrupted cross-file rename

Macro expansion splices nodes from the **macro's definition site** into the calling file's AST, and those nodes carry the *other* file's `Source`. `ExtractFileRefs` stamped them with the calling file, producing a reference with `File=b.lisp` and `Source=a.lisp:3:40`.

`lsp/rename.go:111` takes the edit URI from `File` and the edit range from `Source`. So cross-file rename would have written edits into `b.lisp` at coordinates belonging to `a.lisp`, and `lsp/references.go:54` would have reported a bogus location. The per-document path was safe, because it uses `ref.Source.File` for the URI.

`ExtractFileRefs` now skips references whose text lives in another file; they are captured correctly when the defining file is itself scanned. `TestScanWorkspaceRefs_MacroExpansionKeepsRefsInOwnFile` pins it.

I verified the test actually detects the regression rather than merely passing: removing the guard fails it with `reference recorded in .../b.lisp but sourced in .../a.lisp`.

## Other blast radius

- A **third** `ScanWorkspaceRefs` caller exists that #353 did not list: `lint/lint.go:431`, which also sets `MacroExpander`. CLI lint's cross-file `unused-function` detection now sees macro-reachable references.
- `mcpserver/service.go:692` calls `ScanWorkspaceRefs` *before* `LoadWorkspaceMacros` at :700, so its expander is typically nil at scan time. Unaffected here, but worth a separate look.
- With expansion on, a macro call site records one reference instead of two — the opaque path recorded the head as a macro reference and again as a walked child. That removes duplicate rename edits at the same range.
- `ScanWorkspaceRefs` fans out over `NumCPU` workers against the single mutex-serialised `EnvMacroExpander`. Documented thread-safe; the timing above is measured with that contention.

## Verification

`go build ./...` clean, full `go test ./...` green, `gofmt -l` clean on touched files, `golangci-lint run` over `analysis/ lint/ astutil/ lsp/ mcpserver/` reports 0 issues. The pre-existing `analysis/analyzer.go` gofmt diff on main is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_