### PR TITLE
Stop the cyclic-value fuzz target rewriting the standard library

### DIFF
--- a/lisp/builtin_formals_test.go
+++ b/lisp/builtin_formals_test.go
@@ -1,0 +1,71 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"fmt"
+	"strings"
+)
+
+// builtinFormalsSnapshot is a rendering of every builtin's formal argument
+// list, and the third process-wide guard TestMain installs.
+//
+// WHY IT IS NEEDED.  The builtin tables (langBuiltins, userBuiltins) are
+// package-level vars whose Formals() lists are constructed exactly once, when
+// this package is initialized.  AddBuiltins stores f.Formals() straight into
+// LFun.Cells[0] with no copy, so ONE formals list is shared by every LEnv the
+// process will ever create -- including every environment created after a
+// write to it.  A test that walks a value, reaches a function through it and
+// appends a cell to the list it finds in Cells[0] has therefore edited the
+// standard library for the remainder of the process, and nothing in that test
+// is looking.
+//
+// That is not hypothetical: FuzzCyclicValueWalks did exactly this from its
+// own seed corpus, and every test in the package passed while it happened
+// (issue #398).  The singleton snapshot above cannot see it -- the singletons
+// are Nil and the two Bools, not the builtin table -- and main has no
+// sealed-AST verifier, so before this snapshot there was no second observer
+// at all.
+//
+// The rendering, rather than the pointers, is what is compared: an append
+// that fits in the existing slice capacity leaves the *LVal identical and the
+// backing array edited in place, which a pointer comparison would miss.
+type builtinFormalsSnapshot struct {
+	rendered string
+}
+
+func takeBuiltinFormalsSnapshot() builtinFormalsSnapshot {
+	return builtinFormalsSnapshot{rendered: renderBuiltinFormals()}
+}
+
+func renderBuiltinFormals() string {
+	var b strings.Builder
+	for _, def := range DefaultBuiltins() {
+		fmt.Fprintf(&b, "%s %s\n", def.Name(), def.Formals().String())
+	}
+	return b.String()
+}
+
+// verify reports the builtins whose formals differ from the snapshot, or ""
+// when the table is intact.
+func (s builtinFormalsSnapshot) verify() string {
+	now := renderBuiltinFormals()
+	if now == s.rendered {
+		return ""
+	}
+	was, is := strings.Split(s.rendered, "\n"), strings.Split(now, "\n")
+	var out strings.Builder
+	for i := range max(len(was), len(is)) {
+		var wl, il string
+		if i < len(was) {
+			wl = was[i]
+		}
+		if i < len(is) {
+			il = is[i]
+		}
+		if wl != il {
+			fmt.Fprintf(&out, "  - was: %s\n    now: %s\n", wl, il)
+		}
+	}
+	return out.String()
+}

--- a/lisp/cycle_fuzz_test.go
+++ b/lisp/cycle_fuzz_test.go
@@ -139,12 +139,12 @@ func walkAll(v, other *lisp.LVal) string {
 // knot ties up to n self-references into v, turning the tree fuzzval built
 // into a graph with cycles in it.
 //
-// Only sorted-maps, arrays and non-empty lists are written to: the shared Nil
-// and Bool singletons are an empty list and two symbols, and writing through
-// one of those corrupts every other holder of it (issue #274).  Every target
-// value is a node from v itself, so a knot that lands on an ancestor is a real
-// cycle and one that lands elsewhere is shared structure -- both are shapes
-// the walks have to survive.
+// Only sorted-maps, arrays and non-empty lists are written to, and only ones
+// containers() collected: the shared Nil and Bool singletons are an empty
+// list and two symbols, and writing through one of those corrupts every other
+// holder of it (issue #274).  Every target value is a node from v itself, so
+// a knot that lands on an ancestor is a real cycle and one that lands
+// elsewhere is shared structure -- both are shapes the walks have to survive.
 func knot(v *lisp.LVal, gen *fuzzval.Gen, n int) {
 	nodes := containers(v)
 	if len(nodes) == 0 {
@@ -170,8 +170,33 @@ func knot(v *lisp.LVal, gen *fuzzval.Gen, n int) {
 	}
 }
 
-// containers collects the nodes of v that can be written to, bounded so that a
-// value already carrying a cycle cannot make this walk the unbounded one.
+// containers collects the nodes of v that THIS INPUT BUILT and that can be
+// written to, bounded so that a value already carrying a cycle cannot make
+// this walk the unbounded one.
+//
+// "This input built" is the load-bearing half, and it was missing.  A
+// generated value may CONTAIN a function -- fuzzval's fun() kinds 2 and 3
+// return the environment's own globals, straight from the seed corpus via
+// []byte{kindFun, 2} -- and an LFun's cells are its formals and its body.
+// For a builtin, Cells[0] is the formals list from the package-level builtin
+// table: constructed once when the lisp package is initialized, stored into
+// every LFun by pointer, and therefore shared by every LEnv the process will
+// ever create.  Collecting it handed knot() the standard library to write
+// through, which is what issue #398 was: one seed rewrote lisp:car's
+// signature, every assertion here still passed, and environments built
+// afterwards -- in later tests, in later targets -- got a car that rejects
+// its own argument.
+//
+// So nothing below an LFun is collected or descended into.  The subtree is
+// not ours: for a builtin it is shared process-wide, and for a lambda it is a
+// body the interpreter may hold references into.  On the sealed-AST branches
+// the same rule is spelled `if v.IsSealed() { return }`; main has no seal
+// bit, and on main the sealed subtrees a generated value can reach are
+// exactly the ones under a function.
+//
+// The cost is two seeds' worth of container, and only for values that are
+// nothing BUT a function -- see TestCycleSeedsStillTieCycles, which pins how
+// much of the corpus still ties a real cycle.
 func containers(v *lisp.LVal) []*lisp.LVal {
 	const maxNodes = 256
 	var out []*lisp.LVal
@@ -186,6 +211,10 @@ func containers(v *lisp.LVal) []*lisp.LVal {
 		}
 		seen[v] = struct{}{}
 		switch v.Type {
+		case lisp.LFun:
+			// Not ours to write, and not ours to walk into.  See the doc
+			// comment above and issue #398.
+			return
 		case lisp.LSortMap:
 			out = append(out, v)
 			for _, pair := range v.MapEntries().Cells {

--- a/lisp/cycle_stdlib_test.go
+++ b/lisp/cycle_stdlib_test.go
@@ -3,8 +3,10 @@
 package lisp_test
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/luthersystems/elps/internal/fuzzval"
 	"github.com/luthersystems/elps/lisp"
 )
 
@@ -40,6 +42,73 @@ func TestCycleContainersSkipFunctionSubtrees(t *testing.T) {
 		wrapper := lisp.QExpr([]*lisp.LVal{lisp.Int(1), fn})
 		if got := containers(wrapper); len(got) != 1 || got[0] != wrapper {
 			t.Errorf("containers(list holding %s) collected %d node(s), want exactly the list itself", name, len(got))
+		}
+	}
+}
+
+// TestCycleSeedsStillTieCycles is the other half of the #398 fix: proof that
+// skipping function subtrees in containers() did not quietly turn
+// FuzzCyclicValueWalks into a target that walks trees.
+//
+// A guard against corruption that works by collecting nothing would pass
+// TestCycleContainersSkipFunctionSubtrees and TestMain's formals snapshot
+// perfectly, and would be the same "green by not looking" failure in a new
+// place.  So this pins the opposite direction, over the target's own seed
+// corpus and with the target's own helpers:
+//
+//   - a substantial share of the corpus still yields a writable node;
+//   - all three writable families -- list, array, sorted-map -- are still
+//     reached, so knot()'s three branches are all still exercised;
+//   - and the knotted values really are cyclic afterwards, which is measured
+//     the only way that cannot be faked by the collector: the rendering
+//     carries #<cycle>, which only the recursion guard emits, and only when
+//     it meets a value that contains itself.
+//
+// Measured across the fix: 32 seeds yielded a container before and 23 after,
+// and every one of the nine differences is a value that is NOTHING but a
+// function, whose only "container" was that function's formals list.  Not one
+// node the input actually built was dropped.  A 60s `-fuzz` run either side
+// agreed: 511 vs 513 interesting inputs from ~161k execs.
+func TestCycleSeedsStillTieCycles(t *testing.T) {
+	// Floors, not exact counts: fuzzval.Seeds() grows when a value kind is
+	// added, and this test should not have to be edited for that.  They sit
+	// just under the measured values (23 seeds, families 24/9/6).
+	const minSeedsWithContainers = 20
+	const minCyclicRenders = 20
+
+	env := newCycleEnv(t)
+	seeds := append(fuzzval.Seeds(), []byte{0x00}, []byte{0xff, 0xff, 0xff, 0xff})
+	families := map[lisp.LType]int{}
+	var withContainers, cyclic int
+	for i, data := range seeds {
+		gen := fuzzval.New(data, env)
+		v := gen.Value()
+		nodes := containers(v)
+		if len(nodes) > 0 {
+			withContainers++
+		}
+		for _, c := range nodes {
+			families[c.Type]++
+		}
+		knot(v, gen, i%maxKnots+1)
+		if strings.Contains(v.String(), "#<cycle>") {
+			cyclic++
+		}
+	}
+
+	if withContainers < minSeedsWithContainers {
+		t.Errorf("only %d of %d seeds yielded a writable node, want at least %d:"+
+			"\ncontainers() has stopped collecting the values the input built, and the target no longer ties cycles",
+			withContainers, len(seeds), minSeedsWithContainers)
+	}
+	if cyclic < minCyclicRenders {
+		t.Errorf("only %d of %d seeds rendered #<cycle> after knotting, want at least %d:"+
+			"\nthe target is walking trees, which is what it was written to stop doing",
+			cyclic, len(seeds), minCyclicRenders)
+	}
+	for _, typ := range []lisp.LType{lisp.LSExpr, lisp.LArray, lisp.LSortMap} {
+		if families[typ] == 0 {
+			t.Errorf("no %v was ever collected: knot()'s %v branch is unreachable from the seed corpus", typ, typ)
 		}
 	}
 }

--- a/lisp/cycle_stdlib_test.go
+++ b/lisp/cycle_stdlib_test.go
@@ -1,0 +1,45 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// TestCycleContainersSkipFunctionSubtrees pins the rule that keeps
+// FuzzCyclicValueWalks inside the value it built: containers() may only offer
+// knot() nodes the input constructed, and everything below an LFun -- its
+// formals and its body -- belongs to whoever defined the function.
+//
+// fuzzval hands back the environment's own global function objects (fun()
+// kinds 2 and 3, reached from the seed corpus by []byte{kindFun, 2}), whose
+// Cells[0] is the process-wide formals list from the builtin table.  Before
+// issue #398 containers() collected that list and knot() appended to it, so
+// running the seed corpus rewrote lisp:car's signature for the rest of the
+// process.
+//
+// This is the attributable half of the guard pair.  TestMain's
+// builtin-formals snapshot says the standard library was corrupted; this says
+// by whom, and fails on the collection rather than on its consequence.
+func TestCycleContainersSkipFunctionSubtrees(t *testing.T) {
+	env := newCycleEnv(t)
+	for _, name := range []string{"lisp:car", "lisp:identity", "lisp:map", "lisp:let", "lisp:defmacro"} {
+		fn := env.GetGlobal(lisp.Symbol(name))
+		if fn.Type != lisp.LFun {
+			t.Fatalf("%s is not a function: %v", name, fn.Type)
+		}
+		if got := containers(fn); len(got) != 0 {
+			t.Errorf("containers(%s) offered knot() %d node(s) inside a function value -- the first is a %v: %s"+
+				"\nthose cells are %s's own formals and body, shared by every environment in the process,"+
+				"\nnot structure this input built", name, len(got), got[0].Type, got[0], name)
+		}
+		// The same function nested inside a container the input DID build:
+		// the list is writable, nothing under the function is.
+		wrapper := lisp.QExpr([]*lisp.LVal{lisp.Int(1), fn})
+		if got := containers(wrapper); len(got) != 1 || got[0] != wrapper {
+			t.Errorf("containers(list holding %s) collected %d node(s), want exactly the list itself", name, len(got))
+		}
+	}
+}

--- a/lisp/main_test.go
+++ b/lisp/main_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 )
 
-// TestMain wraps the package test suite with two complementary
-// singleton guards.
+// TestMain wraps the package test suite with three complementary guards
+// over the state this process shares between every environment it builds.
 //
-// The snapshot check detects a singleton whose *value* differs at the
+// The singleton snapshot detects a singleton whose *value* differs at the
 // end of the run from the start — a tree-walker that failed to guard
 // against them, say. See issue #274.
 //
@@ -21,8 +21,18 @@ import (
 // goroutines happened to collide. The watchdog makes any unsynchronized
 // write to a singleton race deterministically under `make race`. See
 // singleton_watchdog_test.go for its scope and limits.
+//
+// The builtin-formals snapshot extends the first check from the three
+// singletons to the other process-wide shared structure: the formals lists
+// in the builtin tables, which AddBuiltins hands to every LEnv by pointer.
+// A test that reaches one through a function value and writes to it
+// corrupts every environment created afterwards, in this process, in any
+// later test — and issue #398 is exactly that, arriving from a fuzz
+// target's own seed corpus with every assertion in the package satisfied.
+// See builtin_formals_test.go.
 func TestMain(m *testing.M) {
 	snap := TakeSingletonSnapshot()
+	formals := takeBuiltinFormalsSnapshot()
 	stopWatchdog := startSingletonWriteWatchdog()
 	code := m.Run()
 	stopWatchdog()
@@ -30,6 +40,14 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr,
 			"FATAL: singleton %s was mutated during test run\n  Nil=%+v\n  True=%+v\n  False=%+v\n",
 			drift, singletonNil, singletonTrue, singletonFalse)
+		if code == 0 {
+			code = 1
+		}
+	}
+	if drift := formals.verify(); drift != "" {
+		fmt.Fprintf(os.Stderr,
+			"FATAL: the process-wide builtin formals were mutated during the test run;\n"+
+				"every LEnv built after the write saw the mutated list:\n%s", drift)
 		if code == 0 {
 			code = 1
 		}


### PR DESCRIPTION
Fixes #398.

`FuzzCyclicValueWalks` (added by #391) writes through cells of values it did not construct, and some of those cells are the standard library's own formals lists. **This happens on every plain `go test ./lisp/`, not just under `-fuzz`** — the triggering seed is already committed in `fuzzval.Seeds()`.

## Why the sharing is total

The builtin tables are package-level vars whose `Formals(...)` lists are built once at package init, and `FunInPackage` stores that list into the function value with no copy:

```go
Cells: []*LVal{formals, String("")},
```

One formals `*LVal` per builtin is therefore shared by **every `LEnv` the process will ever create — including ones created after a write**. `containers()` collected `v.Cells` for all types including `LFun`, so it handed `knot()` the stdlib's own definitions to tie cycles through.

## The failure mode this PR is really about

With a builtin-formals snapshot added to the existing `TestMain`, unfixed `main` prints both of these **in the same run**:

```
PASS

FATAL: the process-wide builtin formals were mutated during the test run;
every LEnv built after the write saw the mutated list:
  - was: car '(lis)
    now: car '(lis #<cycle> #<cycle>)
```

The target's own assertions are satisfied, so nothing signals. Behaviourally, after the run a **brand new** environment gives:

```
(car '(1 2 3))  =>  lisp:car: invalid number of arguments: 1
```

The standard library is broken for the rest of the process, so any later failure in an unrelated target is unattributable — and a *passing* run may have corrupted something no assertion looks at.

## The fix

`containers()` returns immediately on `lisp.LFun`, collecting and descending nothing below a function. The shared subtrees a generated value can reach are exactly those under an `LFun` — `fuzzval.fun()` returns `env.GetGlobal` results verbatim — and `fuzzval` itself already refuses to write to them. `containers()` had not got the memo.

## Coverage survives — measured three ways

A fix that quietly turns the target into a no-op would be the same "green by not looking" failure in a new place, so this is checked explicitly:

- **Per-seed container delta, node by node**, over all 142 seeds: seeds yielding ≥1 container 32 → 23. All nine differences are `rootType=function` seeds, and every dropped node is a formals list. **Not one node an input actually constructed was dropped.**
- **`-fuzz` for 60s each**, `go clean -fuzzcache` before both: 511 → 513 new interesting inputs. Statistically identical.
- **A committed regression guard**, `TestCycleSeedsStillTieCycles`: asserts ≥20 seeds still yield a writable node, ≥20 still render `#<cycle>` after knotting, and that all three `knot()` branches (list, array, sorted-map) are still reached — measured 24/9/6. Verified to bite by sabotaging `containers()` to `return nil`: all five assertions fail.

## Note for the nightly sweep

Under `-fuzz` the corruption happens in worker subprocesses, so a coordinator-side snapshot stays clean. The detection point is the seed-corpus run — which is what PR CI runs.

## Gates

`go test ./...`, `go test -race ./lisp/...`, `golangci-lint run ./...` (0 issues), `elps fmt -l ./...`, `scripts/confidentiality-guard.sh`, `scripts/ci-gates-test.sh` (126 passed), `scripts/fuzz-budget-check.sh` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_