### PR TITLE
Stop Package.Get writing FunNames on the read path (#397)

### DIFF
--- a/lisp/package.go
+++ b/lisp/package.go
@@ -30,12 +30,22 @@ func (r *PackageRegistry) DefinePackage(name string) *Package {
 // Package is a named set of bound symbols.  A package is interpreted code and
 // belongs to the LEnv that creates it.
 type Package struct {
-	Name       string
-	Doc        string
+	Name string
+	Doc  string
+	// Symbols holds the package's bindings.  Write it through Put or
+	// Update rather than assigning to the map directly: those maintain
+	// FunNames alongside it, and nothing on the read path repairs a
+	// FunNames entry that a direct assignment skipped.  A function bound
+	// by direct assignment still works; it just renders without its name
+	// in stack traces.
 	Symbols    map[string]*LVal
 	SymbolDocs map[string]string
-	FunNames   map[string]string
-	Externals  []string
+	// FunNames maps a function's FID to the name it was most recently
+	// bound under in this package.  It is populated exclusively by the
+	// write path (see put).  Reads must not write it: a *Package is
+	// routinely shared by pointer across goroutines.  See issue #397.
+	FunNames  map[string]string
+	Externals []string
 }
 
 // NewPackage initializes and returns a package with the given name.
@@ -49,17 +59,26 @@ func NewPackage(name string) *Package {
 }
 
 // Get takes an LSymbol k and returns the LVal it is bound to in pkg.
+//
+// Get is a pure read.  It used to record FunNames[fid] = k.Str on every
+// successful function lookup, so that the name the caller used won over the
+// name the binding was created with.  That made a read method write a map
+// that is shared by pointer across goroutines — embedders hand the same
+// *Package to concurrent requests — with no synchronisation.  Under -race it
+// is a data race; without -race the Go runtime kills the process outright
+// with "fatal error: concurrent map read and map write", which is a runtime
+// throw that neither recover() nor handler-bind can intercept.  See issue
+// #397.
+//
+// FunNames is maintained on the write path instead: put records the name for
+// every LFun that enters Symbols, so the map is already populated by the time
+// anything reads it.  The one behaviour that goes away is the "last lookup
+// wins" preference when a single function value is bound under several names
+// in the same package: GetFunName now reports the name most recently *bound*
+// rather than the name most recently *looked up*.  That is cosmetic — it
+// affects the function name rendered in stack traces and error messages only.
 func (pkg *Package) Get(k *LVal) *LVal {
-	v := pkg.get(k)
-	if v.Type == LFun {
-		// Set the function's name here in case the same function is defined
-		// with multiple names.  We want to try and use the name the programmer
-		// used.  The name may even come from a higher scope.
-		if fid := v.FID(); pkg.FunNames[fid] != k.Str {
-			pkg.FunNames[fid] = k.Str
-		}
-	}
-	return v
+	return pkg.get(k)
 }
 
 func (pkg *Package) get(k *LVal) *LVal {
@@ -75,14 +94,6 @@ func (pkg *Package) get(k *LVal) *LVal {
 	}
 	v, ok := pkg.Symbols[k.Str]
 	if ok {
-		if v.Type == LFun {
-			// Set the function's name here in case the same function is
-			// defined with multiple names.  We want to try and use the name
-			// the programmer used.
-			if fid := v.FID(); pkg.FunNames[fid] != k.Str {
-				pkg.FunNames[fid] = k.Str
-			}
-		}
 		return v
 	}
 	lerr := Errorf("unbound symbol: %v", k)

--- a/lisp/package_bench_test.go
+++ b/lisp/package_bench_test.go
@@ -1,0 +1,90 @@
+// Copyright © 2025 The ELPS authors
+
+package lisp
+
+import (
+	"strconv"
+	"testing"
+)
+
+// benchPackage builds a package with a realistic number of bindings, a
+// mix of functions and non-functions, plus one function value bound
+// under two names (the shape that used to make Package.Get write
+// FunNames on every other lookup — see issue #397).
+func benchPackage() (*Package, []*LVal, []*LVal) {
+	pkg := NewPackage("bench")
+	shared := FunInPackage("bench", "fid-shared", Formals(), func(env *LEnv, args *LVal) *LVal {
+		return Nil()
+	})
+	pkg.Put(Symbol("alpha"), shared)
+	pkg.Put(Symbol("beta"), shared)
+
+	funSyms := []*LVal{Symbol("alpha"), Symbol("beta")}
+	valSyms := make([]*LVal, 0, 128)
+	for i := range 128 {
+		name := "fn-" + strconv.Itoa(i)
+		pkg.Put(Symbol(name), FunInPackage("bench", "fid-"+strconv.Itoa(i), Formals(),
+			func(env *LEnv, args *LVal) *LVal { return Nil() }))
+		funSyms = append(funSyms, Symbol(name))
+
+		vname := "val-" + strconv.Itoa(i)
+		pkg.Put(Symbol(vname), Int(i))
+		valSyms = append(valSyms, Symbol(vname))
+	}
+	return pkg, funSyms, valSyms
+}
+
+// BenchmarkPackageGetFun measures the hot path: looking up a symbol
+// bound to a function.  This is the path issue #397 lived on.
+func BenchmarkPackageGetFun(b *testing.B) {
+	pkg, funSyms, _ := benchPackage()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		pkg.Get(funSyms[i%len(funSyms)])
+	}
+}
+
+// BenchmarkPackageGetFunAliased hammers only the two names bound to the
+// same function value.  Pre-fix every iteration wrote FunNames; post-fix
+// it is a pure read.
+func BenchmarkPackageGetFunAliased(b *testing.B) {
+	pkg, _, _ := benchPackage()
+	alpha, beta := Symbol("alpha"), Symbol("beta")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		if i%2 == 0 {
+			pkg.Get(alpha)
+		} else {
+			pkg.Get(beta)
+		}
+	}
+}
+
+// BenchmarkPackageGetVal is the control: looking up a non-function
+// binding never touched FunNames, so this arm should not move.
+func BenchmarkPackageGetVal(b *testing.B) {
+	pkg, _, valSyms := benchPackage()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		pkg.Get(valSyms[i%len(valSyms)])
+	}
+}
+
+// BenchmarkPackageGetFunParallel measures the concurrent case the fix
+// exists for: many goroutines reading one shared *Package.  Pre-fix this
+// benchmark is not merely slow, it is a fatal runtime error.
+func BenchmarkPackageGetFunParallel(b *testing.B) {
+	pkg, funSyms, _ := benchPackage()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			pkg.Get(funSyms[i%len(funSyms)])
+			i++
+		}
+	})
+}

--- a/lisp/package_race_test.go
+++ b/lisp/package_race_test.go
@@ -1,0 +1,229 @@
+// Copyright © 2025 The ELPS authors
+
+// Concurrent-Get regression test for issue #397.
+//
+// Pre-fix, (*Package).Get wrote pkg.FunNames on the read path: on every
+// successful lookup of an LFun it stored FunNames[fid] = k.Str, guarded
+// by nothing.  A *Package is shared by pointer across goroutines in
+// production (mcpserver's docEnv copies the shared registry's *Package
+// values into a per-request LEnv), so two concurrent symbol lookups
+// raced on that map.
+//
+// The race is not a benign one.  Under `-race` it is a data-race report;
+// *without* `-race` the Go runtime kills the process with
+//
+//	fatal error: concurrent map read and map write
+//
+// which is a runtime throw, not a panic: no recover() and no
+// handler-bind can catch it.  A single concurrent lookup takes down the
+// host process.
+//
+// TestPackageGetConcurrentReadsAreSafe reproduces the race in-process
+// (it is the arm `-race` flags).  TestPackageGetSurvivesConcurrentReads
+// re-execs it in a subprocess and asserts the process actually exits 0,
+// because the fatal error terminates the runtime outright and no
+// in-process assertion survives it.
+
+package lisp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// packageRaceSubprocessEnv gates the in-process arm so the parent test
+// can re-exec exactly that one test and observe the child's exit status.
+const packageRaceSubprocessEnv = "ELPS_TEST_PACKAGE_GET_RACE_CHILD"
+
+// newFunNameRacePackage builds a package in the shape that drives the
+// #397 write: one function value bound under two different names.  Get
+// stored "the name the programmer used", so alternating lookups of the
+// two names produced an unbounded stream of writes to FunNames rather
+// than a single settling write.  Filler bindings give the map enough
+// entries that concurrent readers land on it while a writer holds it.
+func newFunNameRacePackage() (*Package, []string) {
+	pkg := NewPackage("racetest")
+	fn := FunInPackage("racetest", "fid-shared", Formals(), func(env *LEnv, args *LVal) *LVal {
+		return Nil()
+	})
+	pkg.Put(Symbol("alpha"), fn)
+	pkg.Put(Symbol("beta"), fn)
+
+	filler := make([]string, 0, 256)
+	for i := range 256 {
+		name := "filler-" + strconv.Itoa(i)
+		other := FunInPackage("racetest", "fid-"+strconv.Itoa(i), Formals(), func(env *LEnv, args *LVal) *LVal {
+			return Nil()
+		})
+		pkg.Put(Symbol(name), other)
+		filler = append(filler, name)
+	}
+	return pkg, filler
+}
+
+// hammerPackageGet runs concurrent Get calls against a single shared
+// *Package.  Pre-fix this races (under -race) or kills the process with
+// "fatal error: concurrent map read and map write" (without -race).
+func hammerPackageGet(goroutines, iterations int) {
+	pkg, filler := newFunNameRacePackage()
+
+	// Writers alternate the two aliases of the same function value, so
+	// the pre-fix `if pkg.FunNames[fid] != k.Str` guard never settles
+	// and every iteration writes.  Readers walk the filler bindings,
+	// reading FunNames concurrently with those writes.
+	alpha := Symbol("alpha")
+	beta := Symbol("beta")
+	fillerSyms := make([]*LVal, len(filler))
+	for i, name := range filler {
+		fillerSyms[i] = Symbol(name)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := range goroutines {
+		go func(g int) {
+			defer wg.Done()
+			for i := range iterations {
+				switch g % 3 {
+				case 0:
+					pkg.Get(alpha)
+				case 1:
+					pkg.Get(beta)
+				default:
+					pkg.Get(fillerSyms[i%len(fillerSyms)])
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// TestPackageGetConcurrentReadsAreSafe is the in-process arm.  Under
+// `go test -race` it reports a data race on Package.FunNames without the
+// fix and is clean with it.  Without `-race` it is the body the
+// subprocess arm below runs, where the failure mode is a fatal runtime
+// error rather than a test failure.
+//
+// Reproduction rates measured against main (f18e118) on a 4-core amd64
+// box: this arm under -race failed 20/20 runs, and the subprocess arm
+// below failed 25/25 runs.  The counts below are sized for that.
+// Smaller ones are not a gate: at 8 goroutines x 20k iterations the
+// -race arm reproduced only 19/20, and at 8 x 200k the subprocess arm
+// reproduced only 15/20.  The subprocess arm costs ~2s when it passes.
+func TestPackageGetConcurrentReadsAreSafe(t *testing.T) {
+	if os.Getenv(packageRaceSubprocessEnv) == "" {
+		// Parent-side invocation.  The race detector needs far fewer
+		// iterations than the runtime's map guard does, and each one
+		// costs ~10x more under instrumentation.
+		hammerPackageGet(8, 100000)
+		return
+	}
+	// Subprocess arm: no race detector, so the only observer is the map
+	// implementation's own concurrent-access guard.  It fires only when
+	// a reader enters the map inside the writer's critical section, so
+	// this needs both more goroutines than GOMAXPROCS and more
+	// iterations.
+	hammerPackageGet(32, 3000000)
+}
+
+// TestPackageGetSurvivesConcurrentReads asserts the *process* survives
+// concurrent Package.Get.  A "fatal error: concurrent map read and map
+// write" is a runtime throw: it is not a panic, recover() cannot see it,
+// and no assertion inside the racing process runs afterwards.  The only
+// way to assert on it is out of process, on the child's exit status and
+// stderr.
+func TestPackageGetSurvivesConcurrentReads(t *testing.T) {
+	if os.Getenv(packageRaceSubprocessEnv) != "" {
+		t.Skip("child process arm")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+	// #nosec G204 -- exe is this test binary's own path.
+	cmd := exec.CommandContext(ctx, exe,
+		"-test.run", "^TestPackageGetConcurrentReadsAreSafe$", "-test.v")
+	cmd.Env = append(os.Environ(), packageRaceSubprocessEnv+"=1")
+	out, err := cmd.CombinedOutput()
+	text := string(out)
+	if strings.Contains(text, "concurrent map read and map write") ||
+		strings.Contains(text, "concurrent map writes") {
+		t.Fatalf("concurrent Package.Get killed the process with a fatal runtime error "+
+			"(unrecoverable: no recover() or handler-bind can catch it):\n%s", text)
+	}
+	if strings.Contains(text, "DATA RACE") {
+		t.Fatalf("concurrent Package.Get raced on shared state:\n%s", text)
+	}
+	if err != nil {
+		t.Fatalf("child process failed (%v):\n%s", err, text)
+	}
+}
+
+// TestPackageFunNamesPopulatedByWritePath pins the invariant the fix
+// relies on: every LFun that reaches Package.Symbols does so through
+// put, which records FunNames[fid].  If that ever stops holding, the
+// read path would need to compensate again and this test fails first.
+func TestPackageFunNamesPopulatedByWritePath(t *testing.T) {
+	pkg := NewPackage("writepath")
+	fn := FunInPackage("writepath", "fid-1", Formals(), func(env *LEnv, args *LVal) *LVal {
+		return Nil()
+	})
+	if lerr := pkg.Put(Symbol("f"), fn); lerr.Type == LError {
+		t.Fatalf("Put: %v", lerr)
+	}
+	if got := pkg.GetFunName("fid-1"); got != "f" {
+		t.Fatalf("GetFunName after Put = %q, want %q", got, "f")
+	}
+
+	// Update goes through the same put and must keep FunNames current.
+	fn2 := FunInPackage("writepath", "fid-2", Formals(), func(env *LEnv, args *LVal) *LVal {
+		return Nil()
+	})
+	if lerr := pkg.Update(Symbol("f"), fn2); lerr.Type == LError {
+		t.Fatalf("Update: %v", lerr)
+	}
+	if got := pkg.GetFunName("fid-2"); got != "f" {
+		t.Fatalf("GetFunName after Update = %q, want %q", got, "f")
+	}
+
+	// A Get must not be required to populate FunNames, and must not
+	// mutate it.
+	before := fmt.Sprint(pkg.FunNames)
+	for range 10 {
+		pkg.Get(Symbol("f"))
+	}
+	if after := fmt.Sprint(pkg.FunNames); after != before {
+		t.Fatalf("Package.Get mutated FunNames: before=%s after=%s", before, after)
+	}
+
+	// The same, in the aliased shape that actually drove the #397 write:
+	// one function value under two names, looked up by the name it was
+	// not most recently bound under.  On main this Get rewrote
+	// FunNames[fid] to "one" and this assertion fails; the write is the
+	// bug, so its absence is the fix.
+	alias := NewPackage("alias")
+	afn := FunInPackage("alias", "fid-a", Formals(), func(env *LEnv, args *LVal) *LVal {
+		return Nil()
+	})
+	alias.Put(Symbol("one"), afn)
+	alias.Put(Symbol("two"), afn)
+	aliasBefore := fmt.Sprint(alias.FunNames)
+	alias.Get(Symbol("one"))
+	if got := fmt.Sprint(alias.FunNames); got != aliasBefore {
+		t.Fatalf("Package.Get wrote FunNames on the read path: before=%s after=%s",
+			aliasBefore, got)
+	}
+	if got := alias.GetFunName("fid-a"); got != "two" {
+		t.Fatalf("GetFunName = %q, want %q (the most recently bound name, "+
+			"not the most recently looked-up one)", got, "two")
+	}
+}


### PR DESCRIPTION
Fixes #397.

**Stacked on #406** (`claude/fix-396-expander-alias`). Review only the top commit; the base PR is separate. Files are disjoint from the base — this touches `lisp/package.go` only.

## The bug

`Package.Get` recorded `FunNames[fid] = k.Str` on every successful function lookup, so the name the caller *used* won over the name the binding was *created* with. That made a read method write a map that is shared by pointer across goroutines — `mcpserver/service.go:1749-1755` injects shared `*Package` pointers into per-request envs, and `libhelp` calls `pkg.Get` on them from concurrent document requests.

Without `-race` this is not a race report, it is **`fatal error: concurrent map read and map write`** — a runtime throw that neither `recover()` nor `handler-bind` can intercept. Concurrent MCP doc requests kill the server outright.

It was doing the write *twice*, incidentally: once in `Get` and once in the `get` helper `Get` wraps.

## The fix — a deletion, and no lock

Both writes are removed; `Get` is now a one-line delegation to `get`. `FunNames` is maintained solely by `put`, which **already** recorded it at `package.go:156`. No new code, no lock on any path.

Verified `put` genuinely covers everything rather than assuming it: `lisp/package.go:158` is the only production write to `Package.Symbols` in the tree (the `analysis/scope.go` matches are an unrelated `Symbols` type). Also checked empirically with an instrumented `Get` that counted would-be writes, classified as `ABSENT` (write path missed it) vs `ALIAS` (name churn), run across the whole repo suite: **zero hits**, with a positive control confirming the counter fires for both classes. `Get` was not compensating for anything.

## A mutex was built and measured, then rejected

Two reasons, in order of importance:

1. **It does not close the hole.** `FunNames` is an exported field, read directly at `lisp/env.go:500` and reachable by any embedder. A private mutex covers neither.
2. **It costs real time.** Interleaved arms, n=12, benchstat:

```
                       │  base (main) │              fix               │             mutex              │
                       │    sec/op    │   sec/op     vs base           │   sec/op     vs base           │
PackageGetFun-4          78.44n ± 5%    29.14n ± 5%  -62.84% (p=0.000)   91.75n ± 4%  +16.98% (p=0.002)
PackageGetFunAliased-4   74.56n ± 3%    16.85n ± 9%  -77.41% (p=0.000)  119.30n ± 4%  +59.99% (p=0.000)
PackageGetVal-4          31.70n ± 4%    28.33n ± 3%  -10.65% (p=0.000)   31.10n ± 4%       ~ (p=0.266)
geomean                  57.02n         24.05n       -57.83%             69.82n       +22.45%

PackageGetFunParallel-4    fix 15.88n ± 29%  vs  mutex 121.20n ± 5%  +662.98% (p=0.000 n=12)
```

`B/op` and `allocs/op` are 0 in every arm. The parallel arm has no base column because pre-fix it is a fatal error, not a slow benchmark.

**Read the win honestly:** the serial −57.8% geomean is real but *not user-visible* — end-to-end interpreter benchmarks (`EnvGet`, `EnvFunCallBuiltin/Recursion/Pos`, n=10 interleaved) show no significant change in any arm (all p>0.10); the micro win is diluted by the rest of the evaluator. The concurrency win is the point.

## Red-then-green

| Test | Mode | Failure on main | Rate |
|---|---|---|---|
| `TestPackageGetConcurrentReadsAreSafe` | `-race` | race report, `mapaccess1_faststr` @ `package.go:82` vs `mapassign_faststr` @ `:83` | 20/20 |
| `TestPackageGetSurvivesConcurrentReads` | no `-race` | `fatal error: concurrent map read and map write`, process killed | 25/25 |
| `TestPackageFunNamesPopulatedByWritePath` | either | wrong value — `Get` rewrote `FunNames[fid-a]` from `two` to `one` | deterministic |

Independently re-run against `main` at `f18e118` before stacking; the race reproduces at exactly those two lines.

Iteration counts are baked into the tests (`8×100k` under `-race`, `32×3M` in the subprocess arm) and were tuned deliberately — at `8×20k` the `-race` arm was only 19/20 and at `8×200k` the subprocess arm only 15/20, which is not a gate. Green cost ~2s. The fatal-error arm asserts **out of process** via a re-exec of the test binary, because a runtime throw is not a panic and no in-process assertion survives it.

## Behaviour changes — two, both cosmetic, both documented

1. Where one function value is bound under several names in a package, `GetFunName` now reports the name most recently **bound** rather than most recently **looked up**. Affects the name rendered in stack traces and error messages only. Zero occurrences across the repo suite.
2. An embedder assigning `pkg.Symbols[name] = fn` directly, bypassing `Put`, no longer gets a lazily-repaired `FunNames` entry on first lookup — that function renders without its name. The `Symbols` and `FunNames` field docs now state the invariant rather than the code accommodating the bypass.

## Same-pattern audit

Every exported reader on `Package` / `PackageRegistry` / `LEnv` was checked for receiver-rooted writes. `Package.Get` was the only exported reader on `Package` that wrote shared state. `LEnv.Get` does the same "name the programmer used" preference correctly, via `FunRef`, which **copies** the `LVal` — that is the model this fix follows.

One thing found and deliberately **not** fixed here: `PackageRegistry.DefinePackage` writes `r.Packages` unsynchronised. It is not on a concurrent path in this scenario — mcpserver's per-request env has its own registry map, and only the `*Package` values are shared — so `(defpackage …)` at request time writes the per-request map. It is a load-time API and fixing it is not #397.

## Gates

`go build`, `go vet`, `go test ./...`, `go test -race ./...`, `golangci-lint run ./...` (0 issues), `gofmt -l` (clean), `confidentiality-guard.sh`, `ci-gates-test.sh` (127 passed / 0 failed), `fuzz-budget-check.sh` (fits, 10 min headroom). Full suite re-run by me after the rebase onto the base branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_