### PR TITLE
Scrub customer references from comments; add confidentiality CI guard

### DIFF
--- a/.github/workflows/elps.yml
+++ b/.github/workflows/elps.yml
@@ -24,6 +24,16 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
+      # Fails when a confidential customer name appears anywhere in the
+      # tracked tree.  The forbidden term is assembled from character codes
+      # inside the script -- never written literally -- so neither the
+      # script nor this workflow can trip the guard, and nothing has to be
+      # excluded from the scan.  Word-boundary matching keeps unrelated
+      # English words from false-positiving; the script self-tests both
+      # directions on every run.  See scripts/confidentiality-guard.sh.
+      - name: Confidentiality guard
+        run: bash scripts/confidentiality-guard.sh
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -1967,7 +1967,7 @@ func parseAndAnalyzeWithExpander(t *testing.T, macroSource, callSource string) *
 }
 
 func TestAnalyze_MacroExpansion_LambdaParams(t *testing.T) {
-	// Pattern from def-acre-route: macro introduces lambda parameters.
+	// Pattern from def-app-route: macro introduces lambda parameters.
 	// Without expansion: req/resp flagged as undefined.
 	// With expansion: they resolve as lambda params.
 	// Note: macro name intentionally doesn't start with "def" to avoid
@@ -1996,7 +1996,7 @@ func TestAnalyze_MacroExpansion_LambdaParams(t *testing.T) {
 }
 
 func TestAnalyze_MacroExpansion_NestedMacros(t *testing.T) {
-	// Pattern from def-acre-route-get calling def-acre-route.
+	// Pattern from def-app-route-get calling def-app-route.
 	// Outer macro expands, inner macro expands on next recursion.
 	result := parseAndAnalyzeWithExpander(t,
 		`(defmacro make-route (name args &rest exprs)

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -207,7 +207,7 @@ func TestLoadWorkspaceMacros_PackageContext(t *testing.T) {
 }
 
 func TestLoadWorkspaceMacros_PackageAutoCreated(t *testing.T) {
-	// Workspace packages (e.g. "acre") don't exist in the boot env.
+	// Workspace packages (e.g. "app") don't exist in the boot env.
 	// in-package in the preamble auto-creates them.
 	env := newTestEnv(t)
 

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -543,7 +543,7 @@ func TestScanWorkspaceRefs_QuasiquoteTemplateCrossFile(t *testing.T) {
 	require.NoError(t, err)
 
 	// macro.lisp defines a macro whose quasiquote template references
-	// helpers:get-valid-me. This is the pattern from def-acre-route.
+	// helpers:get-valid-me. This is the pattern from def-app-route.
 	err = os.WriteFile(filepath.Join(dir, "macro.lisp"), []byte(`(in-package 'myapp)
 (export 'my-macro)
 (defmacro my-macro (name)
@@ -866,8 +866,8 @@ func TestExtractFileRefs_QualifiedSymbol(t *testing.T) {
 	t.Run("qualified symbol in quasiquote template", func(t *testing.T) {
 		// A qualified symbol inside a defmacro's quasiquote template should
 		// produce a cross-file reference, just like a direct call would.
-		// This is the pattern used by def-acre-route: the macro template
-		// references acre:get-valid-me which is defined in another file.
+		// This is the pattern used by def-app-route: the macro template
+		// references app:get-valid-me which is defined in another file.
 		cfgWithPkg := &Config{
 			PackageExports: map[string][]ExternalSymbol{
 				"helpers": {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -2100,7 +2100,7 @@ func TestUnusedFunction_Positive_NotInQuasiquoteTemplate(t *testing.T) {
 func TestUnusedFunction_Negative_CrossFileRef_QuasiquoteTemplate(t *testing.T) {
 	// A function defined in one file, referenced via qualified symbol in
 	// another file's defmacro quasiquote template, should NOT be flagged.
-	// This simulates the acre:get-valid-me pattern.
+	// This simulates the app:get-valid-me pattern.
 	source := `(in-package 'helpers)
 (export 'get-valid-me)
 (defun get-valid-me () 42)`
@@ -3091,7 +3091,7 @@ func TestLintFiles_FileNotFound(t *testing.T) {
 func TestLintFiles_UnusedFunction_CrossFileQuasiquoteTemplate(t *testing.T) {
 	// End-to-end: a non-exported function referenced via qualified symbol
 	// in another file's quasiquote template must not be flagged as unused.
-	// This is the def-acre-route pattern where the helper is internal.
+	// This is the def-app-route pattern where the helper is internal.
 	dir := t.TempDir()
 
 	writeTempLisp(t, dir, "macro.lisp", `(in-package 'myapp)

--- a/scripts/confidentiality-guard.sh
+++ b/scripts/confidentiality-guard.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Confidentiality guard: fails CI when a forbidden (confidential customer)
+# term appears anywhere in the tracked tree.
+#
+# Two deliberate design points:
+#
+#  1. The forbidden term is NEVER written literally in this script (or in
+#     the workflow that invokes it).  It is assembled below from octal
+#     character codes.  That way the guard's own source can never trip the
+#     guard, and this file never needs to be excluded from the scan -- an
+#     exclusion would be a hole a future violation could hide in.
+#
+#  2. The scan uses a case-insensitive WORD-BOUNDARY pattern (\b...\b), so
+#     ordinary English words that merely contain the term as a substring
+#     (e.g. "massacre", "acreage", "wiseacre") never false-positive.  The
+#     self-test below proves both directions on every run: those substring
+#     words must NOT match, and runtime-constructed bounded occurrences
+#     (bare, hyphenated identifier, package-qualified) MUST match.  Note
+#     the negative fixtures are safe to write literally here precisely
+#     because they do not match the bounded pattern.
+#
+# On a hit the script prints file:line locations only -- not the matched
+# text -- so the term does not end up echoed into public CI logs.
+#
+# Usage: scripts/confidentiality-guard.sh   (run from anywhere in the repo)
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Forbidden term, assembled from octal codes so it never appears literally.
+TERM_="$(printf '\141\143\162\145')"
+PATTERN="\\b${TERM_}\\b"
+
+# --- self-test: boundary handling -------------------------------------------
+
+# Substring-containing words must NOT match (word boundaries do the work).
+for fixture in "massacre" "acreage" "wiseacre" "LambdaCreatesGlobal"; do
+	if printf '%s\n' "$fixture" | grep -qiE "$PATTERN"; then
+		echo "guard self-test failed: false positive on substring word '$fixture'" >&2
+		exit 2
+	fi
+done
+
+# Bounded occurrences (constructed at runtime, never stored literally)
+# MUST match: bare word, mixed case, hyphenated identifier, pkg-qualified.
+UP="$(printf '%s' "$TERM_" | tr '[:lower:]' '[:upper:]')"
+for fixture in "$TERM_" "$UP" "def-${TERM_}-route" "${TERM_}:helper" "(${TERM_})"; do
+	if ! printf '%s\n' "$fixture" | grep -qiE "$PATTERN"; then
+		echo "guard self-test failed: pattern missed a bounded occurrence" >&2
+		exit 2
+	fi
+done
+
+# --- scan the tracked tree ---------------------------------------------------
+
+# git grep exits 0 when it finds a match, 1 when clean.
+if matches="$(git grep -inE "$PATTERN" -- . 2>/dev/null)"; then
+	echo "confidentiality guard: forbidden term found at the following locations:" >&2
+	# file:line only; deliberately do not echo the matched text.
+	printf '%s\n' "$matches" | cut -d: -f1,2 >&2
+	echo "confidentiality guard: remove the term before merging (ask a maintainer if unsure which term this is)." >&2
+	exit 1
+fi
+
+echo "confidentiality guard: clean"


### PR DESCRIPTION
## Summary

A customer name appeared in test comments in this public repository. This PR removes every occurrence from the tracked tree and adds a CI guard so it cannot come back.

The term itself is deliberately not written anywhere in this PR, in the guard script, or in the workflow.

## Part 1 — comment replacements

All 9 occurrences were in **comments only**. No test code, fixture data, identifier, or assertion changed, so behaviour is untouched. Each replacement keeps the documentary value of the comment — the reader still learns which real-world macro shape the test is modelling, just under a generic name.

| File | Comment lines | Replacement |
|---|---|---|
| `analysis/analysis_test.go` | 2 (3 occurrences) | macro-pattern reference → `def-app-route`, `def-app-route-get` |
| `analysis/expander_test.go` | 1 | example workspace package → `"app"` |
| `analysis/workspace_test.go` | 3 | → `def-app-route`, `app:get-valid-me` |
| `lint/lint_test.go` | 2 | → `app:get-valid-me`, `def-app-route` |

The identifier-embedded forms were renamed consistently: the hyphenated macro name became `def-app-route` (and `def-app-route-get` for the nested-macro case), and the package-qualified form became `app:get-valid-me`, matching the `"app"` workspace package used in the expander test.

## Part 2 — guard design

`scripts/confidentiality-guard.sh`, invoked from the existing `lint-and-test` job in `.github/workflows/elps.yml` (already covered by the `Required: build & test` aggregate, so it needs no branch-protection change).

Three properties were required, and each is enforced rather than assumed:

**1. The guard cannot trip on its own pattern.** The forbidden term is never written literally — it is assembled at runtime from octal character codes. This is the reason there is **no exclusion list**: the guard script and the workflow are scanned exactly like every other tracked file. An exclusion would have been a hole a future real violation could hide in, and it would have had to be maintained forever.

**2. Word boundaries, so ordinary English never matches.** The pattern is `\bTERM\b` (case-insensitive), where `TERM` is the runtime-assembled string. Words that merely *contain* the term as a substring do not match.

**3. The failure message never echoes the term.** On a hit the script prints `confidentiality guard: forbidden term found` followed by `file:line` locations only — the matched text is cut away, so the term is never republished into public CI logs.

The script also **self-tests both directions on every run**, before it scans anything. If the pattern ever stopped matching real occurrences, or started matching innocent words, the guard fails with exit 2 rather than silently passing. A guard that can only report success looks exactly like a guard that works.

## Red-proof

Guard verified red-then-green against a scratch violation. Term redacted as `███` below; the guard's own output needed no redaction because it prints locations only.

```
########## STEP 1: baseline (clean tree) ##########
confidentiality guard: clean
exit=0

########## STEP 2: introduce scratch violation ##########
$ printf '// pattern from def-███-route helper\npackage scratch\n' > scratch_violation.go
$ git add -N scratch_violation.go
confidentiality guard: forbidden term found at the following locations:
scratch_violation.go:1
confidentiality guard: remove the term before merging (ask a maintainer if unsure which term this is).
exit=1

########## STEP 3: remove violation ##########
confidentiality guard: clean
exit=0
```

Boundary proof — a file containing `massacre`, `acreage`, `wiseacre`, `TestLambdaCreatesGlobal` and their upper/mixed-case variants, all present in the tracked scan at once:

```
confidentiality guard: clean
exit=0   (no false positive on any substring word)
```

And the guard's own files are in the scan, not excluded:

```
$ git ls-files | grep -E 'confidentiality-guard|elps.yml'
.github/workflows/elps.yml
scripts/confidentiality-guard.sh
confidentiality guard: clean
exit=0
```

## Gates

- `go build ./...` — clean
- `golangci-lint run ./...` — 0 issues
- `make test` — pass
- `shellcheck -S warning scripts/*.sh` — clean (the new script is picked up automatically; `ci-gates-test.sh` discovers `scripts/*.sh` by glob rather than a hand-maintained list)
- `bash -n` on the new script — clean
- Tracked-tree scan — no remaining occurrences

## Residuals (not addressed by this PR)

Historical metadata lives outside the tracked tree, so the guard does not cover it and this PR does not change it. A full census was done separately:

- **Bodies cleaned in place** (no history rewrite): 4 PR descriptions and 6 issue descriptions were edited to generic phrasing. All 230 PR bodies and all 154 issue bodies were then re-scanned and are clean.
- **Comments: 10 remain, and cannot be fixed by tooling.** The GitHub API surface available here can create comments but not edit existing ones, so these need manual editing by their author. The list of URLs is in the session report.
- **Commit messages: 6 hits on `main`** — accepted residue. Removing them would require a history rewrite, which is out of scope and not worth the disruption to a public repo. The guard scans file contents, not commit messages, so these do not fail CI.
- **Caveat on body edits:** GitHub retains the *edit history* of issue and PR descriptions, and anyone who can read the issue can read prior revisions. Editing a body lowers casual visibility but does **not** erase the term. Only GitHub Support can purge that history. This is worth knowing before treating Part 2 as "done".

## Note for #374

Once this merges, **#374 will need `main` merged forward** before it can pass the new guard — that branch predates the scrub and still carries the term in its test comments. That merge is intentionally **not** done here; #374 has an active owner.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA