### PR TITLE
Return errors instead of panicking on embedder mistakes in elpsutil

### DIFF
--- a/elpsutil/elpsutil.go
+++ b/elpsutil/elpsutil.go
@@ -1,10 +1,18 @@
 package elpsutil
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/luthersystems/elps/lisp"
 )
 
 // Function is a helper to construct builtins.
+//
+// formals must be a list of symbols, as returned by lisp.Formals.  A function
+// that takes no arguments is declared with lisp.Formals(), the empty list; a
+// nil formals list is not a valid spelling of that and is rejected by
+// PackageLoader and Validate.
 func Function(name string, formals *lisp.LVal, fun lisp.LBuiltin) *Builtin {
 	return &Builtin{formals, fun, name}
 }
@@ -113,8 +121,14 @@ func packageMacros(p Package) []lisp.LBuiltinDef {
 }
 
 // Load loads an elps package implemented in Go.
+//
+// A loader that returns a Go nil *LVal, rather than lisp.Nil(), is reported as
+// an error naming the loader instead of panicking.
 func Load(env *lisp.LEnv, fn Loader) *lisp.LVal {
-	lerr := fn(env)
+	if fn == nil {
+		return lisp.Errorf("loader is nil")
+	}
+	lerr := loaderResult(fn(env), "loader "+loaderName(fn))
 	if lerr.Type == lisp.LError {
 		return lerr
 	}
@@ -128,10 +142,18 @@ func Load(env *lisp.LEnv, fn Loader) *lisp.LVal {
 }
 
 // LoadAll loads multiple elps files implemented in Go.
-func LoadAll(fn ...Loader) Loader {
+//
+// A loader that returns a Go nil *LVal, rather than lisp.Nil(), is reported as
+// an error naming the loader and its position in the chain instead of
+// panicking.
+func LoadAll(fns ...Loader) Loader {
 	return func(env *lisp.LEnv) *lisp.LVal {
-		for _, fn := range fn {
-			lerr := fn(env)
+		for i, fn := range fns {
+			what := fmt.Sprintf("loader %d of %d, %s", i+1, len(fns), loaderName(fn))
+			if fn == nil {
+				return lisp.Errorf("%s is nil", what)
+			}
+			lerr := loaderResult(fn(env), what)
 			if lerr.Type == lisp.LError {
 				return lerr
 			}
@@ -149,7 +171,10 @@ func LoadAll(fn ...Loader) Loader {
 // LibraryLoader loads multiple elps packages implemented in Go.
 func LibraryLoader(ps ...Package) Loader {
 	return func(env *lisp.LEnv) *lisp.LVal {
-		for _, p := range ps {
+		for i, p := range ps {
+			if p == nil {
+				return lisp.Errorf("package %d of %d is nil", i+1, len(ps))
+			}
 			lerr := Load(env, PackageLoader(p))
 			if lerr.Type == lisp.LError {
 				return lerr
@@ -160,9 +185,24 @@ func LibraryLoader(ps ...Package) Loader {
 }
 
 // PackageLoader loads an elps package implemented in Go.
+//
+// PackageLoader validates the package definition before registering anything,
+// and returns an *LVal error identifying the package and the offending
+// definition rather than letting lisp panic or deferring a nil dereference to
+// call time.  A definition lisp accepts today is still accepted.
 func PackageLoader(p Package) Loader {
 	return func(env *lisp.LEnv) *lisp.LVal {
-		name := lisp.Symbol(p.PackageName())
+		if p == nil {
+			return lisp.Errorf("package is nil")
+		}
+		pkgName := p.PackageName()
+		// A method meant to implement one of the optional Package interfaces
+		// but declared with the wrong signature registers nothing at all, with
+		// no diagnostic on any path.  Report it before the silent load.
+		if problems := checkPackageMethods(p); len(problems) > 0 {
+			return lisp.Errorf("package %q: %s", pkgName, strings.Join(problems, "; "))
+		}
+		name := lisp.Symbol(pkgName)
 		e := env.DefinePackage(name)
 		if !e.IsNil() {
 			return e
@@ -175,18 +215,21 @@ func PackageLoader(p Package) Loader {
 			env.SetPackageDoc(dp.PackageDoc())
 		}
 		initLoader := packageInit(p)
-		e = initLoader(env)
+		e = loaderResult(initLoader(env), fmt.Sprintf("package %q: PackageInit", pkgName))
 		if e.Type == lisp.LError {
 			return e
 		}
-		for _, fn := range packageBuiltins(p) {
-			env.AddBuiltins(true, fn)
+		e = addDefs(env, pkgName, kindBuiltin, packageBuiltins(p), env.AddBuiltins)
+		if e.Type == lisp.LError {
+			return e
 		}
-		for _, fn := range packageSpecialOps(p) {
-			env.AddSpecialOps(true, fn)
+		e = addDefs(env, pkgName, kindSpecialOp, packageSpecialOps(p), env.AddSpecialOps)
+		if e.Type == lisp.LError {
+			return e
 		}
-		for _, fn := range packageMacros(p) {
-			env.AddMacros(true, fn)
+		e = addDefs(env, pkgName, kindMacro, packageMacros(p), env.AddMacros)
+		if e.Type == lisp.LError {
+			return e
 		}
 		return lisp.Nil()
 	}

--- a/elpsutil/elpsutil_fuzz_test.go
+++ b/elpsutil/elpsutil_fuzz_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -134,31 +135,44 @@ import (
 //     something calls it. This is also the only way the fuzzer supplies the
 //     ARGUMENTS a builtin binds, which is where malformed formals bite.
 //
-// # The panic that is designed in, and why names are pre-checked
+// # The panic that is designed in, and where it went
 //
 // lisp.AddBuiltins ends with
 //
 //	if exist.Type != LError { panic("symbol already defined: " + f.Name()) }
 //
 // and AddMacros/AddSpecialOps have the same shape. That is a deliberate
-// programming-error panic, it is not elpsutil's, and it is trivially reachable
-// -- `Function("true", ...)` alone does it, because Package.get answers the
-// reserved symbols `true` and `false` without consulting the symbol table, so
-// they are "already defined" in a package that is brand new and empty.
+// programming-error panic, it is not elpsutil's, and it used to be trivially
+// reachable through elpsutil -- `Function("true", ...)` alone did it, because
+// Package.get answers the reserved symbols `true` and `false` without
+// consulting the symbol table, so they are "already defined" in a package that
+// is brand new and empty.
 //
-// A harness that let the fuzzer hit it would find that crasher in the first
-// second and then report the same one forever, covering nothing. So the
-// harness PRE-CHECKS every name against the package it is about to be bound in
-// and drops the ones that would collide (nameAvailable). The check is
-// conservative -- it demands an unbound symbol, which is the strictest of the
-// three Add* rules -- so it cannot leave a collision behind for any of them.
+// It is no longer reachable through elpsutil (#351): PackageLoader now
+// refuses a colliding definition with an *LVal error, mirroring each Add*
+// function's own rule, before lisp ever sees the definition. The harness
+// therefore no longer filters names. Earlier versions pre-checked every name
+// against the package it was about to be bound in and dropped the ones that
+// would collide (nameAvailable), which was the only way to fuzz at all while
+// the panic was reachable. Now colliding names are handed straight to
+// elpsutil and the refusal is part of what is fuzzed: markRejectEvidence
+// attributes "already defined" and "reserved constant" load errors to the
+// reject/collision and reject/reserved-name labels, and the guard corpus is
+// required to produce both.
 //
-// The payoff is that the assertion needs no qualification: NO panic is
-// tolerated. There is no recover in elpsutil, none between it and the fuzz
-// function, so a panic during install is an ordinary crash that `go test
-// -fuzz` attributes to its input and writes to testdata. TestCollisionPanicIsReal
-// pins the panic the pre-check exists for, so the pre-check cannot quietly
-// become a filter that suppresses everything.
+// lisp's panic itself is still real, and this harness still depends on it
+// being real: elpsutil's checkPackageName exists only to mirror it, so if the
+// panic changed shape, elpsutil could refuse definitions lisp accepts (or
+// stop refusing ones it rejects) without any test noticing.
+// TestCollisionPanicIsReal pins the panic at its source -- env.AddBuiltins,
+// env.AddSpecialOps and env.AddMacros, called directly -- so that account
+// cannot silently expire.
+//
+// The payoff is that the assertion needs no qualification and no longer rests
+// on a filter: NO panic is tolerated, and nothing is dropped from the input
+// space to keep one at bay. There is no recover in elpsutil, none between it
+// and the fuzz function, so a panic during install is an ordinary crash that
+// `go test -fuzz` attributes to its input and writes to testdata.
 //
 // # What is deliberately NOT fuzzer-controlled
 //
@@ -233,8 +247,9 @@ const (
 	maxNameBytes = 16
 
 	// initSwitchPackage is where the "switch package during init" body goes.
-	// It is a fixed name rather than a fuzzer-chosen one so that nameAvailable
-	// can check candidate names against it; see reserveName.
+	// It is a fixed name rather than a fuzzer-chosen one so the init body can
+	// define and enter it without consuming spec bytes, and so the package a
+	// switching init leaves behind is one the corpus can name.
 	initSwitchPackage = "elpsutil-fuzz-init-switch"
 )
 
@@ -321,9 +336,10 @@ var pkgNames = []string{
 	"fuzz-", // trailing separator-ish
 }
 
-// defNames are symbol names. Names that would collide are still listed: the
-// pre-check drops them, and having them in the table is how the pre-check
-// itself stays exercised.
+// defNames are symbol names. Names that collide are deliberately listed:
+// PackageLoader now refuses them with an install-time error where lisp would
+// have panicked, and having them in the table is how those refusal paths
+// (reject/collision, reject/reserved-name) stay exercised.
 var defNames = []string{
 	"fz-a", "fz-b", "fz-c", "fz-d",
 	"true",   // reserved: Package.get answers it without a symbol-table lookup
@@ -553,68 +569,21 @@ type install struct {
 	// TestElpsutilFuzzReachesEveryFeature.
 	reached map[string]bool
 
-	// nregistered counts defs that survived the name pre-check. The reach
-	// guard asserts it is non-zero across the seed corpus, so a pre-check that
-	// started rejecting everything would be caught.
-	nregistered int
+	// ndefs counts defs decoded from the spec and handed to elpsutil. The
+	// reach guard asserts it is non-zero across the seed corpus, so a decoder
+	// change that quietly stopped describing defs would be caught. A counted
+	// def may still be refused at install time -- that refusal is part of
+	// what the target fuzzes.
+	ndefs int
 
-	// claimed tracks names already spoken for, per package name, across this
-	// whole input. The registry cannot answer on its own: within one
-	// LibraryLoader call, package A's builtins are in the symbol table by the
-	// time package B loads, but the harness reserves ALL names up front.
-	claimed map[string]map[string]bool
-
-	// callable is every symbol actually registered, qualified, so the seed
-	// programs and the guards can call what was installed.
+	// callable is every symbol the spec attached to a def, qualified, so the
+	// guards can call what the install described. A name whose package failed
+	// to load never registered, and calling it yields an unbound-symbol
+	// error, which is itself a fine input.
 	callable []string
 }
 
 func (in *install) mark(label string) { in.reached[label] = true }
-
-// nameAvailable reports whether name can be bound in pkg without taking the
-// documented programming-error panic in lisp's Add* functions.
-//
-// The condition is the strictest of the three: AddBuiltins panics unless the
-// symbol is UNBOUND (Type == LError), while AddMacros and AddSpecialOps also
-// tolerate a symbol bound to nil. Demanding unbound is therefore safe for all
-// three, and it is deliberately not a copy of any one rule -- if lisp's rules
-// ever diverge further, a conservative check stays correct where a mirrored
-// one would not.
-func nameAvailable(pkg *lisp.Package, name string) bool {
-	return pkg.Get(lisp.Symbol(name)).Type == lisp.LError
-}
-
-// reserveName decides whether a def may keep the name the spec gave it.
-//
-// It checks the target package AND initSwitchPackage, because a package whose
-// PackageInit switches packages installs its builtins somewhere other than the
-// package PackageLoader selected, and the harness does not know at reservation
-// time which init body the spec will pick.
-func (in *install) reserveName(pkgName, name string) bool {
-	if in.claimed[pkgName] == nil {
-		in.claimed[pkgName] = map[string]bool{}
-	}
-	if in.claimed[pkgName][name] {
-		return false
-	}
-	for _, target := range []string{pkgName, initSwitchPackage} {
-		// DefinePackage is idempotent and returns the existing package when
-		// there is one, so this creates only what PackageLoader would have
-		// created a moment later.
-		if !nameAvailable(in.env.Runtime.Registry.DefinePackage(target), name) {
-			return false
-		}
-	}
-	if in.claimed[initSwitchPackage] == nil {
-		in.claimed[initSwitchPackage] = map[string]bool{}
-	}
-	if in.claimed[initSwitchPackage][name] {
-		return false
-	}
-	in.claimed[pkgName][name] = true
-	in.claimed[initSwitchPackage][name] = true
-	return true
-}
 
 // plainSymbol reports whether s can appear verbatim in source text and read
 // back as the same symbol. Deliberately strict: the point of qualify is to
@@ -661,16 +630,15 @@ func (in *install) buildDefs(r *specReader, pkgName string, n int) []lisp.LBuilt
 		name := r.name(defNames)
 		fsel := formalsTable[int(r.next())%len(formalsTable)]
 		bsel := bodyTable[int(r.next())%len(bodyTable)]
-		if !in.reserveName(pkgName, name) {
-			// Dropped by the pre-check. Recorded so the reach guard can prove
-			// the pre-check runs and is not vacuous.
-			in.mark("precheck/dropped")
-			continue
-		}
+		// Nothing is filtered: a name that collides -- with another def in
+		// this input, with a symbol already bound in the target package, or
+		// with the reserved constants -- goes to elpsutil anyway, and the
+		// install-time refusal it produces is attributed to a reject/* label
+		// by markRejectEvidence.
 		in.mark("formals/" + fsel.label)
 		in.mark("body/" + bsel.label)
 		defs = append(defs, elpsutil.Function(name, fsel.make(), bsel.fn))
-		in.nregistered++
+		in.ndefs++
 		if sym, ok := qualify(pkgName, name); ok {
 			in.callable = append(in.callable, sym)
 		}
@@ -732,11 +700,11 @@ func (in *install) build(spec []byte) []elpsutil.Loader {
 		//
 		// The packages are SPLIT between the two rather than passed to both.
 		// Passing both would install every package twice, and the second pass
-		// re-registers names the first pass just bound -- which is the
-		// designed-in "symbol already defined" panic, reached by the harness
-		// itself rather than by anything under test. The split keeps every
-		// registration unique, which is the invariant the name pre-check
-		// assumes.
+		// re-registers names the first pass just bound -- a collision
+		// PackageLoader now refuses with an error, so no nested input could
+		// ever load cleanly. The split keeps every registration unique so
+		// this strategy exercises the success path too; the fuzzer is free to
+		// mutate specs into colliding shapes on its own.
 		k := max(1, npkg/2)
 		return []elpsutil.Loader{elpsutil.LoadAll(
 			elpsutil.LibraryLoader(pkgs[:k]...),
@@ -751,7 +719,6 @@ func newInstall(env *lisp.LEnv) *install {
 	return &install{
 		env:     env,
 		reached: map[string]bool{},
-		claimed: map[string]map[string]bool{},
 	}
 }
 
@@ -876,9 +843,9 @@ func runBudgeted(t fatalf, spec, src []byte) *install {
 	}
 	in := newInstall(env)
 
-	// The spec is decoded on THIS goroutine, before the worker starts, because
-	// reserveName reads and writes the registry and nothing else may be
-	// touching it at the time.
+	// The spec is decoded on THIS goroutine, before the worker starts, so
+	// decode-time work on the environment is complete before run() begins and
+	// the two never race.
 	loaders := in.build(spec)
 
 	ctx, cancel := context.WithTimeout(context.Background(), fuzzDeadline)
@@ -916,9 +883,32 @@ func runBudgeted(t fatalf, spec, src []byte) *install {
 	return in
 }
 
+// markRejectEvidence turns install-time refusals into coverage marks, so that
+// a reject/* label can only ever claim a refusal that demonstrably happened:
+// each mark requires the refusal's own error text in a load result. Nothing
+// here asserts -- an input with no refusals simply marks nothing.
+func (in *install) markRejectEvidence(results []*lisp.LVal) {
+	for _, rc := range results {
+		if rc == nil || rc.Type != lisp.LError {
+			continue
+		}
+		msg := rc.String()
+		// The two refusals that replaced lisp's "symbol already defined"
+		// panic on the elpsutil path; the strings are checkPackageName's.
+		if strings.Contains(msg, "already defined in package") {
+			in.mark("reject/collision")
+		}
+		if strings.Contains(msg, "is a reserved constant") {
+			in.mark("reject/reserved-name")
+		}
+	}
+}
+
 // check applies every assertion this target makes.
 func (in *install) check(t fatalf, out *outcome, spec, src []byte) {
 	t.Helper()
+
+	in.markRejectEvidence(out.loadResults)
 
 	for i, rc := range out.loadResults {
 		if rc == nil {
@@ -1109,8 +1099,10 @@ func buildSpec(strategy int, pkgs ...seedPkg) []byte {
 //  1. Nothing panics. There is no recover in elpsutil and none between it and
 //     this function, so an install panic is an ordinary crash that `go test
 //     -fuzz` attributes to its input. The one panic that IS designed in --
-//     lisp's "symbol already defined" -- is kept unreachable by the name
-//     pre-check rather than tolerated; see the header.
+//     lisp's "symbol already defined" -- is answered rather than avoided:
+//     PackageLoader refuses the colliding definition with an error before
+//     lisp can panic, and no input is filtered to keep clear of it; see the
+//     header, and TestCollisionPanicIsReal for the panic itself.
 //  2. Every elpsutil.Load returns a non-nil *LVal that is either nil or an
 //     LError, and never an internal-panic error.
 //  3. When every load succeeded, the interpreter is back in the `user`
@@ -1121,9 +1113,8 @@ func buildSpec(strategy int, pkgs ...seedPkg) []byte {
 //  5. The same three properties for every call autoCall makes, which is where
 //     fuzzer-chosen arguments meet fuzzer-chosen formals.
 //
-// NOT asserted: that any package installs successfully, that any name survives
-// the pre-check, or that src evaluates without error. An LError is the right
-// answer for almost all mutator output.
+// NOT asserted: that any package installs successfully, or that src evaluates
+// without error. An LError is the right answer for almost all mutator output.
 func FuzzElpsutilEmbed(f *testing.F) {
 	add := func(spec []byte, src string) { f.Add(spec, []byte(src)) }
 
@@ -1234,9 +1225,11 @@ func FuzzElpsutilEmbed(f *testing.F) {
 	), `(list (fuzzpkg:fz-a 1 2) (fuzzpkg2:fz-b 3 4) (fuzzpkg:fz-a 5 6))`)
 
 	// Registering into packages that already exist, which is what an embedder
-	// adding to `user` or extending `lisp` does. The pre-check keeps the
-	// colliding names out; the point is the non-colliding ones landing in a
-	// populated package.
+	// adding to `user` or extending `lisp` does. The colliding second def
+	// makes each load fail with PackageLoader's install-time refusal (where
+	// lisp used to panic); the first def is already registered by then, so
+	// the seed covers both halves: a def landing in a populated package, and
+	// the refusal naming the collision.
 	add(buildSpec(0, seedPkg{
 		typ: "type/defs", name: "user", init: "init/nil",
 		builtins: []seedDef{{"fz-a", "unary", "echo"}, {"+", "unary", "echo"}},
@@ -1245,6 +1238,12 @@ func FuzzElpsutilEmbed(f *testing.F) {
 		typ: "type/defs", name: "lisp", init: "init/nil",
 		builtins: []seedDef{{"fz-b", "unary", "echo"}, {"car", "unary", "echo"}},
 	}), `(fz-b 1)`)
+	// A duplicate within a single package: the second fz-a arrives after the
+	// first is already in the symbol table, and the load is refused.
+	add(buildSpec(0, seedPkg{
+		typ: "type/defs", name: "fuzzpkg", init: "init/nil",
+		builtins: []seedDef{{"fz-a", "unary", "echo"}, {"fz-a", "binary", "echo"}},
+	}), `(fuzzpkg:fz-a 1)`)
 
 	// Names that are legal registry keys but not legal source text. These
 	// register and are never callable from src, which is the point: the value
@@ -1331,8 +1330,9 @@ func FuzzElpsutilEmbed(f *testing.F) {
 //	type/full   -> the ok branch of all four
 //	init/error  -> PackageLoader's `if e.Type == lisp.LError` after init
 //	load/error  -> the error returns in Load, LoadAll and LibraryLoader
-//	precheck/*  -> the name pre-check actually ran and actually dropped
-//	               something, so it is neither vacuous nor total
+//	reject/*    -> PackageLoader refused a definition -- a name collision or
+//	               a reserved constant -- with an error where lisp would have
+//	               panicked; marked only on the refusal's own error text
 //
 // #348 is why this exists: there, seed-script ordering silently starved whole
 // functions, and measuring was the only way to see it.
@@ -1341,7 +1341,7 @@ var requiredFeatures = []string{
 	"type/plain", "type/defs", "type/init", "type/full",
 	"init/nil", "init/error", "init/eval", "init/switch", "init/doc", "init/drop-user",
 	"load/ok", "load/error", "autocall/ran",
-	"precheck/dropped",
+	"reject/collision", "reject/reserved-name",
 }
 
 // TestElpsutilFuzzReachesEveryFeature runs the seed corpus through the harness
@@ -1361,15 +1361,15 @@ func TestElpsutilFuzzReachesEveryFeature(t *testing.T) {
 		if in == nil {
 			continue
 		}
-		total += in.nregistered
+		total += in.ndefs
 		for k := range in.reached {
 			reached[k] = true
 		}
 	}
 
 	if total == 0 {
-		t.Fatal("the guard corpus registered NO builtins at all: the name pre-check is" +
-			" rejecting everything, so this target installs nothing and asserts nothing")
+		t.Fatal("the guard corpus decoded NO defs at all: the spec decoder is describing" +
+			" empty installs, so this target installs nothing and asserts nothing")
 	}
 
 	var missing []string
@@ -1455,10 +1455,17 @@ func guardCorpus() []guardCase {
 				builtins: []seedDef{{"fz-b", "unary", "echo"}}},
 		), `(fuzzpkg:fz-a 1)`)
 	}
-	// Guarantees precheck/dropped: `true` is "already defined" in any package.
+	// Guarantees reject/reserved-name: `true` can never be bound, and
+	// PackageLoader refuses it with an error where lisp would have panicked.
 	addSpec(buildSpec(0, seedPkg{
 		typ: "type/defs", name: "fuzzpkg", init: "init/nil",
 		builtins: []seedDef{{"true", "unary", "echo"}, {"fz-a", "unary", "echo"}},
+	}), `(fuzzpkg:fz-a 1)`)
+	// Guarantees reject/collision: the second fz-a arrives after the first is
+	// already in the package's symbol table.
+	addSpec(buildSpec(0, seedPkg{
+		typ: "type/defs", name: "fuzzpkg", init: "init/nil",
+		builtins: []seedDef{{"fz-a", "unary", "echo"}, {"fz-a", "binary", "echo"}},
 	}), `(fuzzpkg:fz-a 1)`)
 	return out
 }
@@ -1476,63 +1483,70 @@ func TestElpsutilSeedsTerminate(t *testing.T) {
 	}
 }
 
-// TestCollisionPanicIsReal pins the panic the name pre-check exists to avoid.
+// TestCollisionPanicIsReal pins lisp's designed-in duplicate-registration
+// panic at its source: env.AddBuiltins, env.AddSpecialOps and env.AddMacros,
+// called directly.
 //
-// If lisp ever stops panicking on a duplicate registration, nameAvailable
-// becomes a filter that costs coverage and buys nothing, and the header's
-// claim that "NO panic is tolerated" would be resting on an assumption that
-// had quietly expired. This fails in that case, which is the moment to delete
-// the pre-check rather than the moment to discover it was never needed.
+// The panic is deliberately untouched by #351 but is no longer reachable
+// through elpsutil -- PackageLoader refuses the colliding definition with an
+// error first -- so going through elpsutil.Load here would test the refusal,
+// not the panic. Two things still rest on the panic being real: elpsutil's
+// checkPackageName exists only to mirror these functions' collision rules,
+// and the harness registers its bind-bypass builtins through env.AddBuiltins
+// on the assumption that a fresh name in a fresh environment cannot collide.
+// If lisp's rule ever changes, update checkPackageName and this test
+// together; a divergence between them means elpsutil refuses definitions lisp
+// accepts, or stops refusing ones that panic.
 func TestCollisionPanicIsReal(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
+	kinds := []struct {
 		name string
-		pkg  *pkgData
+		add  func(env *lisp.LEnv, def lisp.LBuiltinDef)
 	}{
-		{"duplicate-builtin", &pkgData{name: "collide1", builtins: []lisp.LBuiltinDef{
-			elpsutil.Function("dup", lisp.Formals("x"), bodyTable[0].fn),
-			elpsutil.Function("dup", lisp.Formals("x"), bodyTable[0].fn),
-		}}},
-		{"reserved-symbol", &pkgData{name: "collide2", builtins: []lisp.LBuiltinDef{
-			elpsutil.Function(lisp.TrueSymbol, lisp.Formals("x"), bodyTable[0].fn),
-		}}},
-		{"existing-lang-symbol", &pkgData{name: "lisp", builtins: []lisp.LBuiltinDef{
-			elpsutil.Function("car", lisp.Formals("x"), bodyTable[0].fn),
-		}}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			env, rc := newEnv()
-			if rc != nil {
-				t.Fatalf("env: %v", rc)
-			}
-			// The pre-check must agree that this is a collision, or it is
-			// checking something other than what panics.
-			in := newInstall(env)
-			target := tc.pkg.name
-			if in.reserveName(target, tc.pkg.builtins[0].Name()) &&
-				len(tc.pkg.builtins) == 1 {
-				t.Fatalf("nameAvailable says %q is free in package %q, but registering it"+
-					" panics; the pre-check and lisp's rule have diverged",
-					tc.pkg.builtins[0].Name(), target)
-			}
-
-			defer func() {
-				if r := recover(); r == nil {
-					t.Fatalf("registering %q in package %q did NOT panic."+
-						" lisp's duplicate-symbol panic is the only reason FuzzElpsutilEmbed"+
-						" pre-checks names; if it is gone, delete nameAvailable and let the"+
-						" fuzzer use the whole name table.",
-						tc.pkg.builtins[0].Name(), tc.pkg.name)
+		{"builtin", func(env *lisp.LEnv, def lisp.LBuiltinDef) { env.AddBuiltins(true, def) }},
+		{"special-op", func(env *lisp.LEnv, def lisp.LBuiltinDef) { env.AddSpecialOps(true, def) }},
+		{"macro", func(env *lisp.LEnv, def lisp.LBuiltinDef) { env.AddMacros(true, def) }},
+	}
+	cases := []struct {
+		name string
+		// pkg is the package registered into; defined first if absent.
+		pkg string
+		// names are registered in order and the LAST one must panic.
+		names []string
+	}{
+		{"duplicate-symbol", "collide1", []string{"dup", "dup"}},
+		{"reserved-symbol", "collide2", []string{lisp.TrueSymbol}},
+		{"existing-lang-symbol", "lisp", []string{"car"}},
+	}
+	for _, kind := range kinds {
+		for _, tc := range cases {
+			t.Run(kind.name+"/"+tc.name, func(t *testing.T) {
+				t.Parallel()
+				env, rc := newEnv()
+				if rc != nil {
+					t.Fatalf("env: %v", rc)
 				}
-			}()
-			env2, rc2 := newEnv()
-			if rc2 != nil {
-				t.Fatalf("env: %v", rc2)
-			}
-			_ = elpsutil.Load(env2, elpsutil.PackageLoader(defsPkg{tc.pkg}))
-		})
+				env.Runtime.Registry.DefinePackage(tc.pkg)
+				if lrc := env.InPackage(lisp.String(tc.pkg)); lrc.Type == lisp.LError {
+					t.Fatalf("in-package %q: %v", tc.pkg, lrc)
+				}
+				for _, name := range tc.names[:len(tc.names)-1] {
+					kind.add(env, elpsutil.Function(name, lisp.Formals("x"), bodyTable[0].fn))
+				}
+				last := tc.names[len(tc.names)-1]
+				defer func() {
+					if r := recover(); r == nil {
+						t.Fatalf("registering %s %q in package %q did NOT panic."+
+							" lisp's duplicate-symbol panic is what elpsutil's checkPackageName"+
+							" mirrors and what the fuzz harness's bind-bypass registrations"+
+							" assume; if lisp's rule changed, change checkPackageName and this"+
+							" test together.", kind.name, last, tc.pkg)
+					}
+				}()
+				kind.add(env, elpsutil.Function(last, lisp.Formals("x"), bodyTable[0].fn))
+			})
+		}
 	}
 }
 

--- a/elpsutil/elpsutil_fuzz_test.go
+++ b/elpsutil/elpsutil_fuzz_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -101,15 +102,17 @@ import (
 //     the init one can reach) is dead code unless some package declines to
 //     implement them. Four concrete Go types cover the lattice; see pkgTypes.
 //
-//   - FORMALS are fuzzer-controlled because elpsutil.Function takes an
-//     arbitrary *LVal and performs NO validation on it, and lisp.FunInPackage
-//     performs none either. Whatever an embedder passes is stored verbatim in
-//     Cells[0] and is not looked at again until call time, deep inside
-//     LEnv.bind. The formals table therefore includes shapes an embedder can
-//     plausibly produce by accident -- an LError (which is what
-//     lisp.Formals("&rest") returns), a non-QExpr scalar, a list whose cells
-//     are not symbols, duplicate names, a misplaced control symbol -- because
-//     each of those reaches argument binding as data.
+//   - FORMALS are fuzzer-controlled because the formals list is data the
+//     embedder constructs and can get wrong. elpsutil.Function stores
+//     whatever it is given; PackageLoader now checks the shape at install
+//     time (checkFormals), while lisp.FunInPackage still performs no
+//     validation at all. The table therefore carries both kinds of shape:
+//     well-formed ones, which register and reach argument binding deep inside
+//     LEnv.bind, and malformed ones an embedder can plausibly produce by
+//     accident -- an LError (which is what lisp.Formals("&rest") returns), a
+//     non-QExpr scalar, a list whose cells are not symbols -- which exercise
+//     the install-time refusal AND are still routed into bind through the
+//     validation bypass; see "Formals that elpsutil now refuses" below.
 //
 //   - ONE SHARED FORMALS VALUE, reused across several registrations, is a
 //     formals shape of its own (formalsShared). elpsutil.Builtin.Formals
@@ -196,6 +199,37 @@ import (
 // TestNilContractMistakesAreErrors pins the new behaviour in both directions,
 // so a regression toward the old panics is named there before the fuzzer
 // rediscovers it as a crash.
+//
+// # Formals that elpsutil now refuses, and how bind still sees them
+//
+// Five formals shapes in formalsTable -- error-value, scalar-int,
+// scalar-string, non-symbol-cells and nested -- used to flow through elpsutil
+// into LEnv.bind as data, which is why they are in the table at all: bind is
+// where a malformed formals list finally gets examined, and nothing else in
+// this repository's fuzz corpus reaches it with shapes like these.
+// PackageLoader now refuses them at install time (checkFormals), which is the
+// right boundary behaviour but would, left alone, quietly end that bind
+// coverage while the coverage labels kept passing on decode-time marks.
+//
+// The harness keeps both halves, honestly labelled:
+//
+//   - the def is handed to elpsutil anyway, and the refusal is proved rather
+//     than presumed: markRejectEvidence marks formals-reject/<shape> only
+//     when a load error names the def and carries the shape's problem text;
+//
+//   - buildDefs registers a copy of the def through env.AddBuiltins(true,
+//     ...) -- the documented route that bypasses elpsutil's validation,
+//     available to any embedder that skips PackageLoader -- under a fresh
+//     fz-bind-N name in the user package, so autoCall still drives the shape
+//     into bind, and formals/<shape> is marked at exactly that registration.
+//
+// go-nil is the exception: it takes the refusal half only. Calling a builtin
+// whose formals are Go nil still nil-derefs inside bind -- that panic is
+// lisp's, deliberately untouched by #351 -- and the harness asserts
+// IsInternalPanic on every call result, so a bypass copy would turn the known
+// finding into a permanent red. TestFormalsTableRejectionFlags pins each
+// entry's rejected flag and problem text against elpsutil.Validate, so the
+// table cannot drift from the rule elpsutil actually applies.
 //
 // # What is deliberately NOT fuzzer-controlled
 //
@@ -361,46 +395,80 @@ var formalsShared = lisp.Formals("shared-x", "shared-y")
 // formalsTable is every formals shape the fuzzer can attach to a def,
 // including the Go nil that used to be excluded (see "Go nil, which used to
 // be excluded" in the header).
+//
+// Shapes with rejected set are the ones PackageLoader refuses at install time
+// (checkFormals). They still matter twice over: handed to elpsutil they fuzz
+// the refusal itself (buildDefs records the expectation; markRejectEvidence
+// marks formals-reject/<label> only when a load error proves it), and --
+// except go-nil -- a copy is registered through the validation bypass so
+// LEnv.bind still meets the shape as data; see "Formals that elpsutil now
+// refuses" in the header. TestFormalsTableRejectionFlags pins every rejected
+// flag and problem string against elpsutil.Validate so this table cannot
+// drift from the real rule.
 var formalsTable = []struct {
 	label string
-	make  func() *lisp.LVal
+	// problem is a substring of checkFormals' report for this shape, distinct
+	// per shape, used to attribute a load error to this entry before its
+	// formals-reject/<label> may be marked. Empty for accepted shapes.
+	problem string
+	make    func() *lisp.LVal
+	// rejected marks shapes PackageLoader refuses at install time.
+	rejected bool
+	// bindBypass routes a copy of the def into LEnv.bind through
+	// env.AddBuiltins(true, ...). False only for go-nil: calling a builtin
+	// whose formals are Go nil still nil-derefs inside bind, and the harness
+	// asserts IsInternalPanic on every call result.
+	bindBypass bool
 }{
-	{"nullary", func() *lisp.LVal { return lisp.Formals() }},
-	{"unary", func() *lisp.LVal { return lisp.Formals("x") }},
-	{"binary", func() *lisp.LVal { return lisp.Formals("x", "y") }},
-	{"rest", func() *lisp.LVal { return lisp.Formals("&rest", "xs") }},
-	{"opt", func() *lisp.LVal { return lisp.Formals("x", "&optional", "y") }},
-	{"key", func() *lisp.LVal { return lisp.Formals("&key", "k") }},
+	{label: "nullary", make: func() *lisp.LVal { return lisp.Formals() }},
+	{label: "unary", make: func() *lisp.LVal { return lisp.Formals("x") }},
+	{label: "binary", make: func() *lisp.LVal { return lisp.Formals("x", "y") }},
+	{label: "rest", make: func() *lisp.LVal { return lisp.Formals("&rest", "xs") }},
+	{label: "opt", make: func() *lisp.LVal { return lisp.Formals("x", "&optional", "y") }},
+	{label: "key", make: func() *lisp.LVal { return lisp.Formals("&key", "k") }},
 	// lisp.Formals returns an LError for a misplaced control symbol. An
 	// embedder that ignores the return value stores the ERROR as its formals.
-	{"error-value", func() *lisp.LVal { return lisp.Formals("&rest") }},
+	{label: "error-value", rejected: true, bindBypass: true,
+		problem: "formals are an error value",
+		make:    func() *lisp.LVal { return lisp.Formals("&rest") }},
 	// A control symbol with nothing after it: accepted at registration,
 	// rejected by bindFormalNext at call time.
-	{"dangling-opt", func() *lisp.LVal { return lisp.Formals("&optional") }},
-	{"dangling-key", func() *lisp.LVal { return lisp.Formals("&key") }},
+	{label: "dangling-opt", make: func() *lisp.LVal { return lisp.Formals("&optional") }},
+	{label: "dangling-key", make: func() *lisp.LVal { return lisp.Formals("&key") }},
 	// Duplicate formal names: no error anywhere, second binding wins.
-	{"duplicate", func() *lisp.LVal { return lisp.Formals("x", "x") }},
+	{label: "duplicate", make: func() *lisp.LVal { return lisp.Formals("x", "x") }},
 	// Not a list at all. bind reads fun.Cells[0].Cells, which is empty for
-	// these, so they silently become nullary.
-	{"scalar-int", func() *lisp.LVal { return lisp.Int(3) }},
-	{"scalar-string", func() *lisp.LVal { return lisp.String("x") }},
+	// these, so through the bypass they silently become nullary.
+	{label: "scalar-int", rejected: true, bindBypass: true,
+		problem: "formals are a int, not a list",
+		make:    func() *lisp.LVal { return lisp.Int(3) }},
+	{label: "scalar-string", rejected: true, bindBypass: true,
+		problem: "formals are a string, not a list",
+		make:    func() *lisp.LVal { return lisp.String("x") }},
 	// A list whose cells are not symbols.
-	{"non-symbol-cells", func() *lisp.LVal {
-		return lisp.QExpr([]*lisp.LVal{lisp.Int(1), lisp.String("s")})
-	}},
-	// An SExpr where a QExpr is expected.
-	{"sexpr", func() *lisp.LVal {
+	{label: "non-symbol-cells", rejected: true, bindBypass: true,
+		problem: "formal argument 0 is a int, not a symbol",
+		make: func() *lisp.LVal {
+			return lisp.QExpr([]*lisp.LVal{lisp.Int(1), lisp.String("s")})
+		}},
+	// An SExpr where a QExpr is expected. checkFormals accepts it (same LType,
+	// symbol cells), so it reaches bind on the ordinary path.
+	{label: "sexpr", make: func() *lisp.LVal {
 		return lisp.SExpr([]*lisp.LVal{lisp.Symbol("x")})
 	}},
 	// Nested list as a formal.
-	{"nested", func() *lisp.LVal {
-		return lisp.QExpr([]*lisp.LVal{lisp.QExpr([]*lisp.LVal{lisp.Symbol("x")})})
-	}},
-	{"shared", func() *lisp.LVal { return formalsShared }},
+	{label: "nested", rejected: true, bindBypass: true,
+		problem: "formal argument 0 is a list, not a symbol",
+		make: func() *lisp.LVal {
+			return lisp.QExpr([]*lisp.LVal{lisp.QExpr([]*lisp.LVal{lisp.Symbol("x")})})
+		}},
+	{label: "shared", make: func() *lisp.LVal { return formalsShared }},
 	// Go nil where lisp.Formals() belongs: the plausible mis-spelling of
 	// "takes no arguments". PackageLoader refuses it at install time; see
-	// TestNilContractMistakesAreErrors.
-	{"go-nil", func() *lisp.LVal { return nil }},
+	// TestNilContractMistakesAreErrors. No bindBypass -- see that field.
+	{label: "go-nil", rejected: true,
+		problem: "formals are nil",
+		make:    func() *lisp.LVal { return nil }},
 }
 
 // bodyTable is every builtin body the fuzzer can attach to a def.
@@ -585,11 +653,30 @@ type install struct {
 	// what the target fuzzes.
 	ndefs int
 
-	// callable is every symbol the spec attached to a def, qualified, so the
-	// guards can call what the install described. A name whose package failed
-	// to load never registered, and calling it yields an unbound-symbol
-	// error, which is itself a fine input.
+	// callable is every symbol the spec attached to a def, qualified, plus
+	// the bind-bypass names, so the guards can call what the install
+	// described. A name whose package failed to load never registered, and
+	// calling it yields an unbound-symbol error, which is itself a fine
+	// input.
 	callable []string
+
+	// expectRejects records each def the spec gave an install-rejected
+	// formals shape, with the evidence markRejectEvidence must find in a load
+	// error before the shape's formals-reject/<label> may be marked.
+	expectRejects []expectReject
+
+	// nbypass numbers the bind-bypass registrations so their names are unique
+	// within this install; see buildDefs.
+	nbypass int
+}
+
+// expectReject is one predicted install-time refusal: the def's name as the
+// spec chose it, the formals shape's label, and the shape's problem text as
+// checkFormals reports it.
+type expectReject struct {
+	defName string
+	label   string
+	problem string
 }
 
 func (in *install) mark(label string) { in.reached[label] = true }
@@ -639,13 +726,41 @@ func (in *install) buildDefs(r *specReader, pkgName string, n int) []lisp.LBuilt
 		name := r.name(defNames)
 		fsel := formalsTable[int(r.next())%len(formalsTable)]
 		bsel := bodyTable[int(r.next())%len(bodyTable)]
-		// Nothing is filtered: a name that collides -- with another def in
-		// this input, with a symbol already bound in the target package, or
-		// with the reserved constants -- goes to elpsutil anyway, and the
-		// install-time refusal it produces is attributed to a reject/* label
-		// by markRejectEvidence.
-		in.mark("formals/" + fsel.label)
-		in.mark("body/" + bsel.label)
+		if fsel.rejected {
+			// The def still goes to elpsutil below -- the refusal is part of
+			// what this target fuzzes -- but formals/<label> may NOT be
+			// marked here: the shape will not reach LEnv.bind through
+			// elpsutil, and a coverage label must not claim more than the
+			// harness does. markRejectEvidence marks formals-reject/<label>
+			// instead, when a load error proves the refusal happened.
+			in.expectRejects = append(in.expectRejects, expectReject{
+				defName: name, label: fsel.label, problem: fsel.problem,
+			})
+			if fsel.bindBypass {
+				// Register a copy through the documented validation bypass so
+				// bind still meets the shape as data (see the header). This
+				// runs at decode time, before any loader: the env is fresh,
+				// the current package is `user`, and fz-bind-N cannot be
+				// bound yet, so AddBuiltins -- which panics on collision, see
+				// TestCollisionPanicIsReal -- cannot be handed one. A
+				// fuzzer-chosen def that later collides with this name is
+				// refused by PackageLoader like any other collision.
+				bname := fmt.Sprintf("fz-bind-%d", in.nbypass)
+				in.nbypass++
+				in.env.AddBuiltins(true, elpsutil.Function(bname, fsel.make(), bsel.fn))
+				in.mark("formals/" + fsel.label)
+				in.mark("body/" + bsel.label)
+				in.callable = append(in.callable, bname)
+			}
+		} else {
+			in.mark("formals/" + fsel.label)
+			in.mark("body/" + bsel.label)
+		}
+		// Nothing is filtered: a def whose formals are malformed, or whose
+		// name collides -- with another def in this input, with a symbol
+		// already bound in the target package, or with the reserved constants
+		// -- goes to elpsutil anyway, and the install-time refusal it
+		// produces is attributed to its label by markRejectEvidence.
 		defs = append(defs, elpsutil.Function(name, fsel.make(), bsel.fn))
 		in.ndefs++
 		if sym, ok := qualify(pkgName, name); ok {
@@ -852,9 +967,9 @@ func runBudgeted(t fatalf, spec, src []byte) *install {
 	}
 	in := newInstall(env)
 
-	// The spec is decoded on THIS goroutine, before the worker starts, so
-	// decode-time work on the environment is complete before run() begins and
-	// the two never race.
+	// The spec is decoded on THIS goroutine, before the worker starts:
+	// buildDefs registers the bind-bypass builtins straight into the
+	// environment, and nothing else may be touching the registry at the time.
 	loaders := in.build(spec)
 
 	ctx, cancel := context.WithTimeout(context.Background(), fuzzDeadline)
@@ -914,6 +1029,16 @@ func (in *install) markRejectEvidence(results []*lisp.LVal) {
 		// Go nil *LVal instead of lisp.Nil(); the string is loaderResult's.
 		if strings.Contains(msg, "returned a nil *LVal") {
 			in.mark("loader-nil/reported")
+		}
+		// Formals refusals are attributed to the table entry that predicted
+		// them: the error must name the def AND carry the shape's own problem
+		// text. Problem strings are distinct per shape, so a mark can only be
+		// earned by the refusal it claims.
+		for _, er := range in.expectRejects {
+			if strings.Contains(msg, strconv.Quote(er.defName)) &&
+				strings.Contains(msg, er.problem) {
+				in.mark("formals-reject/" + er.label)
+			}
 		}
 	}
 }
@@ -1406,9 +1531,21 @@ func TestElpsutilFuzzReachesEveryFeature(t *testing.T) {
 	}
 
 	// Every formals shape and every body must be reachable too, or the table
-	// entry is dead weight.
+	// entry is dead weight. What "reachable" means depends on the shape:
+	// accepted shapes must register through elpsutil (formals/<label>);
+	// install-rejected shapes must demonstrably be refused by PackageLoader
+	// (formals-reject/<label>, marked only on the refusal's own error text)
+	// and, where the bypass applies, must also reach LEnv.bind through it
+	// (formals/<label>, marked at the bypass registration).
 	for _, fs := range formalsTable {
-		if !reached["formals/"+fs.label] {
+		if fs.rejected {
+			if !reached["formals-reject/"+fs.label] {
+				t.Errorf("no guard-corpus load error proved PackageLoader refuses formals shape %q", fs.label)
+			}
+			if fs.bindBypass && !reached["formals/"+fs.label] {
+				t.Errorf("no guard-corpus input carried formals shape %q into LEnv.bind through the bypass", fs.label)
+			}
+		} else if !reached["formals/"+fs.label] {
 			t.Errorf("no guard-corpus input registered a builtin with formals shape %q", fs.label)
 		}
 	}
@@ -1416,6 +1553,44 @@ func TestElpsutilFuzzReachesEveryFeature(t *testing.T) {
 		if !reached["body/"+b.label] {
 			t.Errorf("no guard-corpus input registered a builtin with body %q", b.label)
 		}
+	}
+}
+
+// TestFormalsTableRejectionFlags pins each formalsTable entry's rejected flag
+// and problem text against elpsutil's real validation rule, through the
+// exported Validate. A shape the table calls accepted that elpsutil refuses
+// would silently lose its bind coverage; a shape the table calls rejected
+// that elpsutil accepts would make its formals-reject label unreachable and
+// the guard above permanently red. Either way the drift is named here, at the
+// table entry, rather than discovered from a coverage failure.
+func TestFormalsTableRejectionFlags(t *testing.T) {
+	t.Parallel()
+	for _, fs := range formalsTable {
+		t.Run(fs.label, func(t *testing.T) {
+			t.Parallel()
+			p := &pkgData{name: "probe", builtins: []lisp.LBuiltinDef{
+				elpsutil.Function("probe-fn", fs.make(), bodyTable[0].fn),
+			}}
+			err := elpsutil.Validate(defsPkg{p})
+			switch {
+			case fs.rejected && err == nil:
+				t.Fatalf("formalsTable calls shape %q install-rejected but elpsutil.Validate"+
+					" accepts it; if checkFormals relaxed, clear the entry's rejected flag so"+
+					" the shape goes back to reaching bind through elpsutil", fs.label)
+			case fs.rejected && !strings.Contains(err.Error(), fs.problem):
+				t.Fatalf("shape %q is refused but not with the recorded problem text %q: %v."+
+					" markRejectEvidence matches on that text, so the entry's formals-reject"+
+					" label could never be earned; update the entry's problem string", fs.label, fs.problem, err)
+			case !fs.rejected && err != nil:
+				t.Fatalf("formalsTable calls shape %q accepted but elpsutil.Validate refuses"+
+					" it: %v. Set the entry's rejected flag (and problem text) or the shape's"+
+					" coverage label claims a registration that can no longer happen", fs.label, err)
+			}
+			if fs.bindBypass && !fs.rejected {
+				t.Fatalf("shape %q sets bindBypass without rejected; the bypass exists only"+
+					" for shapes elpsutil refuses", fs.label)
+			}
+		})
 	}
 }
 

--- a/elpsutil/elpsutil_fuzz_test.go
+++ b/elpsutil/elpsutil_fuzz_test.go
@@ -174,31 +174,30 @@ import (
 // and the fuzz function, so a panic during install is an ordinary crash that
 // `go test -fuzz` attributes to its input and writes to testdata.
 //
+// # Go nil, which used to be excluded and is now fuzzer-controlled
+//
+// Earlier versions of this target never generated a Go nil, in two places,
+// and recorded both exclusions as findings: a builtin registered with nil
+// formals (`elpsutil.Function(name, nil, fn)`, the plausible mis-spelling of
+// lisp.Formals()) registered cleanly and then nil-derefed inside LEnv.bind on
+// the first call, and a Loader or PackageInit returning a Go nil *LVal
+// nil-derefed immediately inside elpsutil itself, as an uncaught panic in the
+// embedder's process. Both were contract violations only a public-API change
+// could fix, and this header used to say that decision was not this target's
+// to take.
+//
+// That decision has since been taken (#351): elpsutil now validates at the
+// boundary. PackageLoader refuses nil formals at INSTALL time with an error
+// naming the package and definition, and every loader entry point reports a
+// nil loader result as an error naming the loader. Both shapes are therefore
+// generated like any other input: formalsTable carries a go-nil entry and
+// initTable carries init/go-nil, and the resulting loads must fail with
+// ordinary errors -- never a panic, never an internal-panic LVal.
+// TestNilContractMistakesAreErrors pins the new behaviour in both directions,
+// so a regression toward the old panics is named there before the fuzzer
+// rediscovers it as a crash.
+//
 // # What is deliberately NOT fuzzer-controlled
-//
-// GO NIL IS NEVER GENERATED, in two places, and both are recorded findings
-// rather than oversights:
-//
-//   - `elpsutil.Function(name, nil, fn)` -- a plausible way to write "takes no
-//     arguments", the correct spelling being lisp.Formals() -- registers
-//     without complaint and then nil-derefs inside LEnv.bind at
-//     `fun.Cells[0].Cells` on the first call. The panic is laundered by
-//     lisp.eval's recover into an internal-panic LError, so the embedder sees
-//     a lisp error rather than a crash, at call time rather than at install
-//     time.
-//
-//   - A Loader (or PackageInit) that returns a Go nil *LVal nil-derefs
-//     immediately, in elpsutil itself, at `lerr.Type == lisp.LError` in Load /
-//     LoadAll and at `e.Type == lisp.LError` in PackageLoader. That one is an
-//     uncaught panic in the embedder's process.
-//
-// Both are contract violations by the embedder rather than defects in
-// elpsutil's own logic, and fixing either means adding validation to a public
-// constructor, which is an API decision and not this target's to take. They
-// are excluded from generation so the target is not permanently red on two
-// known inputs; TestKnownNilContractViolations pins the current behaviour so
-// that a future fix is noticed here rather than silently diverging from this
-// comment.
 //
 // NO FILESYSTEM. Runtime.Library is left nil for the same reason FuzzEval
 // leaves it nil: it is what makes load-file return an error rather than
@@ -359,8 +358,9 @@ var defNames = []string{
 // aliasing in the header.
 var formalsShared = lisp.Formals("shared-x", "shared-y")
 
-// formalsTable is every formals shape the fuzzer can attach to a def. Nothing
-// here is a Go nil -- see "What is deliberately NOT fuzzer-controlled".
+// formalsTable is every formals shape the fuzzer can attach to a def,
+// including the Go nil that used to be excluded (see "Go nil, which used to
+// be excluded" in the header).
 var formalsTable = []struct {
 	label string
 	make  func() *lisp.LVal
@@ -397,6 +397,10 @@ var formalsTable = []struct {
 		return lisp.QExpr([]*lisp.LVal{lisp.QExpr([]*lisp.LVal{lisp.Symbol("x")})})
 	}},
 	{"shared", func() *lisp.LVal { return formalsShared }},
+	// Go nil where lisp.Formals() belongs: the plausible mis-spelling of
+	// "takes no arguments". PackageLoader refuses it at install time; see
+	// TestNilContractMistakesAreErrors.
+	{"go-nil", func() *lisp.LVal { return nil }},
 }
 
 // bodyTable is every builtin body the fuzzer can attach to a def.
@@ -499,6 +503,11 @@ var initTable = []struct {
 		delete(env.Runtime.Registry.Packages, lisp.DefaultUserPackage)
 		return lisp.Nil()
 	}},
+	// A PackageInit that returns a Go nil *LVal: the loader-side nil mistake,
+	// and the only fuzzer-reachable route to loaderResult's nil branch inside
+	// PackageLoader. Reported as an error naming the package and PackageInit;
+	// see TestNilContractMistakesAreErrors.
+	{"init/go-nil", func(env *lisp.LEnv) *lisp.LVal { return nil }},
 }
 
 // strategyLabels are the four ways the generated packages get installed. Every
@@ -900,6 +909,11 @@ func (in *install) markRejectEvidence(results []*lisp.LVal) {
 		}
 		if strings.Contains(msg, "is a reserved constant") {
 			in.mark("reject/reserved-name")
+		}
+		// loaderResult's report of a loader (here: a PackageInit) returning a
+		// Go nil *LVal instead of lisp.Nil(); the string is loaderResult's.
+		if strings.Contains(msg, "returned a nil *LVal") {
+			in.mark("loader-nil/reported")
 		}
 	}
 }
@@ -1333,6 +1347,9 @@ func FuzzElpsutilEmbed(f *testing.F) {
 //	reject/*    -> PackageLoader refused a definition -- a name collision or
 //	               a reserved constant -- with an error where lisp would have
 //	               panicked; marked only on the refusal's own error text
+//	loader-nil/reported -> loaderResult reported a loader returning a Go nil
+//	               *LVal (via init/go-nil), likewise marked on the report's
+//	               own error text
 //
 // #348 is why this exists: there, seed-script ordering silently starved whole
 // functions, and measuring was the only way to see it.
@@ -1340,6 +1357,7 @@ var requiredFeatures = []string{
 	"strategy/load-each", "strategy/library-loader", "strategy/load-all", "strategy/nested",
 	"type/plain", "type/defs", "type/init", "type/full",
 	"init/nil", "init/error", "init/eval", "init/switch", "init/doc", "init/drop-user",
+	"init/go-nil", "loader-nil/reported",
 	"load/ok", "load/error", "autocall/ran",
 	"reject/collision", "reject/reserved-name",
 }
@@ -1550,19 +1568,22 @@ func TestCollisionPanicIsReal(t *testing.T) {
 	}
 }
 
-// TestKnownNilContractViolations pins the two Go-nil behaviours the fuzzer is
-// deliberately kept away from, so that the header's account of them cannot
-// silently go stale.
+// TestNilContractMistakesAreErrors pins the boundary validation that lets the
+// fuzzer generate Go nil at all: formalsTable's go-nil shape and initTable's
+// init/go-nil body exist on the strength of the behaviour asserted here.
 //
-// Neither is asserted to be CORRECT. They are asserted to be what they
-// currently are, with a message saying what a change means: if elpsutil grows
-// validation for either, this test is the thing that says the header's
-// "deliberately not fuzzer-controlled" section can be narrowed and those
-// inputs handed back to the fuzzer.
-func TestKnownNilContractViolations(t *testing.T) {
+// This test replaces TestKnownNilContractViolations, which pinned the
+// opposite -- nil formals deferring to a call-time internal panic, and a nil
+// loader result panicking uncaught inside elpsutil.Load -- back when the
+// fuzzer was deliberately kept away from both inputs. #351 moved the check to
+// the install boundary, so the tripwire now points the other way: if either
+// behaviour regresses toward a panic, this test names the change before
+// FuzzElpsutilEmbed rediscovers it as a crash, and the two table entries must
+// be pulled back out of the fuzzer's reach.
+func TestNilContractMistakesAreErrors(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil-formals-defers-to-call-time", func(t *testing.T) {
+	t.Run("nil-formals-rejected-at-install", func(t *testing.T) {
 		t.Parallel()
 		env, rc := newEnv()
 		if rc != nil {
@@ -1572,32 +1593,54 @@ func TestKnownNilContractViolations(t *testing.T) {
 			// The plausible mistake: nil where lisp.Formals() belongs.
 			elpsutil.Function("boom", nil, bodyTable[0].fn),
 		}}
-		if lrc := elpsutil.Load(env, elpsutil.PackageLoader(defsPkg{p})); lrc.Type == lisp.LError {
-			t.Fatalf("registering a builtin with nil formals now fails at INSTALL time: %v."+
-				" That is an improvement; FuzzElpsutilEmbed's header says it does not, and"+
-				" formalsTable may now include a nil entry.", lrc)
+		lrc := elpsutil.Load(env, elpsutil.PackageLoader(defsPkg{p}))
+		if lrc == nil || lrc.Type != lisp.LError {
+			t.Fatalf("registering a builtin with nil formals did not fail at install time"+
+				" (got %v). The old behaviour -- registering cleanly and nil-derefing inside"+
+				" LEnv.bind at first call -- is exactly what formalsTable's go-nil entry would"+
+				" turn into a permanent fuzz crash; restore the install-time check or pull the"+
+				" entry.", lrc)
 		}
+		msg := lrc.String()
+		for _, want := range []string{`"nilformals"`, `"boom"`, "formals are nil"} {
+			if !strings.Contains(msg, want) {
+				t.Fatalf("the install error does not name the mistake: missing %q in %q", want, msg)
+			}
+		}
+		// Nothing may have been half-installed: the call must fail as an
+		// ordinary unbound-symbol error, never as a recovered Go panic.
 		res := env.LoadString("t", "(nilformals:boom)")
-		if !lisp.IsInternalPanic(res) {
-			t.Fatalf("calling a builtin with nil formals no longer produces an internal panic"+
-				" (got %v). FuzzElpsutilEmbed excludes nil formals on the strength of this"+
-				" behaviour; re-read its header before changing either.", res)
+		if res == nil || res.Type != lisp.LError {
+			t.Fatalf("the rejected builtin is still callable: %v", res)
+		}
+		if lisp.IsInternalPanic(res) {
+			t.Fatalf("calling the rejected builtin recovered a Go panic: %v", res)
 		}
 	})
 
-	t.Run("nil-loader-return-panics", func(t *testing.T) {
+	t.Run("nil-loader-return-reported", func(t *testing.T) {
 		t.Parallel()
 		env, rc := newEnv()
 		if rc != nil {
 			t.Fatalf("env: %v", rc)
 		}
-		defer func() {
-			if r := recover(); r == nil {
-				t.Fatal("a Loader returning a Go nil *LVal no longer panics in elpsutil.Load." +
-					" FuzzElpsutilEmbed excludes that input on the strength of this behaviour;" +
-					" if Load now tolerates nil, the exclusion can be lifted.")
-			}
+		var lrc *lisp.LVal
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("a Loader returning a Go nil *LVal panics inside elpsutil.Load"+
+						" again: %v. initTable's init/go-nil entry generates exactly this input,"+
+						" so the fuzzer would report the panic as a crash on its first pass;"+
+						" restore the nil check or pull the entry.", r)
+				}
+			}()
+			lrc = elpsutil.Load(env, func(env *lisp.LEnv) *lisp.LVal { return nil })
 		}()
-		_ = elpsutil.Load(env, func(env *lisp.LEnv) *lisp.LVal { return nil })
+		if lrc == nil || lrc.Type != lisp.LError {
+			t.Fatalf("a nil loader result was not reported as an error: %v", lrc)
+		}
+		if !strings.Contains(lrc.String(), "returned a nil *LVal") {
+			t.Fatalf("the error does not say what the loader did wrong: %v", lrc)
+		}
 	})
 }

--- a/elpsutil/loader_test.go
+++ b/elpsutil/loader_test.go
@@ -1,0 +1,325 @@
+// Copyright © 2026 The ELPS authors
+
+package elpsutil_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"testing"
+
+	"github.com/luthersystems/elps/elpsutil"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/require"
+)
+
+// nilLoader is the mistake under test: the Loader signature permits a Go nil
+// *LVal, and returning one instead of lisp.Nil() is an easy slip. Every reader
+// of a Loader's result -- Load, LoadAll and PackageLoader all test
+// `x.Type == lisp.LError` -- dereferences it, so an unchecked nil panics
+// uncaught in the embedder's process at load time.
+func nilLoader(env *lisp.LEnv) *lisp.LVal { return nil }
+
+func okLoader(env *lisp.LEnv) *lisp.LVal { return lisp.Nil() }
+
+// loaderEntryPoint is an exported elpsutil function that runs an
+// embedder-supplied Loader, paired with a way to drive it.
+type loaderEntryPoint struct {
+	// name must match the Go identifier, because the sweep in
+	// TestLoaderEntryPointsAreCovered compares this table against the
+	// package's declarations.
+	name string
+	// run invokes the entry point so that fn is the embedder-supplied Loader
+	// it ends up calling, and returns the result LVal.
+	run func(env *lisp.LEnv, fn elpsutil.Loader) *lisp.LVal
+	// wantNil are substrings the error must contain when fn returns a Go nil.
+	// Every case requires something that identifies the offending loader: an
+	// error naming no loader makes an embedder with a long chain hunt.
+	wantNil []string
+}
+
+func loaderEntryPoints() []loaderEntryPoint {
+	return []loaderEntryPoint{{
+		name: "Load",
+		run: func(env *lisp.LEnv, fn elpsutil.Loader) *lisp.LVal {
+			return elpsutil.Load(env, fn)
+		},
+		wantNil: []string{"nil *LVal", "lisp.Nil()", "nilLoader", "loader_test.go"},
+	}, {
+		name: "LoadAll",
+		run: func(env *lisp.LEnv, fn elpsutil.Loader) *lisp.LVal {
+			return elpsutil.LoadAll(okLoader, fn, okLoader)(env)
+		},
+		wantNil: []string{"nil *LVal", "lisp.Nil()", "nilLoader", "loader 2 of 3"},
+	}, {
+		name: "PackageLoader",
+		run: func(env *lisp.LEnv, fn elpsutil.Loader) *lisp.LVal {
+			// PackageLoader runs exactly one embedder loader, the package's
+			// PackageInit.
+			return elpsutil.PackageLoader(&testPackage{name: "initpkg", initFn: fn})(env)
+		},
+		wantNil: []string{"nil *LVal", "lisp.Nil()", "initpkg", "PackageInit"},
+	}, {
+		name: "LibraryLoader",
+		run: func(env *lisp.LEnv, fn elpsutil.Loader) *lisp.LVal {
+			return elpsutil.LibraryLoader(&testPackage{name: "libpkg", initFn: fn})(env)
+		},
+		wantNil: []string{"nil *LVal", "lisp.Nil()", "libpkg", "PackageInit"},
+	}}
+}
+
+// TestLoadersRejectNilResults covers issue #351 defect 2 for every exported
+// entry point that runs an embedder-supplied Loader.
+func TestLoadersRejectNilResults(t *testing.T) {
+	for _, ep := range loaderEntryPoints() {
+		t.Run(ep.name, func(t *testing.T) {
+			t.Run("nil_result", func(t *testing.T) {
+				env := testEnv(t)
+				var rc *lisp.LVal
+				require.NotPanics(t, func() {
+					rc = ep.run(env, nilLoader)
+				}, "%s panicked on a loader returning a Go nil *LVal", ep.name)
+				require.NotNil(t, rc)
+				require.Equal(t, lisp.LError, rc.Type, "%s accepted a nil loader result: %v", ep.name, rc)
+				for _, want := range ep.wantNil {
+					require.Contains(t, rc.String(), want)
+				}
+			})
+			t.Run("good_loader", func(t *testing.T) {
+				// Correct code must see no difference.
+				env := testEnv(t)
+				rc := ep.run(env, okLoader)
+				require.NotNil(t, rc)
+				require.NotEqual(t, lisp.LError, rc.Type, "%s rejected a well-formed loader: %v", ep.name, rc)
+			})
+		})
+	}
+}
+
+// TestLoadersRejectNilLoaders covers the two entry points an embedder hands a
+// Loader value to directly, where the value itself may be nil.
+func TestLoadersRejectNilLoaders(t *testing.T) {
+	env := testEnv(t)
+	var rc *lisp.LVal
+	require.NotPanics(t, func() {
+		rc = elpsutil.Load(env, nil)
+	})
+	require.Equal(t, lisp.LError, rc.Type)
+	require.Contains(t, rc.String(), "nil")
+
+	require.NotPanics(t, func() {
+		rc = elpsutil.LoadAll(okLoader, nil, okLoader)(env)
+	})
+	require.Equal(t, lisp.LError, rc.Type)
+	require.Contains(t, rc.String(), "loader 2 of 3")
+}
+
+// TestLoaderEntryPointsAreCovered is the systemic half of the fix. It parses
+// elpsutil's own source and requires every exported function that accepts a
+// Loader to appear in the table above. A new entry point added later that
+// forgets the nil check fails this test rather than shipping the next instance
+// of defect 2.
+func TestLoaderEntryPointsAreCovered(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", nil, 0)
+	require.NoError(t, err)
+	src, ok := pkgs["elpsutil"]
+	require.True(t, ok, "did not find package elpsutil in the working directory")
+
+	var declared []string
+	for _, file := range src.Files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || !fn.Name.IsExported() {
+				continue
+			}
+			if !usesLoader(fn.Type) {
+				continue
+			}
+			declared = append(declared, fn.Name.Name)
+		}
+	}
+	sort.Strings(declared)
+	// Guard against the sweep silently finding nothing: a source scan that
+	// matches zero functions would pass while asserting nothing at all.
+	require.NotEmpty(t, declared, "found no exported functions accepting a Loader; the source scan is broken")
+	t.Logf("exported functions accepting a Loader: %v", declared)
+
+	covered := make(map[string]bool)
+	for _, ep := range loaderEntryPoints() {
+		covered[ep.name] = true
+	}
+	for _, name := range declared {
+		require.True(t, covered[name],
+			"elpsutil.%s runs an embedder-supplied Loader but is not covered by TestLoadersRejectNilResults; "+
+				"a Loader returning a Go nil *LVal must produce an error naming the loader, not a panic", name)
+	}
+}
+
+// TestPackageLoaderKindsAreCovered is the same guard for definition kinds. It
+// counts the addDefs call sites in PackageLoader -- one per kind of definition
+// a Package can contribute -- and requires the defKinds table to match. A
+// fourth kind added later is checked by the mistake table in
+// TestPackageLoaderRejectsBadDefinitions rather than being validated only for
+// builtins.
+func TestPackageLoaderKindsAreCovered(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", nil, 0)
+	require.NoError(t, err)
+	src, ok := pkgs["elpsutil"]
+	require.True(t, ok, "did not find package elpsutil in the working directory")
+
+	kinds := make(map[string]bool)
+	for _, file := range src.Files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			id, ok := call.Fun.(*ast.Ident)
+			if !ok || id.Name != "addDefs" || len(call.Args) < 3 {
+				return true
+			}
+			if kind, ok := call.Args[2].(*ast.Ident); ok {
+				kinds[kind.Name] = true
+			}
+			return true
+		})
+	}
+	require.NotEmpty(t, kinds, "found no addDefs call sites; the source scan is broken")
+	require.Len(t, defKinds("x"), len(kinds),
+		"PackageLoader registers %d kinds of definition (%v) but defKinds covers %d",
+		len(kinds), kinds, len(defKinds("x")))
+}
+
+// usesLoader reports whether fn takes or returns a Loader, i.e. whether it is
+// on the path that runs code an embedder supplied. PackageLoader and
+// LibraryLoader take a Package but return a Loader that ends up calling the
+// package's PackageInit, so both directions count.
+func usesLoader(fn *ast.FuncType) bool {
+	for _, fields := range []*ast.FieldList{fn.Params, fn.Results} {
+		if fields == nil {
+			continue
+		}
+		for _, field := range fields.List {
+			typ := field.Type
+			if e, ok := typ.(*ast.Ellipsis); ok {
+				typ = e.Elt
+			}
+			if id, ok := typ.(*ast.Ident); ok && id.Name == "Loader" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// --- Package method signature detection -------------------------------------
+
+// wrongBuiltins is the mistake the issue records as "harder": a Builtins
+// method returning the wrong slice type. It does not satisfy PackageBuiltins,
+// so packageBuiltins's type assertion fails and returns nil, and every builtin
+// vanishes -- the load succeeds and the symbols are simply unbound at call
+// time, with no diagnostic anywhere.
+type wrongBuiltins struct{}
+
+func (p *wrongBuiltins) PackageName() string { return "wrongbuiltins" }
+
+func (p *wrongBuiltins) Builtins() []*elpsutil.Builtin {
+	return []*elpsutil.Builtin{elpsutil.Function("f", lisp.Formals(), nopBuiltin)}
+}
+
+// valueReceiverBuiltins declares Builtins on the pointer receiver but is
+// passed by value, so the method is not in its method set and the definitions
+// are dropped the same way.
+type valueReceiverBuiltins struct{}
+
+func (p valueReceiverBuiltins) PackageName() string { return "valuereceiver" }
+
+func (p *valueReceiverBuiltins) Builtins() []lisp.LBuiltinDef {
+	return []lisp.LBuiltinDef{elpsutil.Function("f", lisp.Formals(), nopBuiltin)}
+}
+
+// wrongPackageInit mistypes PackageInit, so the package is loaded without ever
+// being initialized.
+type wrongPackageInit struct{}
+
+func (p *wrongPackageInit) PackageName() string { return "wronginit" }
+
+func (p *wrongPackageInit) PackageInit(env *lisp.LEnv) error { return nil }
+
+func (p *wrongPackageInit) Builtins() []lisp.LBuiltinDef {
+	return []lisp.LBuiltinDef{elpsutil.Function("f", lisp.Formals(), nopBuiltin)}
+}
+
+// emptyPackage contributes nothing at all. Validate reports it; PackageLoader
+// deliberately does not, because a namespace-only package is unusual rather
+// than illegal.
+type emptyPackage struct{}
+
+func (p *emptyPackage) PackageName() string { return "emptypkg" }
+
+func TestPackageLoaderReportsUnsatisfiedInterfaces(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  elpsutil.Package
+		want []string
+	}{{
+		name: "wrong Builtins return type",
+		pkg:  &wrongBuiltins{},
+		want: []string{"wrongbuiltins", "Builtins", "PackageBuiltins", "[]*elpsutil.Builtin", "[]lisp.LBuiltinDef", "silently ignored"},
+	}, {
+		name: "Builtins on the pointer receiver",
+		pkg:  valueReceiverBuiltins{},
+		want: []string{"valuereceiver", "Builtins", "declared on *valueReceiverBuiltins", "passed by value"},
+	}, {
+		name: "wrong PackageInit signature",
+		pkg:  &wrongPackageInit{},
+		want: []string{"wronginit", "PackageInit", "error", "silently ignored"},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env := testEnv(t)
+			var rc *lisp.LVal
+			require.NotPanics(t, func() {
+				rc = elpsutil.Load(env, elpsutil.PackageLoader(test.pkg))
+			})
+			require.Equal(t, lisp.LError, rc.Type,
+				"the package loaded cleanly and registered nothing: %v", rc)
+			for _, want := range test.want {
+				require.Contains(t, rc.String(), want)
+			}
+			require.Error(t, elpsutil.Validate(test.pkg))
+		})
+	}
+}
+
+// TestValidateReportsEmptyPackage documents the one check Validate makes that
+// PackageLoader does not.
+func TestValidateReportsEmptyPackage(t *testing.T) {
+	err := elpsutil.Validate(&emptyPackage{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "emptypkg")
+	require.Contains(t, err.Error(), "has no effect")
+
+	// PackageLoader still loads it: unusual is not illegal.
+	env := testEnv(t)
+	rc := elpsutil.Load(env, elpsutil.PackageLoader(&emptyPackage{}))
+	require.NotEqual(t, lisp.LError, rc.Type, "PackageLoader rejected a namespace-only package: %v", rc)
+}
+
+func TestValidateRejectsNilPackage(t *testing.T) {
+	require.Error(t, elpsutil.Validate(nil))
+	env := testEnv(t)
+	var rc *lisp.LVal
+	require.NotPanics(t, func() {
+		rc = elpsutil.Load(env, elpsutil.PackageLoader(nil))
+	})
+	require.Equal(t, lisp.LError, rc.Type)
+	require.NotPanics(t, func() {
+		rc = elpsutil.LibraryLoader(nil)(env)
+	})
+	require.Equal(t, lisp.LError, rc.Type)
+}

--- a/elpsutil/restore_test.go
+++ b/elpsutil/restore_test.go
@@ -3,7 +3,6 @@
 package elpsutil_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/luthersystems/elps/elpsutil"
@@ -140,8 +139,7 @@ func TestLoadersRejectUninitialisedEnv(t *testing.T) {
 			require.NotNil(t, rc)
 			require.Equal(t, lisp.LError, rc.Type,
 				"%s accepted an uninitialised environment: %v", e.name, rc)
-			require.True(t,
-				strings.Contains(rc.String(), "no current package"),
+			require.Contains(t, rc.String(), "no current package",
 				"%s should say what is wrong with the environment, got: %v", e.name, rc)
 		})
 	}

--- a/elpsutil/validate.go
+++ b/elpsutil/validate.go
@@ -1,0 +1,312 @@
+// Copyright © 2026 The ELPS authors
+
+package elpsutil
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// The checks in this file exist because elpsutil sits on the boundary between
+// an embedder's Go code and the interpreter.  Inside lisp a panic means "this
+// is a bug in the interpreter, or in code that had no business calling this".
+// A mistake in an embedder's package definition is neither -- it is ordinary,
+// recoverable, and belongs to a registration path where every other failure
+// already returns an *LVal error.  So the mistakes are caught here, at the
+// boundary, and reported as errors naming the offending package, definition,
+// or loader.  The panics inside lisp are left exactly as they are.
+
+// Definition kinds.  These are the names used in error messages, and they
+// double as the switch used to reproduce the (differing) collision rules of
+// LEnv.AddBuiltins, LEnv.AddSpecialOps and LEnv.AddMacros.
+const (
+	kindBuiltin   = "builtin"
+	kindSpecialOp = "special operator"
+	kindMacro     = "macro"
+)
+
+// Validate reports mistakes in an elps package implemented in Go that the Go
+// type system cannot catch.  It is intended to be called from an embedder's
+// test:
+//
+//	func TestPackage(t *testing.T) {
+//		if err := elpsutil.Validate(&MyPackage{}); err != nil {
+//			t.Fatal(err)
+//		}
+//	}
+//
+// Validate reports every problem it finds, joined into a single error.  A nil
+// return means PackageLoader will not reject the package.
+//
+// Validate performs one check that PackageLoader deliberately does not: it
+// reports a package that contributes no builtins, no special operators, no
+// macros and has no PackageInit.  Such a package is almost certainly a
+// mistake, but "almost" is not enough to fail a load -- a namespace-only
+// package is unusual, not illegal.
+func Validate(p Package) error {
+	if p == nil {
+		return errors.New("package is nil")
+	}
+	var problems []error
+	add := func(format string, v ...interface{}) {
+		problems = append(problems, fmt.Errorf(format, v...))
+	}
+
+	name := p.PackageName()
+	if name == "" {
+		add("PackageName() returned an empty string")
+	}
+
+	for _, problem := range checkPackageMethods(p) {
+		add("package %q: %s", name, problem)
+	}
+
+	// All three definition kinds share one symbol table, so duplicates are
+	// tracked across kinds rather than within each one.
+	seen := make(map[string]string)
+	kinds := []struct {
+		kind string
+		defs []lisp.LBuiltinDef
+	}{
+		{kindBuiltin, packageBuiltins(p)},
+		{kindSpecialOp, packageSpecialOps(p)},
+		{kindMacro, packageMacros(p)},
+	}
+	ndef := 0
+	for _, k := range kinds {
+		ndef += len(k.defs)
+		for i, def := range k.defs {
+			if isNilDef(def) {
+				add("package %q: %s %d is nil", name, k.kind, i)
+				continue
+			}
+			defName := def.Name()
+			if problem := checkFormals(def.Formals()); problem != "" {
+				add("package %q: %s %q: %s", name, k.kind, defName, problem)
+			}
+			if problem := checkReservedName(defName); problem != "" {
+				add("package %q: %s %q: %s", name, k.kind, defName, problem)
+			}
+			if prev, ok := seen[defName]; ok {
+				add("package %q: %s %q: name is already used by a %s in the same package",
+					name, k.kind, defName, prev)
+				continue
+			}
+			seen[defName] = k.kind
+		}
+	}
+
+	if ndef == 0 {
+		if _, ok := p.(PackageInit); !ok {
+			add("package %q defines no builtins, no special operators and no macros, and has no PackageInit; loading it has no effect", name)
+		}
+	}
+
+	return errors.Join(problems...)
+}
+
+// checkFormals reports what is wrong with an embedder-supplied formal argument
+// list, or "" when the list is usable.
+//
+// A nil formals list is the motivating case: it registers cleanly and is first
+// dereferenced by LEnv.bind at fun.Cells[0].Cells, so the embedder learns
+// about it as an opaque internal-panic the first time a user calls the
+// function.  lisp.Formals() -- an empty list -- is the correct spelling of
+// "takes no arguments".
+func checkFormals(formals *lisp.LVal) string {
+	if formals == nil {
+		return "formals are nil (use lisp.Formals() to declare a function that takes no arguments)"
+	}
+	if formals.Type == lisp.LError {
+		return fmt.Sprintf("formals are an error value: %v", formals)
+	}
+	if formals.Type != lisp.LSExpr {
+		return fmt.Sprintf("formals are a %v, not a list (use lisp.Formals())", formals.Type)
+	}
+	for i, cell := range formals.Cells {
+		if cell == nil {
+			return fmt.Sprintf("formal argument %d is nil", i)
+		}
+		if cell.Type != lisp.LSymbol {
+			return fmt.Sprintf("formal argument %d is a %v, not a symbol", i, cell.Type)
+		}
+	}
+	return ""
+}
+
+// checkReservedName reports whether name collides with a symbol the reader
+// answers without consulting a package's symbol table.  Package.get returns
+// true and false unconditionally, so AddBuiltins concludes the name is taken
+// even in a package that has just been created, and panics.
+func checkReservedName(name string) string {
+	if name == lisp.TrueSymbol || name == lisp.FalseSymbol {
+		return fmt.Sprintf("%q is a reserved constant and can never be bound", name)
+	}
+	return ""
+}
+
+// checkPackageName reports whether name is already bound in pkg, reproducing
+// the collision rule of the LEnv method that registers kind.  AddBuiltins
+// rejects any existing binding; AddSpecialOps and AddMacros permit overwriting
+// a binding whose value is nil.
+func checkPackageName(pkg *lisp.Package, kind, name string) string {
+	if problem := checkReservedName(name); problem != "" {
+		return problem
+	}
+	if pkg == nil {
+		return ""
+	}
+	exist, ok := pkg.Symbols[name]
+	if !ok {
+		return ""
+	}
+	if kind != kindBuiltin && (exist == nil || exist.IsNil()) {
+		return ""
+	}
+	return fmt.Sprintf("symbol is already defined in package %q", pkg.Name)
+}
+
+// isNilDef reports whether def is nil, including a nil pointer stored in a
+// non-nil interface.
+func isNilDef(def lisp.LBuiltinDef) bool {
+	if def == nil {
+		return true
+	}
+	v := reflect.ValueOf(def)
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
+// packageMethod names an optional Package extension interface together with
+// the method that implements it.
+type packageMethod struct {
+	method string
+	want   string
+	iface  reflect.Type
+}
+
+var packageMethods = []packageMethod{
+	{"Builtins", "Builtins() []lisp.LBuiltinDef", reflect.TypeOf((*PackageBuiltins)(nil)).Elem()},
+	{"SpecialOps", "SpecialOps() []lisp.LBuiltinDef", reflect.TypeOf((*PackageSpecialOps)(nil)).Elem()},
+	{"Macros", "Macros() []lisp.LBuiltinDef", reflect.TypeOf((*PackageMacros)(nil)).Elem()},
+	{"PackageInit", "PackageInit(*lisp.LEnv) *lisp.LVal", reflect.TypeOf((*PackageInit)(nil)).Elem()},
+	{"PackageDoc", "PackageDoc() string", reflect.TypeOf((*PackageDocumented)(nil)).Elem()},
+}
+
+// checkPackageMethods reports methods that were evidently meant to implement
+// one of the optional Package interfaces but do not.
+//
+// Go cannot diagnose an interface someone meant to implement: a Builtins()
+// method returning the wrong slice type simply fails the type assertion in
+// packageBuiltins, which returns nil, and every builtin vanishes with no
+// diagnostic anywhere -- the load succeeds and the symbols are unbound at call
+// time.  A method with one of these names and the wrong signature is never
+// intentional, so it is worth naming.
+func checkPackageMethods(p Package) []string {
+	t := reflect.TypeOf(p)
+	if t == nil {
+		return nil
+	}
+	var problems []string
+	for _, m := range packageMethods {
+		if t.Implements(m.iface) {
+			continue
+		}
+		if got, ok := t.MethodByName(m.method); ok {
+			problems = append(problems, fmt.Sprintf(
+				"method %s does not satisfy %s: have %s, want %s; its definitions are silently ignored",
+				m.method, m.iface.Name(), methodSignature(m.method, got.Type), m.want))
+			continue
+		}
+		// A method declared on the pointer receiver is not in the method set
+		// of the value type, so passing the package by value drops it.
+		if t.Kind() != reflect.Pointer {
+			if _, ok := reflect.PointerTo(t).MethodByName(m.method); ok {
+				problems = append(problems, fmt.Sprintf(
+					"method %s is declared on *%s but the package was passed by value, so it does not satisfy %s; pass &%s{} instead",
+					m.method, t.Name(), m.iface.Name(), t.Name()))
+			}
+		}
+	}
+	return problems
+}
+
+// methodSignature renders a reflect method type as a Go signature, dropping
+// the receiver that reflect prepends to the parameter list.
+func methodSignature(name string, t reflect.Type) string {
+	in := make([]string, 0, t.NumIn())
+	for i := 1; i < t.NumIn(); i++ {
+		in = append(in, t.In(i).String())
+	}
+	out := make([]string, 0, t.NumOut())
+	for i := range t.NumOut() {
+		out = append(out, t.Out(i).String())
+	}
+	sig := name + "(" + strings.Join(in, ", ") + ")"
+	switch len(out) {
+	case 0:
+	case 1:
+		sig += " " + out[0]
+	default:
+		sig += " (" + strings.Join(out, ", ") + ")"
+	}
+	return sig
+}
+
+// loaderResult validates the value an embedder-supplied Loader returned.
+//
+// The Loader signature permits a Go nil *LVal, and returning one is an easy
+// slip -- lisp.Nil() is the correct spelling of success.  Every reader of a
+// Loader's result dereferences it, so an unchecked nil panics in the
+// embedder's process at load time.  what identifies the offending loader.
+func loaderResult(v *lisp.LVal, what string) *lisp.LVal {
+	if v == nil {
+		return lisp.Errorf("%s returned a nil *LVal (a Loader must return lisp.Nil() on success)", what)
+	}
+	return v
+}
+
+// loaderName identifies a Loader by the Go function it was built from, so that
+// an error about "loader 3 of 7" points at a file and line.
+func loaderName(fn Loader) string {
+	if fn == nil {
+		return "<nil>"
+	}
+	f := runtime.FuncForPC(reflect.ValueOf(fn).Pointer())
+	if f == nil {
+		return "<unknown>"
+	}
+	file, line := f.FileLine(f.Entry())
+	return fmt.Sprintf("%s (%s:%d)", f.Name(), filepath.Base(file), line)
+}
+
+// addDefs registers defs with add, rejecting the definitions that would make
+// lisp panic or defer a nil dereference to call time.  The checks mirror the
+// ones the LEnv methods make before panicking, so a definition that is
+// accepted today is still accepted.
+func addDefs(env *lisp.LEnv, pkgName string, kind string, defs []lisp.LBuiltinDef, add func(bool, ...lisp.LBuiltinDef)) *lisp.LVal {
+	for i, def := range defs {
+		if isNilDef(def) {
+			return lisp.Errorf("package %q: %s %d is nil", pkgName, kind, i)
+		}
+		name := def.Name()
+		if problem := checkFormals(def.Formals()); problem != "" {
+			return lisp.Errorf("package %q: %s %q: %s", pkgName, kind, name, problem)
+		}
+		if problem := checkPackageName(env.Runtime.Package, kind, name); problem != "" {
+			return lisp.Errorf("package %q: %s %q: %s", pkgName, kind, name, problem)
+		}
+		add(true, def)
+	}
+	return lisp.Nil()
+}

--- a/elpsutil/validate_test.go
+++ b/elpsutil/validate_test.go
@@ -1,0 +1,289 @@
+// Copyright © 2026 The ELPS authors
+
+package elpsutil_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/elpsutil"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// testPackage is a Package assembled from whatever the test needs it to
+// contribute.  The optional Package interfaces are all satisfied, so the
+// registration paths under test are always reached.
+type testPackage struct {
+	name       string
+	builtins   []lisp.LBuiltinDef
+	specialOps []lisp.LBuiltinDef
+	macros     []lisp.LBuiltinDef
+	initFn     elpsutil.Loader
+}
+
+func (p *testPackage) PackageName() string { return p.name }
+
+func (p *testPackage) Builtins() []lisp.LBuiltinDef { return p.builtins }
+
+func (p *testPackage) SpecialOps() []lisp.LBuiltinDef { return p.specialOps }
+
+func (p *testPackage) Macros() []lisp.LBuiltinDef { return p.macros }
+
+func (p *testPackage) PackageInit(env *lisp.LEnv) *lisp.LVal {
+	if p.initFn == nil {
+		return lisp.Nil()
+	}
+	return p.initFn(env)
+}
+
+func nopBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal { return lisp.Nil() }
+
+func testEnv(t *testing.T) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	rc := lisp.InitializeUserEnv(env)
+	require.True(t, rc.IsNil(), "InitializeUserEnv failed: %v", rc)
+	rc = env.InPackage(lisp.String(lisp.DefaultUserPackage))
+	require.True(t, rc.IsNil(), "InPackage failed: %v", rc)
+	return env
+}
+
+// defKind names one of the three definition lists a Package can contribute.
+// Every check that applies to a builtin applies identically to a special
+// operator and to a macro -- they are three copies of the same registration
+// code in lisp -- so the mistake table below is run against all three.  A
+// fourth kind added to PackageLoader must be added here, or the source sweep
+// in TestPackageLoaderKindsAreCovered fails.
+type defKind struct {
+	name  string
+	build func(defs ...lisp.LBuiltinDef) *testPackage
+}
+
+func defKinds(pkgName string) []defKind {
+	return []defKind{
+		{"builtin", func(defs ...lisp.LBuiltinDef) *testPackage {
+			return &testPackage{name: pkgName, builtins: defs}
+		}},
+		{"special operator", func(defs ...lisp.LBuiltinDef) *testPackage {
+			return &testPackage{name: pkgName, specialOps: defs}
+		}},
+		{"macro", func(defs ...lisp.LBuiltinDef) *testPackage {
+			return &testPackage{name: pkgName, macros: defs}
+		}},
+	}
+}
+
+// TestPackageLoaderRejectsBadDefinitions covers issue #351 defects 1 and 3: a
+// definition registered with nil formals, and a definition whose name collides
+// with a symbol the package already answers.  Both currently reach lisp -- the
+// first as a nil dereference inside LEnv.bind at call time, reported as an
+// opaque internal-panic, the second as an outright panic at registration.
+//
+// elpsutil is the boundary between an embedder's Go code and the interpreter.
+// A mistake in a package definition is an ordinary, recoverable failure on a
+// path where every other failure returns an *LVal error, so it is caught here
+// and reported as one.  The panics in lisp are unchanged: they still mean
+// "this is a bug in the interpreter, or in code that had no business calling
+// this".
+func TestPackageLoaderRejectsBadDefinitions(t *testing.T) {
+	tests := []struct {
+		name string
+		def  func() lisp.LBuiltinDef
+		// want are substrings the error must contain.  Every case requires
+		// the offending definition's name: an error that says only "invalid
+		// formals" makes the embedder hunt.
+		want []string
+	}{{
+		name: "nil formals",
+		def:  func() lisp.LBuiltinDef { return elpsutil.Function("takes-nothing", nil, nopBuiltin) },
+		want: []string{"testpkg", "takes-nothing", "formals are nil", "lisp.Formals()"},
+	}, {
+		name: "error formals",
+		// lisp.Formals reports a misplaced &rest by returning an error value,
+		// which is easy to store unexamined.
+		def: func() lisp.LBuiltinDef {
+			return elpsutil.Function("bad-rest", lisp.Formals("&rest", "a", "b"), nopBuiltin)
+		},
+		want: []string{"testpkg", "bad-rest", "formals are an error value"},
+	}, {
+		name: "formals not a list",
+		def: func() lisp.LBuiltinDef {
+			return elpsutil.Function("scalar-formals", lisp.Symbol("a"), nopBuiltin)
+		},
+		want: []string{"testpkg", "scalar-formals", "not a list"},
+	}, {
+		name: "nil formal cell",
+		def: func() lisp.LBuiltinDef {
+			return elpsutil.Function("nil-cell", lisp.QExpr([]*lisp.LVal{nil}), nopBuiltin)
+		},
+		want: []string{"testpkg", "nil-cell", "formal argument 0 is nil"},
+	}, {
+		name: "non-symbol formal cell",
+		def: func() lisp.LBuiltinDef {
+			return elpsutil.Function("int-cell", lisp.QExpr([]*lisp.LVal{lisp.Int(1)}), nopBuiltin)
+		},
+		want: []string{"testpkg", "int-cell", "formal argument 0", "not a symbol"},
+	}, {
+		name: "reserved name true",
+		def:  func() lisp.LBuiltinDef { return elpsutil.Function("true", lisp.Formals(), nopBuiltin) },
+		want: []string{"testpkg", `"true"`, "reserved constant"},
+	}, {
+		name: "reserved name false",
+		def:  func() lisp.LBuiltinDef { return elpsutil.Function("false", lisp.Formals(), nopBuiltin) },
+		want: []string{"testpkg", `"false"`, "reserved constant"},
+	}, {
+		name: "nil definition",
+		def:  func() lisp.LBuiltinDef { return nil },
+		want: []string{"testpkg", "is nil"},
+	}, {
+		name: "typed nil definition",
+		def:  func() lisp.LBuiltinDef { return (*elpsutil.Builtin)(nil) },
+		want: []string{"testpkg", "is nil"},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, kind := range defKinds("testpkg") {
+				t.Run(kind.name, func(t *testing.T) {
+					env := testEnv(t)
+					pkg := kind.build(test.def())
+					var rc *lisp.LVal
+					require.NotPanics(t, func() {
+						rc = elpsutil.Load(env, elpsutil.PackageLoader(pkg))
+					})
+					require.Equal(t, lisp.LError, rc.Type, "load succeeded: %v", rc)
+					msg := rc.String()
+					for _, want := range test.want {
+						require.Contains(t, msg, want)
+					}
+					// The kind belongs in the message too, so an embedder
+					// with a name used by both a builtin and a macro knows
+					// which list to look in.
+					require.Contains(t, msg, kind.name)
+
+					// Validate is the same checks without an env, for use in
+					// an embedder's own test.
+					require.Error(t, elpsutil.Validate(pkg))
+				})
+			}
+		})
+	}
+}
+
+// TestPackageLoaderRejectsDuplicateNames covers the redefinition half of
+// defect 3: a name already bound in the target package.  lisp panics with
+// "symbol already defined" at registration.
+func TestPackageLoaderRejectsDuplicateNames(t *testing.T) {
+	env := testEnv(t)
+	first := &testPackage{
+		name:     "dup",
+		builtins: []lisp.LBuiltinDef{elpsutil.Function("f", lisp.Formals(), nopBuiltin)},
+	}
+	rc := elpsutil.Load(env, elpsutil.PackageLoader(first))
+	require.NotEqual(t, lisp.LError, rc.Type, "first load failed: %v", rc)
+
+	second := &testPackage{
+		name:     "dup",
+		builtins: []lisp.LBuiltinDef{elpsutil.Function("f", lisp.Formals(), nopBuiltin)},
+	}
+	require.NotPanics(t, func() {
+		rc = elpsutil.Load(env, elpsutil.PackageLoader(second))
+	})
+	require.Equal(t, lisp.LError, rc.Type, "reloading a package redefined f without complaint")
+	require.Contains(t, rc.String(), `"f"`)
+	require.Contains(t, rc.String(), "already defined")
+	require.Contains(t, rc.String(), "dup")
+}
+
+// TestPackageLoaderRejectsIntraPackageDuplicates checks a package that names
+// the same symbol twice in its own definitions, which Validate can catch
+// without an env.
+func TestPackageLoaderRejectsIntraPackageDuplicates(t *testing.T) {
+	pkg := &testPackage{
+		name: "dup2",
+		builtins: []lisp.LBuiltinDef{
+			elpsutil.Function("f", lisp.Formals(), nopBuiltin),
+			elpsutil.Function("f", lisp.Formals("a"), nopBuiltin),
+		},
+	}
+	err := elpsutil.Validate(pkg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"f"`)
+
+	env := testEnv(t)
+	var rc *lisp.LVal
+	require.NotPanics(t, func() {
+		rc = elpsutil.Load(env, elpsutil.PackageLoader(pkg))
+	})
+	require.Equal(t, lisp.LError, rc.Type, "load accepted a duplicated name: %v", rc)
+}
+
+// TestPackageLoaderAcceptsGoodDefinitions is the other half of the contract:
+// correct code sees no difference.  A well-formed package still loads, its
+// builtins are still callable, and the values they return are unchanged.
+func TestPackageLoaderAcceptsGoodDefinitions(t *testing.T) {
+	env := testEnv(t)
+	pkg := &testPackage{
+		name: "good",
+		builtins: []lisp.LBuiltinDef{
+			elpsutil.Function("nullary", lisp.Formals(), func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+				return lisp.Int(1)
+			}),
+			elpsutil.Function("unary", lisp.Formals("x"), func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+				return args.Cells[0]
+			}),
+			// A builtin's variadic argument arrives flattened into Cells.
+			elpsutil.Function("varargs", lisp.Formals("&rest", "xs"), func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+				return lisp.Int(len(args.Cells))
+			}),
+			elpsutil.Function("optional", lisp.Formals("&optional", "x"), func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+				return args.Cells[0]
+			}),
+			elpsutil.Function("keyword", lisp.Formals("&key", "x"), func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+				return args.Cells[0]
+			}),
+		},
+	}
+	require.NoError(t, elpsutil.Validate(pkg))
+	rc := elpsutil.Load(env, elpsutil.PackageLoader(pkg))
+	require.NotEqual(t, lisp.LError, rc.Type, "load failed: %v", rc)
+
+	for _, test := range []struct {
+		expr string
+		want string
+	}{
+		{"(good:nullary)", "1"},
+		{"(good:unary 2)", "2"},
+		{"(good:varargs 1 2 3)", "3"},
+		{"(good:optional)", "()"},
+		{"(good:keyword :x 7)", "7"},
+	} {
+		v := evalString(t, env, test.expr)
+		require.NotEqual(t, lisp.LError, v.Type, "%s => %v", test.expr, v)
+		require.Equal(t, test.want, v.String(), "%s", test.expr)
+	}
+}
+
+// TestNilFormalsWouldPanicAtCallTime pins the reason nil formals must be
+// rejected at registration: without the boundary check the nil is stored in
+// Cells[0] and first dereferenced by LEnv.bind, long after the embedder's
+// registration code has returned successfully.
+func TestNilFormalsWouldPanicAtCallTime(t *testing.T) {
+	env := testEnv(t)
+	fn := lisp.FunInPackage("user", "<test>", nil, nopBuiltin)
+	env.PutGlobal(lisp.Symbol("nil-formals"), fn)
+	v := evalString(t, env, "(nil-formals)")
+	require.Equal(t, lisp.LError, v.Type,
+		"expected the unguarded path to fail; if this now succeeds the boundary check may be unnecessary")
+}
+
+func evalString(t *testing.T, env *lisp.LEnv, expr string) *lisp.LVal {
+	t.Helper()
+	var v *lisp.LVal
+	require.NotPanics(t, func() {
+		v = env.LoadString("test.lisp", expr)
+	})
+	return v
+}

--- a/lisp/lisplib/formals_test.go
+++ b/lisp/lisplib/formals_test.go
@@ -1,0 +1,77 @@
+// Copyright © 2026 The ELPS authors
+
+package lisplib_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisteredFunctionsHaveWellFormedFormals asserts that every function
+// reachable in a fully loaded environment carries a formal argument list
+// LEnv.bind can actually walk.
+//
+// bind reads fun.Cells[0].Cells and then argSym.Str on each cell without
+// checking either, because on every path that starts in lisp the formals came
+// from the reader or from lisp.Formals and cannot be otherwise. They can be
+// otherwise when a Go caller supplies them: a registration that passes a nil
+// *LVal for "takes no arguments" -- rather than lisp.Formals(), the empty
+// list -- succeeds, and is first dereferenced when a user calls the function,
+// surfacing as an opaque internal-panic with nothing pointing at the cause.
+// That is luthersystems/elps#351, fixed at the elpsutil boundary; this sweep
+// is the standing check that no definition inside elps itself acquires the
+// same shape.
+//
+// The properties pinned here are exactly the ones bind assumes: the formals
+// are a non-nil list, and every cell in it is a non-nil symbol.
+func TestRegisteredFunctionsHaveWellFormedFormals(t *testing.T) {
+	env, err := lisplib.NewDocEnv()
+	require.NoError(t, err)
+
+	pkgNames := make([]string, 0, len(env.Runtime.Registry.Packages))
+	for name := range env.Runtime.Registry.Packages {
+		pkgNames = append(pkgNames, name)
+	}
+	sort.Strings(pkgNames)
+
+	nfun := 0
+	for _, pkgName := range pkgNames {
+		pkg := env.Runtime.Registry.Packages[pkgName]
+		symNames := make([]string, 0, len(pkg.Symbols))
+		for sym := range pkg.Symbols {
+			symNames = append(symNames, sym)
+		}
+		sort.Strings(symNames)
+
+		for _, sym := range symNames {
+			v := pkg.Symbols[sym]
+			if v == nil || v.Type != lisp.LFun {
+				continue
+			}
+			nfun++
+			qualified := pkgName + ":" + sym
+			// An LFun keeps its formal list in Cells[0].
+			require.NotEmpty(t, v.Cells, "%s has no formals cell", qualified)
+			formals := v.Cells[0]
+			require.NotNil(t, formals,
+				"%s was registered with nil formals; use lisp.Formals() to declare a function that takes no arguments",
+				qualified)
+			require.Equal(t, lisp.LSExpr, formals.Type,
+				"%s was registered with formals of type %v, not a list", qualified, formals.Type)
+			for i, cell := range formals.Cells {
+				require.NotNil(t, cell, "%s formal argument %d is nil", qualified, i)
+				require.Equal(t, lisp.LSymbol, cell.Type,
+					"%s formal argument %d is a %v, not a symbol", qualified, i, cell.Type)
+			}
+		}
+	}
+
+	// Guard against the sweep silently finding nothing -- a registry walk that
+	// matches zero functions would pass this test while asserting nothing.
+	require.NotZero(t, nfun, "found no functions to check; the registry walk is broken")
+	t.Logf("checked the formals of %d registered functions", nfun)
+}


### PR DESCRIPTION
Fixes #351. Three embedder mistakes that panicked — in the embedder's process, or deferred to call time — now return an `*LVal` error naming what was wrong and which thing was wrong.

## Nothing under `lisp/` changed behaviour

The only file added there is a test. The panics in `LEnv.bind`, `AddBuiltins` and `Package.get` are untouched, deliberately. A panic in `lisp` means "this is a bug in the interpreter, or in code that had no business calling this"; weakening it blunts a real signal to serve a case the boundary serves better — and serves it with a far more useful message, because elpsutil knows the package name, the definition kind and the definition name, where `lisp` at that point knows only a symbol.

## What an embedder now sees

1. **nil formals** — `package "acme": builtin "do-thing": formals are nil (use lisp.Formals() to declare a function that takes no arguments)`. Also covers formals that are an `LError` (what `lisp.Formals("&rest","a","b")` returns), a non-list, a nil cell, and a non-symbol cell.
2. **nil loader result** — `loader github.com/acme/pkg.MyLoader (pkg.go:41) returned a nil *LVal (a Loader must return lisp.Nil() on success)`, identified via `runtime.FuncForPC`; in a chain, `loader 2 of 5, …`; from a package, `package "acme": PackageInit returned a nil *LVal …`.
3. **reserved / taken name** — `package "acme": builtin "true": "true" is a reserved constant and can never be bound`, and for a real collision `package "lisp": builtin "car": symbol is already defined in package "lisp"`.

Registration routes through `addDefs`, which mirrors the collision rules of `AddBuiltins`/`AddSpecialOps`/`AddMacros` exactly (`AddBuiltins` rejects any existing binding; the other two tolerate overwriting a nil-valued one), so a definition `lisp` accepts today is still accepted.

## The silent `Builtins()` trap, addressed

#351 records a harder related problem: a `Package` whose `Builtins()` signature does not exactly match `Builtins() []lisp.LBuiltinDef` fails the type assertion in `packageBuiltins`, which returns nil — so **every builtin silently vanishes** and `Load` returns success. I hit this myself while writing #351's reproductions.

Go cannot detect an interface someone *meant* to implement, but it can detect a **near miss**. `checkPackageMethods` uses reflect: for each optional interface, if the type does not satisfy it but does have a method of that name, it reports have/want; if the method exists only on the pointer type and the package was passed by value, it says so.

```
package "wrongbuiltins": method Builtins does not satisfy PackageBuiltins:
  have Builtins() []*elpsutil.Builtin, want Builtins() []lisp.LBuiltinDef;
  its definitions are silently ignored
```

This runs from `PackageLoader`, not only from the new exported `Validate(p Package) error`. It cannot break working code: a package in this state registered *nothing*, so there is no behaviour to preserve — it converts a silent no-op into a named error.

**Residual risk, stated plainly:** a `Package` with an unrelated method coincidentally named `Builtins`/`Macros`/`PackageDoc` with a different signature would now fail to load. Judged vanishingly unlikely and worth the trade, but it is the one change here that could surprise an existing consumer. See the release note below.

The issue's other suggestion — flagging a package that contributes nothing — is in `Validate` **only**. Unlike a signature mismatch, "empty" is not provably a mistake: a namespace-only package is unusual, not illegal.

## Tests

Systemic where systemic was achievable:

- **`TestLoaderEntryPointsAreCovered`** parses elpsutil's own source with `go/ast` and requires every exported function taking or returning a `Loader` to appear in the nil-result table. A new entry point that forgets the check fails this.
- **`TestPackageLoaderKindsAreCovered`** counts `addDefs` call sites and requires the kind table to match, so a fourth definition kind gets the full mistake table.
- **`lisp/lisplib/formals_test.go`** walks the registry of a fully loaded env and asserts every registered function's `Cells[0]` is a non-nil list of non-nil symbols — exactly what `LEnv.bind` assumes. This is what finds the next instance of defect 1 inside elps itself. 400+ functions; fails rather than passes if the walk finds none.
- Negative controls load and *call* nullary / unary / `&rest` / `&optional` / `&key` builtins, so a check that is too strict fails.

## Deliberately left alone

- Every panic under `lisp/`, including `Package.get` answering `true`/`false` without consulting the symbol table — the proximate cause of defect 3. The elpsutil check turns it into a named error; changing `get` would alter reader semantics to fix a registration-path problem.
- `elpsutil.Function`'s signature: it returns `*Builtin` and cannot report an error. The nil-formals constraint is documented on it instead.
- **Direct `env.AddBuiltins(true, elpsutil.Function(…))` calls bypass all of this** and still panic exactly as before; three exist in elps's own tests. Covering that would mean changing `lisp`, which this fix is structured to avoid. Embedders on that path can call `Validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA

---

## Merged with `main` (`f18e118`) — conflict with #360 resolved

This branch predated #357 and #360. It is now merged with current `main`; head `2ec69fa`.

### The conflict

#360 (*Restore the caller's package across elpsutil loads*) rewrote the same three functions this PR rewrites: `Load`, `LoadAll` and `PackageLoader`. `git merge` conflicts in all three. Both sides are kept, and none of #360's shipped behaviour is dropped:

- **#360's restoration.** `Load` and `LoadAll` save the caller's package and restore it; `LoadAll` restores the *caller's* package, not `DefaultUserPackage`, and runs each loader from it; `PackageLoader` defers the restore and re-establishes the loaded package after `PackageInit` returns.
- **#361's validation.** Nil loaders, nil packages, nil `*LVal` loader results, malformed definitions and near-miss `Package` methods are reported as errors naming the offender.

### Two restoration gaps this merge closes

These are **not** regressions from #360 — they are two defects that #360 shipped with, and that this merge is the natural place to close because it rewrites the same lines. Both were verified absent on `f18e118` before being fixed here, and each is pinned by the new `elpsutil/restore_test.go` and red-tested by deleting the behaviour:

1. **The restore did not run on the error path.** `Load` returned the loader's error *before* restoring, so a loader that failed after switching packages left the embedder in that package — the same defect #352 fixes for the success path. `Load` now restores unconditionally and still prefers the loader's error. Deleting the fix fails `TestLoad_ErrorRestoresPrevious` and `TestLoadAll_ErrorRestoresPrevious`.
2. **The save was unguarded.** `prevPkg := env.Runtime.Package.Name` nil-dereferences on an `LEnv` that never ran `lisp.InitializeUserEnv` — a panic introduced by the restore itself, and exactly the class of defect this PR exists to remove. `currentPackageName` now returns an error `*LVal`. Deleting the guard fails all four subtests of `TestLoadersRejectUninitialisedEnv` (`Load`, `LoadAll`, `PackageLoader`, `LibraryLoader`) by panicking.

### Test-helper collision with #360

#360 landed `elpsutil/elpsutil_test.go` carrying a `testPackage` of its own, which collides with this branch's `testPackage` in package `elpsutil_test`. This branch's copy is renamed `validationPackage`; #360's shipped helper is untouched.

### The five subtests that were red after a clean merge

`main`'s `elpsutil/elpsutil_fuzz_test.go` (from #357) deliberately pinned the panics this PR removes. On a merge with the conflict resolved but nothing else changed, `go test ./elpsutil/` fails exactly five subtests — verified on a scratch branch. All five now pass:

| Subtest | Why it passes now |
|---|---|
| `TestCollisionPanicIsReal/existing-lang-symbol` | **Retargeted.** lisp's panic is unchanged and still pinned — the test now calls `env.AddBuiltins`/`AddSpecialOps`/`AddMacros` directly instead of reaching them through elpsutil, which no longer lets the collision through. elpsutil's refusal is separately covered by `TestPackageLoaderRejectsBadDefinitions` and by the `reject/collision` / `reject/reserved-name` fuzz labels. |
| `TestCollisionPanicIsReal/duplicate-builtin` | **Retargeted** (now `duplicate-symbol`, run against all three registration kinds — 9 subtests where there were 3). |
| `TestCollisionPanicIsReal/reserved-symbol` | **Retargeted.** |
| `TestKnownNilContractViolations/nil-formals-defers-to-call-time` | **Behaviour genuinely changed.** Nil formals are refused at install instead of nil-dereferencing inside `LEnv.bind` at first call. The tripwire is flipped: `TestNilContractMistakesAreErrors/nil-formals-rejected-at-install`. |
| `TestKnownNilContractViolations/nil-loader-return-panics` | **Behaviour genuinely changed.** A `Loader` returning a Go nil `*LVal` is reported as a named error instead of panicking. Flipped to `TestNilContractMistakesAreErrors/nil-loader-return-reported`. |

The harness's `nameAvailable`/`reserveName` pre-check is retired: with collisions refused rather than panicking, it prevented no panic and only subtracted inputs. Go nil is handed back to the fuzzer (`formalsTable` gains `go-nil`, `initTable` gains `init/go-nil`) on the strength of the two flipped assertions.

One further correctness point, easy to miss: `checkFormals` refuses five formals shapes at install, which silently ended their `LEnv.bind` coverage **while their coverage labels kept passing**, because labels are marked at spec-decode time rather than at successful registration — the completeness test had gone vacuous without failing. Both halves are now kept: the def still goes through elpsutil so the refusal is fuzzed, and a copy is registered through the documented `AddBuiltins` bypass so `bind` still meets the shape. `TestFormalsTableRejectionFlags` pins the table against `elpsutil.Validate` and fails if an entry's `rejected` flag drifts from what `Validate` does (verified by flipping one).

---

## Release note (draft)

> ### elpsutil rejects package definitions with a near-miss optional method
>
> `elpsutil.PackageLoader`, `elpsutil.LibraryLoader` and the new `elpsutil.Validate` now inspect a `Package` for methods that *look like* one of the optional `Package` interfaces (`Builtins`, `SpecialOps`, `Macros`, `PackageInit`, `PackageDoc`) but do not satisfy it — a wrong return type, a wrong signature, or a method declared only on the pointer type when the package is passed by value. Such a package is refused with an error naming the method, what it has and what it wants.
>
> **This can reject a package that loaded successfully before.** Previously the type assertion simply failed, the method's definitions were silently ignored, and the load returned success — so an affected package loaded and registered nothing from that method. Those loads now return an error instead.
>
> **What to check:** any embedder whose `Package` type has a method named `Builtins`, `SpecialOps`, `Macros`, `PackageInit` or `PackageDoc` that is *not* the elpsutil interface method — for example an unrelated helper that happens to share the name, or an interface method implemented on the pointer receiver while the value is passed to `LibraryLoader`. If the method was meant to implement the interface, its definitions were never being registered, and the new error is the first report of a pre-existing bug. If the name collision is coincidental, rename the method.
>
> **How to check without deploying:** call `elpsutil.Validate(p)` on each `Package` in a test. It reports the same problems without loading anything.
>
> Also in this release: `elpsutil` reports nil `Loader`s, nil `Package`s, `Loader`s that return a Go nil `*LVal`, and malformed formals as errors identifying the offender, instead of panicking in the embedder's process or deferring a nil dereference to call time. `Load`, `LoadAll`, `LibraryLoader` and `PackageLoader` also restore the caller's package when a load *fails*, not only when it succeeds, and report an environment that never ran `lisp.InitializeUserEnv` as an error rather than panicking. Direct `env.AddBuiltins(true, ...)` calls bypass all of this and panic as before.

**Consumers still unverified against the near-miss detector:** `luthersystems/svc/libhandlebars` has not been built against this branch, and neither has `substrate` (carried over from the original verification note). Neither checkout is reachable from this session; both should be built before this ships.

---

## Gates against `f18e118`

| Gate | Result |
|---|---|
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `go test ./...` | pass (all packages) |
| `go test -race ./...` | pass (all packages) |
| `golangci-lint run ./...` | 0 issues |
| `gofmt -l` | unchanged from `main` (the same 17 pre-existing files; none touched here) |
| `elps fmt -l ./...` | clean |
| `scripts/confidentiality-guard.sh` | clean |
| `bash scripts/ci-gates-test.sh` | 127 passed, 0 failed |
| `bash scripts/fuzz-budget-check.sh` | the sweep fits (23 targets, 6 shards, 50 min required vs 60 min timeout) |
| `FuzzElpsutilEmbed -fuzztime 60s` | 117,521 execs, 222 new interesting, **0 crashers** |

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_
