### PR TITLE
libjson: add :exact-integers so JSON integers above 2^53 survive a load (#350)

### DIFF
--- a/lisp/lisplib/libjson/encode.go
+++ b/lisp/lisplib/libjson/encode.go
@@ -310,17 +310,30 @@ func (enc *encoder) encodeFloat(x float64) error {
 }
 
 // scratchFloat encodes x to enc.scratch and returns a slice of that array.
-//
-// NOTE:  scratchFloat is adapted from floatEncoder.encode in encoding/json,
-// simplified to only work with native float64 values.
-// https://cs.opensource.google/go/go/+/refs/tags/go1.16.4:src/encoding/json/encode.go;l=575
 func (enc *encoder) scratchFloat(x float64) []byte {
+	return appendJSONFloat(enc.scratch[:0], x)
+}
+
+// appendJSONFloat appends the canonical JSON text of x to b.
+//
+// "Canonical" is meant literally and is depended upon outside the encoder:
+// this is the ONLY rendering of a float this package ever emits, so the decode
+// side can ask whether a number literal it is looking at is already the
+// canonical text of the float it parses to.  That question is what separates a
+// document elps can read back unchanged from one it can only round -- see
+// loadNumber in json.go.  Any caller that formatted floats separately would
+// let the two sides drift, and the drift would show up as this package
+// refusing to load its own output.
+//
+// NOTE:  adapted from floatEncoder.encode in encoding/json, simplified to only
+// work with native float64 values.
+// https://cs.opensource.google/go/go/+/refs/tags/go1.16.4:src/encoding/json/encode.go;l=575
+func appendJSONFloat(b []byte, x float64) []byte {
 	// Convert as if by ES6 number to string conversion.
 	// This matches most other JSON generators.
 	// See golang.org/issue/6384 and golang.org/issue/14135.
 	// Like fmt %g, but the exponent cutoffs are different
 	// and exponents themselves are not padded to two digits.
-	b := enc.scratch[:0]
 	abs := math.Abs(x)
 	fmt := byte('f')
 	// NOTE:   Because ELPS only natively supports float64 values the exponent
@@ -328,13 +341,14 @@ func (enc *encoder) scratchFloat(x float64) []byte {
 	if abs != 0 && (abs < 1e-6 || abs >= 1e21) {
 		fmt = 'e'
 	}
+	n := len(b)
 	b = strconv.AppendFloat(b, x, fmt, -1, 64)
 	if fmt == 'e' {
 		// clean up e-09 to e-9
-		n := len(b)
-		if n >= 4 && b[n-4] == 'e' && b[n-3] == '-' && b[n-2] == '0' {
-			b[n-2] = b[n-1]
-			b = b[:n-1]
+		m := len(b)
+		if m-n >= 4 && b[m-4] == 'e' && b[m-3] == '-' && b[m-2] == '0' {
+			b[m-2] = b[m-1]
+			b = b[:m-1]
 		}
 	}
 	return b

--- a/lisp/lisplib/libjson/fuzz_test.go
+++ b/lisp/lisplib/libjson/fuzz_test.go
@@ -31,13 +31,17 @@ import (
 //     against the first, which is the strongest form that is actually
 //     guaranteed -- see the note on integers below.
 //
-// NOT asserted: that Load(b) preserves the numeric text of b.  encoding/json
-// decodes every JSON number into a float64 here, so integers beyond 2^53 are
-// rounded on the way in.  That is a known, deliberately out-of-scope defect;
-// asserting text preservation would turn it into permanent fuzz noise.
-// Comparing decode-of-re-encode against the FIRST decode sidesteps it: the
-// rounding has already happened before the comparison starts, and float64 ->
-// shortest-repr -> float64 is exact.
+// NOT asserted HERE: that Load(b) preserves the numeric text of b.  In the two
+// modes this target covers, encoding/json decodes every JSON number into a
+// float64, so integers beyond 2^53 are rounded on the way in (issue #350).
+// This target measures the DEFAULT, which still rounds on purpose, so
+// asserting text preservation would be permanent noise.  Comparing
+// decode-of-re-encode against the FIRST decode sidesteps it: the rounding has
+// already happened before the comparison starts, and float64 -> shortest-repr
+// -> float64 is exact.
+//
+// FuzzLoadExactIntegers, below, covers the mode where text preservation IS the
+// contract and asserts it directly.
 
 func stringNumberModes() []bool { return []bool{false, true} }
 
@@ -222,4 +226,166 @@ func newJSONEnv(tb testing.TB) *lisp.LEnv {
 		tb.Fatalf("in-package: %v", rc)
 	}
 	return env
+}
+
+// FuzzLoadExactIntegers covers the :exact-integers decode path (issue #350),
+// which FuzzLoadJSON does not reach: that target measures the default, where
+// every number is a float64 and the >2^53 rounding is deliberate.
+//
+// This one is where text preservation IS the contract, so it is asserted
+// directly rather than sidestepped.
+//
+// INVARIANTS
+//
+//  1. Load never panics and never returns nil, exactly as in the default mode.
+//
+//  2. A document that is a bare integer literal either round-trips
+//     BYTE-IDENTICALLY or fails loudly. There is no third outcome, and a
+//     silently rounded value is precisely the outcome the option exists to
+//     remove. This is the assertion with teeth.
+//
+//  3. Dump/Load agree: whatever the option decodes, Dump must encode and the
+//     option must read that back, and the value must then be STABLE under
+//     further round trips -- the read-modify-write shape every consumer of
+//     this package has. Emitting bytes the package's own decoder rejects is
+//     the strongest form of encoder bug there is, and the option can commit
+//     it in a way the default cannot, because the option is allowed to refuse
+//     a number.
+//
+//     Stability is asserted from the SECOND decode, exactly as FuzzLoadJSON
+//     and FuzzDumpJSON do, and for a reason specific to this mode: the rule
+//     for what is an integer is SYNTACTIC, and Dump normalises a float's text.
+//     "100e7" decodes to the float 1e9, which Dump writes as "1000000000",
+//     which IS an integer literal and so decodes to an int the second time.
+//     The value is right at every step and stable from the second decode on;
+//     it is the document that changed, not the rule. LoadOpts.ExactIntegers
+//     documents this.
+//
+//  4. The opt-in never ACCEPTS a document the default rejects. A node that has
+//     turned the option on and a node that has not must not disagree about
+//     whether replicated state is well formed; disagreeing about the VALUE of
+//     a large integer is the known, documented cost of the option, but
+//     disagreeing about validity would be a new defect introduced by the fix.
+//     The converse is allowed and expected: an integer too large for a lisp
+//     int is an error under the option and a rounded float without it.
+func FuzzLoadExactIntegers(f *testing.F) {
+	seeds := []string{
+		"", " ", "null", "true", "false",
+		"0", "-0", "1", "-1", "1.5", "1e2", "1E2", "1.0", "1e400", "-1e400", "1e-400",
+		"9007199254740991", // 2^53-1: exact as a float too
+		"9007199254740992", // 2^53
+		"9007199254740993", // 2^53+1: the value in the issue
+		"-9007199254740993",
+		"9223372036854775807",  // int64 max
+		"-9223372036854775808", // int64 min
+		"9223372036854775808",  // int64 max + 1: must be an error, not a float
+		"-9223372036854775809",
+		"12345678901234567890123456789",
+		"00", "01", "-", "+1", "1.", ".1", "1e", "1e+", "0e0",
+		`""`, `"9007199254740993"`, `"😀"`,
+		"[]", "{}", "[1,2,3]", `{"a":1}`,
+		`{"id":9007199254740993}`,
+		`[9007199254740993,9223372036854775807,-9223372036854775808]`,
+		`{"a":{"b":[{"c":9223372036854775808}]}}`,
+		"[1,2", `{"a":`, "1 2", "nulll", "\xff", "\x00",
+		strings.Repeat("[", 200) + strings.Repeat("]", 200),
+		strings.Repeat("9", 400),
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		opts := libjson.LoadOpts{ExactIntegers: true}
+		v := libjson.LoadWith(data, opts)
+		if v == nil {
+			t.Fatal("LoadWith returned a nil LVal")
+		}
+		_ = v.String()
+
+		def := libjson.Load(data, false)
+		if def == nil {
+			t.Fatal("Load returned a nil LVal")
+		}
+
+		if v.Type == lisp.LError {
+			// Invariant 2, the loud half: a bare integer literal that does not
+			// round-trip must have failed, and it did.
+			return
+		}
+
+		// Invariant 4.
+		if def.Type == lisp.LError {
+			t.Fatalf("the option ACCEPTED a document the default rejects: %s\n--- default ---\n%s\n--- input ---\n%q",
+				v, def, data)
+		}
+
+		enc, err := libjson.Dump(v, false)
+		if err != nil {
+			t.Fatalf("Dump rejected a value LoadWith produced: %v\n--- value ---\n%s", err, v)
+		}
+
+		// Invariant 2, the exact half.
+		//
+		// The assertion is on the BYTES, not on the type. An integer that fits
+		// a lisp int becomes one; an integer too large for a lisp int is
+		// accepted as a float only when the literal is already that float's
+		// canonical text, which by construction re-encodes to the same bytes.
+		// Both outcomes preserve the document exactly, which is the contract.
+		// Anything that would not have been reached the third branch above and
+		// returned an error.
+		if lit, ok := bareJSONInteger(data); ok && string(enc) != lit {
+			t.Fatalf("integer literal did not round-trip byte-identically\n--- in  ---\n%s\n--- out ---\n%s\n--- decoded as ---\n%s (%s)",
+				lit, enc, lisp.GetType(v).Str, v)
+		}
+
+		// Invariant 3.
+		back := libjson.LoadWith(enc, opts)
+		if back == nil || back.Type == lisp.LError {
+			t.Fatalf("LoadWith rejected Dump's output: %v\n--- re-encoded ---\n%s", back, enc)
+		}
+		reenc, err := libjson.Dump(back, false)
+		if err != nil {
+			t.Fatalf("Dump rejected the value its own output decoded to: %v\n--- re-encoded ---\n%s", err, enc)
+		}
+		again := libjson.LoadWith(reenc, opts)
+		if again == nil || again.Type == lisp.LError {
+			t.Fatalf("LoadWith rejected the re-encoded output: %v\n--- re-re-encoded ---\n%s", again, reenc)
+		}
+		if got, want := again.String(), back.String(); got != want {
+			t.Fatalf("the value drifted across a second round trip\n--- first decode ---\n%s\n--- second decode ---\n%s\n--- encoded ---\n%s\n--- re-encoded ---\n%s",
+				want, got, enc, reenc)
+		}
+		enc2, err := libjson.Dump(v, false)
+		if err != nil {
+			t.Fatalf("second Dump of the same value failed: %v", err)
+		}
+		if !bytes.Equal(enc, enc2) {
+			t.Fatalf("Dump is not deterministic\n--- run 1 ---\n%s\n--- run 2 ---\n%s", enc, enc2)
+		}
+	})
+}
+
+// bareJSONInteger reports whether data is a whole JSON document consisting of
+// nothing but an integer literal, and returns that literal. It is deliberately
+// stricter than the JSON grammar -- it rejects anything it is not certain
+// about -- because it gates an assertion, and a false positive there is a
+// spurious failure rather than a finding.
+func bareJSONInteger(data []byte) (string, bool) {
+	s := strings.TrimSpace(string(data))
+	if s == "" || s == "-" || s == "-0" {
+		return "", false
+	}
+	digits := s
+	if digits[0] == '-' {
+		digits = digits[1:]
+	}
+	if digits == "" || (len(digits) > 1 && digits[0] == '0') {
+		return "", false // JSON forbids leading zeros
+	}
+	for i := range len(digits) {
+		if digits[i] < '0' || digits[i] > '9' {
+			return "", false
+		}
+	}
+	return s, true
 }

--- a/lisp/lisplib/libjson/json.go
+++ b/lisp/lisplib/libjson/json.go
@@ -61,34 +61,50 @@ func Builtins(s *Serializer) []*libutil.Builtin {
 			(json.RawMessage) suitable for embedding in Go structures.
 			The :string-numbers keyword controls whether numbers are
 			serialized as JSON strings (default: serializer setting).`),
-		libutil.FunctionDoc("load-message", lisp.Formals("json-message", lisp.KeyArgSymbol, "string-numbers"), s.LoadMessageBuiltin,
+		libutil.FunctionDoc("load-message", lisp.Formals("json-message", lisp.KeyArgSymbol, "string-numbers", "exact-integers"), s.LoadMessageBuiltin,
 			`Parses a native JSON message object (json.RawMessage) into
 			ELPS values. The :string-numbers keyword controls whether
 			JSON numbers are returned as strings (default: serializer
-			setting).`),
+			setting). The :exact-integers keyword controls whether JSON
+			integer literals are returned as ints rather than floats
+			(default: serializer setting).`),
 		libutil.FunctionDoc("dump-bytes", lisp.Formals("object", lisp.KeyArgSymbol, "string-numbers"), s.DumpBytesBuiltin,
 			`Serializes an ELPS value to JSON and returns the result as
 			bytes. Sorted-maps become JSON objects, arrays become JSON
 			arrays, strings/ints/floats map naturally. The :string-numbers
 			keyword controls whether numbers are serialized as strings.`),
-		libutil.FunctionDoc("load-bytes", lisp.Formals("json-bytes", lisp.KeyArgSymbol, "string-numbers"), s.LoadBytesBuiltin,
+		libutil.FunctionDoc("load-bytes", lisp.Formals("json-bytes", lisp.KeyArgSymbol, "string-numbers", "exact-integers"), s.LoadBytesBuiltin,
 			`Parses a JSON bytes value into ELPS values. JSON objects become
 			sorted-maps, arrays become ELPS arrays, strings/numbers map
 			naturally. The :string-numbers keyword controls whether JSON
-			numbers are returned as strings.`),
+			numbers are returned as strings. The :exact-integers keyword
+			controls whether JSON integer literals are returned as ints
+			rather than floats.`),
 		libutil.FunctionDoc("dump-string", lisp.Formals("object", lisp.KeyArgSymbol, "string-numbers"), s.DumpStringBuiltin,
 			`Serializes an ELPS value to a JSON string. Like dump-bytes
 			but returns a string instead of bytes. The :string-numbers
 			keyword controls whether numbers are serialized as strings.`),
-		libutil.FunctionDoc("load-string", lisp.Formals("json-string", lisp.KeyArgSymbol, "string-numbers"), s.LoadStringBuiltin,
+		libutil.FunctionDoc("load-string", lisp.Formals("json-string", lisp.KeyArgSymbol, "string-numbers", "exact-integers"), s.LoadStringBuiltin,
 			`Parses a JSON string into ELPS values. Like load-bytes but
 			accepts a string argument. The :string-numbers keyword controls
-			whether JSON numbers are returned as strings.`),
+			whether JSON numbers are returned as strings. The
+			:exact-integers keyword controls whether JSON integer literals
+			are returned as ints rather than floats.`),
 		libutil.FunctionDoc("use-string-numbers", lisp.Formals("bool"), s.UseStringNumbersBuiltin,
 			`Sets the default string-numbers mode for the JSON serializer.
 			When true, numbers are serialized as JSON strings and JSON
 			numbers are parsed as strings. Affects all dump/load functions
 			that don't explicitly pass :string-numbers. Returns nil.`),
+		libutil.FunctionDoc("use-exact-integers", lisp.Formals("bool"), s.UseExactIntegersBuiltin,
+			`Sets the default exact-integers mode for the JSON serializer.
+			When true, a JSON number written as an integer is parsed as an
+			int holding its exact value instead of a float, and an integer
+			too large for an int raises json:integer-range-error instead of
+			silently rounding. Numbers written with a fraction or an
+			exponent are unaffected. When false (the default) every JSON
+			number is parsed as a float, so integers above 2^53 are rounded
+			without warning. Affects all load functions that don't
+			explicitly pass :exact-integers. Returns nil.`),
 	}
 }
 
@@ -102,12 +118,64 @@ func Load(b []byte, stringNums bool) *lisp.LVal {
 	return DefaultSerializer().Load(b, stringNums)
 }
 
+// LoadWith parses b as JSON under opts and returns an equivalent LVal.
+func LoadWith(b []byte, opts LoadOpts) *lisp.LVal {
+	return DefaultSerializer().LoadWith(b, opts)
+}
+
+// LoadOpts controls how a JSON document is decoded into lisp values.
+//
+// The zero value reproduces Load(b, false) exactly -- the behaviour every
+// caller of this package has had since 2018.  Every field is an opt-in.
+type LoadOpts struct {
+	// MaxAlloc bounds the number of elements in any single array or object in
+	// the document.  Zero means unbounded.
+	MaxAlloc int
+
+	// StringNumbers decodes every JSON number as a lisp string holding the
+	// number's literal text.  It takes precedence over ExactIntegers: a
+	// caller that sets both gets strings, exactly as it does today.
+	StringNumbers bool
+
+	// ExactIntegers decodes a JSON integer literal as a lisp int rather than
+	// a lisp float.
+	//
+	// encoding/json decodes every JSON number into a float64, and a float64
+	// carries 53 bits of integer precision.  So with ExactIntegers false --
+	// the default, and the only behaviour that existed before this option --
+	// an integer larger than 2^53 is rounded to the nearest float64 on the
+	// way in, and NOTHING reports it: the rounded value still compares = to
+	// the integer it was meant to be, so a program can read a corrupted
+	// identifier, check it against the value it expected, match, and carry
+	// on.  That is issue #350.
+	//
+	// With ExactIntegers true a JSON number whose literal text is written as
+	// an integer -- no '.', no exponent -- decodes to a lisp int holding its
+	// exact value, and one that does not fit in a lisp int is an ERROR
+	// (condition json:integer-range-error) rather than a rounded float.
+	// Numbers written with a fraction or an exponent are untouched and still
+	// decode as floats.
+	//
+	// The rule is SYNTACTIC on purpose.  "1e2" denotes an integer but is not
+	// written as one, and it keeps decoding to a float; so does "-0", which
+	// parses to the integer 0 and would therefore re-encode as "0" rather
+	// than the "-0" it produces today.  A rule that depends only on the bytes
+	// of the document, and never on the value they denote, is reproducible on
+	// every node that reads the same bytes -- which is the property that
+	// matters where this package decodes replicated state.
+	ExactIntegers bool
+}
+
 // Serializer defines JSON serialization rules for lisp values.
 type Serializer struct {
 	True             *lisp.LVal
 	False            *lisp.LVal
 	Null             *lisp.LVal
 	UseStringNumbers bool
+	// UseExactIntegers is the default for LoadOpts.ExactIntegers used by the
+	// package builtins when the caller passes no :exact-integers keyword.  It
+	// does NOT affect Load or LoadMax, which take their options as arguments.
+	UseExactIntegers bool
 }
 
 // Load parses b and returns an LVal representing its structure.
@@ -118,18 +186,34 @@ func (s *Serializer) Load(b []byte, stringNums bool) *lisp.LVal {
 // LoadMax is like Load but enforces a maximum allocation size for arrays
 // and maps parsed from JSON.  When maxAlloc is 0, no limit is enforced.
 func (s *Serializer) LoadMax(b []byte, stringNums bool, maxAlloc int) *lisp.LVal {
+	return s.LoadWith(b, LoadOpts{StringNumbers: stringNums, MaxAlloc: maxAlloc})
+}
+
+// LoadWith parses b under opts and returns an LVal representing its structure.
+func (s *Serializer) LoadWith(b []byte, opts LoadOpts) *lisp.LVal {
 	var x interface{}
-	err := s.jsonDecode(b, &x, stringNums)
+	err := s.jsonDecodeOpts(b, &x, opts)
 	if err != nil {
 		var syntaxErr *json.SyntaxError
-		if errors.As(err, &syntaxErr) {
+		var exactErr syntaxError
+		if errors.As(err, &syntaxErr) || errors.As(err, &exactErr) {
 			lerr := lisp.Error(err)
 			lerr.Str = "json:syntax-error"
 			return lerr
 		}
 		return lisp.Error(err)
 	}
-	return s.loadInterfaceMax(x, maxAlloc)
+	return s.loadInterfaceOpts(x, opts)
+}
+
+func (s *Serializer) jsonDecodeOpts(b []byte, dst interface{}, opts LoadOpts) error {
+	if opts.StringNumbers {
+		return s.jsonDecode(b, dst, true)
+	}
+	if !opts.ExactIntegers {
+		return s.jsonDecode(b, dst, false)
+	}
+	return decodeExactNumbers(b, dst)
 }
 
 func (s *Serializer) jsonDecode(b []byte, dst interface{}, stringNums bool) error {
@@ -146,6 +230,107 @@ func (s *Serializer) jsonDecode(b []byte, dst interface{}, stringNums bool) erro
 	return err
 }
 
+// syntaxError is a malformed-document error raised by the exact-integer decode
+// path.
+//
+// json.Unmarshal reports an empty document and trailing content after a
+// complete value as *json.SyntaxError, which LoadWith turns into the catchable
+// json:syntax-error condition.  json.Decoder -- which the exact-integer path
+// must use, because UseNumber only exists on a decoder -- reports the same two
+// documents as io.EOF and as the failing Unmarshaler's own error, neither of
+// which is a *json.SyntaxError.  Without this type an adopter's
+// (handler-bind ([json:syntax-error ...])) would quietly stop catching
+// malformed input the moment they turned the option on, which is precisely the
+// class of silent change this option exists to remove.
+type syntaxError string
+
+func (e syntaxError) Error() string { return string(e) }
+
+// decodeExactNumbers decodes b with numbers left as their literal text, so
+// loadNumber can decide per value whether it is an integer or a float.
+func decodeExactNumbers(b []byte, dst interface{}) error {
+	d := json.NewDecoder(bytes.NewReader(b))
+	d.UseNumber()
+	if err := d.Decode(dst); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return syntaxError("unexpected end of JSON input")
+		}
+		return err
+	}
+	rest := failUnmarshal()
+	if err := d.Decode(&rest); !errors.Is(err, io.EOF) {
+		return syntaxError("invalid character after top-level value")
+	}
+	return nil
+}
+
+// loadNumber converts the literal text of a JSON number to a lisp value under
+// LoadOpts.ExactIntegers.  The decoder has already validated text against the
+// JSON number grammar, so the only thing that can go wrong here is range.
+func loadNumber(text string) *lisp.LVal {
+	if !isJSONInteger(text) {
+		return loadFloat(text)
+	}
+	// IntSize, not 64: lisp.Int takes a Go int, and on a 32-bit build a silent
+	// truncation to int32 would be the same defect in a smaller register.
+	// Parsing at the width of the destination makes the overflow a range error
+	// instead.
+	n, err := strconv.ParseInt(text, 10, strconv.IntSize)
+	if err == nil {
+		return lisp.Int(int(n))
+	}
+	// The integer is too large for a lisp int, so the only thing left is a
+	// float -- and taking one silently is the defect this option exists to
+	// remove.  It is taken in exactly one case: when text is ALREADY the
+	// canonical rendering of the float it parses to, so the float loses
+	// nothing the document was carrying.
+	//
+	// That case is not hypothetical, and refusing it outright is not an
+	// option.  This package renders every float above 2^63 and below 1e21 as
+	// plain digits, so a phylum holding an ordinary float of 1e19 would dump
+	// its state and then be unable to load it back -- a value that cannot read
+	// its own serialisation, which is worse than the rounding.  Anchoring the
+	// test on appendJSONFloat, the one function that renders a float here,
+	// makes "anything Dump can emit, Load can read" true by construction.
+	//
+	// Everything else -- 9223372036854775808, or a thirty-digit id -- is a
+	// document that says something elps cannot hold, and it fails loudly.
+	f, ferr := strconv.ParseFloat(text, 64)
+	if ferr == nil && string(appendJSONFloat(nil, f)) == text {
+		return lisp.Float(f)
+	}
+	lerr := lisp.Errorf("json integer does not fit in a lisp int: %s", text)
+	lerr.Str = "json:integer-range-error"
+	return lerr
+}
+
+func loadFloat(text string) *lisp.LVal {
+	f, err := strconv.ParseFloat(text, 64)
+	if err != nil {
+		// Matches the message encoding/json produces for the same document on
+		// the default path, so turning the option on does not change what a
+		// caller reading the error text sees.
+		return lisp.Errorf("json: cannot unmarshal number %s into Go value of type float64", text)
+	}
+	return lisp.Float(f)
+}
+
+// isJSONInteger reports whether text -- already validated by the decoder as a
+// JSON number -- is WRITTEN as an integer.  See LoadOpts.ExactIntegers for why
+// the test is on the text rather than on the value, and why "-0" is excluded.
+func isJSONInteger(text string) bool {
+	if text == "-0" {
+		return false
+	}
+	for i := range len(text) {
+		switch text[i] {
+		case '.', 'e', 'E':
+			return false
+		}
+	}
+	return true
+}
+
 var errUnexpectedJSON = errors.New("unexpected json in stream")
 
 type unmarshalFailer struct{}
@@ -158,7 +343,8 @@ func (*unmarshalFailer) UnmarshalJSON([]byte) error {
 	return errUnexpectedJSON
 }
 
-func (s *Serializer) loadInterfaceMax(x interface{}, maxAlloc int) *lisp.LVal {
+func (s *Serializer) loadInterfaceOpts(x interface{}, opts LoadOpts) *lisp.LVal {
+	maxAlloc := opts.MaxAlloc
 	// NOTE:  The order of types in this switch is deliberate to try and
 	// minimize the number of skipped branches.
 	switch x := x.(type) {
@@ -170,7 +356,7 @@ func (s *Serializer) loadInterfaceMax(x interface{}, maxAlloc int) *lisp.LVal {
 		}
 		m := SortedMap(x)
 		for k, v := range m {
-			lval := s.loadInterfaceMax(v, maxAlloc)
+			lval := s.loadInterfaceOpts(v, opts)
 			if lval.Type == lisp.LError {
 				return lval
 			}
@@ -183,7 +369,7 @@ func (s *Serializer) loadInterfaceMax(x interface{}, maxAlloc int) *lisp.LVal {
 		}
 		cells := make([]*lisp.LVal, len(x))
 		for i := range x {
-			cells[i] = s.loadInterfaceMax(x[i], maxAlloc)
+			cells[i] = s.loadInterfaceOpts(x[i], opts)
 			if cells[i].Type == lisp.LError {
 				return cells[i]
 			}
@@ -194,8 +380,13 @@ func (s *Serializer) loadInterfaceMax(x interface{}, maxAlloc int) *lisp.LVal {
 	case float64:
 		return lisp.Float(x)
 	case json.Number:
-		// This can only show up if stringNums was true.
-		return lisp.String(string(x))
+		// Only reachable when the decoder was put in UseNumber mode, which
+		// happens for exactly two options.  StringNumbers wins, so a caller
+		// that set both sees what it has always seen.
+		if opts.StringNumbers {
+			return lisp.String(string(x))
+		}
+		return loadNumber(string(x))
 	case nil:
 		return lisp.Nil()
 	default:
@@ -219,6 +410,33 @@ func (s *Serializer) UseStringNumbersBuiltin(env *lisp.LEnv, args *lisp.LVal) *l
 
 func (s *Serializer) useStringNumbers(_ *lisp.LEnv) *lisp.LVal {
 	return lisp.Bool(s.UseStringNumbers)
+}
+
+func (s *Serializer) UseExactIntegersBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+	confirm := args.ReqArg(env, 0)
+	if confirm.Type == lisp.LError {
+		return confirm
+	}
+	s.UseExactIntegers = lisp.True(confirm)
+	return lisp.Nil()
+}
+
+// loadOpts resolves the load options for one builtin call.  An unsupplied
+// keyword (nil) falls back to the serializer default, which is what
+// :string-numbers has always done.
+func (s *Serializer) loadOpts(env *lisp.LEnv, stringNums, exactInts *lisp.LVal) LoadOpts {
+	opts := LoadOpts{
+		MaxAlloc:      env.Runtime.MaxAllocBytes(),
+		StringNumbers: s.UseStringNumbers,
+		ExactIntegers: s.UseExactIntegers,
+	}
+	if !stringNums.IsNil() {
+		opts.StringNumbers = lisp.True(stringNums)
+	}
+	if !exactInts.IsNil() {
+		opts.ExactIntegers = lisp.True(exactInts)
+	}
+	return opts
 }
 
 // Dump serializes v as JSON and returns any error.
@@ -275,7 +493,7 @@ func (s *Serializer) DumpBytesBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVa
 }
 
 func (s *Serializer) LoadMessageBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
-	lmsg, stringNums := args.ReqArg(env, 0), args.KeyArg(1)
+	lmsg, stringNums, exactInts := args.ReqArg(env, 0), args.KeyArg(1), args.KeyArg(2)
 	if lmsg.Type == lisp.LError {
 		return lmsg
 	}
@@ -286,24 +504,18 @@ func (s *Serializer) LoadMessageBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.L
 	if !ok {
 		return env.Errorf("argument is not a raw json-message: %v", msg)
 	}
-	return s.LoadBytesBuiltin(env, lisp.SExpr([]*lisp.LVal{lisp.Bytes([]byte(*msg)), stringNums}))
+	return s.LoadBytesBuiltin(env, lisp.SExpr([]*lisp.LVal{lisp.Bytes([]byte(*msg)), stringNums, exactInts}))
 }
 
 func (s *Serializer) LoadBytesBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
-	js, stringNums := args.ReqArg(env, 0), args.KeyArg(1)
+	js, stringNums, exactInts := args.ReqArg(env, 0), args.KeyArg(1), args.KeyArg(2)
 	if js.Type == lisp.LError {
 		return js
 	}
 	if js.Type != lisp.LBytes {
 		return env.Errorf("argument is not bytes: %v", js.Type)
 	}
-	if stringNums.IsNil() {
-		stringNums = s.useStringNumbers(env)
-		if stringNums.Type == lisp.LError {
-			return stringNums
-		}
-	}
-	return s.attachStack(env, s.LoadMax(js.Bytes(), lisp.True(stringNums), env.Runtime.MaxAllocBytes()))
+	return s.attachStack(env, s.LoadWith(js.Bytes(), s.loadOpts(env, stringNums, exactInts)))
 }
 
 func (s *Serializer) DumpStringBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
@@ -325,20 +537,14 @@ func (s *Serializer) DumpStringBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LV
 }
 
 func (s *Serializer) LoadStringBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
-	js, stringNums := args.ReqArg(env, 0), args.KeyArg(1)
+	js, stringNums, exactInts := args.ReqArg(env, 0), args.KeyArg(1), args.KeyArg(2)
 	if js.Type == lisp.LError {
 		return js
 	}
 	if js.Type != lisp.LString {
 		return env.Errorf("argument is not a string: %v", js.Type)
 	}
-	if stringNums.IsNil() {
-		stringNums = s.useStringNumbers(env)
-		if stringNums.Type == lisp.LError {
-			return stringNums
-		}
-	}
-	return s.attachStack(env, s.LoadMax([]byte(js.Str), lisp.True(stringNums), env.Runtime.MaxAllocBytes()))
+	return s.attachStack(env, s.LoadWith([]byte(js.Str), s.loadOpts(env, stringNums, exactInts)))
 }
 
 // GoValue converts v to its natural representation in Go.  Quotes are ignored

--- a/lisp/lisplib/libjson/libjson_integer_test.lisp
+++ b/lisp/lisplib/libjson/libjson_integer_test.lisp
@@ -1,0 +1,138 @@
+; Copyright © 2026 The ELPS authors
+
+; Lisp-level tests for issue #350 -- integers above 2^53 and the
+; :exact-integers opt-in that makes them survive a load.
+;
+; Like libjson_cycle_test.lisp, this lives in its own file rather than in
+; libjson_test.lisp because BenchmarkPackage/$load parses and evaluates that
+; file on every iteration: source added to it is charged to a benchmark meant
+; to measure the loader, and the CI benchmark gate reads the jump as a
+; regression.  See TestPackageExactIntegers.
+
+(use-package 'testing)
+
+; The defect, from the phylum author's side.  Every number decodes as a float,
+; a float carries 53 bits of integer precision, and nothing anywhere says so.
+(test "default-rounds-silently"
+  ; 2^53+1 comes back as 2^53.
+  (assert-string= "float" (to-string (type (json:load-string "9007199254740993"))))
+  (assert-string= "9007199254740992"
+                  (json:dump-string (json:load-string "9007199254740993")))
+  ; int64 max comes back as something that is not even an int64.
+  (assert-string= "9223372036854776000"
+                  (json:dump-string (json:load-string "9223372036854775807")))
+  ; A value just below the boundary is unaffected.
+  (assert-string= "9007199254740991"
+                  (json:dump-string (json:load-string "9007199254740991"))))
+
+; THE HIDING MECHANISM.  This is why the defect sat open since 2018: the
+; corrupted value still compares = to the integer it was supposed to be, so a
+; phylum can read a corrupted identifier, check it against the value it
+; expected, match, and carry on.  Nothing signals.
+;
+; The assertion is deliberately written the "wrong" way round -- it asserts the
+; corruption is INVISIBLE -- because that makes it a tripwire.  If the default
+; is ever flipped, this test fails and names what changed, instead of the
+; change reaching a node quietly.
+(test "corruption-is-invisible-by-default"
+  (let ([loaded (json:load-string "9007199254740993")])
+    ; It equals the integer it was meant to be ...
+    (assert= 9007199254740993 loaded)
+    ; ... and it equals the DIFFERENT integer it was actually rounded to, so
+    ; two distinct documents are indistinguishable once loaded.
+    (assert= loaded (json:load-string "9007199254740992"))
+    ; The only thing that gives it away is its type.
+    (assert-string= "float" (to-string (type loaded)))))
+
+; The opt-in.
+(test "exact-integers-round-trip"
+  (assert-string= "int" (to-string (type (json:load-string "9007199254740993" :exact-integers true))))
+  (assert= 9007199254740993 (json:load-string "9007199254740993" :exact-integers true))
+  (assert-string= "9007199254740993"
+                  (json:dump-string (json:load-string "9007199254740993" :exact-integers true)))
+  (assert-string= "9223372036854775807"
+                  (json:dump-string (json:load-string "9223372036854775807" :exact-integers true)))
+  (assert-string= "-9223372036854775808"
+                  (json:dump-string (json:load-string "-9223372036854775808" :exact-integers true)))
+  ; Just below 2^53: an int now, and the same digits either way.
+  (assert-string= "9007199254740991"
+                  (json:dump-string (json:load-string "9007199254740991" :exact-integers true)))
+  ; Nested, which is where real documents keep their identifiers.
+  (assert-string= """{"id":9007199254740993}"""
+                  (json:dump-string
+                    (json:load-string """{"id":9007199254740993}""" :exact-integers true))))
+
+; Under the opt-in the two documents that were indistinguishable above are
+; distinguishable, which is the whole point of turning it on.
+(test "exact-integers-distinguishes"
+  (assert-not (=  (json:load-string "9007199254740993" :exact-integers true)
+                 (json:load-string "9007199254740992" :exact-integers true))))
+
+; Anything that cannot be represented fails LOUDLY rather than rounding.
+(test "exact-integers-range-error"
+  (assert-string= "caught"
+                  (handler-bind ([json:integer-range-error (lambda (_c _) "caught")])
+                    (json:load-string "9223372036854775808" :exact-integers true)))
+  (assert-string= "caught"
+                  (handler-bind ([json:integer-range-error (lambda (_c _) "caught")])
+                    (json:load-string "123456789012345678901234567890" :exact-integers true)))
+  ; ... including from inside a container.
+  (assert-string= "caught"
+                  (handler-bind ([json:integer-range-error (lambda (_c _) "caught")])
+                    (json:load-string """{"a":[9223372036854775808]}""" :exact-integers true))))
+
+; The rule is syntactic: a number written with a fraction or an exponent is
+; still a float, exactly as it is by default.
+(test "exact-integers-leaves-floats-alone"
+  (assert-string= "float" (to-string (type (json:load-string "1.5" :exact-integers true))))
+  (assert-string= "float" (to-string (type (json:load-string "1.0" :exact-integers true))))
+  (assert-string= "float" (to-string (type (json:load-string "1e2" :exact-integers true))))
+  (assert-string= "float" (to-string (type (json:load-string "-0" :exact-integers true))))
+  (assert-string= "-0" (json:dump-string (json:load-string "-0" :exact-integers true)))
+  (assert-string= "100" (json:dump-string (json:load-string "1e2" :exact-integers true))))
+
+; Malformed input stays catchable as json:syntax-error under the opt-in.  The
+; opt-in has to use a streaming decoder, which reports some malformed documents
+; differently from json.Unmarshal; an adopter's handler-bind must not quietly
+; stop firing.
+(test "exact-integers-syntax-errors-stay-catchable"
+  (assert-string= "syntax"
+                  (handler-bind ([json:syntax-error (lambda (_c _) "syntax")])
+                    (json:load-string "{false:true}" :exact-integers true)))
+  (assert-string= "syntax"
+                  (handler-bind ([json:syntax-error (lambda (_c _) "syntax")])
+                    (json:load-string "" :exact-integers true)))
+  (assert-string= "syntax"
+                  (handler-bind ([json:syntax-error (lambda (_c _) "syntax")])
+                    (json:load-string "1 2" :exact-integers true))))
+
+; :string-numbers still wins when both are set, so a caller that already uses
+; it sees no change at all.
+(test "string-numbers-takes-precedence"
+  (assert-string= "string"
+                  (to-string (type (json:load-string "9007199254740993"
+                                                     :string-numbers true
+                                                     :exact-integers true))))
+  (assert-string= "9007199254740993"
+                  (json:load-string "9007199254740993"
+                                    :string-numbers true
+                                    :exact-integers true)))
+
+; The serializer-wide default, and that an explicit keyword still overrides it.
+(test "use-exact-integers-default"
+  (assert-string= "float" (to-string (type (json:load-string "9007199254740993"))))
+  (assert-nil (json:use-exact-integers true))
+  (assert-string= "int" (to-string (type (json:load-string "9007199254740993"))))
+  (assert-string= "9007199254740993" (json:dump-string (json:load-string "9007199254740993")))
+  ; An explicit false still opts back out.
+  (assert-string= "float"
+                  (to-string (type (json:load-string "9007199254740993" :exact-integers false))))
+  (assert-nil (json:use-exact-integers false))
+  (assert-string= "float" (to-string (type (json:load-string "9007199254740993")))))
+
+; load-bytes and load-message honour the keyword too.
+(test "exact-integers-on-every-load-entry-point"
+  (assert= 9007199254740993
+           (json:load-bytes (to-bytes "9007199254740993") :exact-integers true))
+  (assert= 9007199254740993
+           (json:load-message (json:dump-message 9007199254740993) :exact-integers true)))

--- a/lisp/lisplib/libjson/libjson_test.go
+++ b/lisp/lisplib/libjson/libjson_test.go
@@ -29,6 +29,14 @@ func TestPackageCyclicValue(t *testing.T) {
 	r.RunTestFile(t, "libjson_cycle_test.lisp")
 }
 
+// TestPackageExactIntegers runs the lisp-level tests for issue #350.  Same
+// reasoning as TestPackageCyclicValue for why they get their own file.
+func TestPackageExactIntegers(t *testing.T) {
+	r := &elpstest.Runner{}
+	defer r.Close()
+	r.RunTestFile(t, "libjson_integer_test.lisp")
+}
+
 func BenchmarkPackage(b *testing.B) {
 	r := &elpstest.Runner{}
 	defer r.Close()

--- a/lisp/lisplib/libjson/load_bench_test.go
+++ b/lisp/lisplib/libjson/load_bench_test.go
@@ -1,0 +1,81 @@
+// Copyright © 2026 The ELPS authors
+
+package libjson_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libjson"
+)
+
+// The package had benchmarks for the ENCODE direction only (BenchmarkEncode,
+// BenchmarkEncode_stringNumbers). Decode had none, which is why the cost of
+// the :exact-integers option could not be stated before it was added.
+//
+// The option matters here specifically: it replaces json.Unmarshal's
+// float64 fast path with json.Decoder in UseNumber mode, which materialises
+// every number as a json.Number -- a string -- before it is parsed. That is a
+// different allocation profile on a path that decodes replicated state on
+// every read.
+//
+// The "default" arm is the one to watch across a base/PR comparison: it is the
+// path every existing caller is on, and it must not move.
+
+const benchLoadDocument = `{
+	"id": 9007199254740993,
+	"seq": 421,
+	"name": "a record with a few fields",
+	"active": true,
+	"score": 1.5,
+	"tags": ["alpha", "beta", "gamma"],
+	"counts": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+	"nested": {
+		"a": {"b": {"c": 9223372036854775807}},
+		"list": [{"x": 1, "y": 2}, {"x": 3, "y": 4}],
+		"null": null
+	}
+}`
+
+func benchLoad(b *testing.B, load func([]byte) *lisp.LVal) {
+	b.Helper()
+	doc := []byte(benchLoadDocument)
+	if v := load(doc); v.Type == lisp.LError {
+		b.Fatalf("benchmark document does not load: %s", v)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if v := load(doc); v.Type == lisp.LError {
+			b.Fatal(v)
+		}
+	}
+}
+
+func BenchmarkLoad(b *testing.B) {
+	b.Run("default", func(b *testing.B) {
+		benchLoad(b, func(doc []byte) *lisp.LVal { return libjson.Load(doc, false) })
+	})
+	b.Run("stringNumbers", func(b *testing.B) {
+		benchLoad(b, func(doc []byte) *lisp.LVal { return libjson.Load(doc, true) })
+	})
+	b.Run("exactIntegers", func(b *testing.B) {
+		benchLoad(b, func(doc []byte) *lisp.LVal {
+			return libjson.LoadWith(doc, libjson.LoadOpts{ExactIntegers: true})
+		})
+	})
+}
+
+// BenchmarkLoadIntegers isolates the number path from the container walk, so a
+// change in the cost of decoding a number is visible rather than diluted.
+func BenchmarkLoadIntegers(b *testing.B) {
+	doc := `[1,2,3,4,5,6,7,8,9,10,9007199254740993,9223372036854775807,-9223372036854775808]`
+	b.Run("default", func(b *testing.B) {
+		benchLoad(b, func(_ []byte) *lisp.LVal { return libjson.Load([]byte(doc), false) })
+	})
+	b.Run("exactIntegers", func(b *testing.B) {
+		benchLoad(b, func(_ []byte) *lisp.LVal {
+			return libjson.LoadWith([]byte(doc), libjson.LoadOpts{ExactIntegers: true})
+		})
+	})
+}

--- a/lisp/lisplib/libjson/number_test.go
+++ b/lisp/lisplib/libjson/number_test.go
@@ -1,0 +1,494 @@
+// Copyright © 2026 The ELPS authors
+
+package libjson_test
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libjson"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #350.  encoding/json decodes every JSON number into a float64, and a
+// float64 holds 53 bits of integer precision, so json:load silently rounds
+// every integer above 2^53.  These tests cover both halves of the fix:
+//
+//   - the OPT-IN half, LoadOpts.ExactIntegers, under which an integer that
+//     fits round-trips exactly and one that does not is a loud error; and
+//
+//   - the DEFAULT half, which must keep rounding exactly as it always has,
+//     because libjson decodes replicated state and two nodes on different
+//     elps versions must not disagree about what a document means.
+//
+// The default-half assertions are not decoration.  They are the thing that
+// makes the opt-in an opt-in, and a change that "fixes" them has silently
+// widened the blast radius from one call site to every phylum in the fleet.
+
+const (
+	maxExactFloat = 1 << 53 // 9007199254740992: the largest 2^k a float64 holds
+	int64Max      = math.MaxInt64
+	int64Min      = math.MinInt64
+)
+
+func exact() libjson.LoadOpts { return libjson.LoadOpts{ExactIntegers: true} }
+
+// TestLoadExactIntegers is the green half of the red-then-green for #350.
+func TestLoadExactIntegers(t *testing.T) {
+	tests := []struct {
+		json string
+		want int64
+	}{
+		{"9007199254740993", maxExactFloat + 1}, // 2^53+1, the value in the issue
+		{"9223372036854775807", int64Max},       // int64 max
+		{"-9223372036854775808", int64Min},      // int64 min
+		{"9007199254740991", maxExactFloat - 1}, // just below 2^53: must be unaffected
+		{"9007199254740992", maxExactFloat},     // 2^53 itself
+		{"-9007199254740993", -(maxExactFloat + 1)},
+		{"0", 0},
+		{"1", 1},
+		{"-1", -1},
+	}
+	for _, test := range tests {
+		t.Run(test.json, func(t *testing.T) {
+			v := libjson.LoadWith([]byte(test.json), exact())
+			require.NotEqual(t, lisp.LError, v.Type, "load failed: %s", v)
+			require.Equal(t, lisp.LInt, v.Type,
+				"loaded %s as %s, not an int", v.String(), lisp.GetType(v).Str)
+			assert.Equal(t, test.want, int64(v.Int))
+			// Rendering must show the exact digits too.  A value that is
+			// right in the machine and wrong on the screen is still wrong in
+			// a log, an error message and a hash of a formatted record.
+			assert.Equal(t, test.json, v.String())
+		})
+	}
+}
+
+// TestLoadRoundTripIntegers is the round-trip half: load, then dump, then
+// assert the bytes are the bytes we started with, across the 2^53 boundary and
+// at both int64 extremes.
+func TestLoadRoundTripIntegers(t *testing.T) {
+	var values []int64
+	for delta := int64(-4); delta <= 4; delta++ {
+		values = append(values, maxExactFloat+delta, -(maxExactFloat + delta))
+	}
+	for d := range 5 {
+		delta := int64(d)
+		values = append(values, int64Max-delta, int64Min+delta)
+	}
+	values = append(values, 0, 1, -1, 1<<31, 1<<62, -(1 << 62))
+
+	for _, n := range values {
+		text := strconv.FormatInt(n, 10)
+		t.Run(text, func(t *testing.T) {
+			v := libjson.LoadWith([]byte(text), exact())
+			require.NotEqual(t, lisp.LError, v.Type, "load failed: %s", v)
+			require.Equal(t, lisp.LInt, v.Type)
+			require.Equal(t, n, int64(v.Int))
+
+			out, err := libjson.Dump(v, false)
+			require.NoError(t, err)
+			assert.Equal(t, text, string(out), "round trip was not byte-identical")
+
+			// And again, so a document that is read, written and read once
+			// more -- every read-modify-write path there is -- is stable.
+			again := libjson.LoadWith(out, exact())
+			require.Equal(t, lisp.LInt, again.Type)
+			assert.Equal(t, n, int64(again.Int))
+		})
+	}
+}
+
+// TestLoadRoundTripNestedIntegers proves the round trip holds inside the
+// containers real documents use, not only for a bare number at top level.
+func TestLoadRoundTripNestedIntegers(t *testing.T) {
+	docs := []string{
+		`[9007199254740993,9223372036854775807,-9223372036854775808]`,
+		`{"id":9007199254740993,"n":-9007199254740993}`,
+		`{"a":{"b":[{"c":9223372036854775807}]}}`,
+		// Keys are emitted in sorted order and non-integer numbers keep
+		// decoding as floats, so this is written the way it comes back out.
+		`{"big":9223372036854775807,"float":1.5,"neg-zero":-0,"small":1}`,
+	}
+	for _, doc := range docs {
+		t.Run(doc, func(t *testing.T) {
+			v := libjson.LoadWith([]byte(doc), exact())
+			require.NotEqual(t, lisp.LError, v.Type, "load failed: %s", v)
+			out, err := libjson.Dump(v, false)
+			require.NoError(t, err)
+			assert.Equal(t, doc, string(out))
+		})
+	}
+}
+
+// TestLoadExactIntegerRangeFails pins the loud half of the contract: a value
+// that cannot be represented is an error, never a rounded float.
+func TestLoadExactIntegerRangeFails(t *testing.T) {
+	tests := []string{
+		"9223372036854775808",  // int64 max + 1
+		"-9223372036854775809", // int64 min - 1
+		"123456789012345678901234567890",
+		"10000000000000000000000000000000000000000",
+	}
+	for _, test := range tests {
+		t.Run(test, func(t *testing.T) {
+			v := libjson.LoadWith([]byte(test), exact())
+			require.Equal(t, lisp.LError, v.Type,
+				"out-of-range integer loaded as %s (%s) instead of failing",
+				lisp.GetType(v).Str, v.String())
+			assert.Equal(t, "json:integer-range-error", v.Str,
+				"the range failure must be a catchable condition")
+			assert.Contains(t, v.String(), test)
+		})
+	}
+}
+
+// TestLoadExactIntegerRangeFailsNested proves the error propagates out of a
+// container rather than being swallowed and leaving a hole in the document.
+func TestLoadExactIntegerRangeFailsNested(t *testing.T) {
+	for _, doc := range []string{
+		`[1,2,9223372036854775808]`,
+		`{"a":{"b":9223372036854775808}}`,
+	} {
+		v := libjson.LoadWith([]byte(doc), exact())
+		require.Equal(t, lisp.LError, v.Type, "doc %s loaded as %s", doc, v.String())
+		assert.Equal(t, "json:integer-range-error", v.Str)
+	}
+}
+
+// TestLoadExactNonIntegers pins the syntactic rule.  A number written with a
+// fraction or an exponent is a float in exact mode exactly as it is by
+// default, so turning the option on moves integer literals and nothing else.
+func TestLoadExactNonIntegers(t *testing.T) {
+	tests := []struct {
+		json string
+		want float64
+	}{
+		{"1.5", 1.5},
+		{"1.0", 1},
+		{"1e2", 100},
+		{"1E2", 100},
+		{"9007199254740993.0", maxExactFloat}, // written as a float, stays lossy
+		{"9223372036854775807e0", float64(int64Max)},
+		{"-0", math.Copysign(0, -1)}, // parses to integer 0, but "0" != "-0"
+		{"-0.0", math.Copysign(0, -1)},
+		{"1e-400", 0}, // underflows to zero without an error, as it does today
+	}
+	for _, test := range tests {
+		t.Run(test.json, func(t *testing.T) {
+			v := libjson.LoadWith([]byte(test.json), exact())
+			require.Equal(t, lisp.LFloat, v.Type,
+				"loaded %s as %s, want a float", test.json, lisp.GetType(v).Str)
+			// Bit equality, not epsilon: the point is that the option does not
+			// perturb a float by so much as a ulp, and it also settles the
+			// sign of zero, which "-0" turns on.
+			assert.Equal(t, math.Float64bits(test.want), math.Float64bits(v.Float),
+				"got %v, want %v", v.Float, test.want)
+		})
+	}
+}
+
+// TestLoadExactNegativeZeroRoundTrips is the reason "-0" is excluded from the
+// integer rule: as the integer 0 it would re-encode as "0".
+func TestLoadExactNegativeZeroRoundTrips(t *testing.T) {
+	v := libjson.LoadWith([]byte("-0"), exact())
+	require.Equal(t, lisp.LFloat, v.Type)
+	out, err := libjson.Dump(v, false)
+	require.NoError(t, err)
+	assert.Equal(t, "-0", string(out))
+}
+
+// TestLoadExactAcceptsCanonicalLargeFloats pins the one case where an integer
+// literal too large for a lisp int is NOT an error: when the literal is
+// already the canonical rendering of the float it parses to, so taking the
+// float discards nothing the document was carrying.
+//
+// This is not a softening of the loud-failure rule, it is what makes the rule
+// survivable. This package renders every float in [2^63, 1e21) as plain
+// digits, so without this a phylum holding an ordinary float of 1e19 would
+// dump its state and then be unable to read it back. "Anything Dump can emit,
+// Load can read" has to hold, or the option is a liveness bug.
+func TestLoadExactAcceptsCanonicalLargeFloats(t *testing.T) {
+	for _, text := range []string{
+		"10000000000000000000",  // 1e19
+		"100000000000000000000", // 1e20
+		"9223372036854776000",   // the canonical text of float64(int64 max)
+		"-9223372036854776000",
+	} {
+		t.Run(text, func(t *testing.T) {
+			v := libjson.LoadWith([]byte(text), exact())
+			require.Equal(t, lisp.LFloat, v.Type, "got %s: %s", lisp.GetType(v).Str, v)
+			out, err := libjson.Dump(v, false)
+			require.NoError(t, err)
+			assert.Equal(t, text, string(out), "the float must re-encode to the same digits")
+		})
+	}
+}
+
+// TestLoadExactDumpLoadIsClosed is the invariant the case above exists to
+// protect, stated directly: every float this package can emit, the option can
+// read back.
+func TestLoadExactDumpLoadIsClosed(t *testing.T) {
+	floats := []float64{
+		0, 1, -1, 1.5, 1e-7, 1e-6, 1e20, 1e21, 1e30, -1e19,
+		float64(int64Max), float64(int64Min), maxExactFloat, maxExactFloat + 2,
+		math.SmallestNonzeroFloat64, math.MaxFloat64, math.Copysign(0, -1),
+	}
+	for _, f := range floats {
+		enc, err := libjson.Dump(lisp.Float(f), false)
+		require.NoError(t, err)
+		back := libjson.LoadWith(enc, exact())
+		require.NotEqual(t, lisp.LError, back.Type,
+			"the option refused this package's own output for %v: %s (%s)", f, enc, back)
+		reenc, err := libjson.Dump(back, false)
+		require.NoError(t, err)
+		assert.Equal(t, string(enc), string(reenc), "not stable for %v", f)
+	}
+}
+
+// TestLoadExactExponentFormNormalises pins the known asymmetry the fuzzer
+// found, so that it is a decision rather than an accident.
+//
+// The integer rule is syntactic, and Dump normalises a float's text. A
+// document written "100e7" is not an integer literal, so it decodes to a
+// float; Dump writes that float as "1000000000", which IS an integer literal,
+// so a re-read makes it an int. The value is correct throughout and stable
+// from the second read on -- what changed is the document.
+//
+// The alternative, deciding int-vs-float from the VALUE rather than the text,
+// would also make "1.0" an int and needs exact decimal arithmetic to be
+// reproducible. It widens what the option touches and enlarges the surface
+// that has to be identical on every node, for a case that machine-generated
+// JSON does not produce: Go, JavaScript and Python all render 1e9 as plain
+// digits already.
+func TestLoadExactExponentFormNormalises(t *testing.T) {
+	first := libjson.LoadWith([]byte("100e7"), exact())
+	require.Equal(t, lisp.LFloat, first.Type)
+
+	enc, err := libjson.Dump(first, false)
+	require.NoError(t, err)
+	require.Equal(t, "1000000000", string(enc))
+
+	second := libjson.LoadWith(enc, exact())
+	assert.Equal(t, lisp.LInt, second.Type,
+		"after one rewrite the exponent form is gone and the value is an int")
+	assert.Equal(t, 1000000000, second.Int)
+
+	// Stable from here on.
+	reenc, err := libjson.Dump(second, false)
+	require.NoError(t, err)
+	assert.Equal(t, "1000000000", string(reenc))
+	third := libjson.LoadWith(reenc, exact())
+	assert.Equal(t, lisp.LInt, third.Type)
+}
+
+// ---------------------------------------------------------------------------
+// The default half: today's behaviour, pinned.
+// ---------------------------------------------------------------------------
+
+// TestIssue350HidingMechanism pins the mechanism that let this sit open since
+// 2018: the rounded value still compares = to the integer it was meant to be.
+// A program reads a corrupted identifier, checks it against the value it
+// expected, matches, and carries on -- nothing signals.
+//
+// This test asserts the hiding mechanism is STILL THERE in default mode, which
+// sounds backwards until you notice what it buys: it is the tripwire on the
+// default. If someone later flips the default to exact integers, or "cleans
+// up" the float64 case, this test fails and says so, instead of the fleet
+// finding out. When the default is deliberately flipped, this test is the one
+// that must be rewritten in the same commit -- on purpose, in the open.
+func TestIssue350HidingMechanism(t *testing.T) {
+	const text = "9007199254740993" // 2^53+1
+	loaded := libjson.Load([]byte(text), false)
+
+	require.Equal(t, lisp.LFloat, loaded.Type,
+		"DEFAULT mode must still decode this as a float; if this fails the"+
+			" default has been flipped and every consumer's (type x) changed")
+	require.Equal(t, math.Float64bits(float64(maxExactFloat)), math.Float64bits(loaded.Float),
+		"the value has been rounded down by one")
+
+	// The hiding mechanism itself.
+	eq := loaded.Equal(lisp.Int(maxExactFloat + 1))
+	assert.True(t, lisp.True(eq),
+		"the corrupted value must still compare = to its integer -- that is"+
+			" WHY nothing reports the corruption, and pinning it here is what"+
+			" stops the regression returning silently")
+
+	// It also compares = to the value it was actually rounded TO, which is
+	// how two distinct JSON documents become indistinguishable in memory.
+	other := libjson.Load([]byte("9007199254740992"), false)
+	assert.True(t, lisp.True(loaded.Equal(other)),
+		"9007199254740993 and 9007199254740992 must be indistinguishable"+
+			" after a default load -- the corruption is not detectable by"+
+			" comparison, only by opting in")
+
+	// And the same value under the opt-in is distinguishable, which is the
+	// whole point.
+	exactLoaded := libjson.LoadWith([]byte(text), exact())
+	exactOther := libjson.LoadWith([]byte("9007199254740992"), exact())
+	require.Equal(t, lisp.LInt, exactLoaded.Type)
+	assert.False(t, lisp.True(exactLoaded.Equal(exactOther)),
+		"under :exact-integers the two documents must be distinguishable")
+}
+
+// TestLoadDefaultUnchanged pins the default decode for the inputs the fix
+// touches. Any diff here is a consensus-visible change to what a JSON
+// document MEANS, on nodes that never opted in.
+func TestLoadDefaultUnchanged(t *testing.T) {
+	tests := []struct {
+		json  string
+		typ   lisp.LType
+		value string // LVal.String()
+		dump  string
+	}{
+		{"9007199254740993", lisp.LFloat, "9.007199254740992e+15", "9007199254740992"},
+		{"9223372036854775807", lisp.LFloat, "9.223372036854776e+18", "9223372036854776000"},
+		{"-9223372036854775808", lisp.LFloat, "-9.223372036854776e+18", "-9223372036854776000"},
+		{"9007199254740991", lisp.LFloat, "9.007199254740991e+15", "9007199254740991"},
+		{"1", lisp.LFloat, "1", "1"},
+		{"-0", lisp.LFloat, "-0", "-0"},
+		{"1e2", lisp.LFloat, "100", "100"},
+		{"1.5", lisp.LFloat, "1.5", "1.5"},
+		{"123456789012345678901234567890", lisp.LFloat, "1.2345678901234568e+29", "1.2345678901234568e+29"},
+	}
+	for _, test := range tests {
+		t.Run(test.json, func(t *testing.T) {
+			v := libjson.Load([]byte(test.json), false)
+			require.Equal(t, test.typ, v.Type, "got %s", lisp.GetType(v).Str)
+			assert.Equal(t, test.value, v.String())
+			out, err := libjson.Dump(v, false)
+			require.NoError(t, err)
+			assert.Equal(t, test.dump, string(out))
+		})
+	}
+}
+
+// TestLoadStringNumbersUnchanged pins the other pre-existing option, including
+// that it still WINS over exact-integers when a caller sets both.
+func TestLoadStringNumbersUnchanged(t *testing.T) {
+	for _, text := range []string{"9007199254740993", "9223372036854775807", "1", "1e2", "-0"} {
+		v := libjson.Load([]byte(text), true)
+		require.Equal(t, lisp.LString, v.Type)
+		assert.Equal(t, text, v.Str)
+
+		both := libjson.LoadWith([]byte(text), libjson.LoadOpts{StringNumbers: true, ExactIntegers: true})
+		require.Equal(t, lisp.LString, both.Type,
+			":string-numbers must take precedence over :exact-integers")
+		assert.Equal(t, text, both.Str)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The dump side.
+// ---------------------------------------------------------------------------
+
+// TestDumpIntegersAreExact answers the question directly: does json:dump round
+// large integers on the way OUT as well? It does not. encodeLInt uses
+// strconv.AppendInt on the int64, which is exact for every int64. The rounding
+// seen in a load-then-dump is entirely the load's -- the value handed to Dump
+// is already a float by then.
+func TestDumpIntegersAreExact(t *testing.T) {
+	for _, n := range []int64{
+		0, 1, -1, maxExactFloat - 1, maxExactFloat, maxExactFloat + 1,
+		int64Max, int64Max - 1, int64Min, int64Min + 1,
+	} {
+		text := strconv.FormatInt(n, 10)
+		out, err := libjson.Dump(lisp.Int(int(n)), false)
+		require.NoError(t, err)
+		assert.Equal(t, text, string(out), "Dump rounded an int on the way out")
+
+		out, err = libjson.Dump(lisp.Int(int(n)), true)
+		require.NoError(t, err)
+		assert.Equal(t, `"`+text+`"`, string(out))
+	}
+}
+
+// TestDumpFloatIsWhereTheDigitsGo shows the other side of the same coin: a
+// float carrying a large integer dumps the float's digits, which is correct
+// for a float and wrong for the integer the document contained. Dump has no
+// way to tell the difference -- by then the information is gone. That is why
+// the fix belongs on the load side.
+func TestDumpFloatIsWhereTheDigitsGo(t *testing.T) {
+	out, err := libjson.Dump(lisp.Float(float64(int64Max)), false)
+	require.NoError(t, err)
+	assert.Equal(t, "9223372036854776000", string(out))
+
+	// The emitted digits overflow an int64, which is itself the point: what
+	// comes back out is not a number the document could have contained.
+	got, ok := new(big.Int).SetString(string(out), 10)
+	require.True(t, ok)
+	drift := new(big.Int).Sub(got, big.NewInt(int64Max))
+	assert.Equal(t, "193", drift.String(),
+		"int64 max does not survive a default load/dump; this pins the drift")
+}
+
+// ---------------------------------------------------------------------------
+// Error shapes.
+// ---------------------------------------------------------------------------
+
+// TestLoadExactSyntaxErrors pins that malformed input is still reported as the
+// catchable json:syntax-error condition under the opt-in. The opt-in has to
+// use json.Decoder (UseNumber only exists there), and the decoder reports an
+// empty document and trailing content in shapes json.Unmarshal does not, so
+// without deliberate work an adopter's handler-bind would quietly stop firing.
+func TestLoadExactSyntaxErrors(t *testing.T) {
+	for _, text := range []string{
+		"", " ", "{false:true}", "nulll", "1 2", "[1,2", `{"a":`, "[,]", "\x00",
+	} {
+		t.Run(fmt.Sprintf("%q", text), func(t *testing.T) {
+			v := libjson.LoadWith([]byte(text), exact())
+			require.Equal(t, lisp.LError, v.Type, "got %s", v.String())
+			assert.Equal(t, "json:syntax-error", v.Str,
+				"malformed input must stay catchable as json:syntax-error")
+
+			// The default path agrees that this is malformed.
+			d := libjson.Load([]byte(text), false)
+			assert.Equal(t, lisp.LError, d.Type)
+		})
+	}
+}
+
+// TestLoadExactFloatOverflow keeps the one non-integer failure aligned with
+// the default path, which also refuses a number that overflows a float64.
+func TestLoadExactFloatOverflow(t *testing.T) {
+	for _, text := range []string{"1e400", "-1e400"} {
+		v := libjson.LoadWith([]byte(text), exact())
+		require.Equal(t, lisp.LError, v.Type)
+		assert.Contains(t, v.String(), "cannot unmarshal number")
+
+		d := libjson.Load([]byte(text), false)
+		require.Equal(t, lisp.LError, d.Type)
+	}
+}
+
+// TestLoadExactMaxAlloc proves the allocation bound still applies on the new
+// decode path.
+func TestLoadExactMaxAlloc(t *testing.T) {
+	doc := []byte(`[1,2,3,4,5]`)
+	v := libjson.LoadWith(doc, libjson.LoadOpts{ExactIntegers: true, MaxAlloc: 3})
+	require.Equal(t, lisp.LError, v.Type)
+	assert.Contains(t, v.String(), "exceeds maximum")
+
+	v = libjson.LoadWith(doc, libjson.LoadOpts{ExactIntegers: true, MaxAlloc: 5})
+	require.NotEqual(t, lisp.LError, v.Type, "%s", v)
+}
+
+// TestLoadOptsZeroValueIsTodayExactly pins that the zero LoadOpts is the old
+// behaviour, so an embedder that adopts LoadWith without setting anything gets
+// no change at all.
+func TestLoadOptsZeroValueIsTodayExactly(t *testing.T) {
+	for _, text := range []string{
+		"9007199254740993", "1", "1.5", "-0", "1e2", `{"a":[1,2.5,null,true]}`,
+		"", "{false:true}", "1e400",
+	} {
+		want := libjson.Load([]byte(text), false)
+		got := libjson.LoadWith([]byte(text), libjson.LoadOpts{})
+		assert.Equal(t, want.Type, got.Type, "%q", text)
+		assert.Equal(t, want.String(), got.String(), "%q", text)
+	}
+}

--- a/lisp/lisplib/libjson/testdata/fuzz/FuzzLoadExactIntegers/exponent-form-integer-normalises-on-dump
+++ b/lisp/lisplib/libjson/testdata/fuzz/FuzzLoadExactIntegers/exponent-form-integer-normalises-on-dump
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("100e7")


### PR DESCRIPTION
Addresses #350.

**Position 3 of a four-PR bug-crush chain.** Stacked on #407. Review only the top commit. Diff is confined to `lisp/lisplib/libjson/` — nothing in `lisp/` core, nothing seal- or elpspath-related.

## Read this first: the P0 is not fixed by default. It is made *fixable*.

This ships an **opt-in** `:exact-integers` option. Default `json:load` still silently rounds integers above 2^53. That is a deliberate choice for a consensus-sensitive codebase, and it is the main thing to agree or disagree with in review.

**Why not just flip it.** The blast radius of `UseNumber` is *every number in every document*, not only the broken ones. `{"count":3}` stops being a float. `(type x)` goes `float` → `int` fleet-wide, and with it `int?`/`float?`, `nth` (which rejects a float index today), and any branch on type. Two nodes on different elps versions would disagree about what the same bytes *mean*.

Two things that would have made a flip catastrophic were checked, and neither holds: `(/ 7 2)` is `3.5` regardless of operand types, so there is no integer-division divergence; and `to-string`/`format-string` agree for every value below 2^53. So a default flip is *survivable* later — but it buys nothing a per-call-site opt-in doesn't, while an opt-in lets a phylum migrate one call at a time.

`TestIssue350HidingMechanism` and `default-rounds-silently` pin the broken default **on purpose**, so the eventual flip cannot happen quietly — it must rewrite those tests in the same commit.

## The bug, reproduced end-to-end

`json:dump-string` of `json:load-string` of a literal, on `main` at `f18e118` vs this branch:

| input | main **and branch default** | branch `:exact-integers` |
|---|---|---|
| `9007199254740993` | `9007199254740992` | `9007199254740993` |
| `9223372036854775807` | `9223372036854776000` | `9223372036854775807` |
| `-9223372036854775808` | `-9223372036854776000` | `-9223372036854775808` |

The int64-max drift is **193**, not 1,193 as triage recorded (`9223372036854776000 − 9223372036854775807`). Pinned with `math/big` in `TestDumpFloatIsWhereTheDigitsGo`.

**`json:dump` is not the culprit.** `encodeLInt` uses `strconv.AppendInt` and is exact for every int64 in both `:string-numbers` modes. By the time `Dump` sees the value it is already a float and the digits are gone — which is why the fix is on the load side.

## The rule is syntactic, for consensus

Integer-shaped means *no `.`, no exponent* — a property of the bytes, never of the value they denote. Every node reading the same document reaches the same answer without depending on shared floating-point or decimal-arithmetic behaviour.

## Red-then-green

`TestPackageExactIntegers` (`libjson_integer_test.lisp`) uses only the lisp surface, so it compiles and runs on `f18e118`. There it fails 6 subtests with `json:load-string: unrecognized keyword argument: exact-integers`; on this branch all 11 pass.

Being honest about what that is: for an opt-in feature, "red on main" means *feature absent*, not *behaviour wrong*. The behavioural evidence is the table above, carried by tests that pass on **both** sides (`TestLoadDefaultUnchanged`, `default-rounds-silently`) and assert the wrong output literally — which is what makes them useful as a revert check.

## What an adopter gets — release note

> ### `json:load` — new `:exact-integers` option (issue #350)
>
> **Nothing changes unless you opt in.** Default `json:load-string`/`load-bytes`/`load-message`, `:string-numbers`, all `json:dump-*`, and the Go `Load`/`LoadMax`/`Dump` signatures behave exactly as before. Verified rather than asserted: 120,118 decode results across both pre-existing modes and 450,000 encode results spanning the full float64 bit-pattern space are byte-identical to `f18e118`, and allocation counts on every pre-existing benchmark are unchanged to the byte.
>
> For a caller who turns it on:
>
> 1. A JSON number written as an integer decodes to an **int**, not a float — *every* such number, not only large ones. `(type x)` returns `'int`, `(int? x)` is true, and the value is usable where an int is required (e.g. `nth`'s index).
> 2. Integers above 2^53 keep their exact value and re-serialize with their exact digits. `to-string` changes from `9.007199254740992e+15` to `9007199254740993`.
> 3. An integer literal too large for a lisp int raises the catchable condition **`json:integer-range-error`** instead of silently becoming a rounded float. Documents that loaded before can now fail — that is the point.
> 4. Numbers with a fraction or exponent are **unchanged** and still decode as floats: `1.5`, `1.0`, `1e2`, `1E2`, `-0`. `-0` is deliberately excluded so it keeps re-serializing as `-0`.
> 5. **Known asymmetry.** The rule is syntactic and `json:dump` normalizes float text, so `100e7` decodes as a float, dumps as `1000000000`, and a *re-read* makes it an int. The value is correct at every step and stable from the second read on; what changed is the document, not the rule. All nodes reading the same bytes still agree — a phylum-authoring footgun, not a consensus hazard. Pinned by `TestLoadExactExponentFormNormalises`. Machine-generated JSON does not hit it: Go, JavaScript and Python all render `1e9` as plain digits.
> 6. **One deliberate exception to rule 3.** An oversized integer literal is accepted as a *float* when the literal is already that float's canonical text (e.g. `10000000000000000000`). Nothing is discarded, so nothing is hidden. This is required: elps renders every float in [2^63, 1e21) as plain digits, so without it a phylum holding an ordinary float of `1e19` could dump its state and be unable to read it back. `9223372036854775808` is *not* canonical text and still fails loudly.
> 7. `:string-numbers` takes precedence when both are set.
> 8. Malformed input stays catchable as `json:syntax-error`. The option needs a streaming decoder (`UseNumber` exists only there), which reports empty input and trailing content differently from `json.Unmarshal`; those are normalized so an adopter's `handler-bind` does not quietly stop firing.
>
> **Not fixed by default.** Flipping the default changes `(type x)` for every integer in every document on every node, and is a separate scheduled change.

## Round-trips and fuzzing

Byte-identical load→dump for 2^53 ± 4, −2^53 ± 4, int64 max/min and four neighbours each, plus 0, ±1, 2^31, ±2^62 — then re-loaded to prove stability. Also nested in arrays and objects. `FuzzLoadExactIntegers` asserts byte-identity for any bare integer literal: 2M execs clean.

The fuzzer earned its place: it surfaced two design defects *before* commit — exponent-form normalization, and the encoder emitting documents the option would then refuse, which would have been a liveness bug in substrate.

## Benchstat — allocation is the reliable signal here

Interleaved, n=10, `GOMAXPROCS=4`.

```
                       │     base     │                  pr                  │
                       │  allocs/op   │  allocs/op    vs base                │
Encode-4                 214.0 ± 0%     214.0 ± 0%    ~ (p=1.000 n=10)
Encode_stringNumbers-4   30.00 ± 0%     30.00 ± 0%    ~ (p=1.000 n=10)
Load/default-4           135.0 ± 0%     135.0 ± 0%    ~ (p=1.000 n=10)
Load/stringNumbers-4     141.0 ± 0%     141.0 ± 0%    ~ (p=1.000 n=10)
LoadIntegers/default-4   49.00 ± 0%     49.00 ± 0%    ~ (p=1.000 n=10)
Load/exactIntegers-4                    141.0 ± 0%     (new)
LoadIntegers/exact-4                    53.00 ± 0%     (new)
```

Every pre-existing path allocates byte-for-byte as before. The `UseNumber` cost lands only in the new arm and is the cost `:string-numbers` already pays. **Wall-clock on this host is too noisy to claim anything** (±25–55% even at 500 ms/op) and is not dressed up as a result. The decode direction had no benchmark at all before this.

## Out of scope, reported not fixed

Two unrelated defects found in the deprecated Go walkers, each deserving its own issue rather than riding a consensus-sensitive PR:

- **`GoInt`/`GoFloat64` have an inverted guard** — `if v.IsNumeric() { return 0, false }` refuses every number and *accepts* every non-number. `GoInt(Int(42))` → `(0, false)`; `GoInt(String("hello"))` → `(0, true)`. The accept-a-string case is the same class as #350 — a silent wrong number instead of an error — by a different mechanism. One-character fix, but it changes a deprecated exported API.
- **`GoSlice`/`GoMap` are unguarded entry points** into the unbounded walk `GoValue`'s doc comment warns about (#390 / #391), without carrying the warning.

`GoValue`/`GoSlice`/`GoMap` do **not** share the #350 defect — they walk LVal→Go, so there is no float64 funnel.

## Gates

`go build`, `go vet`, `go test ./...`, `golangci-lint run ./...` (0 issues), `gofmt -l` (byte-identical to base), `confidentiality-guard.sh`, `ci-gates-test.sh` (78 pass / 0 fail), `fuzz-budget-check.sh` (fits, headroom unchanged), `elps doc -m` ("All functions and exports are documented"). Full suite and `-race` re-run by me at the stack tip after rebasing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_