### PR TITLE
Stop macro expansion aliasing the form it expands, in the analyzer and in lisp (#396)

### DIFF
--- a/analysis/expander.go
+++ b/analysis/expander.go
@@ -281,7 +281,35 @@ func (e *EnvMacroExpander) expand(form *lisp.LVal, pkg string) *lisp.LVal {
 		return nil
 	}
 
-	args := lisp.SExpr(form.Cells[1:])
+	// Copy the argument cells into storage this call owns, rather than slicing
+	// form's backing array (elps#396).
+	//
+	// lisp.SExpr does not copy; it wraps the slice it is handed. Macro
+	// arguments are not evaluated, so a header over form.Cells[1:] reaches the
+	// macro's parameters unchanged — LEnv.bindFormalNext binds a variadic
+	// parameter to QExpr(args.Rest()), and argParser.Rest returns p.args[p.i:],
+	// yet another window onto the same array. Any destructive builtin in the
+	// macro body (stable-sort, sort, append!) then writes through into `form`,
+	// which is the analyzer's parse tree and not a scratch copy.
+	//
+	// This is the runtime's own discipline, which the analyzer was missing.
+	// LEnv.evalSExprCells is the only other path that reaches a macro, and on
+	// the IsSpecialFun branch it builds the argument list as
+	// `newCells := make([]*LVal, 1, len(s.Cells))` followed by
+	// `append(newCells, cells...)` — a FRESH array holding the caller's
+	// element pointers. The two lines below reproduce that exactly, so
+	// expanding a form here now perturbs it neither more nor less than
+	// evaluating it does.
+	//
+	// The copy is shallow for the same reason the runtime's is. The ELEMENTS
+	// must stay the caller's nodes: the expansion splices them into its result
+	// and the analyzer reads position information off exactly those nodes, so
+	// deep-copying would both diverge from eval and change what the language
+	// means. What must not be shared is the ARRAY — the only thing an in-place
+	// mutator applied to the &rest list itself can reach.
+	margs := make([]*lisp.LVal, len(form.Cells)-1)
+	copy(margs, form.Cells[1:])
+	args := lisp.SExpr(margs)
 	mark := e.Env.MacroCall(mac, args)
 	if mark.Type == lisp.LError || mark.Type != lisp.LMarkMacExpand {
 		return nil

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -637,3 +637,94 @@ func TestEnvMacroExpanderIsPanicReporter(t *testing.T) {
 	require.True(t, ok, "EnvMacroExpander must satisfy PanicReporter")
 	assert.Equal(t, uint64(0), pr.ExpansionPanics())
 }
+
+// TestExpandMacroDoesNotAliasCallerForm pins elps#396.
+//
+// ExpandMacro used to build the macro's argument list as
+// lisp.SExpr(form.Cells[1:]) — a fresh LVal header over the CALLER'S OWN
+// backing array. Macro arguments are not evaluated, so that array travels
+// unchanged into the macro's &rest binding: LEnv.bindFormalNext hands the
+// variadic parameter QExpr(args.Rest()), and argParser.Rest returns
+// p.args[p.i:], another window onto the same array. A macro body that calls
+// any in-place mutator (stable-sort here; append! and the rest of the kernel's
+// destructive builtins have the same shape) therefore writes straight through
+// into the tree the ANALYZER is holding.
+//
+// The tree the analyzer is holding is not a scratch copy. It is what backs
+// diagnostics, go-to-definition and lint results, and since #359 widened where
+// ExpandMacro runs — workspace scans across NumCPU workers, updateFileRefs —
+// the mutation can also be latched into the LSP's long-lived workspaceRefs
+// index. One expansion poisons every later query for the life of the process.
+//
+// The assertion is deliberately on the SOURCE TREE, not on the expansion's
+// result: the expansion returning something sensible is exactly what made this
+// invisible. What is wrong is the side effect on the caller's form.
+//
+// The second subtest states the invariant the fix is actually pinned to.
+// LEnv.evalSExprCells is the runtime's only other route to a macro, and on its
+// IsSpecialFun branch it copies the caller's cells into a fresh array. So the
+// runtime already leaves `(sort-my-args 3 1 2)` alone, and merely ANALYZING a
+// file was more destructive than RUNNING it. Comparing the two directly, rather
+// than hardcoding "unchanged", is what keeps this honest if the language's
+// macro-argument semantics are ever revised: whatever eval does to a form,
+// expansion-for-analysis must do no more.
+func TestExpandMacroDoesNotAliasCallerForm(t *testing.T) {
+	const macros = `
+(defmacro sort-my-args (&rest body)
+  (stable-sort < body)
+  (quasiquote 0))`
+
+	// parseForm parses one top-level form the way the analyzer does, so the
+	// cells under test are genuine parse-tree storage and not a hand-built
+	// slice that happens to have spare capacity.
+	parseForm := func(t *testing.T, src string) *lisp.LVal {
+		t.Helper()
+		s := token.NewScanner("alias_test.lisp", strings.NewReader(src))
+		exprs, err := rdparser.New(s).ParseProgram()
+		require.NoError(t, err)
+		require.Len(t, exprs, 1)
+		return exprs[0]
+	}
+	argInts := func(form *lisp.LVal) []int {
+		out := make([]int, 0, len(form.Cells)-1)
+		for _, c := range form.Cells[1:] {
+			out = append(out, c.Int)
+		}
+		return out
+	}
+
+	const src = "(sort-my-args 3 1 2)"
+
+	t.Run("expansion leaves the caller's form alone", func(t *testing.T) {
+		env := newTestEnv(t)
+		evalSource(t, env, macros)
+
+		form := parseForm(t, src)
+		require.Len(t, form.Cells, 4)
+		require.Equal(t, []int{3, 1, 2}, argInts(form), "precondition: source order")
+
+		expander := &EnvMacroExpander{Env: env}
+		_ = expander.ExpandMacro(form, lisp.DefaultUserPackage)
+
+		assert.Equal(t, []int{3, 1, 2}, argInts(form),
+			"macro expansion rewrote the caller's parse tree in place —"+
+				" the analyzer's own AST was corrupted by expanding a macro over it")
+	})
+
+	t.Run("expansion perturbs the form no more than eval does", func(t *testing.T) {
+		evalEnv := newTestEnv(t)
+		evalSource(t, evalEnv, macros)
+		evaled := parseForm(t, src)
+		require.NotEqual(t, lisp.LError, evalEnv.Eval(evaled).Type)
+
+		expandEnv := newTestEnv(t)
+		evalSource(t, expandEnv, macros)
+		expanded := parseForm(t, src)
+		_ = (&EnvMacroExpander{Env: expandEnv}).ExpandMacro(expanded, lisp.DefaultUserPackage)
+
+		assert.Equal(t, argInts(evaled), argInts(expanded),
+			"analyzing the form mutated it differently than evaluating it did —"+
+				" ExpandMacro must build the macro's argument list the same way"+
+				" LEnv.evalSExprCells does")
+	})
+}

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -582,12 +582,12 @@ func builtinMacroExpand(env *LEnv, args *LVal) *LVal {
 		if form.IsNil() {
 			return form
 		}
-		macsym, macargs := form.Cells[0], form.Cells[1:]
+		macsym := form.Cells[0]
 		if macsym.Type != LSymbol {
 			return form
 		}
 		mac := env.Get(macsym)
-		r, ok := macroExpand1(env, mac, SExpr(macargs))
+		r, ok := macroExpand1(env, mac, macroArgList(form))
 		if !ok {
 			return form
 		}
@@ -606,16 +606,50 @@ func builtinMacroExpand1(env *LEnv, args *LVal) *LVal {
 	if form.IsNil() {
 		return form
 	}
-	macsym, macargs := form.Cells[0], form.Cells[1:]
+	macsym := form.Cells[0]
 	if macsym.Type != LSymbol {
 		return form
 	}
 	mac := env.Get(macsym)
-	r, ok := macroExpand1(env, mac, SExpr(macargs))
+	r, ok := macroExpand1(env, mac, macroArgList(form))
 	if !ok {
 		return form
 	}
 	return r
+}
+
+// macroArgList builds the argument list for expanding the macro call `form`,
+// over storage this call owns rather than over form's own backing array
+// (elps#396).
+//
+// SExpr does not copy — it wraps the slice it is handed — so SExpr(form.Cells[1:])
+// produces a header carrying the CALLER'S backing array. Macro arguments are
+// not evaluated, so that array arrives at the macro's parameters untouched:
+// LEnv.bindFormalNext binds a variadic parameter to QExpr(args.Rest()), and
+// argParser.Rest returns p.args[p.i:], one more window onto the same storage.
+// Any destructive builtin in the macro body (stable-sort, append!) then
+// writes through into `form`. For (macroexpand form) called from lisp, `form`
+// is the evaluated first argument — typically the caller's own quoted literal,
+// a node of the source program — so expanding a form silently rewrote it.
+//
+// This is the discipline the evaluator already has. LEnv.evalSExprCells is the
+// runtime's normal route to a macro, and on its IsSpecialFun branch it builds
+// the argument list over a FRESH array (`make([]*LVal, 1, len(s.Cells))` then
+// `append(newCells, cells...)`) holding the caller's element pointers. This
+// reproduces that exactly, so (macroexpand form) now perturbs form neither more
+// nor less than evaluating it does. Before the fix the introspective operation
+// was strictly MORE destructive than the one that actually runs the macro.
+//
+// The copy is shallow for the same reason the runtime's is. The ELEMENTS must
+// stay the caller's nodes: the expansion splices them into its result and
+// callers read source positions off exactly those nodes, so deep-copying would
+// both diverge from eval and change what the language means. What must not be
+// shared is the ARRAY — the only thing an in-place mutator applied to the &rest
+// list itself can reach.
+func macroArgList(form *LVal) *LVal {
+	margs := make([]*LVal, len(form.Cells)-1)
+	copy(margs, form.Cells[1:])
+	return SExpr(margs)
 }
 
 func macroExpand1(env *LEnv, mac *LVal, args *LVal) (*LVal, bool) {

--- a/lisp/macroexpand_alias_test.go
+++ b/lisp/macroexpand_alias_test.go
@@ -1,0 +1,149 @@
+// Copyright © 2018 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/elpstest"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// destructiveMacroSrc defines a macro whose body mutates its &rest list in
+// place.  stable-sort is the clearest of the kernel's destructive builtins --
+// seqCells hands it list.Cells and sort.Stable reorders that array -- but sort
+// and append! have the same shape, so this stands in for all of them.
+//
+// The macro returns a constant so that nothing about the RESULT can mask a
+// side effect on the argument list.  That is the whole point: the expansion
+// always looked fine, which is why this went unnoticed.
+const destructiveMacroSrc = `
+(defmacro sort-my-args (&rest body)
+  (stable-sort < body)
+  (quasiquote 0))`
+
+// TestMacroExpandDoesNotAliasCallerForm pins the lisp-builtin half of elps#396.
+//
+// builtinMacroExpand and builtinMacroExpand1 both built the macro's argument
+// list as SExpr(form.Cells[1:]).  SExpr does not copy -- it wraps the slice it
+// is handed -- so that header carried the backing array of `form`, and `form`
+// is the builtin's FIRST ARGUMENT, already evaluated.  When lisp code writes
+// (macroexpand '(m 3 1 2)) or stores the form in a variable first, that value
+// is the caller's own quoted literal: a node of the running program's parse
+// tree, not a scratch copy.
+//
+// Macro arguments are not evaluated, so the borrowed array reached the macro's
+// parameters untouched -- LEnv.bindFormalNext binds a variadic parameter to
+// QExpr(args.Rest()) and argParser.Rest returns p.args[p.i:], another window
+// onto the same storage -- and any in-place mutator in the macro body wrote
+// straight back through into the caller's form.
+//
+// The assertions are on the CALLER'S FORM, never on the expansion's result.
+//
+// This needs no library and no analysis machinery; it is reachable from four
+// lines of ordinary lisp.
+func TestMacroExpandDoesNotAliasCallerForm(t *testing.T) {
+	tests := elpstest.TestSuite{
+		{"macroexpand does not rewrite the caller's form", elpstest.TestSequence{
+			{destructiveMacroSrc, "()", ""},
+			{"(set 'form '(sort-my-args 3 1 2))", "'(sort-my-args 3 1 2)", ""},
+			{"(macroexpand form)", "0", ""},
+			// Before the fix this read '(sort-my-args 1 2 3): asking what a
+			// form expands to rewrote the form.
+			{"form", "'(sort-my-args 3 1 2)", ""},
+		}},
+		{"macroexpand-1 does not rewrite the caller's form", elpstest.TestSequence{
+			{destructiveMacroSrc, "()", ""},
+			{"(set 'form '(sort-my-args 3 1 2))", "'(sort-my-args 3 1 2)", ""},
+			{"(macroexpand-1 form)", "0", ""},
+			{"form", "'(sort-my-args 3 1 2)", ""},
+		}},
+		// The invariant the fix is actually pinned to, stated as a
+		// comparison rather than as a hardcoded "unchanged".
+		//
+		// LEnv.evalSExprCells is the runtime's normal route to a macro, and on
+		// its IsSpecialFun branch it copies the caller's cells into a fresh
+		// array before binding them.  So RUNNING the form was already
+		// harmless, and only INSPECTING it was destructive -- the passive
+		// operation was strictly worse than the active one.  Comparing the two
+		// keeps this honest if macro-argument semantics are ever revised:
+		// whatever eval does to a form, macroexpand must do no more.
+		{"macroexpand perturbs a form no more than eval does", elpstest.TestSequence{
+			{destructiveMacroSrc, "()", ""},
+			{"(set 'evaled '(sort-my-args 3 1 2))", "'(sort-my-args 3 1 2)", ""},
+			{"(set 'expanded '(sort-my-args 3 1 2))", "'(sort-my-args 3 1 2)", ""},
+			{"(eval evaled)", "0", ""},
+			{"(macroexpand expanded)", "0", ""},
+			{"(equal? evaled expanded)", "true", ""},
+		}},
+	}
+	elpstest.RunTestSuite(t, tests)
+}
+
+// TestMacroExpandDoesNotAliasParsedForm is the same defect observed on genuine
+// parse-tree storage reached through the Go API, so the cells under test are
+// what the reader produced rather than a hand-built slice that happens to have
+// spare capacity.
+//
+// It also measures the eval/macroexpand asymmetry directly: the same form is
+// handed to the `eval` builtin in one env and to `macroexpand` in another, and
+// the two source trees are required to come out identical.
+func TestMacroExpandDoesNotAliasParsedForm(t *testing.T) {
+	// newEnv returns an initialized env with a reader attached, plus the
+	// destructive macro already defined.
+	newEnv := func(t *testing.T) *lisp.LEnv {
+		t.Helper()
+		env := lisp.NewEnv(nil)
+		env.Runtime.Reader = parser.NewReader()
+		require.NoError(t, lisp.GoError(lisp.InitializeUserEnv(env)))
+		lerr := env.LoadString("macro.lisp", destructiveMacroSrc)
+		require.NoError(t, lisp.GoError(lerr))
+		return env
+	}
+
+	// readForm parses one quoted form and returns the parse-tree node.
+	readForm := func(t *testing.T, env *lisp.LEnv) *lisp.LVal {
+		t.Helper()
+		form := env.LoadString("form.lisp", `'(sort-my-args 3 1 2)`)
+		require.NoError(t, lisp.GoError(form))
+		require.Equal(t, lisp.LSExpr, form.Type)
+		return form
+	}
+
+	// callBuiltin invokes a global builtin by name with a single argument.
+	callBuiltin := func(t *testing.T, env *lisp.LEnv, name string, arg *lisp.LVal) *lisp.LVal {
+		t.Helper()
+		fun := env.GetGlobal(lisp.Symbol(name))
+		require.NoError(t, lisp.GoError(fun))
+		r := env.FunCall(fun, lisp.SExpr([]*lisp.LVal{arg}))
+		require.NoError(t, lisp.GoError(r))
+		return r
+	}
+
+	for _, name := range []string{"macroexpand", "macroexpand-1"} {
+		t.Run(name, func(t *testing.T) {
+			env := newEnv(t)
+			form := readForm(t, env)
+			before := form.String()
+			callBuiltin(t, env, name, form)
+			assert.Equal(t, before, form.String(),
+				"(%s form) rewrote the caller's form in place", name)
+		})
+	}
+
+	t.Run("parity with eval", func(t *testing.T) {
+		evalEnv := newEnv(t)
+		evaled := readForm(t, evalEnv)
+		callBuiltin(t, evalEnv, "eval", evaled)
+
+		expandEnv := newEnv(t)
+		expanded := readForm(t, expandEnv)
+		callBuiltin(t, expandEnv, "macroexpand", expanded)
+
+		assert.Equal(t, evaled.String(), expanded.String(),
+			"macroexpand must perturb a form no more than eval does")
+	})
+}


### PR DESCRIPTION
Fixes #396.

**Base of a four-PR bug-crush chain.** Nothing here touches the sealing framework or elpspath. Two commits: the analyzer path, then the same defect on the lisp-reachable path.

## The bug

Macro arguments are built as `SExpr(form.Cells[1:])`. `SExpr` does not copy — it wraps the slice it is handed. Macro arguments are not evaluated, so that header reaches the macro's parameters unchanged, and `bindFormalNext` binds a variadic parameter to `QExpr(args.Rest())`, which is yet another window onto the same backing array. Any destructive builtin in the macro body — `stable-sort`, `sort`, `append!` — writes straight through into `form`, which is the caller's own parse tree.

Two call sites had it:

| commit | site | reachable from |
|---|---|---|
| 1 | `analysis/expander.go:281` | the LSP, `elps doc`, the linter — anything that *analyses* a file |
| 2 | `lisp/builtins.go:585` and `:609` (`macroexpand`, `macroexpand-1`) | ordinary lisp |

## The part worth pausing on

**Merely asking about a form was more destructive than running it.**

`LEnv.evalSExprCells` already copies the caller's cells into a fresh array on its `IsSpecialFun` branch, so actually *executing* a destructive macro leaves the form alone. Only the passive, introspective operations corrupted it:

```
(eval fa)         => 0      fa still '(sort-my-args 3 1 2)   <- running it is harmless
(macroexpand fb)  => 0      fb now   '(sort-my-args 1 2 3)   <- asking about it corrupts it
```

The same shape on the analyzer side: static tooling silently rewrote the program it was only meant to read, and it stayed rewritten for the life of the process. On the lisp side it bites harder still — `macroexpand` is the tool you reach for when a macro is *already* misbehaving, so **the diagnostic was editing the evidence**.

## The fix

Reproduce what the runtime already does, at both sites:

```go
margs := make([]*LVal, len(form.Cells)-1)
copy(margs, form.Cells[1:])
return SExpr(margs)
```

The copy is **shallow on purpose**, for the same reason the runtime's is: the elements must stay the caller's nodes, because the expansion splices them into its result and the analyzer reads position information off exactly those nodes. Deep-copying would both diverge from `eval` and change what the language means. Only the *array* must not be shared.

## Red-then-green

Reverting only the copy lines, on this branch:

**Analyzer** — `TestExpandMacroDoesNotAliasCallerForm`:
```
--- FAIL: .../expansion_leaves_the_caller's_form_alone
    macro expansion rewrote the caller's parse tree in place
--- FAIL: .../expansion_perturbs_the_form_no_more_than_eval_does
    expected: []int{3, 1, 2}   actual: []int{1, 2, 3}
```

**Lisp** — `TestMacroExpandDoesNotAliasCallerForm` + `TestMacroExpandDoesNotAliasParsedForm`, all six subtests fail:
```
test 0 "macroexpand does not rewrite the caller's form":   expected '(sort-my-args 3 1 2) (got '(sort-my-args 1 2 3))
test 1 "macroexpand-1 does not rewrite the caller's form": expected '(sort-my-args 3 1 2) (got '(sort-my-args 1 2 3))
test 2 "macroexpand perturbs a form no more than eval does": expected true (got false)
```

The parity subtests are the ones that matter long-term: they pin macro expansion to `eval` as the oracle and state the invariant as a comparison (`(equal? evaled expanded)`), so the two paths cannot silently drift apart again under any future revision of macro-argument semantics.

## Neighbouring sites examined and cleared

The governing fact, from reading `LEnv.bind`: for a builtin, `funenv` is nil, so bind accumulates into a `builtinArgs := make([]*LVal, 0, ...)` and returns `QExpr(builtinArgs)`. A builtin's `args.Cells` is **always** an array minted for that one call, on every path in including `env.FunCall` from Go. So slicing `args.Cells` is safe; slicing an *element* of it is not — and that element is exactly what macroexpand was slicing.

- **`builtins.go:503` `builtinInPackage`** — not a bug, twice over: the array is bind's scratch, and the loop only reads `arg.Str` into a `[]string`. Nothing escapes.
- **`builtins.go:644` `builtinFunCall`** — not a bug. It does hand a borrowed backing to something that can mutate it, but the lender is bind's per-call scratch, which dies with the call and which no lisp value references. Exact parity with a direct call. Confirmed at lisp level: `(funcall 'sort-em 3 1 2)` leaves every caller-visible value untouched.
- **`builtins.go:660` `builtinApply`** — not a bug, **and it is the precedent for this fix.** Apply splices `argtail.Cells`, which *is* a caller-visible list, so it would be a genuine defect — but it already copies both halves into a fresh `argcells`. That copy was proven load-bearing rather than decorative: a scratch build passing `SExpr(argtail.Cells)` directly makes `(apply 'sort-em lis)` reorder `lis` in place. (Scratch experiment reverted, not committed.)

So: apply already did the copy, funcall and in-package do not need one, macroexpand and macroexpand-1 needed one.

## Gates

`go build ./...`, `go vet ./...`, `go test ./...` (full tree), `golangci-lint run ./...` (0 issues), `gofmt -l` clean, `confidentiality-guard.sh`, `ci-gates-test.sh` (127 pass / 0 fail), `fuzz-budget-check.sh` fits. Fuzzing: `FuzzEval` 683k execs, `FuzzApplyStdlib` 144k, `FuzzDebugEval` 85k — all clean, no new corpus entries.

`go test -race ./...` is clean except `TestEvalTerminatingSeedsComplete/tail-recursion-bounded`, which trips its 2s wall-clock deadline under whole-package race parallelism on a loaded host. Verified pre-existing: it fails identically with these changes stashed, and passes when run alone. Throughput flake, not a regression.