### PR TITLE
elpsvet escape-aliasing rule + singleton sealing (stacked on #374)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
-elps
+# Anchored: only the built binary at the repo root.  A bare `elps`
+# pattern matches ANY path component named elps -- including
+# cmd/elpsvet/testdata/src/github.com/luthersystems/elps/..., which
+# silently kept new analysistest stub packages out of the repository
+# (they existed locally, so tests passed locally and failed in CI).
+/elps
 .firecrawl/
 .claude/settings.local.json
 .claude/worktrees/

--- a/cmd/elpsvet/alias.go
+++ b/cmd/elpsvet/alias.go
@@ -103,7 +103,7 @@ func newAliasTracker(pass *analysis.Pass, fresh map[types.Object]bool, ann map[i
 
 func (t *aliasTracker) report(pos token.Pos, op string) {
 	line := t.pass.Fset.Position(pos).Line
-	if t.ann[line] || t.ann[line-1] {
+	if t.ann[line] {
 		return
 	}
 	t.pass.Reportf(pos,

--- a/cmd/elpsvet/escape.go
+++ b/cmd/elpsvet/escape.go
@@ -36,11 +36,18 @@
 //   - a field write rooted at a package-level variable — the
 //     registry-reachable shape.
 //
-// CLEAN: a location routed through copyLocation (or any func(*Location)
-// *Location named copyLocation), a &token.Location{...} literal, and
-// &local where local is a value-typed variable (the parser's deref-copy
-// idiom: src := *loc; v.SetSource(&src)) — all of these give the escaping
-// value its own memory.
+// CLEAN: a &token.Location{...} literal, &local where local is a
+// value-typed variable (the parser's deref-copy idiom: src := *loc;
+// v.SetSource(&src)), and — the cross-package part — the result of ANY
+// function or method PROVEN to allocate the location it returns.  That
+// proof is the freshLocation fact (locfact.go): the analyzer summarises
+// each location-returning function in the package it is analysing and
+// exports the summary along the import graph, so copyLocation,
+// lisp.LEnv.Source (which returns copyLocation(env.loc)) and
+// token.Scanner.LocStart (which mints a &Location{...} per token) are clean
+// at every call site, in every package, WITHOUT an annotation.  An embedder
+// using the sanctioned copying accessor must never have to annotate; only a
+// deliberate alias should.
 //
 // Out of scope (documented limitations, consistent with the freshness
 // rule's intraprocedural approximation): function parameters are not taint
@@ -49,7 +56,10 @@
 // (stampMacroExpansion receives callSite by parameter); whole-struct copies
 // (*cp = *v) alias the source field implicitly and remain the freshness
 // rule's and the seal design's concern; index reads (locs[i]) are not taint
-// sources.
+// sources.  A callee with NO freshness fact — an un-analysed package, an
+// interface method, a function whose body has one leaking return — keeps
+// the conservative treatment, so the fact can only ever retire a proven
+// false positive, never open a hole.
 //
 // Escape hatch: //elps:aliases trailing the flagged line, standing alone on
 // the line directly above it, or in the enclosing function's doc comment.
@@ -75,12 +85,17 @@ const tokenPkgPath = "github.com/luthersystems/elps/parser/token" //nolint:gosec
 const aliasesMarker = "elps:aliases"
 
 var escapeAnalyzer = &analysis.Analyzer{
-	Name: "elpsescape",
-	Doc:  "flag runtime-owned *token.Location pointers (env.Loc, v.source, parser token locations) stored uncopied into fields of escaping values (the pre-fix ErrorCondition/ErrorConditionf and ErrorAssociate aliasing, issue #375); suppress with //elps:aliases",
-	Run:  runEscape,
+	Name:      "elpsescape",
+	Doc:       "flag runtime-owned *token.Location pointers (env.Loc, v.source, parser token locations) stored uncopied into fields of escaping values (the pre-fix ErrorCondition/ErrorConditionf and ErrorAssociate aliasing, issue #375); suppress with //elps:aliases",
+	Run:       runEscape,
+	FactTypes: []analysis.Fact{new(freshLocation)},
 }
 
 func runEscape(pass *analysis.Pass) (interface{}, error) {
+	// Summarise this package's location-returning functions first: an
+	// in-package call site below must be able to consult the fact, and the
+	// callee may live in a file this loop has not reached yet.
+	exportFreshLocationFacts(pass)
 	for _, file := range pass.Files {
 		ann := markerLines(pass.Fset, file, aliasesMarker)
 		for _, decl := range file.Decls {
@@ -367,10 +382,13 @@ func (t *escTracker) locTaint(e ast.Expr) bool {
 	return false
 }
 
-// callLocTaint decides taint for a call in location position: copyLocation
-// cleanses; a location-returning method aliases its receiver's state
-// (p.Location()); a plain location-returning function propagates its
-// arguments' taint (intraprocedural helper approximation).
+// callLocTaint decides taint for a call in location position: a callee
+// PROVEN to allocate its result cleanses (the freshLocation fact — see
+// locfact.go; this is what makes copyLocation, lisp.LEnv.Source and
+// token.Scanner.LocStart safe at any call site, in any package, with no
+// annotation); a location-returning method with no such proof aliases its
+// receiver's state (p.Location()); a plain location-returning function
+// propagates its arguments' taint (intraprocedural helper approximation).
 func (t *escTracker) callLocTaint(call *ast.CallExpr) bool {
 	fn, ok := typeutil.Callee(t.pass.TypesInfo, call).(*types.Func)
 	if !ok {
@@ -380,8 +398,8 @@ func (t *escTracker) callLocTaint(call *ast.CallExpr) bool {
 	if !ok || sig.Results().Len() != 1 || !isLocationPtr(sig.Results().At(0).Type()) {
 		return false
 	}
-	if fn.Name() == "copyLocation" {
-		return false // the sanctioned cleanser (lisp/detach.go)
+	if freshLocationCallee(t.pass, fn) {
+		return false // proven to hand back memory it allocated
 	}
 	if sig.Recv() != nil {
 		if sel, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr); ok {
@@ -456,7 +474,15 @@ func isLocationPtr(t types.Type) bool {
 	if !ok {
 		return false
 	}
-	named, ok := types.Unalias(p.Elem()).(*types.Named)
+	return isLocationValue(p.Elem())
+}
+
+// isLocationValue reports whether t is token.Location itself.
+func isLocationValue(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	named, ok := types.Unalias(t).(*types.Named)
 	if !ok {
 		return false
 	}

--- a/cmd/elpsvet/escape.go
+++ b/cmd/elpsvet/escape.go
@@ -51,8 +51,10 @@
 // rule's and the seal design's concern; index reads (locs[i]) are not taint
 // sources.
 //
-// Escape hatch: //elps:aliases on the flagged line, the line above it, or
-// the enclosing function's doc comment.  Every annotation must carry a
+// Escape hatch: //elps:aliases trailing the flagged line, standing alone on
+// the line directly above it, or in the enclosing function's doc comment.
+// A TRAILING justification covers only the line it trails; a STANDALONE one
+// is a preamble and covers the statement below (see markerLines).  Every annotation must carry a
 // justification a reader can audit — the deliberate aliases are the ones
 // whose producers freeze the location before the value can escape
 // (post-parse sealed locations) or whose consumers are runtime-internal
@@ -169,7 +171,7 @@ func collectReturned(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object]
 
 func (t *escTracker) report(pos token.Pos, what string) {
 	line := t.pass.Fset.Position(pos).Line
-	if t.ann[line] || t.ann[line-1] {
+	if t.ann[line] {
 		return
 	}
 	t.pass.Reportf(pos,

--- a/cmd/elpsvet/escape.go
+++ b/cmd/elpsvet/escape.go
@@ -1,0 +1,463 @@
+// Copyright © 2026 The ELPS authors
+
+// The elpsescape analyzer is the third elpsvet rule: an escape-aliasing
+// check for runtime-owned *token.Location pointers (issue #375).
+//
+// The freshness rule (freshness.go) polices the mutation direction: writes
+// to LVal storage the writer does not own.  The pre-fix ErrorCondition/
+// ErrorConditionf bug (fixed in ac0a326) and the original ErrorAssociate
+// aliasing (fixed in d922290) were the mirror image and structurally
+// invisible to it: a shared, runtime-owned pointer (env.Loc) stored
+// UNCOPIED into a freshly constructed error that escapes the function.
+// The write target was fresh, so freshness had nothing to say — the bug
+// was in what was stored, not where.
+//
+// Rule: TAINT every *token.Location read off runtime or LVal state —
+// env.Loc, v.source, fun.source, parser/scanner token locations, call-stack
+// frame locations; concretely, any *token.Location-typed field read whose
+// receiver chain does not root at a value this function constructed, and
+// any *token.Location-returning method called on such a receiver
+// (p.Location()).  Taint propagates through local assignments
+// (last-assignment-wins, path-insensitive, exactly like the freshness and
+// alias maps) and through plain functions that return a *token.Location
+// when fed a tainted argument.
+//
+// FLAG any store of a tainted pointer into a field of a value that escapes:
+//
+//   - an LVal field write (lerr.source = env.Loc — the pre-fix
+//     ErrorAssociate shape) or an LVal composite literal field
+//     (&LVal{source: env.Loc} — the pre-fix ErrorCondition shape); an LVal
+//     is presumed escaping, that is what LVals are for;
+//   - a SetSource call with a tainted argument (the setter is the exported
+//     spelling of the same field write);
+//   - a field write on a local the function returns, and a returned
+//     composite literal (or local initialized from one) capturing a tainted
+//     location — the return-escape shape;
+//   - a field write rooted at a package-level variable — the
+//     registry-reachable shape.
+//
+// CLEAN: a location routed through copyLocation (or any func(*Location)
+// *Location named copyLocation), a &token.Location{...} literal, and
+// &local where local is a value-typed variable (the parser's deref-copy
+// idiom: src := *loc; v.SetSource(&src)) — all of these give the escaping
+// value its own memory.
+//
+// Out of scope (documented limitations, consistent with the freshness
+// rule's intraprocedural approximation): function parameters are not taint
+// sources in the callee (PushFID storing its src argument is its callers'
+// concern); a tainted pointer passed as a call argument escapes tracking
+// (stampMacroExpansion receives callSite by parameter); whole-struct copies
+// (*cp = *v) alias the source field implicitly and remain the freshness
+// rule's and the seal design's concern; index reads (locs[i]) are not taint
+// sources.
+//
+// Escape hatch: //elps:aliases on the flagged line, the line above it, or
+// the enclosing function's doc comment.  Every annotation must carry a
+// justification a reader can audit — the deliberate aliases are the ones
+// whose producers freeze the location before the value can escape
+// (post-parse sealed locations) or whose consumers are runtime-internal
+// (TaggedValue, Lambda), and the justification must say which.
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/types/typeutil"
+)
+
+const tokenPkgPath = "github.com/luthersystems/elps/parser/token"
+
+const aliasesMarker = "elps:aliases"
+
+var escapeAnalyzer = &analysis.Analyzer{
+	Name: "elpsescape",
+	Doc:  "flag runtime-owned *token.Location pointers (env.Loc, v.source, parser token locations) stored uncopied into fields of escaping values (the pre-fix ErrorCondition/ErrorConditionf and ErrorAssociate aliasing, issue #375); suppress with //elps:aliases",
+	Run:  runEscape,
+}
+
+func runEscape(pass *analysis.Pass) (interface{}, error) {
+	for _, file := range pass.Files {
+		ann := markerLines(pass.Fset, file, aliasesMarker)
+		for _, decl := range file.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				if d.Body == nil || hasMarker(d.Doc, aliasesMarker) {
+					continue
+				}
+				checkEscape(pass, d.Body, ann)
+			case *ast.GenDecl:
+				// Function literals in package-level var initializers.
+				ast.Inspect(d, func(n ast.Node) bool {
+					if lit, ok := n.(*ast.FuncLit); ok {
+						checkEscape(pass, lit.Body, ann)
+						return false
+					}
+					return true
+				})
+			}
+		}
+	}
+	return nil, nil
+}
+
+// escTracker holds the per-function-body taint state for the escape rule.
+type escTracker struct {
+	pass     *analysis.Pass
+	fresh    map[types.Object]bool // LVal locals this function constructed
+	tainted  map[types.Object]bool // *token.Location locals aliasing runtime state
+	carrier  map[types.Object]bool // locals whose composite literal captured a tainted location
+	returned map[types.Object]bool // locals that appear in a return statement
+	ann      map[int]bool
+}
+
+// checkEscape walks one function body in source order.  Nested function
+// literals share the maps — the same intraprocedural approximation the
+// freshness rule uses.
+func checkEscape(pass *analysis.Pass, body *ast.BlockStmt, ann map[int]bool) {
+	t := &escTracker{
+		pass:     pass,
+		fresh:    make(map[types.Object]bool),
+		tainted:  make(map[types.Object]bool),
+		carrier:  make(map[types.Object]bool),
+		returned: collectReturned(pass, body),
+		ann:      ann,
+	}
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch stmt := n.(type) {
+		case *ast.AssignStmt:
+			t.handleAssign(stmt)
+		case *ast.ValueSpec:
+			t.handleValueSpec(stmt)
+		case *ast.CallExpr:
+			t.checkSetSource(stmt)
+		case *ast.CompositeLit:
+			t.checkLValComposite(stmt)
+		case *ast.ReturnStmt:
+			t.checkReturn(stmt)
+		}
+		return true
+	})
+}
+
+// collectReturned pre-collects the local identifiers a body returns, so a
+// store into their fields earlier in source order is known to escape.
+func collectReturned(pass *analysis.Pass, body *ast.BlockStmt) map[types.Object]bool {
+	returned := make(map[types.Object]bool)
+	ast.Inspect(body, func(n ast.Node) bool {
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		for _, res := range ret.Results {
+			res = ast.Unparen(res)
+			if u, ok := res.(*ast.UnaryExpr); ok && u.Op == token.AND {
+				res = ast.Unparen(u.X)
+			}
+			if id, ok := res.(*ast.Ident); ok {
+				if obj := pass.TypesInfo.ObjectOf(id); obj != nil {
+					returned[obj] = true
+				}
+			}
+		}
+		return true
+	})
+	return returned
+}
+
+func (t *escTracker) report(pos token.Pos, what string) {
+	line := t.pass.Fset.Position(pos).Line
+	if t.ann[line] || t.ann[line-1] {
+		return
+	}
+	t.pass.Reportf(pos,
+		"%s stores a runtime-owned *token.Location that its producer may still fix up in place"+
+			" (the escape-aliasing shape behind the pre-fix ErrorCondition/ErrorConditionf"+
+			" and ErrorAssociate bugs);"+
+			" store an independent copy (copyLocation) instead,"+
+			" or annotate //elps:aliases with a justification", what)
+}
+
+// handleAssign tracks freshness/taint/carrier state through identifier
+// assignments and flags escaping stores of tainted locations.
+func (t *escTracker) handleAssign(stmt *ast.AssignStmt) {
+	single := len(stmt.Rhs) == 1
+	for i, lhs := range stmt.Lhs {
+		var rhs ast.Expr
+		if single {
+			rhs = stmt.Rhs[0]
+		} else if i < len(stmt.Rhs) {
+			rhs = stmt.Rhs[i]
+		}
+		lhs = ast.Unparen(lhs)
+		if id, ok := lhs.(*ast.Ident); ok {
+			t.trackIdent(id, rhs, single && len(stmt.Lhs) > 1)
+			continue
+		}
+		if rhs != nil {
+			t.checkFieldStore(lhs, rhs)
+		}
+	}
+}
+
+// handleValueSpec tracks the same state through plain var declarations.
+func (t *escTracker) handleValueSpec(spec *ast.ValueSpec) {
+	if len(spec.Values) != len(spec.Names) {
+		return
+	}
+	for i, name := range spec.Names {
+		t.trackIdent(name, spec.Values[i], false)
+	}
+}
+
+// trackIdent updates the fresh/tainted/carrier maps for one assigned
+// identifier.  tuple reports the x, y := f() form, where per-value
+// expressions are unavailable and everything conservatively clears.
+func (t *escTracker) trackIdent(id *ast.Ident, rhs ast.Expr, tuple bool) {
+	if id.Name == "_" {
+		return
+	}
+	obj := t.pass.TypesInfo.Defs[id]
+	if obj == nil {
+		obj = t.pass.TypesInfo.Uses[id]
+	}
+	if obj == nil {
+		return
+	}
+	if tuple || rhs == nil {
+		t.fresh[obj] = false
+		t.tainted[obj] = false
+		t.carrier[obj] = false
+		return
+	}
+	switch {
+	case isLocationPtr(obj.Type()):
+		t.tainted[obj] = t.locTaint(rhs)
+	case isLValValue(obj.Type()) || isLValPtr(obj.Type()):
+		t.fresh[obj] = isFreshExpr(t.pass, rhs, t.fresh)
+	default:
+		t.carrier[obj] = t.carrierOfLoc(rhs)
+	}
+}
+
+// checkFieldStore flags an assignment whose LHS is a field of an escaping
+// value and whose RHS carries a tainted location.
+func (t *escTracker) checkFieldStore(lhs, rhs ast.Expr) {
+	taint := t.locTaint(rhs)
+	carry := !taint && t.carrierOfLoc(rhs)
+	if !taint && !carry {
+		return
+	}
+	lhs = ast.Unparen(lhs)
+	sel, ok := lhs.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+	if name, ok := lvalFieldSelection(t.pass, sel); ok {
+		t.report(lhs.Pos(), "write to LVal field ."+name)
+		return
+	}
+	// Only direct location stores matter for the non-LVal targets below;
+	// a carrier stored into an arbitrary struct field is out of scope.
+	if !taint {
+		return
+	}
+	root := chainRootIdent(sel.X)
+	if root == nil {
+		return
+	}
+	obj := t.pass.TypesInfo.ObjectOf(root)
+	if obj == nil {
+		return
+	}
+	if v, ok := obj.(*types.Var); ok && v.Parent() == v.Pkg().Scope() {
+		t.report(lhs.Pos(), "write to field ."+sel.Sel.Name+" of package-level state")
+		return
+	}
+	if t.returned[obj] {
+		t.report(lhs.Pos(), "write to field ."+sel.Sel.Name+" of a value this function returns")
+	}
+}
+
+// checkSetSource flags v.SetSource(loc) calls with a tainted argument —
+// the exported spelling of the LVal .source field write.
+func (t *escTracker) checkSetSource(call *ast.CallExpr) {
+	fn := methodCallee(t.pass, call)
+	if fn == nil || fn.Name() != "SetSource" || !recvIsLisp(fn, "LVal") {
+		return
+	}
+	if len(call.Args) == 1 && t.locTaint(call.Args[0]) {
+		t.report(call.Pos(), "SetSource call")
+	}
+}
+
+// checkLValComposite flags a tainted location captured by a field of an
+// LVal composite literal — the pre-fix ErrorCondition/ErrorConditionf
+// shape (&LVal{source: env.Loc, ...}).  An LVal literal is presumed
+// escaping.
+func (t *escTracker) checkLValComposite(lit *ast.CompositeLit) {
+	typ := t.pass.TypesInfo.TypeOf(lit)
+	if typ == nil || !isLValValue(typ) {
+		return
+	}
+	for _, elt := range lit.Elts {
+		name := ""
+		val := elt
+		if kv, ok := elt.(*ast.KeyValueExpr); ok {
+			if id, ok := kv.Key.(*ast.Ident); ok {
+				name = "." + id.Name
+			}
+			val = kv.Value
+		}
+		if t.locTaint(val) {
+			t.report(elt.Pos(), "LVal composite literal field "+name)
+		}
+	}
+}
+
+// checkReturn flags the return-escape shape: returning a composite literal
+// (or a local initialized from one) that captured a tainted location.
+// LVal literals are excluded — checkLValComposite already reports them
+// wherever they appear.
+func (t *escTracker) checkReturn(ret *ast.ReturnStmt) {
+	for _, res := range ret.Results {
+		if t.carrierOfLoc(res) {
+			t.report(res.Pos(), "returning a value whose composite literal captured a field")
+		}
+	}
+}
+
+// locTaint reports whether e evaluates to a *token.Location aliasing
+// runtime or LVal state this function does not own.
+func (t *escTracker) locTaint(e ast.Expr) bool {
+	e = ast.Unparen(e)
+	switch x := e.(type) {
+	case *ast.Ident:
+		obj := t.pass.TypesInfo.Uses[x]
+		if obj == nil {
+			obj = t.pass.TypesInfo.Defs[x]
+		}
+		return obj != nil && t.tainted[obj]
+	case *ast.SelectorExpr:
+		// env.Loc, v.source, tok.Source, frame.Source: a location field
+		// read off anything this function did not construct.
+		s, ok := t.pass.TypesInfo.Selections[x]
+		if !ok || s.Kind() != types.FieldVal || !isLocationPtr(s.Type()) {
+			return false
+		}
+		return !rootIsFresh(t.pass, x.X, t.fresh)
+	case *ast.UnaryExpr:
+		if x.Op != token.AND {
+			return false
+		}
+		// &lit and &local are this function's memory; &shared.LocField
+		// aliases shared storage.
+		inner := ast.Unparen(x.X)
+		if sel, ok := inner.(*ast.SelectorExpr); ok {
+			return !rootIsFresh(t.pass, sel.X, t.fresh)
+		}
+		return false
+	case *ast.CallExpr:
+		return t.callLocTaint(x)
+	}
+	return false
+}
+
+// callLocTaint decides taint for a call in location position: copyLocation
+// cleanses; a location-returning method aliases its receiver's state
+// (p.Location()); a plain location-returning function propagates its
+// arguments' taint (intraprocedural helper approximation).
+func (t *escTracker) callLocTaint(call *ast.CallExpr) bool {
+	fn, ok := typeutil.Callee(t.pass.TypesInfo, call).(*types.Func)
+	if !ok {
+		return false
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || sig.Results().Len() != 1 || !isLocationPtr(sig.Results().At(0).Type()) {
+		return false
+	}
+	if fn.Name() == "copyLocation" {
+		return false // the sanctioned cleanser (lisp/detach.go)
+	}
+	if sig.Recv() != nil {
+		if sel, ok := ast.Unparen(call.Fun).(*ast.SelectorExpr); ok {
+			return !rootIsFresh(t.pass, sel.X, t.fresh)
+		}
+		return true
+	}
+	for _, arg := range call.Args {
+		if t.locTaint(arg) {
+			return true
+		}
+	}
+	return false
+}
+
+// carrierOfLoc reports whether e is (or holds) a non-LVal value whose
+// composite literal captured a tainted location — the return-escape shape
+// (&FunctionInfo{Source: node.source}).
+func (t *escTracker) carrierOfLoc(e ast.Expr) bool {
+	e = ast.Unparen(e)
+	switch x := e.(type) {
+	case *ast.Ident:
+		obj := t.pass.TypesInfo.Uses[x]
+		if obj == nil {
+			obj = t.pass.TypesInfo.Defs[x]
+		}
+		return obj != nil && t.carrier[obj]
+	case *ast.UnaryExpr:
+		return x.Op == token.AND && t.carrierOfLoc(x.X)
+	case *ast.CompositeLit:
+		if typ := t.pass.TypesInfo.TypeOf(x); typ != nil && isLValValue(typ) {
+			return false // LVal literals are checkLValComposite's to report
+		}
+		for _, elt := range x.Elts {
+			if kv, ok := elt.(*ast.KeyValueExpr); ok {
+				elt = kv.Value
+			}
+			if t.locTaint(elt) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// chainRootIdent walks a selector/index/deref chain to its root identifier,
+// or nil when the chain roots elsewhere (a call, a literal).
+func chainRootIdent(e ast.Expr) *ast.Ident {
+	for {
+		e = ast.Unparen(e)
+		switch x := e.(type) {
+		case *ast.Ident:
+			return x
+		case *ast.SelectorExpr:
+			e = x.X
+		case *ast.IndexExpr:
+			e = x.X
+		case *ast.StarExpr:
+			e = x.X
+		default:
+			return nil
+		}
+	}
+}
+
+// isLocationPtr reports whether t is *token.Location.
+func isLocationPtr(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	p, ok := types.Unalias(t).Underlying().(*types.Pointer)
+	if !ok {
+		return false
+	}
+	named, ok := types.Unalias(p.Elem()).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj.Name() == "Location" && obj.Pkg() != nil && obj.Pkg().Path() == tokenPkgPath
+}

--- a/cmd/elpsvet/escape.go
+++ b/cmd/elpsvet/escape.go
@@ -68,7 +68,7 @@ import (
 	"golang.org/x/tools/go/types/typeutil"
 )
 
-const tokenPkgPath = "github.com/luthersystems/elps/parser/token"
+const tokenPkgPath = "github.com/luthersystems/elps/parser/token" //nolint:gosec // an import path (gosec G101 keys on the word "token"), not a credential
 
 const aliasesMarker = "elps:aliases"
 

--- a/cmd/elpsvet/escape_test.go
+++ b/cmd/elpsvet/escape_test.go
@@ -1,0 +1,20 @@
+// Copyright © 2026 The ELPS authors
+
+package main
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// TestEscapeAnalyzer runs the escape-aliasing rule over two fixture
+// packages: the lisp stub carries the in-package retro-catch shapes (the
+// pre-fix ErrorCondition/ErrorConditionf and ErrorAssociate bodies,
+// mirrored verbatim from history), and esc carries the cross-package
+// shapes (SetSource, return-escape, registry stores, the cleansers and
+// the annotation).
+func TestEscapeAnalyzer(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), escapeAnalyzer,
+		"github.com/luthersystems/elps/lisp", "esc")
+}

--- a/cmd/elpsvet/escape_test.go
+++ b/cmd/elpsvet/escape_test.go
@@ -14,6 +14,15 @@ import (
 // mirrored verbatim from history), and esc carries the cross-package
 // shapes (SetSource, return-escape, registry stores, the cleansers and
 // the annotation).
+//
+// esc IMPORTS the lisp stub, so this also exercises the freshLocation fact
+// across a package boundary.  analysistest checks facts as strictly as it
+// checks diagnostics: a `// want Name:"freshLocation"` on a declaration
+// asserts the fact was recorded, and a declaration WITHOUT one asserts it
+// was not.  Every function the fixtures expect to earn no summary — the
+// by-reference accessors, the one-leaking-return accessor, the recursion
+// cycle, the bare-return named result, the loop-rebound local — is pinned
+// by that absence.
 func TestEscapeAnalyzer(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), escapeAnalyzer,
 		"github.com/luthersystems/elps/lisp", "esc")

--- a/cmd/elpsvet/freshness.go
+++ b/cmd/elpsvet/freshness.go
@@ -20,10 +20,12 @@
 //     copy idiom (cp := &LVal{}; *cp = *v; cp.Quoted = ... is fresh — the
 //     write lands in memory this function allocated);
 //
-//   - the enclosing function's doc comment, or a comment on the assignment's
-//     line (or the line directly above it), carries //elps:mutates — the
-//     audited annotation that the function deliberately mutates a value it
-//     does not own.
+//   - the enclosing function's doc comment carries //elps:mutates, or the
+//     assignment's own line carries it as a trailing comment, or the line
+//     directly above carries it as a STANDALONE comment — the audited
+//     annotation that the function deliberately mutates a value it does not
+//     own.  A trailing justification covers only the line it trails; see
+//     markerLines for why that distinction is load-bearing.
 //
 // The analysis is intraprocedural and conservative: an unknown root flags.
 // A value-typed LVal variable is always fresh at its top level (Go value
@@ -123,18 +125,62 @@ func hasMutates(cg *ast.CommentGroup) bool {
 	return hasMarker(cg, mutatesMarker)
 }
 
-// markerLines collects the file lines carrying the given //elps:* marker.
+// markerLines collects the file lines a given //elps:* marker SUPPRESSES.
 // Shared between the freshness/alias rules (elps:mutates) and the escape
 // rule (elps:aliases) so the placement conventions never diverge.
+//
+// The documented convention is "on the flagged line, or the line directly
+// above it", and the reach depends on which of those the author wrote:
+//
+//   - A STANDALONE marker comment — nothing but the comment on its line —
+//     is a preamble for the statement below, so it suppresses its own line
+//     (where nothing can be flagged anyway) and the next one.
+//   - A TRAILING marker comment — one sharing its line with code — belongs
+//     to the statement it trails and suppresses THAT LINE ONLY.
+//
+// Distinguishing them is the point.  Suppressing line+1 unconditionally
+// let a trailing justification silence the next statement's unrelated
+// violation, which is the opposite of an audited annotation: the flag
+// vanishes and nothing in the source says it was ever considered.
 func markerLines(fset *token.FileSet, file *ast.File, marker string) map[int]bool {
+	code := codeLines(fset, file)
 	lines := make(map[int]bool)
 	for _, cg := range file.Comments {
 		for _, c := range cg.List {
-			if commentHasMarker(c.Text, marker) {
-				lines[fset.Position(c.Pos()).Line] = true
+			if !commentHasMarker(c.Text, marker) {
+				continue
+			}
+			line := fset.Position(c.Pos()).Line
+			lines[line] = true
+			if !code[line] {
+				lines[line+1] = true
 			}
 		}
 	}
+	return lines
+}
+
+// codeLines reports which lines of file carry a non-comment token, so a
+// marker comment can be classified as trailing (shares its line with code)
+// or standalone.  A node's Pos and End lines are exactly the lines where
+// code begins and ends; a comment sitting alone inside a multi-line
+// expression falls between them and is correctly seen as standalone.
+func codeLines(fset *token.FileSet, file *ast.File) map[int]bool {
+	lines := make(map[int]bool)
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		if _, ok := n.(*ast.CommentGroup); ok {
+			return false
+		}
+		if _, ok := n.(*ast.Comment); ok {
+			return false
+		}
+		lines[fset.Position(n.Pos()).Line] = true
+		lines[fset.Position(n.End()).Line] = true
+		return true
+	})
 	return lines
 }
 
@@ -226,7 +272,7 @@ func checkWrite(pass *analysis.Pass, lhs ast.Expr, stmtPos token.Pos, fresh map[
 		return
 	}
 	line := pass.Fset.Position(stmtPos).Line
-	if ann[line] || ann[line-1] {
+	if ann[line] {
 		return
 	}
 	if rootIsFresh(pass, recv, fresh) {

--- a/cmd/elpsvet/freshness.go
+++ b/cmd/elpsvet/freshness.go
@@ -116,10 +116,21 @@ func runFreshness(pass *analysis.Pass) (interface{}, error) {
 
 // mutatesLines collects the file lines carrying an //elps:mutates comment.
 func mutatesLines(fset *token.FileSet, file *ast.File) map[int]bool {
+	return markerLines(fset, file, mutatesMarker)
+}
+
+func hasMutates(cg *ast.CommentGroup) bool {
+	return hasMarker(cg, mutatesMarker)
+}
+
+// markerLines collects the file lines carrying the given //elps:* marker.
+// Shared between the freshness/alias rules (elps:mutates) and the escape
+// rule (elps:aliases) so the placement conventions never diverge.
+func markerLines(fset *token.FileSet, file *ast.File, marker string) map[int]bool {
 	lines := make(map[int]bool)
 	for _, cg := range file.Comments {
 		for _, c := range cg.List {
-			if commentIsMutates(c.Text) {
+			if commentHasMarker(c.Text, marker) {
 				lines[fset.Position(c.Pos()).Line] = true
 			}
 		}
@@ -127,22 +138,22 @@ func mutatesLines(fset *token.FileSet, file *ast.File) map[int]bool {
 	return lines
 }
 
-func hasMutates(cg *ast.CommentGroup) bool {
+func hasMarker(cg *ast.CommentGroup, marker string) bool {
 	if cg == nil {
 		return false
 	}
 	for _, c := range cg.List {
-		if commentIsMutates(c.Text) {
+		if commentHasMarker(c.Text, marker) {
 			return true
 		}
 	}
 	return false
 }
 
-func commentIsMutates(text string) bool {
+func commentHasMarker(text, marker string) bool {
 	text = strings.TrimPrefix(text, "//")
 	text = strings.TrimPrefix(text, "/*")
-	return strings.HasPrefix(strings.TrimSpace(text), mutatesMarker)
+	return strings.HasPrefix(strings.TrimSpace(text), marker)
 }
 
 // checkFreshness walks a function body in source order, tracking which local

--- a/cmd/elpsvet/locfact.go
+++ b/cmd/elpsvet/locfact.go
@@ -1,0 +1,354 @@
+// Copyright © 2026 The ELPS authors
+
+// Cross-package freshness summaries for *token.Location results.
+//
+// The escape rule (escape.go) is intraprocedural: it cannot see inside a
+// callee, so its first approximation treated EVERY *token.Location-returning
+// method on a receiver the caller did not construct as a taint source.  That
+// is right for an accessor handing out the receiver's own pointer
+// (rdparser.Parser.Location) and wrong — a false positive — for an accessor
+// that allocates: lisp.LEnv.Source returns copyLocation(env.loc), and
+// token.Scanner.LocStart mints a &Location{...} per token.  Both are the
+// SANCTIONED way to read a location, so an embedder calling the correct API
+// must not have to annotate; the mitigation cannot be an //elps:aliases at
+// every call site.
+//
+// go/analysis solves exactly this with Facts.  This file computes, for every
+// function and method in the package under analysis whose sole result is a
+// *token.Location, the boolean summary "every value this can return is
+// freshly allocated", and exports it as a freshLocation fact.  callLocTaint
+// consults the fact at the call site — for callees in the package under
+// analysis and, because facts are serialized along the import graph, for
+// callees anywhere in the dependency tree.  lisp.LEnv.Source is therefore
+// clean in lsp/, in mcpserver/, and in any embedder, with no annotation.
+//
+// The summary itself is intraprocedural, which keeps the design honest: the
+// analysis WITHIN a body stays the same shape as the rest of elpsvet
+// (source-order walk, last-assignment-wins, path-insensitive), and only the
+// one-bit summary crosses the package boundary.
+//
+// A result is provably fresh when it is:
+//
+//   - nil;
+//   - &token.Location{...} or new(token.Location) — memory this call allocated;
+//   - &local where local is a value-typed token.Location variable or
+//     parameter of this function (the deref-copy idiom, cp := *loc;
+//     return &cp — Go value semantics already gave the function its own
+//     struct); a package-level var is deliberately excluded, its address is
+//     shared;
+//   - the result of calling another function already proven fresh
+//     (copyLocation, and anything built only out of it).
+//
+// Everything else — a field read, a parameter handed straight back, a call
+// with no fact — leaves the summary FALSE, and the call site falls back to
+// the conservative treatment.  The property is proven, never assumed: a
+// function with a single leaking return keeps no fact at all, and one that
+// bare-returns a named result is not analysed (the assignment to the result
+// is not tracked).
+//
+// Mutual and self recursion are handled by a least fixpoint seeded with
+// nothing proven: a function is marked fresh only once every one of its
+// returns is fresh given what is ALREADY proven, so knowledge grows
+// monotonically and a cycle can never bootstrap itself into a fact.
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/types/typeutil"
+)
+
+// freshLocation is the exported fact: the object it is attached to is a
+// function or method whose sole *token.Location result is always freshly
+// allocated, so storing that result into an escaping value is safe.
+type freshLocation struct{}
+
+func (*freshLocation) AFact() {}
+
+func (*freshLocation) String() string { return "freshLocation" }
+
+// exportFreshLocationFacts computes and exports the freshLocation fact for
+// every eligible function in the package under analysis.  It must run before
+// the escape checks so that in-package call sites can consult it.
+func exportFreshLocationFacts(pass *analysis.Pass) {
+	type candidate struct {
+		fn   *types.Func
+		body *ast.BlockStmt
+	}
+	var candidates []candidate
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				continue
+			}
+			fn, _ := pass.TypesInfo.Defs[fd.Name].(*types.Func)
+			if fn == nil || !returnsLocationPtr(fn) {
+				continue
+			}
+			candidates = append(candidates, candidate{fn, fd.Body})
+		}
+	}
+	if len(candidates) == 0 {
+		return
+	}
+	// Least fixpoint from "nothing proven".  Each round can only ADD to
+	// proven, so the loop terminates in at most len(candidates) rounds and a
+	// recursive cycle never proves itself.
+	proven := make(map[*types.Func]bool)
+	for changed := true; changed; {
+		changed = false
+		for _, c := range candidates {
+			if proven[c.fn] {
+				continue
+			}
+			t := &locFresher{pass: pass, proven: proven, fresh: make(map[types.Object]bool)}
+			if t.bodyReturnsFresh(c.body) {
+				proven[c.fn] = true
+				changed = true
+			}
+		}
+	}
+	for fn := range proven {
+		pass.ExportObjectFact(fn, new(freshLocation))
+	}
+}
+
+// freshLocationCallee reports whether fn carries the freshLocation fact —
+// in-package (exported by this pass) or imported from a dependency.
+func freshLocationCallee(pass *analysis.Pass, fn *types.Func) bool {
+	if fn == nil {
+		return false
+	}
+	var fact freshLocation
+	return pass.ImportObjectFact(fn, &fact)
+}
+
+// returnsLocationPtr reports whether fn's signature has exactly one result
+// and that result is *token.Location.  Multi-result accessors are out of
+// scope: (*lisp.LVal).Source returns (token.Location, bool), a VALUE copy
+// that cannot alias anything, so the escape rule never treats it as a
+// location source in the first place.
+func returnsLocationPtr(fn *types.Func) bool {
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+	return sig.Results().Len() == 1 && isLocationPtr(sig.Results().At(0).Type())
+}
+
+// locFresher proves the "every return is freshly allocated" property for one
+// function body.
+//
+// Local *token.Location variables are handled FLOW-INSENSITIVELY: a local is
+// fresh only when EVERY expression ever assigned to it is fresh.  The rest
+// of elpsvet uses a cheaper source-order, last-assignment-wins walk, which
+// is fine for deciding whether to raise a warning but would be unsound here,
+// where the answer is a claim of proof exported to other packages: in
+//
+//	for _, tok := range toks {
+//	    if tok.stop { return loc }   // reached on iteration 2 with the
+//	    loc = tok.Source             // PREVIOUS iteration's value
+//	}
+//
+// a source-order walk sees the return before the assignment and would call
+// loc fresh.  Requiring every assignment to be fresh removes the ordering
+// question entirely.  It costs nothing real — a location local that is first
+// aliased and then overwritten with a copy is not a shape any accessor uses,
+// and refusing to prove it merely leaves the call site conservatively
+// flagged.
+type locFresher struct {
+	pass   *analysis.Pass
+	proven map[*types.Func]bool  // in-package functions proven so far this fixpoint
+	fresh  map[types.Object]bool // *token.Location locals holding fresh memory
+}
+
+// bodyReturnsFresh reports whether every return statement in body yields
+// freshly allocated memory.
+func (t *locFresher) bodyReturnsFresh(body *ast.BlockStmt) bool {
+	t.resolveLocals(body)
+	ok := true
+	ast.Inspect(body, func(n ast.Node) bool {
+		if !ok {
+			return false
+		}
+		switch stmt := n.(type) {
+		case *ast.FuncLit:
+			// A nested literal's returns belong to the literal, not to the
+			// function being summarised.
+			return false
+		case *ast.ReturnStmt:
+			// A bare return in a function with a named result returns
+			// whatever was assigned to that result, which this analysis does
+			// not track.  Refuse to prove anything.
+			if len(stmt.Results) != 1 || !t.isFresh(stmt.Results[0]) {
+				ok = false
+				return false
+			}
+		}
+		return true
+	})
+	return ok
+}
+
+// resolveLocals fills t.fresh with the *token.Location locals every one of
+// whose assignments is fresh, by least fixpoint over the whole body —
+// including inside nested function literals, which can assign to a captured
+// local and must not be able to launder taint past this pass.
+func (t *locFresher) resolveLocals(body *ast.BlockStmt) {
+	assigns := make(map[types.Object][]ast.Expr) // a nil element == untrackable
+	declared := make(map[types.Object]bool)
+	// declare marks a location local as seen without recording an
+	// assignment; record adds one (rhs nil when the analysis cannot see the
+	// assigned expression, which permanently sinks the local).
+	declare := func(id *ast.Ident) types.Object {
+		if id == nil || id.Name == "_" {
+			return nil
+		}
+		obj := t.objectOf(id)
+		if obj == nil || !isLocationPtr(obj.Type()) {
+			return nil
+		}
+		declared[obj] = true
+		return obj
+	}
+	record := func(id *ast.Ident, rhs ast.Expr) {
+		if obj := declare(id); obj != nil {
+			assigns[obj] = append(assigns[obj], rhs)
+		}
+	}
+	ident := func(e ast.Expr) *ast.Ident {
+		id, _ := ast.Unparen(e).(*ast.Ident)
+		return id
+	}
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch stmt := n.(type) {
+		case *ast.AssignStmt:
+			// x, y := f(): the per-value expressions are unavailable.
+			tuple := len(stmt.Rhs) == 1 && len(stmt.Lhs) > 1
+			for i, lhs := range stmt.Lhs {
+				if tuple || i >= len(stmt.Rhs) {
+					record(ident(lhs), nil)
+					continue
+				}
+				record(ident(lhs), stmt.Rhs[i])
+			}
+		case *ast.ValueSpec:
+			switch {
+			case len(stmt.Values) == 0:
+				// `var loc *token.Location`: the zero value is nil, which
+				// aliases nothing.  Declare it, record no assignment.
+				for _, name := range stmt.Names {
+					declare(name)
+				}
+			case len(stmt.Values) == len(stmt.Names):
+				for i, name := range stmt.Names {
+					record(name, stmt.Values[i])
+				}
+			default: // var a, b = f()
+				for _, name := range stmt.Names {
+					record(name, nil)
+				}
+			}
+		case *ast.RangeStmt:
+			// for loc = range ... rebinds from storage this pass cannot see.
+			for _, e := range []ast.Expr{stmt.Key, stmt.Value} {
+				if e != nil {
+					record(ident(e), nil)
+				}
+			}
+		case *ast.UnaryExpr:
+			// &loc hands a **token.Location to something that may rebind loc
+			// out of sight.  Refuse to prove such a local.
+			if stmt.Op == token.AND {
+				record(ident(stmt.X), nil)
+			}
+		}
+		return true
+	})
+	// Least fixpoint from "nothing proven": a local becomes fresh only once
+	// every expression assigned to it is fresh given what is already known,
+	// so an assignment cycle (a = b; b = a) never proves itself.
+	for changed := true; changed; {
+		changed = false
+		for obj := range declared {
+			if t.fresh[obj] {
+				continue
+			}
+			allFresh := true
+			for _, rhs := range assigns[obj] {
+				if rhs == nil || !t.isFresh(rhs) {
+					allFresh = false
+					break
+				}
+			}
+			if allFresh {
+				t.fresh[obj] = true
+				changed = true
+			}
+		}
+	}
+}
+
+// isFresh reports whether e evaluates to a *token.Location this call
+// allocated.
+func (t *locFresher) isFresh(e ast.Expr) bool {
+	e = ast.Unparen(e)
+	switch x := e.(type) {
+	case *ast.Ident:
+		obj := t.objectOf(x)
+		if _, isNil := obj.(*types.Nil); isNil {
+			return true // nil aliases nothing
+		}
+		return obj != nil && t.fresh[obj]
+	case *ast.UnaryExpr:
+		if x.Op != token.AND {
+			return false
+		}
+		switch inner := ast.Unparen(x.X).(type) {
+		case *ast.CompositeLit:
+			return isLocationValue(t.pass.TypesInfo.TypeOf(inner))
+		case *ast.Ident:
+			// &local / &param: Go value semantics already gave this call its
+			// own token.Location struct.  A package-level var is excluded —
+			// its address is process-wide shared storage.
+			v, _ := t.objectOf(inner).(*types.Var)
+			return v != nil && isLocationValue(v.Type()) && !isPackageScoped(v)
+		}
+		return false
+	case *ast.CallExpr:
+		return t.callIsFresh(x)
+	}
+	return false
+}
+
+func (t *locFresher) callIsFresh(call *ast.CallExpr) bool {
+	// new(token.Location)
+	if id, ok := ast.Unparen(call.Fun).(*ast.Ident); ok && id.Name == "new" {
+		if _, ok := t.pass.TypesInfo.Uses[id].(*types.Builtin); ok && len(call.Args) == 1 {
+			return isLocationValue(t.pass.TypesInfo.TypeOf(call.Args[0]))
+		}
+	}
+	fn, ok := typeutil.Callee(t.pass.TypesInfo, call).(*types.Func)
+	if !ok {
+		return false
+	}
+	if t.proven[fn] {
+		return true
+	}
+	return freshLocationCallee(t.pass, fn)
+}
+
+func (t *locFresher) objectOf(id *ast.Ident) types.Object {
+	if obj := t.pass.TypesInfo.Defs[id]; obj != nil {
+		return obj
+	}
+	return t.pass.TypesInfo.Uses[id]
+}
+
+func isPackageScoped(v *types.Var) bool {
+	return v.Pkg() != nil && v.Parent() == v.Pkg().Scope()
+}

--- a/cmd/elpsvet/main.go
+++ b/cmd/elpsvet/main.go
@@ -1,9 +1,11 @@
 // Copyright © 2026 The ELPS authors
 
-// Command elpsvet is a go/analysis prototype with two rules: no
+// Command elpsvet is a go/analysis prototype with three rules: no
 // package-level variable may keep a *lisp.LVal reachable (elpsownership,
-// below), and no function may write a lisp.LVal field on a value it did not
-// construct (elpsfreshness, freshness.go).
+// below), no function may write a lisp.LVal field on a value it did not
+// construct (elpsfreshness, freshness.go), and no function may store a
+// runtime-owned *token.Location uncopied into a field of an escaping value
+// (elpsescape, escape.go).
 //
 // A package-level var whose type transitively contains *lisp.LVal is the
 // producer pattern behind issue #363 — `var builtins = []*libutil.Builtin{...}`
@@ -46,7 +48,7 @@ var analyzer = &analysis.Analyzer{
 	Run:  run,
 }
 
-func main() { multichecker.Main(analyzer, freshnessAnalyzer) }
+func main() { multichecker.Main(analyzer, freshnessAnalyzer, escapeAnalyzer) }
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {

--- a/cmd/elpsvet/testdata/src/a/a.go
+++ b/cmd/elpsvet/testdata/src/a/a.go
@@ -126,3 +126,20 @@ type holder struct {
 func structField(h *holder) {
 	h.node.Str = "x" // want `write to LVal field \.Str on a lisp\.LVal this function did not construct`
 }
+
+// trailingAnnotationReach pins how far a TRAILING justification reaches: the
+// line it trails, and no further.  Suppressing line+1 unconditionally let one
+// audited annotation silence the next statement's unrelated write, which is
+// the opposite of what an audited annotation is for.
+func trailingAnnotationReach(v, w *lisp.LVal) {
+	v.Quoted = false //elps:mutates deliberate in-place unquote, this line only
+	w.Quoted = false // want `write to LVal field \.Quoted on a lisp\.LVal this function did not construct`
+}
+
+// standaloneAnnotationReach is the other half: a marker alone on its line is a
+// preamble for the statement below and must still cover it.
+func standaloneAnnotationReach(v, w *lisp.LVal) {
+	//elps:mutates deliberate rewrite on the next line
+	v.Quoted = false
+	w.Quoted = false // want `write to LVal field \.Quoted on a lisp\.LVal this function did not construct`
+}

--- a/cmd/elpsvet/testdata/src/esc/esc.go
+++ b/cmd/elpsvet/testdata/src/esc/esc.go
@@ -116,3 +116,35 @@ func copyLocation(loc *token.Location) *token.Location {
 	cp := *loc
 	return &cp
 }
+
+// setSourceTrailingAnnotation pins how far a TRAILING justification reaches:
+// the line it trails, and no further.  A blanket line+1 suppression silenced
+// the next statement's unrelated violation with nothing in the source saying
+// it had ever been considered.
+func setSourceTrailingAnnotation(p *parser, v, w *lisp.LVal) {
+	v.SetSource(p.Location()) //elps:aliases fixture justification for this line only
+	w.SetSource(p.Location()) // want `SetSource call stores a runtime-owned \*token\.Location`
+}
+
+// setSourceStandaloneAnnotation is the other half: a marker alone on its line
+// is a preamble and must still cover the statement below it.
+func setSourceStandaloneAnnotation(p *parser, v, w *lisp.LVal) {
+	//elps:aliases fixture justification for the statement below
+	v.SetSource(p.Location())
+	w.SetSource(p.Location()) // want `SetSource call stores a runtime-owned \*token\.Location`
+}
+
+// compositeLiteralAnnotation pins where the justification must go for the
+// RETURN-ESCAPE shape: the diagnostic is reported at the return, so a marker
+// alone on its line inside the literal does not cover it and the annotation
+// belongs above the return (the lsp/definition.go and mcpserver/service.go
+// placement).  A standalone marker inside a multi-line literal still counts
+// as standalone, which is what makes the lisp/env.go field placement work
+// for the diagnostics reported at the field itself.
+func compositeLiteralAnnotation(env *lisp.LEnv) *funcInfo {
+	//elps:aliases fixture justification for the returned literal below
+	return &funcInfo{
+		Name:   "f",
+		Source: env.Loc,
+	}
+}

--- a/cmd/elpsvet/testdata/src/esc/esc.go
+++ b/cmd/elpsvet/testdata/src/esc/esc.go
@@ -1,0 +1,118 @@
+// Package esc exercises the elpsescape analyzer's cross-package shapes:
+// SetSource with a tainted location, the parser-style deref-copy cleanse,
+// return-escape through a composite literal, field writes on returned
+// values and package-level state, method taint sources, and the
+// //elps:aliases escape hatch.
+package esc
+
+import (
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// parser mimics rdparser.Parser: a Location method handing out a pointer
+// into its own token state.
+type parser struct {
+	tok *token.Token
+}
+
+func (p *parser) Location() *token.Location {
+	return p.tok.Source
+}
+
+// funcInfo mimics lisp.FunctionInfo: an exported metadata struct with a
+// location field, returned to embedders.
+type funcInfo struct {
+	Source *token.Location
+	Name   string
+}
+
+// registry mimics registry-reachable state.
+var registry = struct {
+	LastLoc *token.Location
+}{} // package-level: stores into its fields escape process-wide
+
+// setSourceTainted stores a location read off runtime state through the
+// exported setter — the same field write as lerr.source = env.Loc.
+func setSourceTainted(env *lisp.LEnv, v *lisp.LVal) {
+	v.SetSource(env.Loc) // want `SetSource call stores a runtime-owned \*token\.Location`
+}
+
+// setSourceMethodTainted proves method results taint: a location-returning
+// method on a value this function did not construct aliases that value's
+// state (the rdparser p.Location() shape).
+func setSourceMethodTainted(p *parser, v *lisp.LVal) {
+	v.SetSource(p.Location()) // want `SetSource call stores a runtime-owned \*token\.Location`
+}
+
+// setSourceDerefCopy is the parser's sanctioned cleanse: copy the pointed-to
+// value into a local and hand out the local's address.
+func setSourceDerefCopy(p *parser, v *lisp.LVal) {
+	loc := p.Location()
+	if loc == nil {
+		return
+	}
+	src := *loc
+	v.SetSource(&src)
+}
+
+// setSourceFreshLiteral hands out a literal the function owns.
+func setSourceFreshLiteral(v *lisp.LVal) {
+	v.SetSource(&token.Location{File: "builtin"})
+}
+
+// setSourceAnnotated is the deliberate producer-side aliasing contract with
+// its audited justification.
+func setSourceAnnotated(p *parser, v *lisp.LVal) {
+	//elps:aliases fixture justification — producer-owned fixup window; see rdparser.tokenLVal
+	v.SetSource(p.Location())
+}
+
+// returnEscapeComposite captures a tainted location in a composite literal
+// that is returned — the InspectFunction shape.
+func returnEscapeComposite(env *lisp.LEnv) *funcInfo {
+	return &funcInfo{Source: env.Loc} // want `returning a value whose composite literal captured a field stores a runtime-owned \*token\.Location`
+}
+
+// returnEscapeLocal captures the same shape through a local.
+func returnEscapeLocal(env *lisp.LEnv) *funcInfo {
+	info := &funcInfo{Source: env.Loc}
+	info.Name = "f"
+	return info // want `returning a value whose composite literal captured a field stores a runtime-owned \*token\.Location`
+}
+
+// returnedFieldStore stores a tainted location into a field of a value the
+// function returns.
+func returnedFieldStore(env *lisp.LEnv) *funcInfo {
+	info := &funcInfo{Name: "f"}
+	info.Source = env.Loc // want `write to field \.Source of a value this function returns stores a runtime-owned \*token\.Location`
+	return info
+}
+
+// localFieldStoreDoesNotEscape stores a tainted location into a local that
+// never leaves the function: out of the rule's escape scope.
+func localFieldStoreDoesNotEscape(env *lisp.LEnv) string {
+	info := &funcInfo{Name: "f"}
+	info.Source = env.Loc
+	return info.Name
+}
+
+// registryStore stores a tainted location into package-level state.
+func registryStore(env *lisp.LEnv) {
+	registry.LastLoc = env.Loc // want `write to field \.LastLoc of package-level state stores a runtime-owned \*token\.Location`
+}
+
+// copyCleansed routes the location through the copyLocation cleanser.
+func copyCleansed(env *lisp.LEnv) *funcInfo {
+	return &funcInfo{Source: copyLocation(env.Loc)}
+}
+
+// copyLocation mirrors lisp/detach.go's cleanser for the cross-package
+// fixtures (the real one is unexported in package lisp).
+func copyLocation(loc *token.Location) *token.Location {
+	if loc == nil {
+		return nil
+	}
+	cp := *loc
+	return &cp
+}

--- a/cmd/elpsvet/testdata/src/esc/esc.go
+++ b/cmd/elpsvet/testdata/src/esc/esc.go
@@ -13,8 +13,15 @@
 // is exactly the live-tree metadata-translation shape carrying the audited
 // annotations in lsp/definition.go and mcpserver/service.go, so the fixtures
 // take their taint from funcInfo.Source, the struct this package owns.
-// lisp.LEnv's one remaining external route, the copying Source() accessor,
-// is covered by envSourceAccessor at the bottom of the file.
+//
+// The bottom half of the file exercises the CROSS-PACKAGE freshness fact
+// (locfact.go): lisp.LEnv's one remaining external route is the copying
+// Source() accessor, which is clean here with no annotation because the
+// fact travels from package lisp, while the by-reference LocRef() with the
+// identical signature is still flagged.  Each pair below is deliberately
+// both-directions — proven-fresh clean, unproven flagged — because the
+// whole point of the fact is that it distinguishes callees a signature
+// cannot.
 package esc
 
 import (
@@ -122,7 +129,7 @@ func copyCleansed(src *funcInfo) *funcInfo {
 
 // copyLocation mirrors lisp/detach.go's cleanser for the cross-package
 // fixtures (the real one is unexported in package lisp).
-func copyLocation(loc *token.Location) *token.Location {
+func copyLocation(loc *token.Location) *token.Location { // want copyLocation:"freshLocation"
 	if loc == nil {
 		return nil
 	}
@@ -164,20 +171,122 @@ func compositeLiteralAnnotation(src *funcInfo) *funcInfo {
 
 // envSourceAccessor pins what became of the old env.Loc route after #382.
 // lisp.LEnv.loc is unexported now, so the only way out of an environment is
-// the Source() accessor — which returns a COPY and is therefore safe to
-// store.  The rule cannot see that: its method-taint approximation is
-// deliberately intraprocedural, so a location-returning method on a receiver
-// the function did not construct is tainted regardless of what the callee
-// does.  This is the same known false-positive class the live tree annotates
-// at parser/token/scanner.go (LocStart), and an embedder resolves it the
-// same way, with an audited annotation.
+// the Source() accessor — which returns copyLocation(env.loc), a COPY that
+// is safe to store.  It is CLEAN with NO annotation: the freshLocation fact
+// crosses the package boundary from lisp, one call deep through
+// copyLocation.  An embedder using the sanctioned API never annotates.
 func envSourceAccessor(env *lisp.LEnv, v *lisp.LVal) {
-	v.SetSource(env.Source()) // want `SetSource call stores a runtime-owned \*token\.Location`
+	v.SetSource(env.Source())
 }
 
-// envSourceAccessorAnnotated is how that false positive is meant to be
-// retired at a real call site.
-func envSourceAccessorAnnotated(env *lisp.LEnv, v *lisp.LVal) {
-	//elps:aliases fixture justification — LEnv.Source returns a copy (#382); the intraprocedural method-taint approximation cannot see inside the callee
-	v.SetSource(env.Source())
+// envLocRefAccessor is the other direction, and the whole point of proving
+// rather than assuming: same signature, same receiver, but the callee hands
+// out the environment's OWN pointer, so the store is still flagged.
+func envLocRefAccessor(env *lisp.LEnv, v *lisp.LVal) {
+	v.SetSource(env.LocRef()) // want `SetSource call stores a runtime-owned \*token\.Location`
+}
+
+// envLocMaybeAccessor pins that the summary is all-or-nothing: LocMaybe
+// returns a fresh literal on one path and the env's pointer on the other,
+// so it earns no fact and its callers stay flagged.
+func envLocMaybeAccessor(env *lisp.LEnv, v *lisp.LVal) {
+	v.SetSource(env.LocMaybe()) // want `SetSource call stores a runtime-owned \*token\.Location`
+}
+
+// envLocDerefAccessor pins the deref-copy shape as an accessor: &cp where cp
+// is the callee's own token.Location value is fresh, so this is clean too.
+func envLocDerefAccessor(env *lisp.LEnv, v *lisp.LVal) {
+	v.SetSource(env.LocDeref())
+}
+
+// lvalSourceValueAccessor pins the OTHER copying accessor shape:
+// (*lisp.LVal).Source (and ErrorVal.Source, which delegates to it) returns a
+// token.Location BY VALUE, so nothing that reaches the store can alias the
+// LVal's storage — no fact is needed and none is computed (the fact only
+// summarises single *token.Location results).
+func lvalSourceValueAccessor(src, v *lisp.LVal) {
+	loc, ok := src.Source()
+	if !ok {
+		return
+	}
+	v.SetSource(&loc)
+}
+
+// wrapCopy proves the fact is transitive: it is fresh only because
+// copyLocation is, and it is defined AFTER its own callee's users, so the
+// fixpoint — not source order — is what proves it.
+func wrapCopy(loc *token.Location) *token.Location { // want wrapCopy:"freshLocation"
+	return copyLocation(loc)
+}
+
+// wrapCopyStore stores the wrapper's result into an escaping literal.
+func wrapCopyStore(src *funcInfo) *funcInfo {
+	return &funcInfo{Source: wrapCopy(src.Source)}
+}
+
+// passthrough is the counterexample for the plain-function case: handing a
+// parameter straight back proves nothing, so it earns no fact.
+func passthrough(loc *token.Location) *token.Location {
+	return loc
+}
+
+// passthroughStore stays flagged: the argument's taint reaches the store.
+func passthroughStore(src *funcInfo) *funcInfo {
+	return &funcInfo{Source: passthrough(src.Source)} // want `returning a value whose composite literal captured a field stores a runtime-owned \*token\.Location`
+}
+
+// mintFresh is the local mirror of token.Scanner.LocStart: a literal minted
+// per call.  Its call site is clean without the annotation the live tree
+// used to need at parser/token/scanner.go.
+func mintFresh(p *parser) *token.Location { // want mintFresh:"freshLocation"
+	return &token.Location{File: "minted"}
+}
+
+// mintFreshStore is the EmitToken shape: the minted location captured by a
+// composite literal that is returned.
+func mintFreshStore(p *parser) *funcInfo {
+	info := &funcInfo{Source: mintFresh(p)}
+	return info
+}
+
+// loopRebound is why the summary treats location locals FLOW-INSENSITIVELY.
+// Its only two returns are `loc` and nil, and a source-order,
+// last-assignment-wins walk reaches the `return loc` before ever seeing the
+// assignment below it — so it would call loc fresh and hand this function a
+// fact.  On the second iteration `loc` holds the PREVIOUS token's shared
+// pointer.  Requiring every assignment to be fresh removes the ordering
+// question, so no fact is recorded here (analysistest fails on an
+// unexpected one) and the call site stays flagged.
+func (p *parser) loopRebound(toks []*token.Token) *token.Location {
+	var loc *token.Location
+	for _, tok := range toks {
+		if tok.Text == "" {
+			return loc
+		}
+		loc = tok.Source
+	}
+	return nil
+}
+
+func loopReboundStore(p *parser, toks []*token.Token, v *lisp.LVal) {
+	v.SetSource(p.loopRebound(toks)) // want `SetSource call stores a runtime-owned \*token\.Location`
+}
+
+// loopFresh is the same loop with the aliasing assignment replaced by a
+// copy.  Every assignment is fresh, so the fact IS earned despite the return
+// sitting above the assignment — the flow-insensitive rule rejects the
+// ordering hazard, not the loop.
+func (p *parser) loopFresh(toks []*token.Token) *token.Location { // want loopFresh:"freshLocation"
+	var loc *token.Location
+	for _, tok := range toks {
+		if tok.Text == "" {
+			return loc
+		}
+		loc = copyLocation(tok.Source)
+	}
+	return nil
+}
+
+func loopFreshStore(p *parser, toks []*token.Token, v *lisp.LVal) {
+	v.SetSource(p.loopFresh(toks))
 }

--- a/cmd/elpsvet/testdata/src/github.com/luthersystems/elps/lisp/lisp.go
+++ b/cmd/elpsvet/testdata/src/github.com/luthersystems/elps/lisp/lisp.go
@@ -39,6 +39,24 @@ func (v *LVal) SetSource(loc *token.Location) {
 	v.source = loc
 }
 
+// Source mirrors the real (*LVal).Source: the location comes back BY VALUE
+// alongside a boolean, so nothing the caller holds can alias v's storage.
+// It needs no freshLocation fact — the fact summarises single
+// *token.Location results, and a value result is unaliasable by
+// construction.
+func (v *LVal) Source() (token.Location, bool) {
+	if v == nil || v.source == nil {
+		return token.Location{}, false
+	}
+	return *v.source, true
+}
+
+// ErrorVal mirrors lisp.ErrorVal, whose Source delegates to (*LVal).Source
+// and is value-returning for the same reason.
+type ErrorVal LVal
+
+func (e *ErrorVal) Source() (token.Location, bool) { return (*LVal)(e).Source() }
+
 type CallStack struct{}
 
 func (s *CallStack) Copy() *CallStack { return &CallStack{} }
@@ -54,15 +72,44 @@ type LEnv struct {
 
 // Source mirrors the real accessor: the exported read of the env's location
 // hands out a COPY, because the evaluator rebinds and mutates its own
-// register (#382).
-func (env *LEnv) Source() *token.Location {
+// register (#382).  It is the SANCTIONED way out of an environment, and the
+// freshLocation fact must prove it — through copyLocation, one call deep —
+// so no caller in any package has to annotate.
+func (env *LEnv) Source() *token.Location { // want Source:"freshLocation"
 	if env == nil {
 		return nil
 	}
 	return copyLocation(env.loc)
 }
 
-func copyLocation(loc *token.Location) *token.Location {
+// LocRef is Source's counterexample: the same signature, the same
+// not-constructed-here receiver, but it hands out the env's OWN pointer.
+// No fact, so the call site stays flagged.  Source and LocRef differ only
+// in what the callee does, which is exactly what the fact is for.
+func (env *LEnv) LocRef() *token.Location {
+	return env.loc
+}
+
+// LocMaybe proves the summary is all-or-nothing: one leaking return sinks
+// the whole function, even though the other return is a fresh literal.
+func (env *LEnv) LocMaybe() *token.Location {
+	if env.loc == nil {
+		return &token.Location{File: "<native code>"}
+	}
+	return env.loc
+}
+
+// LocDeref mirrors the parser's deref-copy idiom as an accessor: the local
+// is this call's own struct, so its address is fresh.
+func (env *LEnv) LocDeref() *token.Location { // want LocDeref:"freshLocation"
+	if env.loc == nil {
+		return nil
+	}
+	cp := *env.loc
+	return &cp
+}
+
+func copyLocation(loc *token.Location) *token.Location { // want copyLocation:"freshLocation"
 	if loc == nil {
 		return nil
 	}

--- a/cmd/elpsvet/testdata/src/github.com/luthersystems/elps/lisp/lisp.go
+++ b/cmd/elpsvet/testdata/src/github.com/luthersystems/elps/lisp/lisp.go
@@ -1,9 +1,15 @@
 // Package lisp is a minimal stub of github.com/luthersystems/elps/lisp for
-// analysistest.  Only the shapes the elpsfreshness analyzer inspects matter:
-// the LVal struct fields, the constructor names, and the method names.
+// analysistest.  Only the shapes the elpsfreshness and elpsescape analyzers
+// inspect matter: the LVal struct fields, the constructor names, the method
+// names, and the *token.Location-typed runtime state (LVal.source,
+// LEnv.Loc) plus the copyLocation cleanser.
 package lisp
 
+import "github.com/luthersystems/elps/parser/token"
+
 type LType int
+
+const LError LType = 1
 
 type LFunType int
 
@@ -11,6 +17,7 @@ type LBuiltin func(env *LEnv, args *LVal) *LVal
 
 type LVal struct {
 	Native  interface{}
+	source  *token.Location
 	Str     string
 	Cells   []*LVal
 	Type    LType
@@ -21,7 +28,30 @@ type LVal struct {
 	Spliced bool
 }
 
-type LEnv struct{}
+func (v *LVal) SetSource(loc *token.Location) {
+	v.source = loc
+}
+
+type CallStack struct{}
+
+func (s *CallStack) Copy() *CallStack { return &CallStack{} }
+
+type Runtime struct {
+	Stack *CallStack
+}
+
+type LEnv struct {
+	Loc     *token.Location
+	Runtime *Runtime
+}
+
+func copyLocation(loc *token.Location) *token.Location {
+	if loc == nil {
+		return nil
+	}
+	cp := *loc
+	return &cp
+}
 
 var singletonNil = &LVal{}
 var singletonTrue = &LVal{Str: "true"}

--- a/cmd/elpsvet/testdata/src/github.com/luthersystems/elps/lisp/retro.go
+++ b/cmd/elpsvet/testdata/src/github.com/luthersystems/elps/lisp/retro.go
@@ -1,0 +1,107 @@
+// Retro-catch fixtures for the elpsescape analyzer (issue #375): the
+// pre-fix bodies of ErrorCondition/ErrorConditionf (fixed in ac0a326) and
+// ErrorAssociate (fixed in d922290), mirrored from the historical
+// lisp/env.go.  The analyzer must flag each exactly where the aliased
+// env.Loc store sat, proving the rule would have caught both bugs before
+// review did.  The Fixed* variants mirror the post-fix bodies and must
+// stay clean, and the deliberate-alias variants carry the //elps:aliases
+// annotation the real tree uses.
+
+package lisp
+
+// ErrorCondition mirrors the pre-ac0a326 body: env.Loc aliased into the
+// escaping error's source field through the composite literal.
+func (env *LEnv) ErrorCondition(condition string, v ...interface{}) *LVal {
+	cells := make([]*LVal, 0, len(v))
+	for range v {
+		cells = append(cells, &LVal{})
+	}
+	lerr := &LVal{
+		Type:   LError,
+		source: env.Loc, // want `LVal composite literal field \.source stores a runtime-owned \*token\.Location`
+		Str:    condition,
+		Native: env.Runtime.Stack.Copy(),
+		Cells:  cells,
+	}
+	return lerr
+}
+
+// ErrorConditionf mirrors the pre-ac0a326 body of the formatting variant.
+func (env *LEnv) ErrorConditionf(condition string, format string, v ...interface{}) *LVal {
+	lerr := &LVal{
+		source: env.Loc, // want `LVal composite literal field \.source stores a runtime-owned \*token\.Location`
+		Type:   LError,
+		Str:    condition,
+		Native: env.Runtime.Stack.Copy(),
+		Cells:  []*LVal{String(format)},
+	}
+	return lerr
+}
+
+// ErrorAssociate mirrors the pre-d922290 body: env.Loc aliased into an
+// in-flight error the caller keeps.  The target LVal is a parameter — the
+// freshness rule's fresh/not-fresh axis says nothing here; the escape rule
+// flags the tainted store itself.
+func (env *LEnv) ErrorAssociate(lerr *LVal) *LVal {
+	if lerr.Type != LError {
+		return &LVal{Type: LError}
+	}
+	if lerr.source == nil {
+		lerr.source = env.Loc // want `write to LVal field \.source stores a runtime-owned \*token\.Location`
+	}
+	return nil
+}
+
+// FixedErrorConditionf mirrors the post-ac0a326 body: the location is
+// routed through copyLocation, so the store is clean.
+func (env *LEnv) FixedErrorConditionf(condition string, format string, v ...interface{}) *LVal {
+	lerr := &LVal{
+		source: copyLocation(env.Loc),
+		Type:   LError,
+		Str:    condition,
+		Native: env.Runtime.Stack.Copy(),
+		Cells:  []*LVal{String(format)},
+	}
+	return lerr
+}
+
+// FixedErrorAssociate mirrors the post-d922290 body.
+func (env *LEnv) FixedErrorAssociate(lerr *LVal) *LVal {
+	if lerr.source == nil {
+		lerr.source = copyLocation(env.Loc)
+	}
+	return nil
+}
+
+// TaggedValue mirrors the deliberate in-runtime alias shape (lisp/env.go's
+// TaggedValue and Lambda): the annotation with a justification suppresses
+// the diagnostic on the aliasing line.
+func (env *LEnv) TaggedValue(typ *LVal, val *LVal) *LVal {
+	return &LVal{
+		//elps:aliases fixture justification — runtime-internal value; see lisp/env.go
+		source: env.Loc,
+		Str:    typ.Str,
+		Cells:  []*LVal{val},
+	}
+}
+
+// taintThroughLocal proves taint follows local assignments: the location
+// read off runtime state keeps its taint through an intermediate variable.
+func (env *LEnv) taintThroughLocal(lerr *LVal) {
+	loc := env.Loc
+	lerr.source = loc // want `write to LVal field \.source stores a runtime-owned \*token\.Location`
+}
+
+// sourceOffLVal proves v.source reads taint like env.Loc reads: aliasing
+// one value's location into another escaping value is the same bug.
+func sourceOffLVal(dst, src *LVal) {
+	dst.source = src.source // want `write to LVal field \.source stores a runtime-owned \*token\.Location`
+}
+
+// freshSourceIsOwned proves the freshness carve-out: a location read off an
+// LVal this function constructed is this function's own memory, so storing
+// it elsewhere is not an escape of runtime state.
+func freshSourceIsOwned(dst *LVal) {
+	v := &LVal{}
+	dst.source = v.source
+}

--- a/cmd/elpsvet/testdata/src/github.com/luthersystems/elps/lisp/retro.go
+++ b/cmd/elpsvet/testdata/src/github.com/luthersystems/elps/lisp/retro.go
@@ -9,6 +9,8 @@
 
 package lisp
 
+import "github.com/luthersystems/elps/parser/token"
+
 // ErrorCondition mirrors the pre-ac0a326 body: env.loc aliased into the
 // escaping error's source field through the composite literal.
 func (env *LEnv) ErrorCondition(condition string, v ...interface{}) *LVal {
@@ -104,4 +106,62 @@ func sourceOffLVal(dst, src *LVal) {
 func freshSourceIsOwned(dst *LVal) {
 	v := &LVal{}
 	dst.source = v.source
+}
+
+// sourceAccessorInPackage proves the freshLocation fact resolves inside the
+// DEFINING package as well as across the import graph, and across FILES
+// within it: Source is declared in lisp.go, and the summary pass runs over
+// every file before any call site is checked.
+func (env *LEnv) sourceAccessorInPackage(lerr *LVal) {
+	lerr.source = env.Source()
+}
+
+// locRefInPackage is the same store through the by-reference accessor and
+// must still be flagged.  Source and LocRef have identical signatures and
+// identical receivers; only the callee body differs, which is precisely the
+// distinction the fact carries and the old name/receiver heuristic could
+// not make.
+func (env *LEnv) locRefInPackage(lerr *LVal) {
+	lerr.source = env.LocRef() // want `write to LVal field \.source stores a runtime-owned \*token\.Location`
+}
+
+// mintedCopy proves the cleanser is now recognised by PROOF rather than by
+// being spelled "copyLocation": the fact is computed from the body
+// (cp := *loc; return &cp), so this identically-bodied function under a
+// different name is just as clean.
+func mintedCopy(loc *token.Location) *token.Location { // want mintedCopy:"freshLocation"
+	if loc == nil {
+		return nil
+	}
+	cp := *loc
+	return &cp
+}
+
+func mintedCopyStore(dst *LVal, src *LVal) {
+	dst.source = mintedCopy(src.source)
+}
+
+// cycleA and cycleB pin that the least fixpoint cannot bootstrap a
+// recursive cycle into a fact: each one's only return is the other, so
+// neither is ever proven and callers keep the conservative treatment.
+func (env *LEnv) cycleA() *token.Location { return env.cycleB() }
+
+func (env *LEnv) cycleB() *token.Location { return env.cycleA() }
+
+func cycleStore(env *LEnv, dst *LVal) {
+	dst.source = env.cycleA() // want `write to LVal field \.source stores a runtime-owned \*token\.Location`
+}
+
+// namedResultBareReturn pins the bare-return refusal: the assignment to the
+// named result is not tracked, so nothing is proven and the caller below
+// stays flagged even though the body does allocate.  Refusing to prove is
+// the safe direction; a vacuous "all returns are fresh" over zero tracked
+// returns would be a hole.
+func (env *LEnv) namedResultBareReturn() (loc *token.Location) {
+	loc = copyLocation(env.loc)
+	return
+}
+
+func namedResultStore(env *LEnv, dst *LVal) {
+	dst.source = env.namedResultBareReturn() // want `write to LVal field \.source stores a runtime-owned \*token\.Location`
 }

--- a/cmd/elpsvet/testdata/src/github.com/luthersystems/elps/parser/token/token.go
+++ b/cmd/elpsvet/testdata/src/github.com/luthersystems/elps/parser/token/token.go
@@ -1,0 +1,20 @@
+// Package token is a minimal stub of github.com/luthersystems/elps/parser/
+// token for analysistest.  Only the Location shape matters to the
+// elpsescape analyzer.
+package token
+
+type Location struct {
+	File    string
+	Path    string
+	Pos     int
+	Line    int
+	Col     int
+	EndPos  int
+	EndLine int
+	EndCol  int
+}
+
+type Token struct {
+	Text   string
+	Source *Location
+}

--- a/docs/sealed-ast.md
+++ b/docs/sealed-ast.md
@@ -299,11 +299,25 @@ Three `go/analysis` rules, run as `go run ./cmd/elpsvet -test=false ./...`:
   `ErrorAssociate` (d922290) bugs stored `env.Loc` into freshly built
   errors — fresh write targets, so freshness was structurally blind; this
   rule retro-catches all three shapes (fixtures in
-  `cmd/elpsvet/testdata`). The cleanser is `copyLocation` (or an explicit
-  deref copy). Suppression: `//elps:aliases` with a justification.
+  `cmd/elpsvet/testdata`). The cleanser is any function PROVEN to allocate
+  the location it returns: `copyLocation`, an explicit deref copy, a
+  `&token.Location{...}` literal, or anything built only out of those.
+  That proof is a `go/analysis` **fact** (`locfact.go`), computed per
+  location-returning function from its own body and exported along the
+  import graph, so the sanctioned copying accessors — `lisp.LEnv.Source`
+  (returns `copyLocation(env.loc)`) and `token.Scanner.LocStart` (mints a
+  literal per token) — are clean at every call site in every package with
+  no annotation, while a by-reference accessor of identical signature
+  (`rdparser.Parser.Location`) is still flagged. A callee with no fact —
+  un-analysed package, interface method, a body with one leaking return —
+  keeps the conservative treatment, so the fact can only ever retire a
+  proven false positive. Suppression: `//elps:aliases` with a
+  justification.
 
 *Blind spots (documented in the analyzers' own headers):* intraprocedural
-only — `[]*LVal` function parameters are not taint sources in the callee
+within a function body — the escape rule's location-freshness fact is the
+one summary that crosses a call, and it carries a single bit, nothing about
+arguments or aliasing. `[]*LVal` function parameters are not taint sources in the callee
 (and neither are `*token.Location` parameters for the escape rule);
 storing a tainted slice into a field of a pre-existing struct escapes
 tracking; a tainted location passed as a call argument escapes the escape

--- a/docs/sealed-ast.md
+++ b/docs/sealed-ast.md
@@ -69,8 +69,14 @@ the seal point (see the 8d18071 entry above).
 (`LSExpr`, `LQuote`, `LSymbol`, `LQSymbol`, `LString`, `LInt`, `LFloat`);
 runtime-only types (functions, arrays, maps, bytes, natives) stop the walk —
 freezing storage the evaluator legitimately mutates would be wrong. The
-Nil/true/false singletons are skipped: they are already immutable by decree
-and writing even a flag to one would race. Atoms *are* sealed: unlike the
+Nil/true/false singletons are **born sealed** (elps#376): the flag is set in
+their composite literals at package init (`lisp/singleton.go`), so no
+post-construction write exists to race with anything and `SealAST`'s
+already-sealed check stops the walk at one. `IsSealed()` therefore reports
+the do-not-mutate contract on `Nil()`/`Bool()` results too, the CoW guards
+below treat a singleton operand exactly like a shared literal
+(`TestSingletonCoWContainerOps`, `lisp/singleton_seal_cow_test.go`), and
+`SetSource` on a singleton is a no-op. Atoms *are* sealed: unlike the
 eager-copy design, where copying atoms measured a +56% geomean regression,
 marking one costs a bit at parse time, and it makes `IsSealed` meaningful on
 every node a literal can produce.
@@ -164,7 +170,7 @@ tool and silently missed by another.
 
 ### 3.1 elpsvet (static; `cmd/elpsvet`)
 
-Two `go/analysis` rules, run as `go run ./cmd/elpsvet -test=false ./...`:
+Three `go/analysis` rules, run as `go run ./cmd/elpsvet -test=false ./...`:
 
 - **elpsownership** (`main.go`): no package-level var may keep a
   `*lisp.LVal` reachable — the process-wide-shared-table producer pattern
@@ -177,14 +183,28 @@ Two `go/analysis` rules, run as `go run ./cmd/elpsvet -test=false ./...`:
   through assignments, var declarations, slice expressions and slice-type
   conversions (#369's laundering gap, #371). Suppression: `//elps:mutates`
   with a justification.
+- **elpsescape** (`escape.go`, #375): the mirror image of freshness — no
+  function may store a runtime-owned `*token.Location` (`env.Loc`,
+  `v.source`, parser/scanner token state, a location-returning method on a
+  non-fresh receiver) uncopied into a field of an escaping value: an LVal
+  field or composite literal, a `SetSource` call, a field of a returned
+  value, a returned location-capturing composite literal, or package-level
+  state. The pre-fix `ErrorCondition`/`ErrorConditionf` (ac0a326) and
+  `ErrorAssociate` (d922290) bugs stored `env.Loc` into freshly built
+  errors — fresh write targets, so freshness was structurally blind; this
+  rule retro-catches all three shapes (fixtures in
+  `cmd/elpsvet/testdata`). The cleanser is `copyLocation` (or an explicit
+  deref copy). Suppression: `//elps:aliases` with a justification.
 
 *Blind spots (documented in the analyzers' own headers):* intraprocedural
-only — `[]*LVal` function parameters are not taint sources in the callee;
+only — `[]*LVal` function parameters are not taint sources in the callee
+(and neither are `*token.Location` parameters for the escape rule);
 storing a tainted slice into a field of a pre-existing struct escapes
-tracking; a value-typed LVal variable is treated as a fresh root even though
-its `Cells` still alias shared backing. And it is **elps-repo-only**: it
-sees nothing an embedder compiles outside this module. Every suppression is
-an audited claim, not a proof.
+tracking; a tainted location passed as a call argument escapes the escape
+rule's tracking; a value-typed LVal variable is treated as a fresh root
+even though its `Cells` still alias shared backing. And it is
+**elps-repo-only**: it sees nothing an embedder compiles outside this
+module. Every suppression is an audited claim, not a proof.
 
 ### 3.2 Fuzz corruption oracle (dynamic, offline; `lisp/eval_fuzz_test.go`)
 
@@ -210,6 +230,16 @@ of each test file; embedders can call it at their own teardown points.
 Untagged builds compile all of it out to empty inlined hooks
 (`seal_check_default.go`) — release binaries carry zero bookkeeping;
 tagged overhead is about +3% suite wall time (CI-only).
+
+The Nil/true/false singletons are held as **permanent roots** (elps#376):
+fingerprinted at package init, before any user code runs, and re-verified
+on every top-level load and at every teardown verification. Unlike the
+bounded roots table they are never part of a verify-and-drop cycle, so a
+singleton corruption is caught at the load that caused it for the life of
+the process — not only at the value-drift checkpoints `checkSingleton`
+covers. Red-proof: `TestPermanentSingletonRoots_*`
+(`lisp/singleton_seal_elpscheck_test.go`) mutates a singleton and proves
+both hooks report it, naming the root.
 
 *Blind spots:* fingerprint-value comparison is structurally blind to a write
 that stores what a field already holds, and to a metadata write that swaps a
@@ -250,7 +280,13 @@ in-repo code, and the `IsSealed()` contract for everything else:
 Second residual: same-value writes in untagged production builds. In a
 release binary nothing observes them; they are benign in effect on the tree
 bytes but are still data races on shared storage. They are caught in
-development by the watchdog (§3.4) — that split is deliberate.
+development by the watchdog (§3.4) — that split is deliberate, and it
+applies to the singletons the same way: the permanent inspector roots
+(§3.3) catch any value-changing singleton write at the next load, while a
+same-value singleton write remains `-race`-only by design, kept
+deterministic by the singleton write watchdog
+(`lisp/singleton_watchdog_test.go`; mprotect approaches were evaluated and
+rejected in #334).
 
 ## 4. Footguns
 

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -160,6 +160,7 @@ func newEnvN(parent *LEnv, n int) *LEnv {
 		Runtime: runtime,
 		evalCtx: evalCtx,
 	}
+	//elps:aliases the child env's Loc register deliberately aliases the parent's current location: LEnv is runtime-internal state, both registers are rebound on every eval step, and no consumer-facing value is built from this pointer
 	return env
 }
 
@@ -644,6 +645,7 @@ func (env *LEnv) TaggedValue(typ *LVal, val *LVal) *LVal {
 		return env.Errorf("first argument is not a symbol: %v", GetType(typ))
 	}
 	return &LVal{
+		//elps:aliases deliberate in-runtime alias: a tagged value is constructed and consumed inside the same runtime whose evaluator owns env.Loc, and its location is display metadata only — nothing fixes up a tagged value's location after construction
 		source: env.Loc,
 		Type:   LTaggedVal,
 		Str:    typ.Str,
@@ -688,7 +690,8 @@ func (env *LEnv) Lambda(formals *LVal, body []*LVal) *LVal {
 	cells = append(cells, body...)
 	fenv := NewEnv(env)
 	fun := &LVal{
-		Type:   LFun,
+		Type: LFun,
+		//elps:aliases deliberate in-runtime alias: a lambda's location is the defining form's parse location, already frozen before evaluation reaches this constructor, and the function value lives inside the same runtime as env.Loc
 		source: env.Loc,
 		Native: &LFunData{
 			FID:     fenv.getFID(),

--- a/lisp/inspect.go
+++ b/lisp/inspect.go
@@ -58,8 +58,12 @@ func InspectFunction(node *LVal) *FunctionInfo {
 	}
 
 	info := &FunctionInfo{
-		Kind:   head.Str,
-		Source: node.source,
+		Kind: head.Str,
+		// Copied, not aliased: FunctionInfo escapes to embedders through an
+		// exported pointer field, and handing out node's own *token.Location
+		// would let a caller rewrite a (possibly sealed) node's recorded
+		// position in place.  copyLocation preserves nil.
+		Source: copyLocation(node.source),
 	}
 
 	switch head.Str {

--- a/lisp/loader.go
+++ b/lisp/loader.go
@@ -48,7 +48,11 @@ func TextLoader(r Reader, name string, stream io.Reader) (Loader, error) {
 		err := checkLoaderExpr(expr)
 		if err != nil {
 			lerr := Error(err)
-			lerr.source = expr.source
+			// Copied, not aliased: the error escapes to the embedder through
+			// GoError while expr stays part of the loaded program, so the
+			// two must not share a *token.Location (cold path; the copy is
+			// free in practice).
+			lerr.source = copyLocation(expr.source)
 			return nil, GoError(lerr)
 		}
 	}

--- a/lisp/macro.go
+++ b/lisp/macro.go
@@ -402,6 +402,7 @@ func doUnquoteSExpr(env *LEnv, v *LVal, depth int, quoteLevel int) *LVal {
 		cells = newcells
 	}
 	expr := SExpr(cells)
+	//elps:aliases deliberate in-runtime alias on the quasiquote hot path: v is the (sealed) quasiquote template node whose location was frozen at parse time, and the fresh expansion header mirrors it as display metadata — copying here would cost an allocation per quasiquote evaluation
 	expr.source = v.source
 	for range quoteLevel {
 		expr = Quote(expr)

--- a/lisp/package.go
+++ b/lisp/package.go
@@ -118,7 +118,11 @@ func (pkg *Package) get(k *LVal) *LVal {
 		return v
 	}
 	lerr := Errorf("unbound symbol: %v", k)
-	lerr.source = k.source
+	// Copied, not aliased: the error escapes to the evaluator (and possibly
+	// the embedder) while k remains live program state, so the two must not
+	// share a *token.Location (cold error path; the copy is free in
+	// practice).  copyLocation preserves nil.
+	lerr.source = copyLocation(k.source)
 	return lerr
 }
 

--- a/lisp/seal.go
+++ b/lisp/seal.go
@@ -88,8 +88,11 @@ package lisp
 // symbols, strings and numbers.  Any other type (functions, arrays, maps,
 // bytes, errors, natives) was necessarily constructed at runtime; SealAST
 // stops without descending rather than freeze storage the evaluator
-// legitimately mutates.  Singletons (Nil/true/false) are skipped: they are
-// already immutable by decree and writing even a flag to one would race.
+// legitimately mutates.  Singletons (Nil/true/false) are born sealed
+// (lisp/singleton.go, issue #376), so the already-sealed check stops the
+// walk before the write; the explicit isSingleton guard stays as a
+// belt-and-braces statement of intent — writing even a flag to a shared
+// singleton would race.
 //
 // Sealing is idempotent, and an already-sealed node terminates the walk —
 // a sealed node's descendants are always sealed, so revisiting them is

--- a/lisp/seal_check_elpscheck.go
+++ b/lisp/seal_check_elpscheck.go
@@ -92,6 +92,15 @@ type sealCheckState struct {
 // the load that caused it, not just at the value-drift checkpoints
 // checkSingleton covers.  The slice is written once at init and read-only
 // afterwards, so verification needs no lock.
+//elpsvet:allow checked-build verification machinery, not program data: every *LVal in
+// this slice is one of the three singletons from lisp/singleton.go, which are ALREADY
+// package-level and already reachable by every Runtime by design -- each carries its
+// own //elpsvet:allow marker there. This table adds no new cross-Runtime reachability;
+// it is a derived index over values that are shared by decree, holding their init-time
+// fingerprints so that drift in them can be DETECTED. Process-wide lifetime is the
+// point: a baseline captured before any user code runs is worthless if it does not
+// outlive the environments it indicts. Written once at init, read-only afterwards, and
+// absent from release binaries (seal_check_default.go).
 var permanentSealRoots = func() []permanentSealRoot {
 	roots := make([]permanentSealRoot, 0, 3)
 	for _, s := range []struct {

--- a/lisp/seal_check_elpscheck.go
+++ b/lisp/seal_check_elpscheck.go
@@ -76,6 +76,54 @@ type sealCheckState struct {
 	mu    sync.Mutex
 }
 
+// permanentSealRoots are the process-wide singletons (lisp/singleton.go),
+// which are born sealed (issue #376) and registered here at package init —
+// before any user code can run — as PERMANENT inspector roots.  Unlike the
+// bounded roots table they are never part of a verify-and-drop cycle:
+// their fingerprints are held for the life of the process and re-verified
+// at every top-level load (verifySealedLoadRoots) and at every teardown
+// verification (VerifySealedASTs), so a singleton corruption is caught at
+// the load that caused it, not just at the value-drift checkpoints
+// checkSingleton covers.  The slice is written once at init and read-only
+// afterwards, so verification needs no lock.
+var permanentSealRoots = func() []permanentSealRoot {
+	roots := make([]permanentSealRoot, 0, 3)
+	for _, s := range []struct {
+		v    *LVal
+		name string
+	}{
+		{singletonNil, "Nil()"},
+		{singletonTrue, "Bool(true)"},
+		{singletonFalse, "Bool(false)"},
+	} {
+		roots = append(roots, permanentSealRoot{
+			v:    s.v,
+			name: s.name,
+			fp:   SealedASTFingerprint([]*LVal{s.v}),
+		})
+	}
+	return roots
+}()
+
+type permanentSealRoot struct {
+	v    *LVal
+	name string
+	fp   uint64 // fingerprint at package init, before any user code
+}
+
+// verifyPermanentSealRoots re-fingerprints the three singleton roots and
+// panics on the first mismatch.  Called on every top-level load; the
+// singletons are tiny (three nodes, no cells), so the cost is noise even
+// in checked builds.
+func verifyPermanentSealRoots(context string) {
+	for _, r := range permanentSealRoots {
+		if got := SealedASTFingerprint([]*LVal{r.v}); got != r.fp {
+			panic(sealViolationMessage(r.v, r.fp, got,
+				"permanent singleton root "+r.name+", "+context))
+		}
+	}
+}
+
 // recordSealedRoot stores the parse-time fingerprint of a freshly sealed
 // tree.  Called from SealAST with the tree's root; unsealed values (an
 // LError from the parser, a runtime value SealAST declined to mark) are
@@ -106,6 +154,7 @@ func recordSealedRoot(v *LVal) {
 // error does not excuse corrupting the parse.  Panics on a mismatch so
 // the offending load is named while it is still on the stack.
 func verifySealedLoadRoots(exprs []*LVal) {
+	verifyPermanentSealRoots("re-verified after the load that just finished")
 	for i, e := range exprs {
 		if e == nil || !e.sealed {
 			continue
@@ -152,6 +201,17 @@ func VerifySealedASTs() error {
 		bad   int
 		first string
 	)
+	// The permanent singleton roots are verified with the same lens and
+	// reported through the same error, never dropped and never skipped.
+	for _, r := range permanentSealRoots {
+		if got := SealedASTFingerprint([]*LVal{r.v}); got != r.fp {
+			bad++
+			if first == "" {
+				first = sealViolationMessage(r.v, r.fp, got,
+					"permanent singleton root "+r.name+", recorded at package init")
+			}
+		}
+	}
 	for _, e := range entries {
 		if got := SealedASTFingerprint([]*LVal{e.root}); got != e.want {
 			bad++
@@ -161,8 +221,8 @@ func VerifySealedASTs() error {
 		}
 	}
 	if bad > 0 {
-		return fmt.Errorf("%d of %d sealed parse trees were mutated after parsing; first:\n%s",
-			bad, len(entries), first)
+		return fmt.Errorf("%d of %d sealed roots were mutated in place; first:\n%s",
+			bad, len(entries)+len(permanentSealRoots), first)
 	}
 	return nil
 }

--- a/lisp/sealfp.go
+++ b/lisp/sealfp.go
@@ -171,7 +171,10 @@ func (s *sealFP) walk(v *LVal, depth int) {
 	if !v.sealed {
 		// Runtime storage: legitimately mutable, so its contents cannot
 		// participate in a stability digest.  Mark the hole, do not
-		// descend.  (Singletons land here too: they are never sealed.)
+		// descend.  (The Nil/true/false singletons do NOT land here: they
+		// are born sealed — issue #376 — and hash as full nodes, which is
+		// what lets the checked-mode inspector hold them as permanent
+		// roots.)
 		s.mixByte(sealFPMarkHole)
 		return
 	}

--- a/lisp/singleton.go
+++ b/lisp/singleton.go
@@ -33,10 +33,21 @@ import (
 // shared across every Runtime by design, immutable by decree, snapshotted by
 // checkSingleton in elpscheck builds, and exempt from the runtime ownership
 // checker (lisp/ownership_check_elpscheck.go).  Nothing else earns this.
+//
+// SEALED AT BIRTH (issue #376): the three are constructed with the sealed
+// flag already set, so they carry the same layered protection as parsed
+// program nodes.  IsSealed() communicates the do-not-mutate contract to
+// embedders, the copy-on-write mutation-site guards (lisp/seal.go) copy
+// instead of touching their storage when a container op reaches one
+// (stable-sort of a Nil result, append/slice 'vector over an empty
+// sequence), SetSource on one is a no-op, and in elpscheck builds they are
+// permanent inspector roots re-verified at every load and teardown
+// (lisp/seal_check_elpscheck.go).  Setting the flag in the composite
+// literal means no post-construction write exists to race with anything.
 var (
-	singletonNil   = &LVal{Type: LSExpr}                    //elpsvet:allow guarded singleton
-	singletonTrue  = &LVal{Type: LSymbol, Str: TrueSymbol}  //elpsvet:allow guarded singleton
-	singletonFalse = &LVal{Type: LSymbol, Str: FalseSymbol} //elpsvet:allow guarded singleton
+	singletonNil   = &LVal{Type: LSExpr, sealed: true}                    //elpsvet:allow guarded singleton
+	singletonTrue  = &LVal{Type: LSymbol, Str: TrueSymbol, sealed: true}  //elpsvet:allow guarded singleton
+	singletonFalse = &LVal{Type: LSymbol, Str: FalseSymbol, sealed: true} //elpsvet:allow guarded singleton
 )
 
 // isSingleton reports whether v is one of the three shared, immutable
@@ -108,7 +119,8 @@ func (s SingletonSnapshot) Verify() string {
 // (singletons should always have len == 0). The Native interface field
 // is compared with == (singletons should always be nil).
 func singletonLValEqual(a, b *LVal) bool {
-	return a.source == b.source &&
+	return a.sealed == b.sealed &&
+		a.source == b.source &&
 		a.Type == b.Type &&
 		a.Str == b.Str &&
 		a.Int == b.Int &&

--- a/lisp/singleton_seal_cow_test.go
+++ b/lisp/singleton_seal_cow_test.go
@@ -1,0 +1,80 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+)
+
+// TestSingletonCoWContainerOps drives the container-op edge shapes through
+// the copy-on-write guards (lisp/seal.go) with a singleton operand.
+// (rest '(x)) and (cdr '(x)) return the Nil() singleton, which is born
+// sealed (issue #376), so each op below receives sealed singleton storage
+// and must succeed by copying — never by writing the shared bytes.  Every
+// case re-verifies the singleton snapshot afterwards.
+func TestSingletonCoWContainerOps(t *testing.T) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); rc.Type == lisp.LError {
+		t.Fatalf("InitializeUserEnv: %v", rc)
+	}
+	snap := lisp.TakeSingletonSnapshot()
+	for _, tc := range []struct {
+		src  string
+		want string
+	}{
+		// stable-sort of the Nil singleton: the CoW guard sorts a fresh
+		// copy and returns it (empty either way, but the guard path runs).
+		{`(stable-sort < (rest '(1)))`, `()`},
+		{`(stable-sort > (cdr '(1)))`, `()`},
+		// append with the Nil singleton as base sequence, both output
+		// types; 'vector is the spare-capacity write path (#369 shape).
+		{`(append 'list (rest '(1)) 1 2)`, `'(1 2)`},
+		{`(append 'vector (rest '(1)) 1 2)`, `(vector 1 2)`},
+		// slice over the Nil singleton, both output types; 'vector must
+		// hand back mutable storage, never a window onto the singleton.
+		{`(slice 'list (rest '(1)) 0 0)`, `'()`},
+		{`(slice 'vector (rest '(1)) 0 0)`, `(vector)`},
+		// A vector sliced out of the singleton must be independently
+		// mutable: append! writes its backing in place.
+		{`(let ([v (slice 'vector (rest '(1)) 0 0)]) (append! v 9) v)`, `(vector 9)`},
+		// reverse over the singleton allocates fresh output already;
+		// included to pin the edge.
+		{`(reverse 'list (rest '(1)))`, `'()`},
+	} {
+		got := env.LoadString("singleton-cow.lisp", tc.src)
+		if got.Type == lisp.LError {
+			t.Fatalf("eval %q: %v", tc.src, got)
+		}
+		want := env.LoadString("singleton-cow-want.lisp", tc.want)
+		if want.Type == lisp.LError {
+			t.Fatalf("eval %q: %v", tc.want, want)
+		}
+		if got.String() != want.String() {
+			t.Errorf("%s = %s, want %s", tc.src, got, want)
+		}
+		if drift := snap.Verify(); drift != "" {
+			t.Fatalf("%s drifted singleton %s", tc.src, drift)
+		}
+	}
+
+	// The identity claim behind the lisp cases: stable-sort's CoW guard
+	// returns fresh storage, not the singleton, so downstream code holding
+	// the result cannot write singleton memory.
+	res := env.LoadString("singleton-cow-id.lisp", `(stable-sort < (rest '(1)))`)
+	if res.Type == lisp.LError {
+		t.Fatalf("stable-sort: %v", res)
+	}
+	if res == lisp.Nil() {
+		t.Fatal("stable-sort over Nil() returned the singleton itself; the CoW guard must return a fresh copy")
+	}
+	if res.IsSealed() {
+		t.Fatal("stable-sort over Nil() returned sealed storage; the CoW copy must be mutable")
+	}
+	if drift := snap.Verify(); drift != "" {
+		t.Fatalf("identity checks drifted singleton %s", drift)
+	}
+}

--- a/lisp/singleton_seal_elpscheck_test.go
+++ b/lisp/singleton_seal_elpscheck_test.go
@@ -1,0 +1,86 @@
+// Copyright © 2026 The ELPS authors
+
+//go:build elpscheck
+
+package lisp
+
+import (
+	"strings"
+	"testing"
+)
+
+// Red-proof for the permanent singleton inspector roots (issue #376): a
+// deliberate write to a singleton field must be caught by the checked-mode
+// inspector at BOTH of its verification points — the per-load re-check
+// (verifySealedLoadRoots, which every LEnv.load funnels through) and the
+// teardown re-check (VerifySealedASTs, called by TestMain and
+// elpstest.Runner).  Each test mutates a singleton under the paused write
+// watchdog (the mutation is the point; see singleton_watchdog_test.go),
+// proves detection, and restores the bytes before returning so the rest
+// of the suite — and TestMain's own drift check — stays clean.
+
+func TestPermanentSingletonRoots_LoadVerifyCatchesMutation(t *testing.T) {
+	defer pauseSingletonWatchdog()()
+
+	orig := singletonTrue.Str
+	defer func() { singletonTrue.Str = orig }()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected verifySealedLoadRoots to panic on a mutated permanent singleton root")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected panic to be a string, got %T: %v", r, r)
+		}
+		if !strings.Contains(msg, "permanent singleton root Bool(true)") {
+			t.Fatalf("panic should name the permanent singleton root; got: %s", msg)
+		}
+		if !strings.Contains(msg, "sealed program AST mutated after parse") {
+			t.Fatalf("panic should use the seal-violation report; got: %s", msg)
+		}
+	}()
+
+	singletonTrue.Str = "corrupted-by-red-proof"
+	// The empty load: the per-load hook must catch the corruption even
+	// when the load itself evaluated nothing — the roots are permanent,
+	// not tied to any recorded parse.
+	verifySealedLoadRoots(nil)
+}
+
+func TestPermanentSingletonRoots_TeardownVerifyCatchesMutation(t *testing.T) {
+	defer pauseSingletonWatchdog()()
+
+	orig := singletonNil.Quoted
+	defer func() { singletonNil.Quoted = orig }()
+
+	// The #333 write shape (s.Quoted on the Nil singleton) — but storing a
+	// CHANGED value so the fingerprint moves; the same-value flavor remains
+	// -race/watchdog territory by design (see checkSingleton's notes).
+	singletonNil.Quoted = true
+
+	err := VerifySealedASTs()
+	if err == nil {
+		t.Fatal("expected VerifySealedASTs to report a mutated permanent singleton root")
+	}
+	if !strings.Contains(err.Error(), "permanent singleton root Nil()") {
+		t.Fatalf("error should name the permanent singleton root; got: %v", err)
+	}
+
+	// Restore and prove the report clears — the suite continues clean.
+	singletonNil.Quoted = orig
+	if err := VerifySealedASTs(); err != nil {
+		t.Fatalf("VerifySealedASTs still failing after restore: %v", err)
+	}
+}
+
+// TestPermanentSingletonRoots_CleanPass proves the permanent roots verify
+// silently in the steady state at both hooks.
+func TestPermanentSingletonRoots_CleanPass(t *testing.T) {
+	verifySealedLoadRoots(nil)
+	verifyPermanentSealRoots("clean-pass test")
+	if err := VerifySealedASTs(); err != nil {
+		t.Fatalf("VerifySealedASTs: %v", err)
+	}
+}

--- a/lisp/singleton_seal_test.go
+++ b/lisp/singleton_seal_test.go
@@ -1,0 +1,61 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"testing"
+)
+
+// These tests pin the singleton half of the seal design (issue #376): the
+// three process-wide singletons are born sealed, IsSealed communicates the
+// do-not-mutate contract to embedders, and the copy-on-write mutation-site
+// guards treat a singleton exactly like a shared program literal when a
+// container op reaches one (stable-sort of a Nil result, append/slice
+// 'vector over an empty sequence).  Every lisp-level case re-verifies the
+// singleton bytes afterwards — the ops must succeed by copying, never by
+// touching singleton storage.
+
+func TestSingletonsBornSealed(t *testing.T) {
+	for name, v := range map[string]*LVal{
+		"Nil()":       Nil(),
+		"Bool(true)":  Bool(true),
+		"Bool(false)": Bool(false),
+	} {
+		if !v.IsSealed() {
+			t.Errorf("%s: IsSealed() = false, want true (issue #376: singletons are born sealed)", name)
+		}
+	}
+	// The sanctioned mutable spelling of the empty list is unaffected.
+	if SExpr(nil).IsSealed() {
+		t.Error("SExpr(nil): fresh empty list reports sealed; runtime storage must stay mutable")
+	}
+	// Copy-then-mutate remains the sanctioned pattern: the copy's fresh
+	// storage is unsealed and writable without corrupting the singleton.
+	snap := TakeSingletonSnapshot()
+	cp := Nil().Copy()
+	if cp.IsSealed() {
+		t.Fatal("Copy() of Nil() reports sealed; copy-on-write depends on fresh storage being mutable")
+	}
+	if cp == singletonNil {
+		t.Fatal("Copy() of Nil() returned the singleton itself")
+	}
+	cp.Cells = append(cp.Cells, Int(1))
+	cp.Quoted = true
+	if drift := snap.Verify(); drift != "" {
+		t.Fatalf("mutating a Copy() of Nil() drifted singleton %s", drift)
+	}
+}
+
+// TestSingletonSetSourceNoOp pins the metadata edge: SetSource on a sealed
+// value is a no-op, and the singletons are sealed, so no embedder can
+// stamp a location onto shared singleton storage.
+func TestSingletonSetSourceNoOp(t *testing.T) {
+	snap := TakeSingletonSnapshot()
+	loc := nativeLocation()
+	Nil().SetSource(&loc)
+	Bool(true).SetSource(&loc)
+	Bool(false).SetSource(&loc)
+	if drift := snap.Verify(); drift != "" {
+		t.Fatalf("SetSource wrote to singleton %s; sealed values must ignore SetSource", drift)
+	}
+}

--- a/lsp/definition.go
+++ b/lsp/definition.go
@@ -127,6 +127,7 @@ func (s *Server) qualifiedSymbolDefinition(word string) *protocol.Location {
 
 // externalToSymbol converts an ExternalSymbol to a Symbol for common helpers.
 func externalToSymbol(ext *analysis.ExternalSymbol) *analysis.Symbol {
+	//elps:aliases deliberate metadata translation between sibling analysis structs: symbol locations are frozen once analysis produces them, and both structs are read-only views for LSP consumers
 	return &analysis.Symbol{
 		Name:      ext.Name,
 		Kind:      ext.Kind,

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -1224,6 +1224,7 @@ func qualifiedSymbolDefinition(state *workspaceState, word string) *Location {
 }
 
 func externalToSymbol(ext *analysis.ExternalSymbol) *analysis.Symbol {
+	//elps:aliases deliberate metadata translation between sibling analysis structs: symbol locations are frozen once analysis produces them, and both structs are read-only views for MCP consumers
 	return &analysis.Symbol{
 		Name:      ext.Name,
 		Package:   ext.Package,

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -902,6 +902,7 @@ func (p *Parser) tokenLVal(v *lisp.LVal) *lisp.LVal {
 		loc.EndCol = endCol
 		loc.EndPos = endPos
 	}
+	//elps:aliases the documented producer-fixup contract (see the comment above and SetSource's doc): the parser owns this token's Location and keeps fixing up its end-position fields until the parse completes, after which sealing freezes it
 	v.SetSource(loc)
 	if p.preserveFormat {
 		if v.Meta == nil {
@@ -939,6 +940,7 @@ func (p *Parser) Accept(typ ...token.Type) bool {
 
 func (p *Parser) errorf(condition string, format string, v ...interface{}) *lisp.LVal {
 	err := lisp.ErrorConditionf(condition, format, v...)
+	//elps:aliases producer-fixup contract (SetSource's documented convention): the parser owns the current token's Location and may still fix up its end-position fields; a parse error's position moving with those fixups is the intended behavior
 	err.SetSource(p.Location())
 	return err
 }
@@ -951,6 +953,7 @@ func (p *Parser) errorAtf(source *token.Location, condition, format string, v ..
 
 func (p *Parser) scanError(condition string) *lisp.LVal {
 	err := lisp.ErrorCondition(condition, errors.New(p.TokenText()))
+	//elps:aliases producer-fixup contract (SetSource's documented convention) — see errorf above
 	err.SetSource(p.Location())
 	return err
 }

--- a/parser/token/scanner.go
+++ b/parser/token/scanner.go
@@ -90,7 +90,6 @@ func (s *Scanner) EmitToken(typ Type) *Token {
 		Source: s.LocStart(),
 	}
 	s.Ignore()
-	//elps:aliases false positive of the intraprocedural method-taint approximation: LocStart mints a fresh Location per token (the analyzer cannot see inside the call), and the token's Location entering the parser's producer-fixup pipeline afterwards is the documented convention
 	return tok
 }
 

--- a/parser/token/scanner.go
+++ b/parser/token/scanner.go
@@ -90,6 +90,7 @@ func (s *Scanner) EmitToken(typ Type) *Token {
 		Source: s.LocStart(),
 	}
 	s.Ignore()
+	//elps:aliases false positive of the intraprocedural method-taint approximation: LocStart mints a fresh Location per token (the analyzer cannot see inside the call), and the token's Location entering the parser's producer-fixup pipeline afterwards is the documented convention
 	return tok
 }
 


### PR DESCRIPTION
## Summary

Stacked on #374; chain: #374 → **#377** → #388 → #389 → #387 → #386 → #385. Base branch is `claude/exp-seal-tooling` (#374's head); #388 is stacked directly on this branch.

Closes #375 and closes #376 — the two gaps the #374 review surfaced:

1. **`elpsescape` vet rule (#375):** the freshness/alias rules check the mutation direction; this checks the mirror image — runtime-owned `*token.Location` pointers (`env.Loc`, `v.source`, producer-fixup token locations) stored uncopied into escaping values. Retro-catches all three historical bugs verbatim (pre-fix `ErrorCondition`, `ErrorConditionf`, `ErrorAssociate`). Census: 13 flags — 3 fixed with `copyLocation` (including a real latent exposure: `InspectFunction` handed embedders a mutable pointer into a possibly-sealed node's location), 9 annotated `//elps:aliases` with individual justification, 1 false positive retired by proof rather than annotation (below). Vet wall time 0.58s.
2. **Singleton sealing + permanent inspector roots (#376):** `Nil`/`True`/`False` are now sealed (IsSealed() communicates the contract; CoW guards cover container ops — edge shapes tested) and registered as permanent inspector roots re-verified at every load and teardown under `elpscheck`. Red-proofs: a deliberate singleton write is caught by the inspector (fingerprints printed) and by the watchdog under `-race` even for a same-value write. No hot-path changes were needed.

## Cross-package freshness facts (`cmd/elpsvet/locfact.go`)

The rule's first cut treated *every* `*token.Location`-returning method on a receiver the caller did not construct as a taint source. That is right for `rdparser.Parser.Location`, which hands out the parser's own token pointer, and wrong for `lisp.LEnv.Source`, which returns `copyLocation(env.loc)` precisely so callers may keep the result. Annotating the call site was the wrong answer: it pushes the cost onto every embedder using the sanctioned API, and spends an audited annotation on something that is not a claim but a provable fact.

The analyzer now computes, per function whose sole result is a `*token.Location`, the summary "every value this can return is freshly allocated", and exports it as a `go/analysis` fact. Facts travel the import graph, so `LEnv.Source` is clean in `lsp/`, in `mcpserver/` and in any embedder with nothing written at the call site, while `LocRef`-shaped by-reference accessors of identical signature stay flagged. A result qualifies when it is `nil`, a `&token.Location{...}` literal or `new(token.Location)`, `&local` for a value-typed `token.Location` variable or parameter (the deref-copy idiom), or a call to something already proven. Anything else leaves the summary false and the call site conservatively flagged, so the fact can only ever retire a proven false positive.

Two fixpoints keep it honest: functions are proven by least fixpoint from nothing, so a recursion cycle cannot bootstrap itself, and location locals are resolved flow-**insensitively** — every assignment must be fresh — because a source-order walk would call a loop-carried local fresh when a `return loc` textually precedes the `loc = tok.Source` that feeds it on the next iteration.

Consequences: the `copyLocation` name check is gone (the cleanser is now recognised by behaviour, not spelling); the `parser/token/scanner.go` annotation is retired, since `LocStart` mints a fresh `Location` per token and the fact sees it. Annotation count 10 → 9, and every survivor was re-checked by removing it and confirming the diagnostic returns.

`analysistest` checks facts as strictly as diagnostics, so a declaration with **no** `// want Name:"freshLocation"` asserts the summary was not recorded. Pinned in both directions: `LEnv.Source` clean vs `LEnv.LocRef` flagged, the one-leaking-return accessor, the deref-copy accessor, the transitive wrapper, the parameter passthrough, the recursion cycle, the bare-return named result, the loop-rebound local, and `(*LVal).Source` / `ErrorVal.Source`, whose by-value results need no fact at all.

## Performance

Untagged binary: `go tool nm` diff vs base = **0 lines**. Benchstat interleaved n=10: allocs/op and B/op identical on all 19 benchmarks; no significant sec/op row.

## Status

Draft: this branch has **not** yet had the independent adversarial review pass that #374's layers received. Evidence comments: [#375](https://github.com/luthersystems/elps/issues/375#issuecomment-5259621792), [#376](https://github.com/luthersystems/elps/issues/376#issuecomment-5259627078).

## Test plan

- [x] `go test ./...` plain and `-tags elpscheck`; `-race -tags elpscheck ./lisp/` clean
- [x] golangci-lint 0 issues (both passes); elpsvet exit 0
- [x] Retro-catch fixtures + live-tree reverted-fix diagnostics
- [x] Red-proofs for both inspector hooks with restore-and-clean verification
- [x] `analysistest` strictness verified by deleting a `// want` (diagnostic and fact) and confirming failure, then restoring
- [ ] Independent adversarial review

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_