### PR TITLE
lisp: stop sequence views writing through into their source (#373, #369)

### DIFF
--- a/docs/func.md
+++ b/docs/func.md
@@ -177,7 +177,9 @@ elps> (car '("one" "two" "three"))
 
 ## `cdr`
 
-Returns the list after the first item.
+Returns the list after the first item.  Like `slice`, the result is a view
+that shares its elements with the source — see
+[Slices are views, not copies](#slices-are-views-not-copies).
 
 ```Lisp
 elps> (cdr '("head" "body" "tail"))
@@ -186,7 +188,9 @@ elps> (cdr '("head" "body" "tail"))
 
 ## `rest`
 
-Returns the sequence (list, vector) after the first item.
+Returns the sequence (list, vector) after the first item.  Like `slice`, the
+result is a view that shares its elements with the source — see
+[Slices are views, not copies](#slices-are-views-not-copies).
 
 ```Lisp
 elps> (rest (vector "one" "two" "three" "four"))
@@ -434,6 +438,27 @@ Performs a stable sort on a list using a predicate. The last argument can
 optionally be a function that takes the key and returns the comparison value.
 Mutates the list in-place.
 
+Two consequences of "in-place" are worth stating outright, because neither is
+visible at the call site:
+
+- Sorting a **slice, `cdr` or `rest` view** sorts that region of the source
+  too, since a view shares its elements — see
+  [Slices are views, not copies](#slices-are-views-not-copies).
+- Sorting a **quoted literal** rewrites the program's own text, and it stays
+  rewritten for the life of the process:
+
+  ```Lisp
+  elps> (defun probe () (let ([lit '(3 1 2)]) (stable-sort < lit) lit))
+  ()
+  elps> (probe)
+  '(1 2 3)
+  elps> (probe)  ; the literal in the function body is now sorted
+  '(1 2 3)
+  ```
+
+Sort a copy — `(stable-sort < (concat 'list lit))` — whenever the argument is a
+literal or a view you do not own.
+
 ```
 elps> (set 'test '(1 2 3))
 '(1 2 3)
@@ -566,6 +591,59 @@ elps> (slice 'vector "hello" 1 4)
 (vector 101 108 108)
 ```
 
+### Slices are views, not copies
+
+For `list`, `vector` and `bytes` sources the result **shares its elements with
+the source**, the way a Go slice does.  Reading is always safe, and appending
+to a slice is safe — a slice cannot grow into its source, so `append` and
+`append!` on the slice leave the source alone:
+
+```Lisp
+elps> (set 'v (vector 10 20 30 40))
+(vector 10 20 30 40)
+elps> (set 'view (slice 'vector v 0 2))
+(vector 10 20)
+elps> (append! view 999)
+(vector 10 20 999)
+elps> v  ; the source is untouched
+(vector 10 20 30 40)
+```
+
+What sharing still means is that an operation which mutates the slice's own
+elements *in place* is visible through the source.  `stable-sort` is the one to
+watch, because it sorts in place and returns the sequence it sorted:
+
+```Lisp
+elps> (set 'v (vector 5 4 3 2 1))
+(vector 5 4 3 2 1)
+elps> (stable-sort < (slice 'vector v 0 3))
+(vector 3 4 5)
+elps> v  ; the first three elements of v were sorted too
+(vector 3 4 5 2 1)
+```
+
+Take a copy with `concat` when you need a snapshot that nothing can write
+through — `concat` always allocates:
+
+```Lisp
+elps> (set 'v (vector 5 4 3 2 1))
+(vector 5 4 3 2 1)
+elps> (set 'copy (concat 'vector (slice 'vector v 0 3)))
+(vector 5 4 3)
+elps> (stable-sort < copy)
+(vector 3 4 5)
+elps> v  ; unchanged
+(vector 5 4 3 2 1)
+```
+
+This matters most when the source is a quoted literal, because a literal is
+part of the program text rather than a fresh value — sorting one in place
+changes it for the rest of the process.  `(concat 'list ...)` is the idiom for
+taking a literal you intend to mutate.
+
+`(slice 'string ...)` is exempt: strings are immutable, so a string slice can
+never be written through.
+
 ## `list`
 
 Returns a list compose of the supplied parameters.
@@ -588,7 +666,9 @@ elps> (vector 1 "2" 'three)
 
 ## `append`
 
-Appends to the vector, returning a copy without mutating the source vector.
+Appends to the sequence, returning a new sequence and leaving the source
+untouched.  The result never shares storage with the source, so appending to
+the same source twice gives two independent results.
 
 ```Lisp
 elps> (set 'test (vector 1 2))
@@ -597,11 +677,29 @@ elps> (append 'vector test 3)
 (vector 1 2 3)
 elps> test
 (vector 1 2)
+elps> (set 'a (append 'vector test 3))
+(vector 1 2 3)
+elps> (set 'b (append 'vector test 4))
+(vector 1 2 4)
+elps> a  ; unaffected by the append that produced b
+(vector 1 2 3)
 ```
+
+Because the source is never written to, `append` must copy, which makes it
+O(n) in the length of the source.  Building a sequence with repeated
+`(set 'v (append 'vector v x))` is therefore quadratic — use `append!` to
+accumulate.
+
+> Before ELPS fixed issue #373, `append` could grow into spare capacity left
+> in the source and overwrite a result it had already returned — in the
+> example above, `a` would have become `(vector 1 2 4)`.  Code written against
+> that behaviour will now see correct values and one extra copy per append.
 
 ## `append!`
 
-Appends to the vector, mutating the source vector in-place.
+Appends to the vector, mutating the source vector in-place.  This is the
+accumulator: it grows in amortised constant time and does not copy.  Use it in
+loops, and use `append` when the source must not change.
 
 ```Lisp
 elps> (set 'test (vector 1 2))
@@ -614,12 +712,13 @@ elps> test
 
 ## `append-bytes`
 
-Appends to the byte vector, returning a copy without mutating the source vector.
+Appends to the byte vector, returning new bytes and leaving the source
+untouched.  As with `append`, the result never shares storage with the source.
 
 ```
 elps> (set 'test (to-bytes "hello world"))
 #<bytes 104 101 108 108 111 32 119 111 114 108 100>
-elps> (append-bytes! test "!")
+elps> (append-bytes test "!")
 #<bytes 104 101 108 108 111 32 119 111 114 108 100 33>
 elps> (to-string test)
 "hello world"

--- a/docs/lang.md
+++ b/docs/lang.md
@@ -543,6 +543,70 @@ whether the output should be a vector or a list.
 (map 'list double (vector 1 2 3))  ; evaluates to '(2 4 6)
 ```
 
+### Sharing, copying and mutation
+
+Lists and arrays are *references*.  Binding one to a second name does not copy
+it, and neither does taking a sub-sequence: `slice`, `cdr` and `rest` return
+**views** that share their elements with the source, much as slices of a Go
+array do.
+
+The library divides cleanly into functions that mutate and functions that do
+not, and the mutating ones are spelled with a trailing `!`:
+
+| Non-mutating (returns a new value) | Mutating (changes its argument) |
+| ---------------------------------- | ------------------------------- |
+| `append`, `append-bytes`           | `append!`, `append-bytes!`      |
+| `assoc`, `dissoc`                  | `assoc!`, `dissoc!`             |
+| `concat`, `insert-index`, `reverse`, `map`, `select` | `stable-sort` |
+
+`stable-sort` is the exception to the naming rule: it has no `!` but it sorts
+in place and returns the sequence it sorted.
+
+Two rules follow, and together they cover essentially every surprise in this
+area:
+
+1. **Appending to a view never disturbs its source.**  A view cannot grow into
+   the memory behind it; `append` and `append!` allocate instead.
+
+   ```lisp
+   (set 'v (vector 10 20 30 40))
+   (append! (slice 'vector v 0 2) 999)
+   v  ; still (vector 10 20 30 40)
+   ```
+
+2. **Mutating a view's own elements *is* visible through its source**, because
+   those are the same elements.
+
+   ```lisp
+   (set 'v (vector 5 4 3 2 1))
+   (stable-sort < (slice 'vector v 0 3))
+   v  ; (vector 3 4 5 2 1) -- the source was sorted too
+   ```
+
+When you need a value nothing else can write through, copy it with `concat`,
+which always allocates:
+
+```lisp
+(set 'snapshot (concat 'vector (slice 'vector v 0 3)))
+```
+
+This matters most for **quoted literals**.  A literal is part of the program
+text, not a fresh value made on each evaluation, so passing one to a mutating
+function edits the program — and the edit persists for the life of the
+process:
+
+```lisp
+(defun probe ()
+  (let ([lit '(3 1 2)])
+    (stable-sort < lit)   ; sorts the literal in the function body
+    lit))
+(probe)  ; '(1 2 3)
+(probe)  ; '(1 2 3) -- not '(3 1 2); the literal stayed sorted
+```
+
+Use `(concat 'list lit)` — or build the value with `(list ...)` instead of
+quoting it — whenever a literal is going to be mutated.
+
 ### Sorted Maps
 
 A sorted map is a mapping between keys and values which ensures that key

--- a/lisp/alias_bench_test.go
+++ b/lisp/alias_bench_test.go
@@ -1,0 +1,248 @@
+// Copyright © 2018 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/elpstest"
+)
+
+// Benchmarks for the sequence producers and consumers touched by the issue
+// #373 capacity-clamp fix.  They exist to price the fix honestly rather than
+// to defend a number: clamping a capacity is free, but it removes an append's
+// ability to grow into a source's spare capacity, so appends that used to be
+// amortised now reallocate.  The chain benchmarks below are where that shows
+// up, and they are expected to regress.
+//
+// Run both arms from the same file so the comparison is like-for-like:
+//
+//	go test -run '^$' -bench 'Alias' -benchmem -count=10 ./lisp/
+
+// --- producers -------------------------------------------------------------
+
+func BenchmarkAliasSliceVector(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 1000) (append! v n))
+	  (dotimes (n 1000) (slice 'vector v 10 900))
+	`)
+}
+
+func BenchmarkAliasSliceList(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'l (make-sequence 0 1000))
+	  (dotimes (n 1000) (slice 'list l 10 900))
+	`)
+}
+
+// NOTE:  elpstest.RunBenchmark builds its env with InitializeUserEnv only --
+// lisplib is NOT loaded -- so the stdlib `string:` package is unavailable
+// here.  Byte sources are built with core builtins instead.  (An earlier
+// draft of this file used string:repeat; the benchmarks failed at runtime and
+// benchstat silently dropped them from the comparison.)
+func BenchmarkAliasSliceBytes(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'bs (to-bytes ""))
+	  (dotimes (n 1000) (append-bytes! bs "x"))
+	  (dotimes (n 1000) (slice 'bytes bs 10 900))
+	`)
+}
+
+func BenchmarkAliasSliceString(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 's (to-string (to-bytes "")))
+	  (dotimes (n 200) (set 's (concat 'string s "xxxxx")))
+	  (dotimes (n 1000) (slice 'string s 10 900))
+	`)
+}
+
+func BenchmarkAliasCDR(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'l (make-sequence 0 1000))
+	  (dotimes (n 1000) (cdr l))
+	`)
+}
+
+func BenchmarkAliasRest(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 1000) (append! v n))
+	  (dotimes (n 1000) (rest v))
+	`)
+}
+
+// --- consumers: single append off a fixed source ---------------------------
+
+func BenchmarkAliasAppendVectorOnce(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 100) (append! v n))
+	  (dotimes (n 1000) (append 'vector v 1))
+	`)
+}
+
+func BenchmarkAliasAppendListOnce(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'l (make-sequence 0 100))
+	  (dotimes (n 1000) (append 'list l 1))
+	`)
+}
+
+func BenchmarkAliasAppendBytesOnce(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'bs (to-bytes ""))
+	  (dotimes (n 100) (append-bytes! bs "x"))
+	  (dotimes (n 1000) (append-bytes bs "y"))
+	`)
+}
+
+// --- consumers: the accumulate-by-rebinding idiom --------------------------
+//
+// This is the pattern the fix makes more expensive.  Before the clamp these
+// appends could grow into spare capacity and were amortised O(1); now each one
+// copies.  It is also the pattern that was silently unsound whenever anyone
+// held on to an earlier result.  append! is the supported accumulator and is
+// benchmarked alongside for comparison.
+
+func BenchmarkAliasAppendVectorChain(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 500) (set 'v (append 'vector v n)))
+	`)
+}
+
+func BenchmarkAliasAppendBytesChain(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'bs (to-bytes ""))
+	  (dotimes (n 500) (set 'bs (append-bytes bs "y")))
+	`)
+}
+
+func BenchmarkAliasAppendListChain(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'l ())
+	  (dotimes (n 500) (set 'l (append 'list l n)))
+	`)
+}
+
+// --- the accumulation cost, measured at several sizes ----------------------
+//
+// The point of these is to show the SHAPE of the cost, not just its size at
+// one n.  `append` must now copy its source, so accumulating with
+// (set 'v (append 'vector v x)) does total work proportional to n^2, where
+// before the clamp it could grow into spare capacity and was amortised O(n).
+// Doubling n should therefore roughly double the time on main and roughly
+// quadruple it on this branch.
+//
+// `append!` is the supported accumulator and is measured at the same sizes as
+// the control: it is O(n) total in both arms.
+
+func BenchmarkAliasAccumAppend200(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 200) (set 'v (append 'vector v n)))
+	`)
+}
+
+func BenchmarkAliasAccumAppend400(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 400) (set 'v (append 'vector v n)))
+	`)
+}
+
+func BenchmarkAliasAccumAppend800(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 800) (set 'v (append 'vector v n)))
+	`)
+}
+
+func BenchmarkAliasAccumAppend1600(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 1600) (set 'v (append 'vector v n)))
+	`)
+}
+
+func BenchmarkAliasAccumMutate200(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 200) (append! v n))
+	`)
+}
+
+func BenchmarkAliasAccumMutate400(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 400) (append! v n))
+	`)
+}
+
+func BenchmarkAliasAccumMutate800(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 800) (append! v n))
+	`)
+}
+
+func BenchmarkAliasAccumMutate1600(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 1600) (append! v n))
+	`)
+}
+
+// --- mutating accumulators (unchanged by the fix) --------------------------
+
+func BenchmarkAliasAppendMutate(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 1000) (append! v n))
+	`)
+}
+
+func BenchmarkAliasAppendBytesMutate(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'bs (to-bytes ""))
+	  (dotimes (n 1000) (append-bytes! bs "y"))
+	`)
+}
+
+// --- slice-then-append, the shape from the bug report ----------------------
+
+func BenchmarkAliasSliceThenAppendMutate(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 200) (append! v n))
+	  (dotimes (n 500) (append! (slice 'vector v 0 100) 1))
+	`)
+}
+
+// --- stable-sort (touched only in docs; benchmarked to prove that) ---------
+
+func BenchmarkAliasStableSort(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'src (make-sequence 0 500))
+	  (dotimes (n 20) (stable-sort < (concat 'list src)))
+	`)
+}
+
+func BenchmarkAliasStableSortSliceView(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 500) (append! v n))
+	  (dotimes (n 20) (stable-sort < (slice 'vector v 0 400)))
+	`)
+}
+
+// --- concat, the documented copy idiom ------------------------------------
+
+func BenchmarkAliasConcatCopy(b *testing.B) {
+	elpstest.RunBenchmark(b, `
+	  (set 'v (vector))
+	  (dotimes (n 1000) (append! v n))
+	  (dotimes (n 500) (concat 'vector (slice 'vector v 0 900)))
+	`)
+}

--- a/lisp/alias_test.go
+++ b/lisp/alias_test.go
@@ -1,0 +1,250 @@
+// Copyright © 2018 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/elpstest"
+)
+
+// TestSliceCapacityAliasing pins the fix for issue #373 and the corruption it
+// caused (issue #369).
+//
+// Before the fix every sequence producer that carved a sub-slice out of a
+// source handed back a two-index reslice -- `cells[i:j]` -- which keeps the
+// SOURCE's capacity.  A later `append` then had spare room to grow into and
+// wrote through the view into memory the caller never named:
+//
+//	(set 'v (vector 10 20 30 40))
+//	(set 'view (slice 'vector v 0 2))
+//	(append! view 999)
+//	v  ; => (vector 10 20 999 40)   <-- v[2] silently changed
+//
+// The write lands OUTSIDE the view the caller was handed, so no reading of
+// `slice`'s contract justifies it.  Worse, the source is frequently a quoted
+// literal from the program text itself, in which case the corruption is to the
+// program and persists for the lifetime of the process.
+//
+// The fix is capacity discipline: every escaping view is produced with a
+// three-index reslice (`cells[i:j:j]`) so its capacity stops at its length,
+// and every non-mutating append clamps its INPUT the same way so it can never
+// write into its source's spare capacity.  Any append that needs more room
+// must reallocate.
+//
+// These tests are deliberately self-contained -- they assert on observable
+// lisp values only, with no Go-level capacity probing -- so that they keep
+// their meaning if the internals are reorganised.
+func TestSliceCapacityAliasing(t *testing.T) {
+	tests := elpstest.TestSuite{
+		// Variant 1: the report's original reproduction.  A vector view
+		// grown with the MUTATING append wrote past its own end into the
+		// source.
+		{"slice view + append! does not write into the source vector", elpstest.TestSequence{
+			{`(set 'v (vector 10 20 30 40))`, `(vector 10 20 30 40)`, ``},
+			{`(set 'view (slice 'vector v 0 2))`, `(vector 10 20)`, ``},
+			{`(append! view 999)`, `(vector 10 20 999)`, ``},
+			// v[2] must still be 30.  Before the fix this read
+			// (vector 10 20 999 40).
+			{`v`, `(vector 10 20 30 40)`, ``},
+		}},
+
+		// Variant 2: the same defect reached through the NON-mutating
+		// append, with a quoted literal as the victim.  `append` promises
+		// not to mutate the original; before the fix it rewrote an element
+		// of the program's own source text.
+		{"append 'vector on a slice view does not corrupt a quoted literal", elpstest.TestSequence{
+			{`(set 'lit '(1 2 3))`, `'(1 2 3)`, ``},
+			{`(set 'view (slice 'vector lit 0 1))`, `(vector 1)`, ``},
+			{`(append 'vector view 99)`, `(vector 1 99)`, ``},
+			// Before the fix lit read '(1 99 3) -- and stayed that way for
+			// the rest of the process, because `lit` is the literal node in
+			// the function body, not a copy of it.
+			{`lit`, `'(1 2 3)`, ``},
+		}},
+
+		// The literal corruption in variant 2 is persistent, not per-call.
+		// Calling the same function twice must see a pristine literal both
+		// times.
+		{"a corrupted literal does not persist across calls", elpstest.TestSequence{
+			{`(defun probe ()
+			    (let ([lit '(1 2 3)])
+			      (append 'vector (slice 'vector lit 0 1) 99)
+			      lit))`, `()`, ``},
+			{`(probe)`, `'(1 2 3)`, ``},
+			// Before the fix the second call returned '(1 99 3).
+			{`(probe)`, `'(1 2 3)`, ``},
+		}},
+
+		// Variant 3: the bytes flavour.  slice 'bytes handed out a
+		// capacity-retaining []byte view and append-bytes grew into it,
+		// overwriting index 2 of the source.
+		{"slice 'bytes view + append-bytes does not write into the source", elpstest.TestSequence{
+			{`(set 'src (to-bytes "ABCD"))`, `#<bytes 65 66 67 68>`, ``},
+			{`(set 'view (slice 'bytes src 0 2))`, `#<bytes 65 66>`, ``},
+			{`(append-bytes view (to-bytes "Z"))`, `#<bytes 65 66 90>`, ``},
+			// src[2] must still be 'C' (67).  Before the fix it was 'Z' (90).
+			{`src`, `#<bytes 65 66 67 68>`, ``},
+			{`(to-string src)`, `"ABCD"`, ``},
+		}},
+
+		{"slice 'bytes view + append 'bytes does not write into the source", elpstest.TestSequence{
+			{`(set 'src (to-bytes "ABCD"))`, `#<bytes 65 66 67 68>`, ``},
+			{`(set 'view (slice 'bytes src 0 2))`, `#<bytes 65 66>`, ``},
+			{`(append 'bytes view 90)`, `#<bytes 65 66 90>`, ``},
+			{`(to-string src)`, `"ABCD"`, ``},
+		}},
+
+		{"slice 'bytes view + append! does not write into the source", elpstest.TestSequence{
+			{`(set 'src (to-bytes "ABCD"))`, `#<bytes 65 66 67 68>`, ``},
+			{`(set 'view (slice 'bytes src 0 2))`, `#<bytes 65 66>`, ``},
+			{`(append! view 90)`, `#<bytes 65 66 90>`, ``},
+			{`(to-string src)`, `"ABCD"`, ``},
+		}},
+
+		{"slice 'bytes view + append-bytes! does not write into the source", elpstest.TestSequence{
+			{`(set 'src (to-bytes "ABCD"))`, `#<bytes 65 66 67 68>`, ``},
+			{`(set 'view (slice 'bytes src 0 2))`, `#<bytes 65 66>`, ``},
+			{`(append-bytes! view "Z")`, `#<bytes 65 66 90>`, ``},
+			{`(to-string src)`, `"ABCD"`, ``},
+		}},
+
+		// Two independent non-mutating appends off the same source must not
+		// see each other.  This row happens to pass before the fix too --
+		// a freshly built (vector 1 2 3) has no spare capacity to fight
+		// over -- so it is a guard rather than a reproduction.  The two
+		// rows below it are the reproductions: they arrange for the source
+		// to carry spare capacity first.
+		{"two appends off one vector are independent", elpstest.TestSequence{
+			{`(set 'a (vector 1 2 3))`, `(vector 1 2 3)`, ``},
+			{`(set 'x (append 'vector a 100))`, `(vector 1 2 3 100)`, ``},
+			{`(set 'y (append 'vector a 200))`, `(vector 1 2 3 200)`, ``},
+			{`x`, `(vector 1 2 3 100)`, ``},
+			{`y`, `(vector 1 2 3 200)`, ``},
+			{`a`, `(vector 1 2 3)`, ``},
+		}},
+
+		// The same, but where the spare capacity was created by append!
+		// rather than by a previous append.  append! is documented to
+		// mutate in place and keeps its amortised growth, so its target
+		// legitimately carries spare capacity -- the non-mutating append
+		// must refuse to use it.
+		{"append after append! does not reuse the mutated vector's spare capacity", elpstest.TestSequence{
+			{`(set 'a (vector 1 2 3))`, `(vector 1 2 3)`, ``},
+			{`(append! a 4)`, `(vector 1 2 3 4)`, ``},
+			{`(set 'x (append 'vector a 100))`, `(vector 1 2 3 4 100)`, ``},
+			{`(set 'y (append 'vector a 200))`, `(vector 1 2 3 4 200)`, ``},
+			{`x`, `(vector 1 2 3 4 100)`, ``},
+			{`y`, `(vector 1 2 3 4 200)`, ``},
+			{`a`, `(vector 1 2 3 4)`, ``},
+		}},
+
+		{"append-bytes after append-bytes! does not reuse spare capacity", elpstest.TestSequence{
+			{`(set 'b (to-bytes "ab"))`, `#<bytes 97 98>`, ``},
+			{`(append-bytes! b "c")`, `#<bytes 97 98 99>`, ``},
+			{`(set 'x (append-bytes b "d"))`, `#<bytes 97 98 99 100>`, ``},
+			{`(set 'y (append-bytes b "e"))`, `#<bytes 97 98 99 101>`, ``},
+			{`(to-string x)`, `"abcd"`, ``},
+			{`(to-string y)`, `"abce"`, ``},
+			{`(to-string b)`, `"abc"`, ``},
+		}},
+
+		// cdr and rest are the other two producers that carved a view with
+		// `cells[1:]`.  Their views must not be able to grow into whatever
+		// spare capacity the source happened to carry.
+		{"cdr view cannot grow into the source's spare capacity", elpstest.TestSequence{
+			{`(set 'base (vector 1 2 3))`, `(vector 1 2 3)`, ``},
+			{`(append! base 4)`, `(vector 1 2 3 4)`, ``},
+			{`(set 'keep (append 'vector base 9))`, `(vector 1 2 3 4 9)`, ``},
+			{`(set 'tl (rest base))`, `'(2 3 4)`, ``},
+			{`(append 'vector tl 77)`, `(vector 2 3 4 77)`, ``},
+			// keep must be untouched.
+			{`keep`, `(vector 1 2 3 4 9)`, ``},
+			{`base`, `(vector 1 2 3 4)`, ``},
+		}},
+
+		{"cdr view of a list cannot grow into the source's spare capacity", elpstest.TestSequence{
+			{`(set 'base (vector 1 2 3))`, `(vector 1 2 3)`, ``},
+			{`(append! base 4)`, `(vector 1 2 3 4)`, ``},
+			{`(set 'keep (append 'vector base 9))`, `(vector 1 2 3 4 9)`, ``},
+			{`(set 'tl (cdr (slice 'list base 0 4)))`, `'(2 3 4)`, ``},
+			{`(append 'vector tl 77)`, `(vector 2 3 4 77)`, ``},
+			{`keep`, `(vector 1 2 3 4 9)`, ``},
+		}},
+
+		// slice 'list off a vector shares the vector's cells; growing the
+		// list view must not reach back into the vector.
+		{"slice 'list view cannot grow into the source vector", elpstest.TestSequence{
+			{`(set 'v (vector 10 20 30 40))`, `(vector 10 20 30 40)`, ``},
+			{`(set 'l (slice 'list v 0 2))`, `'(10 20)`, ``},
+			{`(append 'vector l 999)`, `(vector 10 20 999)`, ``},
+			{`v`, `(vector 10 20 30 40)`, ``},
+		}},
+
+		// The concat-as-copy idiom documented in docs/func.md: concat
+		// always allocates, so it is the way to take a snapshot that no
+		// later append can disturb.
+		{"concat is a copy that later appends cannot disturb", elpstest.TestSequence{
+			{`(set 'v (vector 10 20 30 40))`, `(vector 10 20 30 40)`, ``},
+			{`(set 'copy (concat 'vector (slice 'vector v 0 2)))`, `(vector 10 20)`, ``},
+			{`(append! copy 999)`, `(vector 10 20 999)`, ``},
+			{`v`, `(vector 10 20 30 40)`, ``},
+			{`copy`, `(vector 10 20 999)`, ``},
+		}},
+
+		// Ordinary behaviour must be unchanged: append! still accumulates
+		// in place and slice still reads the right elements.
+		{"append! still accumulates in place", elpstest.TestSequence{
+			{`(set 'v (vector))`, `(vector)`, ``},
+			{`(dotimes (n 5) (append! v n))`, `()`, ``},
+			{`v`, `(vector 0 1 2 3 4)`, ``},
+			{`(length v)`, `5`, ``},
+		}},
+
+		{"slice still reads the right elements", elpstest.TestSequence{
+			{`(slice 'vector (vector 1 2 3 4 5) 1 4)`, `(vector 2 3 4)`, ``},
+			{`(slice 'list (vector 1 2 3 4 5) 1 4)`, `'(2 3 4)`, ``},
+			{`(slice 'list '(1 2 3 4 5) 0 5)`, `'(1 2 3 4 5)`, ``},
+			{`(slice 'string "abcdef" 1 3)`, `"bc"`, ``},
+			{`(to-string (slice 'bytes (to-bytes "abcdef") 1 3))`, `"bc"`, ``},
+			{`(slice 'vector (vector 1 2 3) 2 2)`, `(vector)`, ``},
+		}},
+	}
+	elpstest.RunTestSuite(t, tests)
+}
+
+// TestSliceViewSharesElements documents the aliasing that this change does
+// NOT remove, so that the boundary of the fix is explicit rather than
+// discovered later by a user.
+//
+// Issue #373 is about writes that land OUTSIDE the view the caller was handed
+// -- spare capacity.  A view still SHARES the elements inside its own bounds
+// with its source, exactly as a Go slice does, so an in-place mutation of the
+// view is still visible through the source.  `stable-sort` is documented to
+// sort in place and returns the mutated sequence, so sorting a view sorts that
+// region of the source.
+//
+// Closing that would require `slice` to copy (or quoted literals to be copied
+// on evaluation), which is a separate semantic decision with its own cost, and
+// is deliberately not made here.  These rows pin the current behaviour so the
+// decision is a visible test change whenever someone does make it.
+func TestSliceViewSharesElements(t *testing.T) {
+	tests := elpstest.TestSuite{
+		{"stable-sort through a view still reorders the source", elpstest.TestSequence{
+			{`(set 'src (vector 5 4 3 2 1))`, `(vector 5 4 3 2 1)`, ``},
+			{`(set 'view (slice 'vector src 0 3))`, `(vector 5 4 3)`, ``},
+			{`(stable-sort < view)`, `(vector 3 4 5)`, ``},
+			// Unchanged by this fix: the first three elements of src are
+			// the same cells the view sorted.
+			{`src`, `(vector 3 4 5 2 1)`, ``},
+		}},
+		{"stable-sort mutates a quoted literal in place", elpstest.TestSequence{
+			{`(defun probe () (let ([lit '(3 1 2)]) (stable-sort < lit) lit))`, `()`, ``},
+			{`(probe)`, `'(1 2 3)`, ``},
+			// Unchanged by this fix: the literal in the function body was
+			// sorted, and stays sorted.
+			{`(probe)`, `'(1 2 3)`, ``},
+		}},
+	}
+	elpstest.RunTestSuite(t, tests)
+}

--- a/lisp/array_test.go
+++ b/lisp/array_test.go
@@ -55,13 +55,23 @@ func TestArray(t *testing.T) {
 			{"v123", "(vector 1 2 3)", ""},
 			{"v1234", "(vector 1 2 3 4)", ""},
 			{"(set 'v1235 (append 'vector v123 5))", "(vector 1 2 3 5)", ""},
-			// The above append reuses excess vector capacity allocated in the
-			// previous append to v12, creating v123.  Analogous to go slices,
-			// this causes side effects in the value of v1234.  The assumed
-			// performance benefit seems valuable but in general (append
-			// 'vector ...) should be used sparingly and with care.  The
-			// append! function will be easier to reason about.
-			{"v1234", "(vector 1 2 3 5)", ""},
+			// Two appends off the same source are independent (issue #373).
+			//
+			// This row used to assert (vector 1 2 3 5).  The append above
+			// reused excess capacity left in v123 by the append that built
+			// it, so it wrote through the shared backing array and rewrote
+			// v1234 -- a value `append` had already returned.  The comment
+			// here called that an "assumed performance benefit" and told
+			// callers to use `append` "sparingly and with care".
+			//
+			// There was no care that helped: nothing about v1234 said it
+			// was still aliased, and `append` is the non-mutating
+			// constructor by contract and by docstring.  Producers now
+			// clamp the capacity of every view they hand out and `append`
+			// clamps its input, so an append needing room reallocates.
+			// `append!` is the in-place accumulator and still grows in
+			// amortised O(1).
+			{"v1234", "(vector 1 2 3 4)", ""},
 		}},
 	}
 	elpstest.RunTestSuite(t, tests)

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -134,10 +134,12 @@ var (
 			`Returns the first element of a list, or nil if empty.`},
 		{"cdr", Formals("lis"), builtinCDR,
 			`Returns a list of all elements except the first, or nil if the
-			list has fewer than two elements.`},
+			list has fewer than two elements. Like slice, the result is a
+			view sharing elements with lis.`},
 		{"rest", Formals("lis"), builtinRest,
 			`Returns a list of all elements except the first. Accepts lists
-			and vectors. Returns nil if fewer than two elements.`},
+			and vectors. Returns nil if fewer than two elements. Like slice,
+			the result is a view sharing elements with lis.`},
 		{"first", Formals("seq"), builtinFirst,
 			`Returns the first element of a sequence (list or vector), or nil
 			if empty.`},
@@ -203,7 +205,11 @@ var (
 		{"stable-sort", Formals("less-predicate", "list", VarArgSymbol, "key-fun"), builtinSortStable,
 			`Sorts list in-place using the binary less-predicate and returns
 			the mutated list. The sort is stable. An optional key-fun
-			extracts comparison keys from elements.`},
+			extracts comparison keys from elements. Because the sort is
+			in-place, sorting a slice view also sorts that region of its
+			source, and sorting a quoted literal rewrites the program's own
+			text for the life of the process; sort (concat 'list x) when x
+			is a literal or a view you do not own.`},
 		{"insert-sorted", Formals("type-specifier", "list", "predicate", "item", VarArgSymbol, "key-fun"), builtinInsertSorted,
 			`Returns a new sequence with item inserted at its sorted position
 			according to predicate. An optional key-fun extracts comparison
@@ -238,7 +244,11 @@ var (
 			type-specifier ('list or 'vector) determines the return type.`},
 		{"slice", Formals("type-specifier", "seq", "start", "end"), builtinSlice,
 			`Returns a subsequence from index start (inclusive) to end
-			(exclusive). Accepts lists, vectors, strings, and bytes.`},
+			(exclusive). Accepts lists, vectors, strings, and bytes. For
+			lists, vectors and bytes the result is a view sharing elements
+			with seq: appending to it cannot disturb seq, but sorting it in
+			place also sorts that region of seq. Use concat to take a copy.
+			String slices are always independent.`},
 		{"list", Formals(VarArgSymbol, "args"), builtinList,
 			`Returns a new list containing all the given arguments.`},
 		{"vector", Formals(VarArgSymbol, "args"), builtinVector,
@@ -250,7 +260,10 @@ var (
 		{"append", Formals("type-specifier", "vec", VarArgSymbol, "values"), builtinAppend,
 			`Returns a new sequence with values appended to vec. The
 			type-specifier ('list, 'vector, or 'bytes) determines the return
-			type. Does not mutate the original.`},
+			type. Does not mutate vec and never shares storage with it, so
+			appending to the same source twice yields independent results.
+			This costs a copy, making append O(n); use append! to accumulate
+			in a loop.`},
 		{"append-bytes!", Formals("bytes", "values"), builtinAppendBytesMutate,
 			`Appends values to bytes, mutating it in place. Values can be a
 			string, bytes, or list of integers. Returns the modified bytes.`},
@@ -258,7 +271,9 @@ var (
 		// because 'string would be equivalent to (concat 'string ...)
 		{"append-bytes", Formals("bytes", "byte-sequence"), builtinAppendBytes,
 			`Returns new bytes with byte-sequence appended. The byte-sequence
-			can be a string, bytes, or list of integers.`},
+			can be a string, bytes, or list of integers. Does not mutate
+			bytes and never shares storage with it; use append-bytes! to
+			accumulate in a loop.`},
 		{"aref", Formals("a", VarArgSymbol, "indices"), builtinARef,
 			`Returns the element at the given indices in an array. Multiple
 			indices access multi-dimensional arrays.`},
@@ -848,8 +863,37 @@ func builtinCDR(env *LEnv, args *LVal) *LVal {
 	if len(v.Cells) < 2 {
 		return Nil()
 	}
-	// TODO:  Copy cells into a new list of cells?
-	return QExpr(v.Cells[1:])
+	// The reslice is three-index so the tail's capacity stops at its length
+	// (issue #373).  A two-index `v.Cells[1:]` inherits whatever spare
+	// capacity v carries, and a later append to the tail grows into it,
+	// writing through this view into memory the caller never named.  The
+	// tail still SHARES its elements with v -- that is what a view is -- but
+	// it can no longer reach past its own end.
+	//
+	// NOTE:  The elements are still shared, so this is not a copy.  See the
+	// note on builtinSlice.
+	return QExpr(clampCap(v.Cells[1:]))
+}
+
+// clampCap returns cells with its capacity cut down to its length, so that a
+// subsequent append is forced to reallocate rather than write into whatever
+// spare capacity the backing array carries.
+//
+// This is the core of the issue #373 fix.  Every sequence view that escapes
+// into lisp is clamped where it is produced, and every non-mutating append
+// clamps its input where it is read; together those make it impossible for an
+// append to write through one value into another.  Clamping is free -- no
+// allocation, no copy -- and is a no-op for the exact-capacity slices that
+// make up the common case.  What it costs is that an append which previously
+// grew into a source's spare capacity must now reallocate.  That is the point
+// of the change, not an accident of it.
+func clampCap(cells []*LVal) []*LVal {
+	return cells[:len(cells):len(cells)]
+}
+
+// clampCapBytes is clampCap for byte slices.
+func clampCapBytes(b []byte) []byte {
+	return b[:len(b):len(b)]
 }
 
 func builtinRest(env *LEnv, args *LVal) *LVal {
@@ -861,8 +905,8 @@ func builtinRest(env *LEnv, args *LVal) *LVal {
 	if len(cells) < 2 {
 		return Nil()
 	}
-	// TODO:  Copy cells into a new list of cells?
-	return QExpr(cells[1:])
+	// Three-index reslice -- see builtinCDR (issue #373).
+	return QExpr(clampCap(cells[1:]))
 }
 
 func builtinFirst(env *LEnv, args *LVal) *LVal {
@@ -1848,14 +1892,33 @@ func builtinSlice(env *LEnv, args *LVal) *LVal {
 		return env.Errorf("end before start")
 	}
 
-	// Create an intermediate sliced list with a similar type
+	// Create an intermediate sliced list with a similar type.
+	//
+	// The bytes and sequence reslices are THREE-index (issue #373).  A
+	// two-index `cells[i:j]` keeps the source's capacity, so a later append
+	// to the returned view had spare room and grew into it -- writing through
+	// the view into source elements at index >= j, which the caller never
+	// named and cannot see in the value they were handed:
+	//
+	//	(set 'v (vector 10 20 30 40))
+	//	(append! (slice 'vector v 0 2) 999)
+	//	v  ; => (vector 10 20 999 40) before the fix
+	//
+	// Clamping the capacity to the view's length forces that append to
+	// reallocate instead.  The view still SHARES the elements in [i,j) with
+	// the source -- slice returns a view, not a copy, and an in-place
+	// mutation such as stable-sort is still visible through the source.  Use
+	// (concat 'vector (slice ...)) when a snapshot is wanted.
+	//
+	// The string case needs no clamp: Go strings are immutable, so a string
+	// view cannot be written through at all.
 	switch list.Type {
 	case LString:
 		list = String(list.Str[i:j])
 	case LBytes:
-		list = Bytes(list.Bytes()[i:j])
+		list = Bytes(clampCapBytes(list.Bytes()[i:j]))
 	default: // isSeq(list)
-		list = QExpr(seqCells(list)[i:j])
+		list = QExpr(clampCap(seqCells(list)[i:j]))
 	}
 
 	// Convert the intermediate sliced value into the desired type
@@ -1909,6 +1972,12 @@ func builtinSlice(env *LEnv, args *LVal) *LVal {
 	}
 }
 
+// NOTE (issue #373):  builtinList and builtinVector are deliberately NOT
+// capacity-clamped.  They hand out the call's own argument slice, which the
+// evaluator has already discarded, so its spare capacity is not reachable from
+// any other live value -- there is nothing for an append to corrupt.  Clamping
+// them would not be free either: it would force the first (append! (vector
+// ...) x) to reallocate for no benefit.
 func builtinList(env *LEnv, v *LVal) *LVal {
 	return QExpr(v.Cells)
 }
@@ -1917,6 +1986,18 @@ func builtinVector(env *LEnv, args *LVal) *LVal {
 	return Array(nil, args.Cells)
 }
 
+// builtinAppendMutate implements the append! builtin.
+//
+// NOTE (issue #373):  This is deliberately NOT capacity-clamped.  append! is
+// the in-place accumulator -- it is documented to mutate its argument and
+// return it -- so it keeps Go's amortised growth and stays O(1) per element.
+// That is safe because the target's spare capacity is not reachable from any
+// other value: every producer of a view (slice, cdr, rest) clamps what it
+// hands out, and every non-mutating append clamps what it reads, so nothing
+// else can be looking at the bytes past vec's length.
+//
+// The caller who reaches for append! has already said they want mutation.
+// The bug in #373 was mutation nobody asked for.
 func builtinAppendMutate(env *LEnv, args *LVal) *LVal {
 	vec, vals := args.Cells[0], args.Cells[1:]
 	if vec.Type == LBytes {
@@ -1934,6 +2015,8 @@ func builtinAppendMutate(env *LEnv, args *LVal) *LVal {
 	return vec
 }
 
+// appendMutateBytes is the bytes path of append!.  Not capacity-clamped,
+// for the reason given on builtinAppendMutate (issue #373).
 func appendMutateBytes(env *LEnv, args *LVal) *LVal {
 	lbytes, xs := args.Cells[0], args.Cells[1:]
 	b := lbytes.Bytes()
@@ -1951,6 +2034,8 @@ func appendMutateBytes(env *LEnv, args *LVal) *LVal {
 	return lbytes
 }
 
+// builtinAppendBytesMutate implements append-bytes!.  Not capacity-clamped,
+// for the reason given on builtinAppendMutate (issue #373).
 func builtinAppendBytesMutate(env *LEnv, args *LVal) *LVal {
 	lbytes, byteseq := args.Cells[0], args.Cells[1]
 	if lbytes.Type != LBytes {
@@ -2003,10 +2088,32 @@ func builtinAppend(env *LEnv, args *LVal) *LVal {
 		list = append(list, vals...)
 		return QExpr(list)
 	case "vector":
-		// The Cells of the returned vector may intersect with seqCells(seq)
-		// when chaining calls to ``append'' so that vectors may be used in a
-		// manner akin to go slices.
-		return Array(nil, append(cells, vals...))
+		// The input is clamped so this append can never write into seq's
+		// spare capacity (issue #373).
+		//
+		// This reverses a deliberate old decision.  The comment here used to
+		// say the result "may intersect with seqCells(seq) when chaining
+		// calls to ``append'' so that vectors may be used in a manner akin
+		// to go slices", and array_test.go pinned that as intended: after
+		//
+		//	(set 'v123 (append 'vector v12 3))
+		//	(set 'v1234 (append 'vector v123 4))
+		//	(set 'v1235 (append 'vector v123 5))
+		//
+		// v1234 read (vector 1 2 3 5) -- the second append had overwritten
+		// the first one's result through their shared backing array.  The
+		// value that changed was one `append` had already handed back and
+		// promised not to touch, so no caller could have defended against
+		// it.  `append` is the non-mutating constructor; its docstring says
+		// so.  Sharing that can rewrite an already-returned value is not a
+		// contract anyone can use correctly, so it is gone.
+		//
+		// The cost is real and is the point: an append that could previously
+		// grow into spare capacity now reallocates and copies, so building a
+		// vector with repeated (set 'v (append 'vector v x)) is quadratic.
+		// `append!` is the in-place accumulator and keeps its amortised
+		// growth -- the docs now say to reach for it.
+		return Array(nil, append(clampCap(cells), vals...))
 	default:
 		return env.Errorf("type specifier is invalid: %v", typespec)
 	}
@@ -2028,7 +2135,10 @@ func builtinAppend_Bytes(env *LEnv, args *LVal) *LVal {
 	if lbytes.Type != LBytes {
 		return env.Errorf("second argument is not bytes: %v", lbytes.Type)
 	}
-	b := lbytes.Bytes()
+	// Clamped so this append cannot write into lbytes' spare capacity
+	// (issue #373) -- `append 'bytes` is non-mutating and must not disturb
+	// the source or any result it handed back earlier.
+	b := clampCapBytes(lbytes.Bytes())
 	xsVal := QExpr(xs)
 	resultLen := len(b) + xsVal.Len()
 	if msg := env.Runtime.CheckAlloc(resultLen); msg != "" {
@@ -2048,7 +2158,9 @@ func builtinAppendBytes(env *LEnv, args *LVal) *LVal {
 	if lbytes.Type != LBytes {
 		return env.Errorf("first argument is not bytes: %v", lbytes.Type)
 	}
-	b := lbytes.Bytes()
+	// Clamped so this append cannot write into lbytes' spare capacity
+	// (issue #373).  append-bytes! is the mutating variant.
+	b := clampCapBytes(lbytes.Bytes())
 	switch byteseq.Type {
 	case LString:
 		b = append(b, byteseq.Str...)

--- a/lisp/bytes_test.go
+++ b/lisp/bytes_test.go
@@ -37,13 +37,13 @@ func TestBytes(t *testing.T) {
 			{`(to-string v123)`, `"abc"`, ``},
 			{`(to-string v1234)`, `"abcd"`, ``},
 			{`(set 'v1235 (append 'bytes v123 101))`, `#<bytes 97 98 99 101>`, ``},
-			// The above append reuses excess vector capacity allocated in the
-			// previous append to v12, creating v123.  Analogous to go slices,
-			// this causes side effects in the value of v1234.  The assumed
-			// performance benefit seems valuable but in general (append ...)
-			// should be used sparingly and with care.  The append!  function
-			// will be easier to reason about.
-			{`(to-string v1234)`, `"abce"`, ``},
+			// Two appends off the same source are independent (issue #373).
+			// This row used to assert "abce": the append above grew into
+			// spare capacity left in v123 and rewrote v1234, a value
+			// `append` had already returned and promised not to touch.
+			// `append 'bytes` now clamps its input so it reallocates
+			// instead; `append-bytes!` is the in-place variant.
+			{`(to-string v1234)`, `"abcd"`, ``},
 		}},
 		// `append` validates the type SPECIFIER and then dispatched to the
 		// bytes path without validating the sequence, so a non-bytes second
@@ -74,13 +74,11 @@ func TestBytes(t *testing.T) {
 			{`(to-string v123)`, `"abc"`, ``},
 			{`(to-string v1234)`, `"abcd"`, ``},
 			{`(set 'v1235 (append-bytes v123 "e"))`, `#<bytes 97 98 99 101>`, ``},
-			// The above append reuses excess vector capacity allocated in the
-			// previous append to v12, creating v123.  Analogous to go slices,
-			// this causes side effects in the value of v1234.  The assumed
-			// performance benefit seems valuable but in general (append-bytes
-			// ...) should be used sparingly and with care.  The append-bytes!
-			// function will be easier to reason about.
-			{`(to-string v1234)`, `"abce"`, ``},
+			// Two appends off the same source are independent (issue #373).
+			// This row used to assert "abce" -- see the note in the
+			// `append 'bytes` sequence above.  `append-bytes!` is the
+			// in-place variant and keeps its amortised growth.
+			{`(to-string v1234)`, `"abcd"`, ``},
 		}},
 	}
 	elpstest.RunTestSuite(t, tests)


### PR DESCRIPTION
Fixes #373. Fixes #369.

**Top of a four-PR bug-crush chain**, stacked on #408. Review only the top commit.

It is deliberately last so it is the one you can drop: it is the only PR in the chain that changes documented behaviour **and the only one with a real performance cost**. Dropping it leaves #406/#407/#408 intact.

## The bug

`slice`, `cdr` and `rest` handed out views that **retained the source's capacity**. `append` then grew into that spare capacity and wrote through into the source — including into **quoted literals**, which are program text, so the corruption persisted for the life of the process.

```lisp
(defun probe ()
  (let ([lit '(1 2 3)])
    (append 'vector (slice 'vector lit 0 1) 99)
    lit))
(probe)  ; '(1 99 3)   <- the literal in the function body was rewritten
(probe)  ; '(1 99 3)   <- and stays rewritten
```

## The fix

A three-index capacity clamp (`cells[:len(cells):len(cells)]`) on every view a producer hands out, and on `append`'s input. A slice can no longer reach storage past its own end, so `append` reallocates instead of writing through.

`append!` and `append-bytes!` are untouched and keep their amortised O(1) growth. They remain the accumulator, and they are the migration path.

## The cost — this is the part to weigh

**`append`-accumulation becomes quadratic. That is not a side effect; it is the price of the fix**, because a non-mutating `append` that may not write into its source must copy.

`(set! v (append 'vector v i))` in a loop, `-benchmem`, base = this PR's parent:

| n | base sec/op | fixed sec/op | base B/op | fixed B/op |
|---|---|---|---|---|
| 200 | 601.8µ | 843.7µ (+40%) | 396.5Ki | 723.5Ki (+82%) |
| 400 | 1.198m | 1.985m (+66%) | 790.3Ki | 2056Ki (+160%) |
| 800 | 2.563m | 5.711m (+123%) | 1.540Mi | 5.827Mi (+279%) |
| 1600 | 4.894m | 17.955m (**+267%**) | 3.089Mi | 18.267Mi (**+491%**) |

Per doubling of n — base ×1.99, ×2.14, ×1.91 (**linear**); fixed ×2.35, ×2.88, ×3.14 (**converging on ×4 — quadratic**). Confirmed empirically rather than asserted.

`allocs/op` rises only ~3.6%: the same *number* of arrays, each now a full copy.

**`append!` is flat — `~` on all three metrics at every size** (1,163,546 B/op identical at n=1600), so the documented migration path costs nothing.

Other significant regressions: `AppendVectorOnce` +26% sec / +140% B, `AppendVectorChain` +64%/+191%, `SliceThenAppendMutate` +37%/+90%, `AppendBytesChain` +18%/+34%. Geomean +16.8% sec/op, +33.6% B/op.

**Zero cost** (all `~`, allocs byte-identical): `slice` ×4, `cdr`, `rest`, `append 'list`, `append!`, `append-bytes!`, `stable-sort`, `concat`. Clamping itself is free; the entire cost is the forced reallocation, exactly where intended.

**What the old speed actually bought.** Appending 500 times off a source carrying spare capacity was cheap on main because every one of those appends wrote into *the same* slot — each result aliased and clobbered the others. The cheapness *was* the corruption. There is no sound fast path being surrendered here.

## Red-then-green — 12 of 13 cases red on main

Re-run independently against `main` at `f18e118`:

```
test 0  slice view + append!            expected (vector 10 20 30 40)  got (vector 10 20 999 40)
test 1  append 'vector on a slice view  expected '(1 2 3)              got '(1 99 3)
test 2  literal corruption persists     expected '(1 2 3)              got '(1 99 3)   (both calls)
test 3  slice 'bytes + append-bytes     expected "ABCD"                got "ABZD"
test 4  slice 'bytes + append 'bytes    expected "ABCD"                got "ABZD"
test 5  slice 'bytes + append!          expected "ABCD"                got "ABZD"
test 6  slice 'bytes + append-bytes!    expected "ABCD"                got "ABZD"
test 8  append after append!            expected (vector 1 2 3 4 100)  got (vector 1 2 3 4 200)
test 9  append-bytes after append-bytes! expected "abcd"               got "abce"
test 10 cdr view of a vector            expected (vector 1 2 3 4 9)    got (vector 1 2 3 4 77)
test 11 cdr view of a list              expected (vector 1 2 3 4 9)    got (vector 1 2 3 4 77)
test 12 slice 'list view                expected (vector 10 20 30 40)  got (vector 10 20 999 40)
```

Test 7 passes on main **by design** — annotated in-file as *"a guard rather than a reproduction"*, because a freshly built `(vector 1 2 3)` has no spare capacity to fight over. Stated rather than quietly counted as a catch.

Tests 8 and 9 are two variants triage did not list: spare capacity left by `append!` let two later `append`s alias, so the first one's returned value was rewritten.

## One reported variant this does NOT fix

`stable-sort` on a quoted literal in a function body still corrupts it permanently:

```lisp
(defun probe () (let ([lit '(3 1 2)]) (stable-sort < lit) lit))
(probe)  ; '(1 2 3)
(probe)  ; '(1 2 3)  -- the literal stayed sorted
```

Different root cause: `env.eval` has `if v.Quoted { return v }`, so literals are returned by identity and never copied, and `stable-sort` mutates in place by documented contract. Three-index slicing cannot reach it — only copy-on-slice or copy-on-quote-eval would, and both are separate semantic decisions with their own costs. Scope was **not** silently widened. `TestSliceViewSharesElements` pins the current behaviour so that decision becomes a visible test change, and both docs files document the hazard with `concat` as the remedy.

## Producer sweep

**Clamped (7):** `builtinSlice` bytes + seq paths, `builtinCDR`, `builtinRest`, `builtinAppend` vector path (input), `builtinAppend_Bytes`, `builtinAppendBytes`.

**Deliberately not clamped, with reasons:** `builtinSlice` string path (Go strings are immutable); `append!`/`append-bytes!` (documented in-place accumulators — keeping amortised O(1) is safe *because* producers clamp and non-mutating appends clamp their input, and clamping here would have made the one supported accumulator quadratic too); `builtinList`/`builtinVector` (hand out the call's own arg slice, already discarded by the evaluator); `builtinConcatSeq` (already three-index); `map`, `insert-index`, `insert-sorted`, `zip`, `select`/`reject`, `cons` (all `make()` fresh, audited individually); `env.go:1596` (function body for the evaluator, never handed to lisp as data); arg-list reslices in `libschema`/`libtesting`/`libhelp` (iteration and copy destinations only).

## Three existing test rows change

`array_test.go` and `bytes_test.go` asserted the corruption as intended behaviour:

> The above append reuses excess vector capacity […] this causes side effects in the value of v1234. The assumed performance benefit seems valuable but in general `(append 'vector ...)` should be used sparingly and with care.

No care helped: nothing about `v1234` said it was still aliased, and `append` is the non-mutating constructor by contract and by docstring. Those rows now assert the uncorrupted value, with the history recorded in-file so the change is not silent.

## Documentation

`docs/func.md:591` claimed `append` returns "a copy without mutating the source" — the copy was not independent. Corrected, plus a "Slices are views, not copies" section, `concat` as the copy idiom, and the quoted-literal trap. `docs/lang.md` was silent and now has "Sharing, copying and mutation" with the mutating/non-mutating table. Five docstrings updated.

One genuine doc bug fixed and proven by running it: the `append-bytes` section called `(append-bytes! test "!")` but asserted `(to-string test)` → `"hello world"`. `append-bytes!` actually gives `"hello world!"`, contradicting the doc's own assertion; `append-bytes` gives `"hello world"`, matching it and matching the heading. Copy-pasted from the section below with the output corrected but the call left wrong.

## Gates

`go build`, `go test ./...`, `go test -race ./...` (all packages), `golangci-lint run` (0 issues), `elps fmt -l`, `elps doc -m`, `elps lint` (exit 0), `make test`, `confidentiality-guard.sh`, `ci-gates-test.sh` (127 passed / 0 failed), `fuzz-budget-check.sh` (fits, 10 min headroom). `gofmt -l` lists 17 files, all pre-existing on main, none from this branch.

Fuzz: full sweep at `FUZZTIME=120s`, **23/23 targets, exit 0, zero crashers**, no new corpus files.