### PR TITLE
Restore the caller's package across elpsutil loads

### DIFF
--- a/elpsutil/elpsutil.go
+++ b/elpsutil/elpsutil.go
@@ -32,9 +32,12 @@ func (fun *Builtin) Eval(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 }
 
 // Loader is a generic function to initialize/load an LEnv.  A Loader should
-// first define and switch into the package(s) it loads.  Typically, after a
-// Loader executes LEnv.InPackage() is executed to switch back into the user
-// package.
+// first define and switch into the package(s) it loads.  The helpers in this
+// package (Load, LoadAll, LibraryLoader and PackageLoader) restore the package
+// that was active when they were called, so that symbols defined after a load
+// end up where the caller expects them.  A load performed from the user
+// package -- the conventional top-level usage -- therefore ends in the user
+// package, as it always has.
 //
 // A chain of loaders may be formed to load a library.
 type Loader = lisp.Loader
@@ -112,32 +115,29 @@ func packageMacros(p Package) []lisp.LBuiltinDef {
 	return _p.Macros()
 }
 
-// Load loads an elps package implemented in Go.
+// Load loads an elps package implemented in Go.  Load restores the package
+// that was active when it was called so that further defined symbols end up in
+// that package by default.
 func Load(env *lisp.LEnv, fn Loader) *lisp.LVal {
+	prevPkg := env.Runtime.Package.Name
 	lerr := fn(env)
 	if lerr.Type == lisp.LError {
 		return lerr
 	}
-	// Switch back to the user package so that further defined symbols end up
-	// in that package by default.
-	lerr = env.InPackage(lisp.String(lisp.DefaultUserPackage))
+	lerr = env.InPackage(lisp.String(prevPkg))
 	if lerr.Type == lisp.LError {
 		return lerr
 	}
 	return lisp.Nil()
 }
 
-// LoadAll loads multiple elps files implemented in Go.
+// LoadAll loads multiple elps files implemented in Go.  Like Load, LoadAll
+// restores the package that was active when it was called, and runs each
+// loader from that package.
 func LoadAll(fn ...Loader) Loader {
 	return func(env *lisp.LEnv) *lisp.LVal {
 		for _, fn := range fn {
-			lerr := fn(env)
-			if lerr.Type == lisp.LError {
-				return lerr
-			}
-			// Switch back to the user package so that further defined symbols end up
-			// in that package by default.
-			lerr = env.InPackage(lisp.String(lisp.DefaultUserPackage))
+			lerr := Load(env, fn)
 			if lerr.Type == lisp.LError {
 				return lerr
 			}
@@ -160,8 +160,19 @@ func LibraryLoader(ps ...Package) Loader {
 }
 
 // PackageLoader loads an elps package implemented in Go.
+//
+// PackageLoader restores the package that was active when it was called, the
+// same invariant the stdlib LoadPackage functions honor
+// (https://github.com/luthersystems/elps/issues/99).  It also re-establishes
+// the loaded package after PackageInit returns, so that a PackageInit which
+// switches packages -- directly, or indirectly through a nested Load -- does
+// not cause the package's builtins, special operators and macros to be
+// registered and exported somewhere else
+// (https://github.com/luthersystems/elps/issues/352).
 func PackageLoader(p Package) Loader {
 	return func(env *lisp.LEnv) *lisp.LVal {
+		prevPkg := env.Runtime.Package.Name
+		defer env.InPackage(lisp.Symbol(prevPkg))
 		name := lisp.Symbol(p.PackageName())
 		e := env.DefinePackage(name)
 		if !e.IsNil() {
@@ -177,6 +188,13 @@ func PackageLoader(p Package) Loader {
 		initLoader := packageInit(p)
 		e = initLoader(env)
 		if e.Type == lisp.LError {
+			return e
+		}
+		// PackageInit may have switched packages -- the Loader convention
+		// documented above tells embedders to do exactly that.  Re-establish
+		// the package being loaded so the definitions below land in it.
+		e = env.InPackage(name)
+		if !e.IsNil() {
 			return e
 		}
 		for _, fn := range packageBuiltins(p) {

--- a/elpsutil/elpsutil_test.go
+++ b/elpsutil/elpsutil_test.go
@@ -1,0 +1,372 @@
+// Copyright © 2026 The ELPS authors
+
+package elpsutil_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/elpsutil"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testPackage is a configurable elpsutil.Package used to exercise the package
+// restoration invariant.
+type testPackage struct {
+	name     string
+	doc      string
+	init     func(env *lisp.LEnv) *lisp.LVal
+	builtins []lisp.LBuiltinDef
+	ops      []lisp.LBuiltinDef
+	macros   []lisp.LBuiltinDef
+}
+
+var (
+	_ elpsutil.PackageInit       = (*testPackage)(nil)
+	_ elpsutil.PackageDocumented = (*testPackage)(nil)
+	_ elpsutil.PackageBuiltins   = (*testPackage)(nil)
+	_ elpsutil.PackageSpecialOps = (*testPackage)(nil)
+	_ elpsutil.PackageMacros     = (*testPackage)(nil)
+)
+
+func (p *testPackage) PackageName() string { return p.name }
+
+func (p *testPackage) PackageDoc() string { return p.doc }
+
+func (p *testPackage) PackageInit(env *lisp.LEnv) *lisp.LVal {
+	if p.init == nil {
+		return lisp.Nil()
+	}
+	return p.init(env)
+}
+
+func (p *testPackage) Builtins() []lisp.LBuiltinDef { return p.builtins }
+
+func (p *testPackage) SpecialOps() []lisp.LBuiltinDef { return p.ops }
+
+func (p *testPackage) Macros() []lisp.LBuiltinDef { return p.macros }
+
+// nilFun is a trivial builtin implementation used by test packages.
+func nilFun(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal { return lisp.Nil() }
+
+func testBuiltin(name string) lisp.LBuiltinDef {
+	return elpsutil.Function(name, lisp.Formals(), nilFun)
+}
+
+func newTestEnv(t *testing.T) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	env.Runtime.Library = &lisp.RelativeFileSystemLibrary{}
+	rc := lisp.InitializeUserEnv(env)
+	require.True(t, rc.IsNil(), "InitializeUserEnv: %v", rc)
+	require.Equal(t, lisp.DefaultUserPackage, env.Runtime.Package.Name)
+	return env
+}
+
+// assertBoundIn asserts that sym is bound and exported in package pkg, and
+// that it is not present in any other package.
+func assertBoundIn(t *testing.T, env *lisp.LEnv, pkg string, sym string) {
+	t.Helper()
+	for name, p := range env.Runtime.Registry.Packages {
+		v := p.Get(lisp.Symbol(sym))
+		if name == pkg {
+			assert.NotEqualf(t, lisp.LError, v.Type,
+				"symbol %q should be bound in package %q", sym, pkg)
+			assert.Containsf(t, p.Externals, sym,
+				"symbol %q should be exported from package %q", sym, pkg)
+			continue
+		}
+		assert.Equalf(t, lisp.LError, v.Type,
+			"symbol %q should not be bound in package %q (expected it in %q)", sym, name, pkg)
+	}
+}
+
+// TestPackageLoader_EachPackageRestoresPrevious mirrors
+// lisplib.TestLoadLibrary_EachPackageRestoresPrevious (the test pinning the fix
+// for https://github.com/luthersystems/elps/issues/99) for the embedder-facing
+// elpsutil.PackageLoader.  See
+// https://github.com/luthersystems/elps/issues/352.
+func TestPackageLoader_EachPackageRestoresPrevious(t *testing.T) {
+	env := newTestEnv(t)
+
+	pkgs := []*testPackage{
+		// A package with no PackageInit at all.
+		{name: "plain", builtins: []lisp.LBuiltinDef{testBuiltin("plain-fn")}},
+		// A package whose PackageInit does not move.
+		{
+			name:     "stationary",
+			init:     func(env *lisp.LEnv) *lisp.LVal { return lisp.Nil() },
+			builtins: []lisp.LBuiltinDef{testBuiltin("stationary-fn")},
+		},
+		// A package whose PackageInit switches package directly, as
+		// elpsutil.Loader's documentation tells embedders to do.
+		{
+			name: "switcher",
+			init: func(env *lisp.LEnv) *lisp.LVal {
+				return elpsutil.Load(env, elpsutil.PackageLoader(&testPackage{
+					name:     "switcher-dep",
+					builtins: []lisp.LBuiltinDef{testBuiltin("switcher-dep-fn")},
+				}))
+			},
+			builtins: []lisp.LBuiltinDef{testBuiltin("switcher-fn")},
+			ops:      []lisp.LBuiltinDef{testBuiltin("switcher-op")},
+			macros:   []lisp.LBuiltinDef{testBuiltin("switcher-macro")},
+		},
+		// A package whose PackageInit lands in an unrelated package and never
+		// comes back.
+		{
+			name: "wanderer",
+			init: func(env *lisp.LEnv) *lisp.LVal {
+				name := lisp.Symbol("elsewhere")
+				if e := env.DefinePackage(name); !e.IsNil() {
+					return e
+				}
+				return env.InPackage(name)
+			},
+			builtins: []lisp.LBuiltinDef{testBuiltin("wanderer-fn")},
+			ops:      []lisp.LBuiltinDef{testBuiltin("wanderer-op")},
+			macros:   []lisp.LBuiltinDef{testBuiltin("wanderer-macro")},
+		},
+	}
+
+	for _, p := range pkgs {
+		t.Run(p.name, func(t *testing.T) {
+			before := env.Runtime.Package.Name
+			rc := elpsutil.PackageLoader(p)(env)
+			require.Truef(t, rc.IsNil(), "PackageLoader(%s) failed: %v", p.name, rc)
+			assert.Equalf(t, before, env.Runtime.Package.Name,
+				"PackageLoader(%s) should restore the previous package", p.name)
+			for _, fn := range p.builtins {
+				assertBoundIn(t, env, p.name, fn.Name())
+			}
+			for _, fn := range p.ops {
+				assertBoundIn(t, env, p.name, fn.Name())
+			}
+			for _, fn := range p.macros {
+				assertBoundIn(t, env, p.name, fn.Name())
+			}
+		})
+	}
+}
+
+// TestPackageLoader_RestoresNonUserCaller checks that the package restored is
+// the caller's package, not simply the user package.
+func TestPackageLoader_RestoresNonUserCaller(t *testing.T) {
+	env := newTestEnv(t)
+	caller := lisp.Symbol("caller")
+	require.True(t, env.DefinePackage(caller).IsNil())
+	require.True(t, env.InPackage(caller).IsNil())
+
+	p := &testPackage{
+		name: "callee",
+		init: func(env *lisp.LEnv) *lisp.LVal {
+			return elpsutil.Load(env, elpsutil.PackageLoader(&testPackage{name: "callee-dep"}))
+		},
+		builtins: []lisp.LBuiltinDef{testBuiltin("callee-fn")},
+	}
+	rc := elpsutil.PackageLoader(p)(env)
+	require.True(t, rc.IsNil(), "PackageLoader: %v", rc)
+	assert.Equal(t, "caller", env.Runtime.Package.Name,
+		"PackageLoader should restore the caller's package, not the user package")
+	assertBoundIn(t, env, "callee", "callee-fn")
+}
+
+// TestPackageLoader_PackageDocNotStolen checks that a PackageInit which
+// switches packages cannot cause the package documentation of the loaded
+// package to be applied elsewhere, and that documentation lands on the loaded
+// package.
+func TestPackageLoader_PackageDoc(t *testing.T) {
+	env := newTestEnv(t)
+	userDoc := env.Runtime.Registry.Packages[lisp.DefaultUserPackage].Doc
+	p := &testPackage{
+		name: "documented",
+		doc:  "a documented package",
+		init: func(env *lisp.LEnv) *lisp.LVal {
+			return elpsutil.Load(env, elpsutil.PackageLoader(&testPackage{name: "documented-dep"}))
+		},
+	}
+	require.True(t, elpsutil.PackageLoader(p)(env).IsNil())
+	assert.Equal(t, "a documented package", env.Runtime.Registry.Packages["documented"].Doc)
+	assert.Equal(t, userDoc, env.Runtime.Registry.Packages[lisp.DefaultUserPackage].Doc,
+		"the user package documentation should be untouched")
+	assert.Empty(t, env.Runtime.Registry.Packages["documented-dep"].Doc)
+}
+
+// TestPackageLoader_ErrorRestoresPrevious checks that the caller's package is
+// restored even when loading fails.
+func TestPackageLoader_ErrorRestoresPrevious(t *testing.T) {
+	env := newTestEnv(t)
+	p := &testPackage{
+		name: "failing",
+		init: func(env *lisp.LEnv) *lisp.LVal {
+			name := lisp.Symbol("failing-elsewhere")
+			if e := env.DefinePackage(name); !e.IsNil() {
+				return e
+			}
+			if e := env.InPackage(name); !e.IsNil() {
+				return e
+			}
+			return env.Errorf("init failed")
+		},
+	}
+	rc := elpsutil.PackageLoader(p)(env)
+	require.Equal(t, lisp.LError, rc.Type, "PackageLoader should propagate the init error")
+	assert.Equal(t, lisp.DefaultUserPackage, env.Runtime.Package.Name,
+		"PackageLoader should restore the previous package when loading fails")
+}
+
+// TestLoad_RestoresPrevious checks elpsutil.Load restores the caller's package.
+func TestLoad_RestoresPrevious(t *testing.T) {
+	env := newTestEnv(t)
+	caller := lisp.Symbol("load-caller")
+	require.True(t, env.DefinePackage(caller).IsNil())
+	require.True(t, env.InPackage(caller).IsNil())
+
+	rc := elpsutil.Load(env, elpsutil.PackageLoader(&testPackage{
+		name:     "load-callee",
+		builtins: []lisp.LBuiltinDef{testBuiltin("load-callee-fn")},
+	}))
+	require.True(t, rc.IsNil(), "Load: %v", rc)
+	assert.Equal(t, "load-caller", env.Runtime.Package.Name,
+		"Load should restore the caller's package")
+	assertBoundIn(t, env, "load-callee", "load-callee-fn")
+}
+
+// TestLoad_FromUserPackage pins the conventional top-level behaviour: a load
+// started from the user package ends in the user package.
+func TestLoad_FromUserPackage(t *testing.T) {
+	env := newTestEnv(t)
+	rc := elpsutil.Load(env, elpsutil.PackageLoader(&testPackage{name: "top-level"}))
+	require.True(t, rc.IsNil(), "Load: %v", rc)
+	assert.Equal(t, lisp.DefaultUserPackage, env.Runtime.Package.Name)
+}
+
+// TestLoadAll_RestoresPrevious checks elpsutil.LoadAll restores the caller's
+// package, both between and after the loaders it runs.
+func TestLoadAll_RestoresPrevious(t *testing.T) {
+	env := newTestEnv(t)
+	caller := lisp.Symbol("loadall-caller")
+	require.True(t, env.DefinePackage(caller).IsNil())
+	require.True(t, env.InPackage(caller).IsNil())
+
+	var between []string
+	loader := elpsutil.LoadAll(
+		elpsutil.PackageLoader(&testPackage{
+			name:     "loadall-a",
+			builtins: []lisp.LBuiltinDef{testBuiltin("loadall-a-fn")},
+		}),
+		func(env *lisp.LEnv) *lisp.LVal {
+			between = append(between, env.Runtime.Package.Name)
+			return lisp.Nil()
+		},
+		elpsutil.PackageLoader(&testPackage{
+			name:     "loadall-b",
+			builtins: []lisp.LBuiltinDef{testBuiltin("loadall-b-fn")},
+		}),
+	)
+	rc := loader(env)
+	require.True(t, rc.IsNil(), "LoadAll: %v", rc)
+	assert.Equal(t, []string{"loadall-caller"}, between,
+		"LoadAll should run each loader from the caller's package")
+	assert.Equal(t, "loadall-caller", env.Runtime.Package.Name,
+		"LoadAll should restore the caller's package")
+	assertBoundIn(t, env, "loadall-a", "loadall-a-fn")
+	assertBoundIn(t, env, "loadall-b", "loadall-b-fn")
+}
+
+// TestLibraryLoader_RestoresPrevious checks elpsutil.LibraryLoader restores the
+// caller's package and puts each package's symbols in the right place.
+func TestLibraryLoader_RestoresPrevious(t *testing.T) {
+	env := newTestEnv(t)
+	caller := lisp.Symbol("lib-caller")
+	require.True(t, env.DefinePackage(caller).IsNil())
+	require.True(t, env.InPackage(caller).IsNil())
+
+	rc := elpsutil.LibraryLoader(
+		&testPackage{name: "lib-a", builtins: []lisp.LBuiltinDef{testBuiltin("lib-a-fn")}},
+		&testPackage{
+			name: "lib-b",
+			init: func(env *lisp.LEnv) *lisp.LVal {
+				return elpsutil.Load(env, elpsutil.PackageLoader(&testPackage{name: "lib-b-dep"}))
+			},
+			builtins: []lisp.LBuiltinDef{testBuiltin("lib-b-fn")},
+		},
+	)(env)
+	require.True(t, rc.IsNil(), "LibraryLoader: %v", rc)
+	assert.Equal(t, "lib-caller", env.Runtime.Package.Name)
+	assertBoundIn(t, env, "lib-a", "lib-a-fn")
+	assertBoundIn(t, env, "lib-b", "lib-b-fn")
+}
+
+// TestPackageLoader_SubstrateShape reproduces the shape of
+// luthersystems/substrate's ShiroPackage.PackageInit, which loads a nested
+// library and then explicitly switches back into its own package before
+// re-exporting the sub-package symbols.  The explicit restoration must remain
+// correct (a redundant no-op) after the fix for #352.
+func TestPackageLoader_SubstrateShape(t *testing.T) {
+	subs := []elpsutil.Package{
+		&testPackage{name: "sub-a", builtins: []lisp.LBuiltinDef{testBuiltin("sub-a-fn")}},
+		&testPackage{name: "sub-b", builtins: []lisp.LBuiltinDef{testBuiltin("sub-b-fn")}},
+	}
+
+	for _, withWorkaround := range []bool{true, false} {
+		name := "without-manual-restore"
+		if withWorkaround {
+			name = "with-manual-restore"
+		}
+		t.Run(name, func(t *testing.T) {
+			env := newTestEnv(t)
+			cc := &testPackage{
+				name: "cc",
+				init: func(env *lisp.LEnv) *lisp.LVal {
+					lerr := elpsutil.Load(env, elpsutil.LibraryLoader(subs...))
+					if lerr.Type == lisp.LError {
+						return lerr
+					}
+					if withWorkaround {
+						// substrate's compensation for #352.
+						lerr = env.InPackage(lisp.Symbol("cc"))
+						if lerr.Type == lisp.LError {
+							return lerr
+						}
+					}
+					for _, sub := range subs {
+						lerr := env.UsePackage(lisp.Symbol(sub.PackageName()))
+						if lerr.Type == lisp.LError {
+							return lerr
+						}
+						pkg := env.Runtime.Registry.Packages[sub.PackageName()]
+						env.Runtime.Package.Externals = append(env.Runtime.Package.Externals, pkg.Externals...)
+					}
+					return lisp.Nil()
+				},
+				builtins: []lisp.LBuiltinDef{testBuiltin("cc-fn")},
+			}
+
+			rc := elpsutil.Load(env, elpsutil.PackageLoader(cc))
+			require.True(t, rc.IsNil(), "Load: %v", rc)
+			assert.Equal(t, lisp.DefaultUserPackage, env.Runtime.Package.Name)
+
+			ccPkg := env.Runtime.Registry.Packages["cc"]
+			require.NotNil(t, ccPkg)
+			// cc's own builtin must be bound in cc.
+			assert.NotEqual(t, lisp.LError, ccPkg.Get(lisp.Symbol("cc-fn")).Type,
+				"cc-fn should be bound in the cc package")
+			assert.Contains(t, ccPkg.Externals, "cc-fn")
+			// The re-exported sub-package symbols must be in cc, not user.
+			for _, sym := range []string{"sub-a-fn", "sub-b-fn"} {
+				assert.NotEqualf(t, lisp.LError, ccPkg.Get(lisp.Symbol(sym)).Type,
+					"%s should be re-exported into the cc package", sym)
+				assert.Containsf(t, ccPkg.Externals, sym, "%s should be external in cc", sym)
+			}
+			userPkg := env.Runtime.Registry.Packages[lisp.DefaultUserPackage]
+			for _, sym := range []string{"cc-fn", "sub-a-fn", "sub-b-fn"} {
+				assert.Equalf(t, lisp.LError, userPkg.Get(lisp.Symbol(sym)).Type,
+					"%s should not leak into the user package", sym)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #352.

elps already treats "a package load restores the previous package" as an invariant for its own stdlib — #99 fixed the `LoadPackage` functions for violating it, and `TestLoadLibrary_EachPackageRestoresPrevious` pins it. That guarantee did not extend through `elpsutil`, which is the one path elps ships specifically *for* embedders.

## Pre-fix failing tests, written before the fix

Run against unmodified `main`, every new test failed except the two pinning behaviour that was already correct:

- `TestPackageLoader_EachPackageRestoresPrevious/{plain,stationary}` — the loader left the env in the loaded package instead of the caller's.
- `.../switcher`, where `PackageInit` does a nested `elpsutil.Load` — `switcher-fn`, `switcher-op` and `switcher-macro` were bound **and exported in `user`, not in `switcher`**, silently, with a nil return. That is the defect verbatim.
- `.../wanderer` — symbols landed in an unrelated package.
- `TestLoad_RestoresPrevious`, `TestLoadAll_RestoresPrevious`, `TestLibraryLoader_RestoresPrevious` and the `PackageLoader` error/doc cases.

## The fix

`PackageLoader` saves the active package on entry, restores it with `defer` (the idiom #99 put in the stdlib loaders, so error paths restore too), and — the actual bug — re-establishes the loaded package after `PackageInit` returns, before `AddBuiltins`/`AddSpecialOps`/`AddMacros`.

**`Load` and `LoadAll` shared it.** They hard-switched to `lisp.DefaultUserPackage` rather than restoring the caller, so a *nested* load silently relocated its caller — precisely what substrate's comment describes. Both now restore the package active when they were called. For the conventional top-level call from `user`, `prev == user`, so behaviour is unchanged; pinned by `TestLoad_FromUserPackage`. `LibraryLoader` needed no change, since it goes through `Load`.

## Breaking-change assessment

Low risk, checked rather than assumed. A code search for `elpsutil.PackageLoader` / `Load` / `LoadAll` / `LibraryLoader` / `PackageInit` across accessible Go code returns only `luthersystems/substrate` and `luthersystems/svc/libhandlebars`. elps itself never calls any of them, consistent with the 0% coverage #352 notes.

Behaviour differs only when a load starts from a non-`user` package. Every substrate entry point starts in `user`, so `prev == user` and their loader chains are bit-identical. No code was found anywhere that deliberately relies on `PackageInit`/`Load` leaving it elsewhere; the one place that observes the old behaviour documents it as a nuisance and compensates.

## substrate

Confirmed both directions with a test reproducing `ShiroPackage.PackageInit` (nested `elpsutil.Load`, then `InPackage`, then `UsePackage` + `Externals` re-export):

- **With** substrate's manual restore: still correct. It becomes a redundant no-op, not a double switch. **Nothing in substrate needs to change to adopt this.**
- **Without** it: also correct now — which was *not* true of a `PackageLoader`-only fix, because substrate keeps doing package-scoped work after the nested `Load` and inside `PackageInit`. That work only lands in the right package because `Load` now restores the caller.

So substrate can drop its `InPackage(p.name)` workaround once it requires an elps containing this, but only then. No substrate changes are in this PR.

## Verification

`go build ./...` clean, `go test ./... -count=1` all packages pass, `gofmt -l` clean on both touched files, `golangci-lint run ./elpsutil/...` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_