### PR TITLE
ci: add reviewed, per-row waivers to the benchmark regression gate

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -88,6 +88,36 @@ benchstat base=/tmp/bench-before.txt pr=/tmp/bench-after.txt
 
 The repo has a benchmark CI workflow (`.github/workflows/benchmark.yml`) that automatically runs benchstat comparisons on PRs. It posts results as a PR comment.
 
+The comparison is adjudicated by `scripts/benchstat-gate.sh`, which fails the PR
+on a significant bad-direction move at or above the threshold for that metric
+class (15% for timing, 5% for allocations — set in `benchmark.yml`).
+
+### When the gate fires on a regression you mean to accept
+
+Do **not** raise either threshold, and do not skip the gate. Those are
+per-metric-class noise floors; moving one to accept a single benchmark blinds
+every other benchmark in the repo to the same magnitude of move. Add a **waiver**
+to `scripts/benchstat-waivers.txt` instead:
+
+```
+pkg | benchmark | metric | ceiling | expires | issue | reason
+```
+
+It covers exactly one package, one benchmark and one metric column; it records a
+ceiling, so the row fails again if the regression grows; it must name a tracking
+issue and it expires. A waived row is still measured, still printed in the job
+log, and still shown in the PR comment marked `WAIVED` — the waiver changes the
+verdict, never the visibility. The format is documented at the top of that file,
+and `scripts/ci-gates-test.sh` covers the mechanism.
+
+Run the gate locally against a saved comparison before pushing:
+
+```bash
+benchstat base=/tmp/bench-before.txt pr=/tmp/bench-after.txt > /tmp/benchstat.txt
+scripts/benchstat-gate.sh /tmp/benchstat.txt              # as CI will judge it
+BENCH_WAIVERS= scripts/benchstat-gate.sh /tmp/benchstat.txt  # with waivers off
+```
+
 ## Checklist
 
 - [ ] Baseline benchmarks captured before changes

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -213,191 +213,25 @@ jobs:
       # hold error text, and the comparison downstream would be meaningless.
       # GitHub's default shell is `bash -e` WITHOUT pipefail, so it must be
       # set explicitly.
+      #
+      # Body lives in scripts/bench-run-arms.sh. Bash inside a `run: |` block is
+      # not syntax-checked, not shellchecked and not testable; a script in
+      # scripts/ is all three, via scripts/ci-gates-test.sh. Referenced through
+      # $GITHUB_WORKSPACE/pr because BOTH checkouts in this job are relocated,
+      # so a root-relative `scripts/...` would exit 127.
       - name: Run benchmarks (both arms, interleaved)
-        run: |
-          set -o pipefail
-          : > bench-baseline.txt
-          : > bench-current.txt
-          for round in $(seq 1 ${{ env.BENCH_COUNT }}); do
-            echo "::group::round ${round}/${{ env.BENCH_COUNT }}"
-            (cd base && go test -bench=. -benchmem -benchtime=100ms -count=1 \
-              -run='^$' -timeout=10m ./...) | tee -a bench-baseline.txt
-            (cd pr && go test -bench=. -benchmem -benchtime=100ms -count=1 \
-              -run='^$' -timeout=10m ./...) | tee -a bench-current.txt
-            echo "::endgroup::"
-          done
+        run: bash "${GITHUB_WORKSPACE}/pr/scripts/bench-run-arms.sh"
 
       - name: Compare with benchstat
         if: github.event_name == 'pull_request'
         id: benchstat
-        run: |
-          set -uo pipefail
-
-          # BOTH trees live in subdirectories (pr/ and base/), so nothing from
-          # the repository is at the workspace root -- including these scripts.
-          # A bare `./scripts/benchstat-gate.sh` here exits 127 "No such file",
-          # which the final step then reported as "Benchmark regressions
-          # detected", i.e. a real-looking failure with a fictional cause. The
-          # existence check below turns that class into a named error, and the
-          # final step no longer attributes unknown exit codes to regressions.
-          #
-          # The scripts come from the PR arm deliberately: a PR that changes the
-          # gate must be adjudicated by its own version of it, not by main's.
-          PR_TREE="${GITHUB_WORKSPACE}/pr"
-          GATE="${PR_TREE}/scripts/benchstat-gate.sh"
-          ARMS="${PR_TREE}/scripts/bench-arms-check.sh"
-
-          missing=""
-          for s in "$GATE" "$ARMS"; do
-            [ -f "$s" ] || missing="${missing} ${s}"
-          done
-          if [ -n "$missing" ]; then
-            echo "::error::benchmark gate scripts missing from the PR checkout:${missing}. The workflow expects the repository at \$GITHUB_WORKSPACE/pr (see the two-tree checkout above); if the checkout layout changed, these paths must change with it."
-            echo "gate_status=2" >> "$GITHUB_OUTPUT"
-            {
-              echo 'result<<BENCHSTAT_EOF'
-              echo '## Benchmark gate could not run'
-              echo ''
-              echo 'The gate scripts were not found in the PR checkout:'
-              echo '```'
-              echo "${missing}"
-              echo '```'
-              echo 'BENCHSTAT_EOF'
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Both arms are produced by the step above, in this job. An empty
-          # baseline is no longer a benign cache miss -- it means the base
-          # checkout or its benchmark run failed, and silently degrading to
-          # "PR results only" would hide that. Fail loudly.
-          if [ ! -s bench-baseline.txt ]; then
-            echo "::error::bench-baseline.txt is empty — the base arm did not produce results."
-            echo "gate_status=2" >> "$GITHUB_OUTPUT"
-            {
-              echo 'result<<BENCHSTAT_EOF'
-              echo '## Benchmark Results (base arm FAILED — no comparison)'
-              echo ''
-              echo 'The base checkout or its benchmark run produced nothing.'
-              echo 'These are the PR-side numbers only; they are NOT a comparison.'
-              echo ''
-              echo '```'
-              cat bench-current.txt
-              echo '```'
-              echo 'BENCHSTAT_EOF'
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Comparability BEFORE comparison. benchstat does not complain when
-          # the arms cannot pair -- it emits a normal-looking table with no
-          # comparison rows, and the gate downstream can only report the
-          # symptom ("could not be interpreted"). This names the cause: a
-          # goos/goarch/cpu mismatch, or a GOMAXPROCS suffix mismatch that
-          # makes EnvGet-4 and EnvGet-2 two unrelated benchmarks.
-          arms_rc=0
-          "$ARMS" bench-baseline.txt bench-current.txt > arms-check.txt 2>&1 || arms_rc=$?
-          cat arms-check.txt
-          if [ "$arms_rc" -ne 0 ]; then
-            echo "::error::The two benchmark arms are not comparable; see the pre-flight report above."
-            echo "gate_status=2" >> "$GITHUB_OUTPUT"
-            {
-              echo 'result<<BENCHSTAT_EOF'
-              echo '## Benchmark arms are NOT comparable — no comparison was made'
-              echo ''
-              echo '```'
-              cat arms-check.txt
-              echo '```'
-              echo 'BENCHSTAT_EOF'
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # benchstat's own exit code is captured rather than discarded with
-          # `|| true`: if it crashed, its error text is all that lands in
-          # benchstat-output.txt, and benchstat-gate.sh turns that into a hard
-          # exit 2 ("cannot interpret") instead of a silent pass. Swallowing it
-          # here is what made a benchstat failure indistinguishable from a clean
-          # comparison.
-          bench_rc=0
-          benchstat base=bench-baseline.txt pr=bench-current.txt \
-            > benchstat-output.txt 2>&1 || bench_rc=$?
-          if [ "$bench_rc" -ne 0 ]; then
-            echo "::warning::benchstat exited ${bench_rc}; the gate will adjudicate its output."
-          fi
-
-          # The gate lives in scripts/benchstat-gate.sh so it can be unit-tested
-          # (scripts/ci-gates-test.sh) and run locally (make ci-gates-test).
-          # It exits 0 = clean, 1 = regression, 2 = could not interpret.
-          #
-          # Run BEFORE the comment is assembled, and its report captured, so the
-          # comment can carry the verdict rather than only the raw table. That
-          # matters most for a WAIVED row: an accepted regression that is only
-          # visible to whoever opens the job log is an accepted regression
-          # nobody reviews, which is the same "green because it stopped
-          # looking" shape this gate was written to fix.
-          #
-          # Redirected rather than piped through tee: this step runs under the
-          # default `bash -e`, and a pipeline whose first element exits 1 (the
-          # gate's normal way of saying "regression") would abort the step
-          # before the PR comment is ever assembled. `|| gate_status=$?` is the
-          # idiom the rest of this step already uses for exactly that reason.
-          gate_status=0
-          "$GATE" benchstat-output.txt > gate-report.txt 2>&1 || gate_status=$?
-          cat gate-report.txt
-          echo "gate_status=${gate_status}" >> "$GITHUB_OUTPUT"
-          case "$gate_status" in
-            0) echo "No benchmark regression at or above the configured gates." ;;
-            1) echo "::warning::Benchstat detected a significant benchmark regression." ;;
-            2) echo "::warning::The benchmark comparison could not be interpreted." ;;
-            *) echo "::warning::${GATE} exited ${gate_status} — it did not run to completion." ;;
-          esac
-
-          # Waived and stale-waiver lines are pulled out of the report and shown
-          # OUTSIDE the collapsed section, so a standing exception is read by
-          # everyone who reads the PR and not only by whoever expands a details
-          # block. `|| true` because grep exits 1 on no match, which is the
-          # normal case and must not fail the step under `set -o pipefail`.
-          waiver_lines="$(grep -E '^  (WAIVED|WAIVER-|waiver-)' gate-report.txt || true)"
-
-          {
-            echo 'result<<BENCHSTAT_EOF'
-            echo '## Benchmark Comparison (main baseline vs PR)'
-            echo ''
-            if [ -n "$waiver_lines" ]; then
-              echo '### Reviewed waivers'
-              echo ''
-              echo 'Declared in `scripts/benchstat-waivers.txt`. A `WAIVED` row was measured,'
-              echo 'DID move, and was accepted within the ceiling recorded there — it is not'
-              echo 'suppressed. `waiver-unused` means that row is no longer regressing and the'
-              echo 'entry can be deleted; `WAIVER-STALE` means it protects nothing at all.'
-              echo ''
-              echo '```'
-              echo "$waiver_lines"
-              echo '```'
-              echo ''
-            fi
-            echo '<details>'
-            echo '<summary>Click to expand benchstat output</summary>'
-            echo ''
-            echo '```'
-            cat benchstat-output.txt
-            echo '```'
-            echo ''
-            echo '</details>'
-            echo ''
-            echo '<details>'
-            echo '<summary>Click to expand the gate report</summary>'
-            echo ''
-            echo '```'
-            cat gate-report.txt
-            echo '```'
-            echo ''
-            echo '</details>'
-            echo ''
-            echo '_Both arms measured on the same runner in the same job, interleaved, n=${{ env.BENCH_COUNT }} each._'
-            echo 'BENCHSTAT_EOF'
-          } >> "$GITHUB_OUTPUT"
+        # Body lives in scripts/bench-compare.sh -- syntax-checked, shellchecked
+        # and fixture-tested by scripts/ci-gates-test.sh, which a `run: |` block
+        # can never be. Referenced through $GITHUB_WORKSPACE/pr because BOTH
+        # checkouts in this job are relocated, so a root-relative `scripts/...`
+        # would exit 127 -- which this workflow once reported as "Benchmark
+        # regressions detected", a real-looking failure with a fictional cause.
+        run: bash "${GITHUB_WORKSPACE}/pr/scripts/bench-compare.sh"
 
       - name: Post PR comment
         if: github.event_name == 'pull_request'
@@ -454,24 +288,14 @@ jobs:
           always() && github.event_name == 'pull_request' &&
           steps.benchstat.outputs.gate_status != 'skipped' &&
           steps.benchstat.outputs.gate_status != '0'
-        run: |
-          status='${{ steps.benchstat.outputs.gate_status }}'
-          case "$status" in
-            1)
-              echo "::error::Benchmark regressions detected (gate exit 1). Review the benchstat comparison in the PR comment and the gate report in the job log."
-              ;;
-            2)
-              echo "::error::The benchmark comparison could not be interpreted (gate exit 2). This is a hard failure by design — a gate that cannot read its input must never report success. See the job log above."
-              ;;
-            *)
-              # Anything else means the gate did not reach a verdict at all --
-              # e.g. exit 127, the script not being found. Reporting that as
-              # "regressions detected" (which this branch used to do) sends the
-              # reader looking for a performance problem that does not exist.
-              echo "::error::The benchmark gate did not run to completion (exit ${status:-<unset>}); it reached no verdict, so this is neither a pass nor a measured regression. See the job log above for the failing command."
-              ;;
-          esac
-          exit 1
+        # Body lives in scripts/bench-gate-fail.sh, where the three-way split
+        # (1 = regressions, 2 = uninterpretable, anything else = no verdict
+        # reached) is fixture-tested by scripts/ci-gates-test.sh. The verdict
+        # arrives via env rather than a `${{ }}` expansion so the script is
+        # runnable, and testable, outside Actions.
+        env:
+          GATE_STATUS: ${{ steps.benchstat.outputs.gate_status }}
+        run: bash "${GITHUB_WORKSPACE}/pr/scripts/bench-gate-fail.sh"
 
   # THE ONE CHECK TO REQUIRE FOR THIS WORKFLOW.
   #
@@ -496,19 +320,17 @@ jobs:
     needs: [gates, queue-watchdog, benchmark]
     if: always()
     steps:
+      # NOTE: this checkout is NEW. This job previously carried its assertion
+      # as inline bash and so needed nothing from the repository. Moving that
+      # body into scripts/require-jobs-succeeded.sh -- so it is shellchecked and
+      # fixture-tested like every other gate here -- means the file has to be
+      # present. This is the one structural change in the extraction: it adds a
+      # failure mode (a checkout that does not complete now fails the required
+      # check) that did not exist before. Same SHA pin as the other jobs.
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+
       - name: Assert every job in this workflow succeeded
         env:
           RESULTS: ${{ join(needs.*.result, ' ') }}
-        run: |
-          echo "upstream job results: ${RESULTS}"
-          rc=0
-          for r in ${RESULTS}; do
-            # success is the ONLY pass. failure, cancelled and skipped all mean
-            # the work was not demonstrably done.
-            [ "$r" = "success" ] || rc=1
-          done
-          if [ "$rc" -ne 0 ]; then
-            echo "::error::A job in this workflow did not succeed (results: ${RESULTS}). Open the individual jobs above."
-            exit 1
-          fi
-          echo "All jobs in this workflow succeeded."
+        run: bash scripts/require-jobs-succeeded.sh

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -326,10 +326,55 @@ jobs:
             echo "::warning::benchstat exited ${bench_rc}; the gate will adjudicate its output."
           fi
 
+          # The gate lives in scripts/benchstat-gate.sh so it can be unit-tested
+          # (scripts/ci-gates-test.sh) and run locally (make ci-gates-test).
+          # It exits 0 = clean, 1 = regression, 2 = could not interpret.
+          #
+          # Run BEFORE the comment is assembled, and its report captured, so the
+          # comment can carry the verdict rather than only the raw table. That
+          # matters most for a WAIVED row: an accepted regression that is only
+          # visible to whoever opens the job log is an accepted regression
+          # nobody reviews, which is the same "green because it stopped
+          # looking" shape this gate was written to fix.
+          #
+          # Redirected rather than piped through tee: this step runs under the
+          # default `bash -e`, and a pipeline whose first element exits 1 (the
+          # gate's normal way of saying "regression") would abort the step
+          # before the PR comment is ever assembled. `|| gate_status=$?` is the
+          # idiom the rest of this step already uses for exactly that reason.
+          gate_status=0
+          "$GATE" benchstat-output.txt > gate-report.txt 2>&1 || gate_status=$?
+          cat gate-report.txt
+          echo "gate_status=${gate_status}" >> "$GITHUB_OUTPUT"
+          case "$gate_status" in
+            0) echo "No benchmark regression at or above the configured gates." ;;
+            1) echo "::warning::Benchstat detected a significant benchmark regression." ;;
+            2) echo "::warning::The benchmark comparison could not be interpreted." ;;
+            *) echo "::warning::${GATE} exited ${gate_status} — it did not run to completion." ;;
+          esac
+
+          # Waived and stale-waiver lines are pulled out of the report and shown
+          # OUTSIDE the collapsed section, so a standing exception is read by
+          # everyone who reads the PR and not only by whoever expands a details
+          # block. `|| true` because grep exits 1 on no match, which is the
+          # normal case and must not fail the step under `set -o pipefail`.
+          waiver_lines="$(grep -E '^  (WAIVED|WAIVER-|waiver-)' gate-report.txt || true)"
+
           {
             echo 'result<<BENCHSTAT_EOF'
             echo '## Benchmark Comparison (main baseline vs PR)'
             echo ''
+            if [ -n "$waiver_lines" ]; then
+              echo '### Reviewed waivers applied to this comparison'
+              echo ''
+              echo 'These rows were measured and DID move; they are declared in'
+              echo '`scripts/benchstat-waivers.txt` and reviewed there, not suppressed.'
+              echo ''
+              echo '```'
+              echo "$waiver_lines"
+              echo '```'
+              echo ''
+            fi
             echo '<details>'
             echo '<summary>Click to expand benchstat output</summary>'
             echo ''
@@ -339,22 +384,18 @@ jobs:
             echo ''
             echo '</details>'
             echo ''
+            echo '<details>'
+            echo '<summary>Click to expand the gate report</summary>'
+            echo ''
+            echo '```'
+            cat gate-report.txt
+            echo '```'
+            echo ''
+            echo '</details>'
+            echo ''
             echo '_Both arms measured on the same runner in the same job, interleaved, n=${{ env.BENCH_COUNT }} each._'
             echo 'BENCHSTAT_EOF'
           } >> "$GITHUB_OUTPUT"
-
-          # The gate lives in scripts/benchstat-gate.sh so it can be unit-tested
-          # (scripts/ci-gates-test.sh) and run locally (make ci-gates-test).
-          # It exits 0 = clean, 1 = regression, 2 = could not interpret.
-          gate_status=0
-          "$GATE" benchstat-output.txt || gate_status=$?
-          echo "gate_status=${gate_status}" >> "$GITHUB_OUTPUT"
-          case "$gate_status" in
-            0) echo "No benchmark regression at or above the configured gates." ;;
-            1) echo "::warning::Benchstat detected a significant benchmark regression." ;;
-            2) echo "::warning::The benchmark comparison could not be interpreted." ;;
-            *) echo "::warning::${GATE} exited ${gate_status} — it did not run to completion." ;;
-          esac
 
       - name: Post PR comment
         if: github.event_name == 'pull_request'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -365,10 +365,12 @@ jobs:
             echo '## Benchmark Comparison (main baseline vs PR)'
             echo ''
             if [ -n "$waiver_lines" ]; then
-              echo '### Reviewed waivers applied to this comparison'
+              echo '### Reviewed waivers'
               echo ''
-              echo 'These rows were measured and DID move; they are declared in'
-              echo '`scripts/benchstat-waivers.txt` and reviewed there, not suppressed.'
+              echo 'Declared in `scripts/benchstat-waivers.txt`. A `WAIVED` row was measured,'
+              echo 'DID move, and was accepted within the ceiling recorded there — it is not'
+              echo 'suppressed. `waiver-unused` means that row is no longer regressing and the'
+              echo 'entry can be deleted; `WAIVER-STALE` means it protects nothing at all.'
               echo ''
               echo '```'
               echo "$waiver_lines"

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+#
+# Adjudicate the two benchmark arms: pre-flight their comparability, run
+# benchstat over them, hand the table to scripts/benchstat-gate.sh, and
+# assemble the PR comment body.
+#
+# Extracted verbatim from the "Compare with benchstat" step of
+# .github/workflows/benchmark.yml so the logic is syntax-checked, shellchecked
+# and testable by scripts/ci-gates-test.sh. Bash inside a `run: |` block is none
+# of those things, and this repo has already lost 473 runs to a CI gate that
+# could never fire. This script makes no decisions of its own -- the verdict is
+# benchstat-gate.sh's, and the pass/fail is scripts/bench-gate-fail.sh's.
+#
+# `set -euo pipefail` reproduces the original step's effective flags exactly:
+# GitHub runs `run:` bodies under `bash -e {0}`, and the step then added
+# `set -uo pipefail` on top of that. The `-e` is load-bearing here only in the
+# sense that every command whose failure is EXPECTED already carries an
+# explicit `|| var=$?` or `|| true`; do not remove those.
+#
+# Inputs (env):
+#   GITHUB_WORKSPACE  root holding the two checkouts (pr/ and base/)
+#   BENCH_COUNT       samples per arm, for the comment footer
+#   GITHUB_OUTPUT     step-output file; `gate_status` and `result` are written
+#
+# Reads bench-baseline.txt / bench-current.txt from $PWD (written by
+# scripts/bench-run-arms.sh) and writes arms-check.txt, benchstat-output.txt and
+# gate-report.txt beside them.
+#
+# Exits 0 in every branch: this script REPORTS the verdict via
+# `gate_status` on $GITHUB_OUTPUT, and the workflow's "Fail on regressions" step
+# is the only thing that turns a verdict into a red build.
+#
+# Run locally as:
+#   GITHUB_WORKSPACE=/path/to/ws GITHUB_OUTPUT=/dev/stdout BENCH_COUNT=10 \
+#     scripts/bench-compare.sh
+set -euo pipefail
+
+# BOTH trees live in subdirectories (pr/ and base/), so nothing from
+# the repository is at the workspace root -- including these scripts.
+# A bare `./scripts/benchstat-gate.sh` here exits 127 "No such file",
+# which the final step then reported as "Benchmark regressions
+# detected", i.e. a real-looking failure with a fictional cause. The
+# existence check below turns that class into a named error, and the
+# final step no longer attributes unknown exit codes to regressions.
+#
+# The scripts come from the PR arm deliberately: a PR that changes the
+# gate must be adjudicated by its own version of it, not by main's.
+PR_TREE="${GITHUB_WORKSPACE}/pr"
+GATE="${PR_TREE}/scripts/benchstat-gate.sh"
+ARMS="${PR_TREE}/scripts/bench-arms-check.sh"
+
+missing=""
+for s in "$GATE" "$ARMS"; do
+  [ -f "$s" ] || missing="${missing} ${s}"
+done
+if [ -n "$missing" ]; then
+  echo "::error::benchmark gate scripts missing from the PR checkout:${missing}. The workflow expects the repository at \$GITHUB_WORKSPACE/pr (see the two-tree checkout above); if the checkout layout changed, these paths must change with it."
+  echo "gate_status=2" >> "$GITHUB_OUTPUT"
+  {
+    echo 'result<<BENCHSTAT_EOF'
+    echo '## Benchmark gate could not run'
+    echo ''
+    echo 'The gate scripts were not found in the PR checkout:'
+    echo '```'
+    echo "${missing}"
+    echo '```'
+    echo 'BENCHSTAT_EOF'
+  } >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# Both arms are produced by the step above, in this job. An empty
+# baseline is no longer a benign cache miss -- it means the base
+# checkout or its benchmark run failed, and silently degrading to
+# "PR results only" would hide that. Fail loudly.
+if [ ! -s bench-baseline.txt ]; then
+  echo "::error::bench-baseline.txt is empty — the base arm did not produce results."
+  echo "gate_status=2" >> "$GITHUB_OUTPUT"
+  {
+    echo 'result<<BENCHSTAT_EOF'
+    echo '## Benchmark Results (base arm FAILED — no comparison)'
+    echo ''
+    echo 'The base checkout or its benchmark run produced nothing.'
+    echo 'These are the PR-side numbers only; they are NOT a comparison.'
+    echo ''
+    echo '```'
+    cat bench-current.txt
+    echo '```'
+    echo 'BENCHSTAT_EOF'
+  } >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# Comparability BEFORE comparison. benchstat does not complain when
+# the arms cannot pair -- it emits a normal-looking table with no
+# comparison rows, and the gate downstream can only report the
+# symptom ("could not be interpreted"). This names the cause: a
+# goos/goarch/cpu mismatch, or a GOMAXPROCS suffix mismatch that
+# makes EnvGet-4 and EnvGet-2 two unrelated benchmarks.
+arms_rc=0
+"$ARMS" bench-baseline.txt bench-current.txt > arms-check.txt 2>&1 || arms_rc=$?
+cat arms-check.txt
+if [ "$arms_rc" -ne 0 ]; then
+  echo "::error::The two benchmark arms are not comparable; see the pre-flight report above."
+  echo "gate_status=2" >> "$GITHUB_OUTPUT"
+  {
+    echo 'result<<BENCHSTAT_EOF'
+    echo '## Benchmark arms are NOT comparable — no comparison was made'
+    echo ''
+    echo '```'
+    cat arms-check.txt
+    echo '```'
+    echo 'BENCHSTAT_EOF'
+  } >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# benchstat's own exit code is captured rather than discarded with
+# `|| true`: if it crashed, its error text is all that lands in
+# benchstat-output.txt, and benchstat-gate.sh turns that into a hard
+# exit 2 ("cannot interpret") instead of a silent pass. Swallowing it
+# here is what made a benchstat failure indistinguishable from a clean
+# comparison.
+bench_rc=0
+benchstat base=bench-baseline.txt pr=bench-current.txt \
+  > benchstat-output.txt 2>&1 || bench_rc=$?
+if [ "$bench_rc" -ne 0 ]; then
+  echo "::warning::benchstat exited ${bench_rc}; the gate will adjudicate its output."
+fi
+
+# The gate lives in scripts/benchstat-gate.sh so it can be unit-tested
+# (scripts/ci-gates-test.sh) and run locally (make ci-gates-test).
+# It exits 0 = clean, 1 = regression, 2 = could not interpret.
+#
+# Run BEFORE the comment is assembled, and its report captured, so the
+# comment can carry the verdict rather than only the raw table. That
+# matters most for a WAIVED row: an accepted regression that is only
+# visible to whoever opens the job log is an accepted regression
+# nobody reviews, which is the same "green because it stopped
+# looking" shape this gate was written to fix.
+#
+# Redirected rather than piped through tee: this step runs under the
+# default `bash -e`, and a pipeline whose first element exits 1 (the
+# gate's normal way of saying "regression") would abort the step
+# before the PR comment is ever assembled. `|| gate_status=$?` is the
+# idiom the rest of this step already uses for exactly that reason.
+gate_status=0
+"$GATE" benchstat-output.txt > gate-report.txt 2>&1 || gate_status=$?
+cat gate-report.txt
+echo "gate_status=${gate_status}" >> "$GITHUB_OUTPUT"
+case "$gate_status" in
+  0) echo "No benchmark regression at or above the configured gates." ;;
+  1) echo "::warning::Benchstat detected a significant benchmark regression." ;;
+  2) echo "::warning::The benchmark comparison could not be interpreted." ;;
+  *) echo "::warning::${GATE} exited ${gate_status} — it did not run to completion." ;;
+esac
+
+# Waived and stale-waiver lines are pulled out of the report and shown
+# OUTSIDE the collapsed section, so a standing exception is read by
+# everyone who reads the PR and not only by whoever expands a details
+# block. `|| true` because grep exits 1 on no match, which is the
+# normal case and must not fail the step under `set -o pipefail`.
+waiver_lines="$(grep -E '^  (WAIVED|WAIVER-|waiver-)' gate-report.txt || true)"
+
+{
+  echo 'result<<BENCHSTAT_EOF'
+  echo '## Benchmark Comparison (main baseline vs PR)'
+  echo ''
+  if [ -n "$waiver_lines" ]; then
+    echo '### Reviewed waivers'
+    echo ''
+    echo 'Declared in `scripts/benchstat-waivers.txt`. A `WAIVED` row was measured,'
+    echo 'DID move, and was accepted within the ceiling recorded there — it is not'
+    echo 'suppressed. `waiver-unused` means that row is no longer regressing and the'
+    echo 'entry can be deleted; `WAIVER-STALE` means it protects nothing at all.'
+    echo ''
+    echo '```'
+    echo "$waiver_lines"
+    echo '```'
+    echo ''
+  fi
+  echo '<details>'
+  echo '<summary>Click to expand benchstat output</summary>'
+  echo ''
+  echo '```'
+  cat benchstat-output.txt
+  echo '```'
+  echo ''
+  echo '</details>'
+  echo ''
+  echo '<details>'
+  echo '<summary>Click to expand the gate report</summary>'
+  echo ''
+  echo '```'
+  cat gate-report.txt
+  echo '```'
+  echo ''
+  echo '</details>'
+  echo ''
+  echo "_Both arms measured on the same runner in the same job, interleaved, n=${BENCH_COUNT} each._"
+  echo 'BENCHSTAT_EOF'
+} >> "$GITHUB_OUTPUT"

--- a/scripts/bench-gate-fail.sh
+++ b/scripts/bench-gate-fail.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Turn the benchmark gate's verdict into a red build, and say WHICH verdict it
+# was.
+#
+# Extracted verbatim from the "Fail on regressions" step of
+# .github/workflows/benchmark.yml so the logic is syntax-checked, shellchecked
+# and testable by scripts/ci-gates-test.sh.
+#
+# This script decides nothing. The workflow's `if:` already established that the
+# gate did not pass; all this does is name the reason before exiting 1. The
+# three-way split is deliberate and must be preserved:
+#
+#   1  regressions found      -- a real, measured performance problem
+#   2  could not interpret    -- a hard failure BY DESIGN; a gate that cannot
+#                               read its input must never report success
+#   *  no verdict reached     -- e.g. exit 127, the script not being found.
+#                               This branch used to say "regressions detected",
+#                               which sent the reader hunting a performance
+#                               problem that did not exist.
+#
+# Inputs (env):
+#   GATE_STATUS   steps.benchstat.outputs.gate_status; may be empty, which the
+#                 `*` branch reports as <unset> exactly as the original did
+#
+# Always exits 1 -- it only runs when the gate did not pass.
+#
+# Run locally as:  GATE_STATUS=2 scripts/bench-gate-fail.sh
+set -euo pipefail
+
+# Sourced from the environment rather than a `${{ }}` template expansion. The
+# `-` (not `:-`) keeps an UNSET variable distinct from nothing at all under
+# `set -u`, so the `${status:-<unset>}` below still behaves as it did when the
+# expansion produced an empty string.
+status="${GATE_STATUS-}"
+case "$status" in
+  1)
+    echo "::error::Benchmark regressions detected (gate exit 1). Review the benchstat comparison in the PR comment and the gate report in the job log."
+    ;;
+  2)
+    echo "::error::The benchmark comparison could not be interpreted (gate exit 2). This is a hard failure by design — a gate that cannot read its input must never report success. See the job log above."
+    ;;
+  *)
+    # Anything else means the gate did not reach a verdict at all --
+    # e.g. exit 127, the script not being found. Reporting that as
+    # "regressions detected" (which this branch used to do) sends the
+    # reader looking for a performance problem that does not exist.
+    echo "::error::The benchmark gate did not run to completion (exit ${status:-<unset>}); it reached no verdict, so this is neither a pass nor a measured regression. See the job log above for the failing command."
+    ;;
+esac
+exit 1

--- a/scripts/bench-run-arms.sh
+++ b/scripts/bench-run-arms.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Measure BOTH benchmark arms -- PR head and PR base -- on this runner, in this
+# job, interleaved.
+#
+# Extracted verbatim from the "Run benchmarks (both arms, interleaved)" step of
+# .github/workflows/benchmark.yml so the logic is syntax-checked, shellchecked
+# and testable by scripts/ci-gates-test.sh. Bash inside a `run: |` block is none
+# of those things, and this repo has already lost 473 runs to a CI gate that
+# could never fire.
+#
+# Interleaved, alternating arms every round rather than running all of one arm
+# then all of the other. A runner that slows down partway through -- thermal
+# throttling, a noisy neighbour -- biases a block-ordered run entirely into
+# whichever arm ran second. Alternating spreads that drift across both arms
+# instead of pooling it into one. Each round contributes one sample per arm, so
+# BENCH_COUNT rounds give BENCH_COUNT samples each.
+#
+# `pipefail` is load-bearing: without it the exit status of `go test ... | tee`
+# is tee's, which is 0 even when the benchmarks fail to compile or panic. The
+# step would go green, the output files would hold error text, and the
+# comparison downstream would be meaningless. GitHub's default shell is
+# `bash -e` WITHOUT pipefail, so the original step had to set it explicitly;
+# here it is part of the `set -euo pipefail` line below, which reproduces that
+# shell's `-e` too.
+#
+# Inputs (env):
+#   BENCH_COUNT   number of interleaved rounds (workflow-level env in
+#                 benchmark.yml; see the long note there for why it is 10)
+#
+# Expects the two working trees at ./base and ./pr, per the two-checkout layout
+# in benchmark.yml. Writes bench-baseline.txt and bench-current.txt in $PWD.
+#
+# Run locally as:  BENCH_COUNT=3 scripts/bench-run-arms.sh
+set -euo pipefail
+
+: > bench-baseline.txt
+: > bench-current.txt
+for round in $(seq 1 "${BENCH_COUNT}"); do
+  echo "::group::round ${round}/${BENCH_COUNT}"
+  (cd base && go test -bench=. -benchmem -benchtime=100ms -count=1 \
+    -run='^$' -timeout=10m ./...) | tee -a bench-baseline.txt
+  (cd pr && go test -bench=. -benchmem -benchtime=100ms -count=1 \
+    -run='^$' -timeout=10m ./...) | tee -a bench-current.txt
+  echo "::endgroup::"
+done

--- a/scripts/benchstat-gate.sh
+++ b/scripts/benchstat-gate.sh
@@ -125,6 +125,38 @@
 # That is left as a follow-up so this change stays a gate fix rather than a
 # benchmark-tuning change.
 #
+# Reviewed waivers
+# ---------------
+# Sometimes a regression is real, understood and deliberately accepted.  The
+# answer to that is NOT a higher threshold -- the thresholds are per-metric-class
+# noise floors, and raising one to accept a single benchmark blinds every other
+# benchmark in the repository to the same magnitude of move, permanently.  It is
+# a per-row waiver, declared in scripts/benchstat-waivers.txt, reviewed in the
+# diff that needs it, and bounded:
+#
+#   * it names ONE package, ONE benchmark and ONE metric column, all matched
+#     exactly, so it cannot reach a row it was not written for;
+#   * it records a CEILING, and the row fails again the moment its regression
+#     grows past what was accepted;
+#   * it carries a reason and a tracking issue, and an entry missing either is a
+#     hard exit 2 rather than a silently-ignored line;
+#   * it EXPIRES, after which it stops suppressing and the row is judged
+#     normally again.
+#
+# A waived row is still parsed, still counted, and still printed -- as WAIVED,
+# with its delta, its ceiling and its issue -- in both the job log and the PR
+# comment.  Dropping it from the report would recreate this gate's founding
+# defect (a check that looks green because it stopped looking) one benchmark at
+# a time, so the waiver changes the VERDICT and never the visibility.
+#
+# Waivers that match nothing are reported too: WAIVER-STALE when the row is
+# absent from the comparison entirely (renamed benchmark, deleted package,
+# typo), waiver-unused when the row is present and no longer regressing.
+#
+# See scripts/benchstat-waivers.txt for the file format; BENCH_WAIVERS overrides
+# the path (set it EMPTY to adjudicate with no waivers at all, which can only
+# ever make the gate stricter).
+#
 # Both benchstat table formats are handled:
 #   new (golang.org/x/perf, box-drawing columns):
 #     EnvGet-4   27.13m ± ∞ ¹   29.16m ± ∞ ¹  +7.14% (p=0.008 n=5)
@@ -138,21 +170,41 @@
 #   1  regression detected
 #   2  the input could not be interpreted (missing/empty file, or NO comparison
 #      row at all -- which means benchstat's output format changed or benchstat
-#      crashed).  Exiting 2 rather than 0 is deliberate: an uninterpretable
-#      comparison must fail loudly instead of reporting "no regression", which
-#      is exactly how the old gate stayed green for 473 runs.
+#      crashed), or the waiver file could not be interpreted.  Exiting 2 rather
+#      than 0 is deliberate: an uninterpretable comparison must fail loudly
+#      instead of reporting "no regression", which is exactly how the old gate
+#      stayed green for 473 runs.  The same reasoning covers the waiver file: a
+#      malformed waiver list must never be read as an empty one.
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 ALPHA="${BENCH_ALPHA:-0.05}"
 THRESHOLD="${BENCH_REGRESSION_THRESHOLD_PCT:-15}"
 ALLOC_THRESHOLD="${BENCH_ALLOC_THRESHOLD_PCT:-5}"
+
+# Overridable so the self-test can drive the waiver logic with fixtures, and so
+# a run can be adjudicated with waivers switched OFF (BENCH_WAIVERS= empty).
+# Disabling them only ever makes the gate stricter, so it is not a bypass.
+DEFAULT_WAIVERS="${SCRIPT_DIR}/benchstat-waivers.txt"
+waivers_set=1
+if [ -z "${BENCH_WAIVERS+x}" ]; then
+	waivers_set=0
+fi
+WAIVERS="${BENCH_WAIVERS-$DEFAULT_WAIVERS}"
+
+# Today, as the waiver expiry check sees it. Overridable so the self-test can
+# exercise both sides of an expiry without waiting for a date to arrive.
+TODAY="${BENCH_WAIVER_TODAY:-$(date -u +%Y-%m-%d)}"
 
 if [ "$#" -ne 1 ]; then
 	echo "usage: $0 <benchstat-output-file>" >&2
 	echo "  env: BENCH_REGRESSION_THRESHOLD_PCT (default 15)  timing metrics: sec/op, B/s" >&2
 	echo "       BENCH_ALLOC_THRESHOLD_PCT      (default 5)   allocation metrics: B/op, allocs/op" >&2
 	echo "       BENCH_ALPHA                    (default 0.05)" >&2
+	echo "       BENCH_WAIVERS                  (default scripts/benchstat-waivers.txt; empty = none)" >&2
+	echo "       BENCH_WAIVER_TODAY             (default today, UTC; YYYY-MM-DD)" >&2
 	exit 2
 fi
 
@@ -168,13 +220,41 @@ if [ ! -s "$input" ]; then
 	exit 2
 fi
 
-report=$(mktemp)
-trap 'rm -f "$report"' EXIT
+if ! printf '%s' "$TODAY" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+	echo "benchstat-gate: BENCH_WAIVER_TODAY='${TODAY}' is not a YYYY-MM-DD date." >&2
+	exit 2
+fi
 
+# An EXPLICIT BENCH_WAIVERS pointing at nothing is an error -- you asked for a
+# specific file and it is not there. The default file being absent is not: the
+# gate still works, it just has no waivers, which is the strict direction.
+waiver_input=$(mktemp)
+trap 'rm -f "$waiver_input"' EXIT
+if [ -n "$WAIVERS" ]; then
+	if [ -f "$WAIVERS" ]; then
+		cat "$WAIVERS" >"$waiver_input"
+	elif [ "$waivers_set" -eq 1 ]; then
+		echo "benchstat-gate: BENCH_WAIVERS points at a file that does not exist: $WAIVERS" >&2
+		exit 2
+	else
+		echo "benchstat-gate: no waiver file at ${WAIVERS}; adjudicating with no waivers."
+	fi
+fi
+
+report=$(mktemp)
+trap 'rm -f "$report" "$waiver_input"' EXIT
+
+# Two inputs: the waiver list first, then the benchstat table. They are told
+# apart by FILENAME rather than by the usual FNR==NR trick, which mis-attributes
+# the first record of the second file whenever the first file is empty -- and an
+# empty waiver list is the normal case.
+#
 # The awk program emits one human-readable line per interesting row, then a
 # final machine-readable line:
-#   "VERDICT <regressions> <significant> <compared> <tilde> <badp>".
-awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRESHOLD" '
+#   "VERDICT <regressions> <significant> <compared> <tilde> <badp> <waived>
+#            <waiver_bad> <waiver_stale> <waiver_unused> <waiver_expired>".
+awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRESHOLD" \
+	-v wfile="$waiver_input" -v wsource="${WAIVERS:-<none>}" -v today="$TODAY" '
 	# Last signed-percentage token (e.g. +7.14% / -1.20%) inside s, "" if none.
 	function last_signed_pct(s,   pos, tok, best, rest) {
 		best = ""
@@ -223,10 +303,117 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 		return 0
 	}
 
+	function trim(s) {
+		gsub(/^[ \t]+|[ \t]+$/, "", s)
+		return s
+	}
+
+	# `go test` appends -<GOMAXPROCS> to every benchmark name (and omits it
+	# entirely at GOMAXPROCS=1), so the suffix follows the RUNNER, not the code.
+	# Waivers are written without it and rows are stripped down to match; that is
+	# what keeps a waiver from silently unbinding when `runs-on` changes.
+	function base_name(n) {
+		sub(/-[0-9]+$/, "", n)
+		return n
+	}
+
+	function waiver_err(lineno, msg) {
+		wbad++
+		printf "  WAIVER-BAD  %s:%d  %s\n", wsource, lineno, msg
+	}
+
+	# One or more tracking references, space separated: elps#412, #412,
+	# luthersystems/elps#412, or a GitHub issue/PR URL. Anything else is not a
+	# reference somebody can be sent to.
+	function issues_ok(s,   i, n, parts, t, good) {
+		n = split(s, parts, /[ \t,]+/)
+		good = 0
+		for (i = 1; i <= n; i++) {
+			t = parts[i]
+			if (t == "") continue
+			if (t ~ /^[A-Za-z0-9._\/-]*#[0-9]+$/) { good++; continue }
+			if (t ~ /^https:\/\/github\.com\/[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+\/(issues|pull)\/[0-9]+$/) { good++; continue }
+			return 0
+		}
+		# At least one reference, and nothing that is not one. Counting rather
+		# than merely not-rejecting matters: a field of "," splits into two
+		# empty tokens, every one of which passes a not-rejected test.
+		return good > 0
+	}
+
+	# Index of the waiver covering this row, or 0. Exact on all three keys.
+	function find_waiver(p, b, m,   i) {
+		for (i = 1; i <= nw; i++) {
+			if (wpkg[i] == p && wbench[i] == b && wmetric[i] == m) return i
+		}
+		return 0
+	}
+
+	# ---- waiver file -----------------------------------------------------
+	FILENAME == wfile {
+		wl = $0
+		sub(/\r$/, "", wl)
+		if (wl ~ /^[ \t]*(#|$)/) next
+
+		nf = split(wl, wf, /\|/)
+		if (nf != 7) {
+			waiver_err(FNR, sprintf("expected 7 |-separated fields (pkg | benchmark | metric | ceiling | expires | issue | reason), found %d: %s", nf, trim(wl)))
+			next
+		}
+		for (i = 1; i <= 7; i++) wf[i] = trim(wf[i])
+
+		bad = 0
+		if (wf[1] == "") { waiver_err(FNR, "empty pkg field; a waiver must name the package it covers"); bad = 1 }
+		if (wf[2] == "") { waiver_err(FNR, "empty benchmark field; a waiver must name the benchmark it covers"); bad = 1 }
+		else if (wf[2] ~ /-[0-9]+$/) {
+			waiver_err(FNR, sprintf("benchmark %s carries a -<GOMAXPROCS> suffix; write it as %s so the waiver does not unbind when the runner changes", wf[2], base_name(wf[2])))
+			bad = 1
+		}
+		if (wf[3] == "") { waiver_err(FNR, "empty metric field; a waiver covers one metric column, not the whole row"); bad = 1 }
+		if (wf[4] !~ /^[0-9]+(\.[0-9]+)?$/ || wf[4] + 0 <= 0) {
+			waiver_err(FNR, sprintf("ceiling %s is not a positive percentage; an unbounded waiver is a threshold increase in disguise", (wf[4] == "" ? "<empty>" : wf[4])))
+			bad = 1
+		}
+		if (wf[5] !~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/) {
+			waiver_err(FNR, sprintf("expires %s is not a YYYY-MM-DD date; a waiver with no end date is never revisited", (wf[5] == "" ? "<empty>" : wf[5])))
+			bad = 1
+		}
+		if (!issues_ok(wf[6])) {
+			waiver_err(FNR, sprintf("issue %s is not a tracking reference (elps#412, #412, owner/repo#412 or a github.com issue/PR URL); a waiver nobody has to come back to is just a silent threshold increase", (wf[6] == "" ? "<empty>" : wf[6])))
+			bad = 1
+		}
+		if (length(wf[7]) < 10) {
+			waiver_err(FNR, "reason is missing or too short; say what the regression buys and what the alternative cost")
+			bad = 1
+		}
+		if (bad) next
+
+		nw++
+		wpkg[nw] = wf[1]; wbench[nw] = wf[2]; wmetric[nw] = wf[3]
+		wceil[nw] = wf[4] + 0; wceilstr[nw] = wf[4]
+		wexp[nw] = wf[5]; wissue[nw] = wf[6]
+		wline[nw] = FNR
+		# ISO dates compare correctly as strings, so no date arithmetic and no
+		# dependency on how the platform date(1) parses things.
+		wexpired[nw] = (today > wf[5]) ? 1 : 0
+		next
+	}
+
+	# ---- benchstat table -------------------------------------------------
 	{
 		line = $0
 
 		if (line ~ /^[ \t]*$/) next
+
+		# `#` comments. benchstat never emits one, but the fixtures in
+		# scripts/testdata/ are annotated with the history of the run they
+		# capture -- and those annotations QUOTE benchstat rows, deltas and
+		# p-values included. Without this, the explanation a fixture carries
+		# is adjudicated as data: the note above the table in
+		# benchstat-libjson-encode-411.txt produced four phantom comparison
+		# rows, one of them a "below-gate" verdict on a sentence. A fixture
+		# must not be able to move the verdict by explaining itself.
+		if (line ~ /^[ \t]*#/) next
 
 		# Context headers.  elps benchmark output carries all four (the `cpu:`
 		# line names the runner CPU, e.g. "Intel(R) Xeon(R) @ 2.80GHz").
@@ -234,6 +421,7 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 			if (line ~ /^pkg:/) {
 				pkg = substr(line, 6)
 				gsub(/^[ \t]+|[ \t]+$/, "", pkg)
+				pkgseen[pkg] = 1
 			}
 			next
 		}
@@ -296,17 +484,29 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 		lastpm = last_spread(region)
 		if (lastpm > 0) region = substr(region, lastpm + 1)
 
+		# The waiver keyed to this row, if any. Looked up here -- before the
+		# significance and threshold tests -- so that a row which is present but
+		# NOT regressing still counts as "the waiver found its row". That is what
+		# separates a waiver that is merely no longer needed (delete it) from one
+		# pointing at a benchmark that no longer exists (it is protecting
+		# nothing, while looking like it is).
+		wi = find_waiver(pkg, base_name(name), metric)
+
 		delta_tok = last_signed_pct(region)
 		if (delta_tok == "") {
 			# A "~" row IS a successfully interpreted comparison -- it just
 			# found no significant difference. Tally it separately so a table
 			# in which nothing moved is not mistaken for "could not parse
 			# anything" and turned into a spurious exit 2.
-			if (index(line, "~") > 0) tilde++
+			if (index(line, "~") > 0) {
+				tilde++
+				if (wi) wseen[wi] = 1
+			}
 			next
 		}
 
 		compared++
+		if (wi) wseen[wi] = 1
 
 		numstr = substr(delta_tok, 1, length(delta_tok) - 1)
 		sub(/^\+/, "", numstr)
@@ -335,26 +535,98 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 		if (regr <= 0) next          # improvement or no change
 
 		significant++
-		if (regr >= gate) {
-			regressions++
-			printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) %s\n",
-				pkg, metric, name, delta_tok, pval_str, gate, dir
-		} else {
+		if (regr < gate) {
 			printf "  below-gate  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) %s\n",
 				pkg, metric, name, delta_tok, pval_str, gate, dir
+			next
 		}
+
+		# At or above the gate. A waiver can turn this into a PASS, but only
+		# a live one, and only while the move stays inside the ceiling it
+		# recorded. Every outcome below is printed either way: the waiver
+		# changes the verdict, never the visibility.
+		if (wi && wexpired[wi]) {
+			regressions++
+			wexpiredhit[wi] = 1
+			printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) WAIVER EXPIRED %s (%s), no longer suppressing %s\n",
+				pkg, metric, name, delta_tok, pval_str, gate, wexp[wi], wissue[wi], dir
+			next
+		}
+		if (wi && regr > wceil[wi]) {
+			regressions++
+			wexceeded[wi] = 1
+			printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) EXCEEDS its waiver ceiling %s%% (%s) %s\n",
+				pkg, metric, name, delta_tok, pval_str, gate, wceilstr[wi], wissue[wi], dir
+			next
+		}
+		if (wi) {
+			waived++
+			wused[wi] = 1
+			printf "  WAIVED      %-46s %-9s %-40s delta=%s p=%s (gate %s%%) accepted: ceiling %s%%, expires %s, %s %s\n",
+				pkg, metric, name, delta_tok, pval_str, gate, wceilstr[wi], wexp[wi], wissue[wi], dir
+			next
+		}
+
+		regressions++
+		printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) %s\n",
+			pkg, metric, name, delta_tok, pval_str, gate, dir
 	}
 
 	END {
-		printf "VERDICT %d %d %d %d %d\n",
-			regressions + 0, significant + 0, compared + 0, tilde + 0, badp + 0
+		# A waiver that matched no row in this comparison, or matched a row it
+		# did not need to suppress, is reported EVERY run. A stale waiver that
+		# rots quietly is how a per-row exception turns back into a blanket one.
+		for (i = 1; i <= nw; i++) {
+			if (!(wpkg[i] in pkgseen)) {
+				# The comparison did not cover this package AT ALL, so there is
+				# nothing to say about the waiver -- it was not exercised, and
+				# calling that "stale" would flood every partial comparison
+				# (every fixture in scripts/testdata/, for one) with warnings
+				# about waivers that are perfectly healthy. Counted, not
+				# printed, so a package that has genuinely disappeared still
+				# shows up as a nonzero number rather than as silence.
+				woutscope++
+			} else if (!(i in wseen)) {
+				wstale++
+				printf "  WAIVER-STALE  %s:%d waives %s / %s / %s -- that package IS in this comparison and that row is not, so the benchmark was renamed or removed and the waiver is protecting nothing. %s\n",
+					wsource, wline[i], wpkg[i], wbench[i], wmetric[i], wissue[i]
+			} else if (!(i in wused) && !(i in wexceeded) && !(i in wexpiredhit)) {
+				wunused++
+				printf "  waiver-unused %s:%d waives %s / %s / %s, and that row is not regressing above its gate -- the waiver can be deleted. %s\n",
+					wsource, wline[i], wpkg[i], wbench[i], wmetric[i], wissue[i]
+			}
+			if (wexpired[i] && (wpkg[i] in pkgseen)) {
+				wexp_n++
+				printf "  WAIVER-EXPIRED %s:%d %s / %s / %s expired on %s and no longer suppresses anything. %s\n",
+					wsource, wline[i], wpkg[i], wbench[i], wmetric[i], wexp[i], wissue[i]
+			}
+		}
+		printf "VERDICT %d %d %d %d %d %d %d %d %d %d %d %d\n",
+			regressions + 0, significant + 0, compared + 0, tilde + 0, badp + 0,
+			waived + 0, wbad + 0, wstale + 0, wunused + 0, wexp_n + 0, nw + 0,
+			woutscope + 0
 	}
-' "$input" >"$report"
+' "$waiver_input" "$input" >"$report"
 
 verdict_line=$(tail -n 1 "$report")
 sed '$d' "$report"
 
-read -r _ n_regressions n_significant n_compared n_tilde n_badp <<<"$verdict_line"
+read -r _ n_regressions n_significant n_compared n_tilde n_badp \
+	n_waived n_waiver_bad n_waiver_stale n_waiver_unused n_waiver_expired n_waivers \
+	n_waiver_outscope <<<"$verdict_line"
+
+if [ "$n_waiver_bad" -gt 0 ]; then
+	cat >&2 <<-EOF
+		benchstat-gate: ${n_waiver_bad} malformed entr(y/ies) in ${WAIVERS} -- see the
+		WAIVER-BAD line(s) above.
+
+		Refusing to report a verdict rather than skipping the bad entries: a waiver
+		list that cannot be read must never be treated as an empty one, and a waiver
+		that silently does not parse is a regression nobody is told about. Fix the
+		entry, or delete it. The format is documented at the top of that file.
+	EOF
+	exit 2
+fi
 
 if [ "$n_badp" -gt 0 ]; then
 	echo "benchstat-gate: ${n_badp} row(s) carried a p-value this gate cannot read -- refusing to report a verdict." >&2
@@ -376,6 +648,12 @@ if [ "$((n_compared + n_tilde))" -eq 0 ]; then
 fi
 
 echo "benchstat-gate: interpreted ${n_compared} delta row(s) + ${n_tilde} no-change row(s); ${n_significant} significant move(s) in the bad direction; ${n_regressions} at or above the gate (timing ${THRESHOLD}%, allocation ${ALLOC_THRESHOLD}%)."
+
+# Printed on EVERY run, including clean ones. A waiver is a standing decision,
+# and a standing decision that stops being visible stops being reviewed.
+if [ "$n_waivers" -gt 0 ] || [ "$n_waived" -gt 0 ]; then
+	echo "benchstat-gate: ${n_waivers} reviewed waiver(s) loaded from ${WAIVERS}; ${n_waived} row(s) WAIVED (measured, reported, and excluded from the verdict), ${n_waiver_stale} stale, ${n_waiver_unused} currently unused, ${n_waiver_expired} expired, ${n_waiver_outscope} for a package this comparison does not cover."
+fi
 
 if [ "$n_regressions" -gt 0 ]; then
 	exit 1

--- a/scripts/benchstat-waivers.txt
+++ b/scripts/benchstat-waivers.txt
@@ -1,0 +1,125 @@
+# Reviewed waivers for the benchmark regression gate (scripts/benchstat-gate.sh).
+#
+# WHAT THIS IS FOR
+# ----------------
+# The gate fails a PR when a benchstat row shows a statistically significant
+# move in the bad direction that is at or above the threshold for that metric
+# class.  Occasionally such a move is REAL, UNDERSTOOD and DELIBERATELY
+# ACCEPTED: the change buys correctness that the cost is worth, and the cheaper
+# implementation was measured and rejected rather than merely imagined.
+#
+# This file is how that decision is recorded.  It is NOT a way to make the gate
+# quieter.  Read this before adding a row:
+#
+#   * DO NOT raise BENCH_REGRESSION_THRESHOLD_PCT or BENCH_ALLOC_THRESHOLD_PCT
+#     to accept one row.  Those are per-metric-class noise floors derived from
+#     measurement (see the note at the top of scripts/benchstat-gate.sh); moving
+#     one to accommodate a single benchmark blinds every other benchmark in the
+#     repository to the same magnitude of regression, permanently and silently.
+#     A waiver costs one row and one benchmark.
+#
+#   * DO NOT add a waiver you cannot justify in the PR description.  Every entry
+#     must name a tracking issue, and the gate REFUSES TO RUN if one does not.
+#
+#   * A waived row is still MEASURED, still REPORTED in the job log and in the
+#     PR comment, and still FAILS if it grows past the ceiling recorded here.
+#     The point is a decision that stays visible, not a row that disappears.
+#     The defect this whole gate exists to fix was a check that looked green
+#     because it had stopped looking; a waiver that hid its row would recreate
+#     exactly that, one benchmark at a time.
+#
+# FORMAT
+# ------
+# One waiver per line, seven `|`-separated fields.  Blank lines and lines whose
+# first non-blank character is `#` are comments.
+#
+#   pkg | benchmark | metric | ceiling | expires | issue | reason
+#
+#   pkg        Full Go import path, matched EXACTLY against benchstat's `pkg:`
+#              header.  Not a prefix, not a pattern -- a waiver for one package
+#              must never reach another.
+#
+#   benchmark  Benchmark name as benchstat prints it but WITHOUT the trailing
+#              `-<GOMAXPROCS>` suffix, matched EXACTLY.  `go test` appends that
+#              suffix from the runner's core count, so a waiver written as
+#              `Encode-2` would stop matching the day the runner or the
+#              GOMAXPROCS pin changed -- silently, which is the failure mode
+#              this repository has been bitten by most.  The gate strips the
+#              suffix from the row before comparing, and REJECTS a waiver whose
+#              benchmark field carries one.  Exact, so `Encode` waives `Encode`
+#              and never `Encode_stringNumbers` or `EncodeNativeSmall`.
+#              Sub-benchmarks keep their slash: `Package/dump-github`.
+#
+#   metric     Metric column, matched EXACTLY: `sec/op`, `B/op`, `allocs/op`,
+#              `B/s`, ...  One waiver covers ONE column.  Accepting an
+#              allocation cost does not accept a timing cost.
+#
+#   ceiling    Percentage.  The largest bad-direction move this waiver accepts.
+#              The row passes while its regression is at or below the ceiling
+#              and FAILS the moment it grows past it, so a waiver bounds the
+#              cost instead of blessing the benchmark forever.  Set it just
+#              above the measured value -- enough headroom for run-to-run
+#              wobble, not enough to hide a second regression landing on top.
+#
+#   expires    YYYY-MM-DD.  Past that date the waiver STOPS SUPPRESSING and the
+#              row is judged normally again, so the decision has to be re-made
+#              rather than inherited.  Expiry is a date rather than "the issue
+#              must still be open" on purpose: the gate must stay hermetic --
+#              runnable offline, from the self-test, with no network and no
+#              token -- and an open-issue check would make a green build depend
+#              on GitHub being reachable and on a token that PRs from forks do
+#              not have.  The tracking issue is recorded below so a human can
+#              check it; the date is what the machine can check honestly.
+#
+#   issue      One or more tracking references, space separated.  `elps#412`,
+#              `#412`, `luthersystems/elps#412` and full GitHub URLs are all
+#              accepted.  An entry with no parseable reference is a hard error:
+#              a waiver nobody is obliged to come back to is just a threshold
+#              increase with better manners.
+#
+#   reason     Free text (no `|`), at least 10 characters.  Say what was bought
+#              and what the alternative cost, not just "accepted".
+#
+# The gate exits 2 -- "could not be interpreted", the same hard failure as an
+# unreadable benchstat table -- on any malformed entry.  A waiver file that
+# cannot be read must never be treated as an empty one.
+#
+# Waivers that match nothing are REPORTED on every run: `WAIVER-STALE` when the
+# row does not appear in the comparison at all (renamed benchmark, deleted
+# package, typo -- a waiver that protects nothing while looking like it does),
+# and `waiver-unused` when the row is there and no longer regressing, which is
+# the signal to delete the entry.
+#
+# ---------------------------------------------------------------------------
+# pkg | benchmark | metric | ceiling | expires | issue | reason
+# ---------------------------------------------------------------------------
+#
+# elps#412 / elps#410 -- libjson BenchmarkEncode, PR #411.
+#
+# TWO entries, not one, and the second one deserves saying out loud.
+#
+# The regression was described going in as a single failing row, allocs/op at
+# +7.94%. It is not. Running the gate over that run's actual benchstat output
+# (preserved as scripts/testdata/benchstat-libjson-encode-411.txt) with waivers
+# switched off reports TWO rows at or above a gate:
+#
+#     Encode-2  B/op       10.05Ki -> 11.30Ki  +12.45% (p=0.000 n=10)   gate 5%
+#     Encode-2  allocs/op    214.0 ->   231.0   +7.94% (p=0.000 n=10)   gate 5%
+#
+# B/op is an ALLOCATION metric, so it is judged against BENCH_ALLOC_THRESHOLD_PCT
+# (5), not against the 15% timing threshold. At +12.45% it is over. Waiving only
+# the count would have produced a waiver that does not work: the build would have
+# stayed red, on a row nobody had reviewed, and the natural next move would have
+# been to widen the allocation threshold -- which is precisely the outcome this
+# mechanism exists to avoid.
+#
+# They are one cost measured two ways: the same 17 extra allocations, ~1.25 KiB
+# of them. Waiving one and not the other would not be narrower, only broken. So
+# both are here, each with its own ceiling, each nameable in review.
+#
+# sec/op is NOT waived. It moves too (+11.00%, p=0.000) but its gate is 15% and
+# it is under it, so it needs nothing -- and leaving it unwaived means the timing
+# cost of this change is still watched at full strength.
+
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | 9 | 2027-02-28 | elps#412 elps#410 | Dump could emit a document Load refuses (elps#410); the fix marshals each native value and validates the bytes it produced. 3 of BenchmarkEncode's 36 stdEncodeTests rows are lisp.Value(map[string]interface{}{...}), i.e. natives, so this microbenchmark pays the check at 214->231 allocs/op (+7.94%) while documents without natives pay nothing -- every realistic JSON row (Package/dump-object, dump-array, dump-nested, dump-github) is flat on all three metrics. A hand-rolled scanner restoring allocation parity was built and measured: an end-to-end substrate benchmark (interleaved, n=12) could not distinguish it from the decode on any of that repo's 20 rows, and it cost ~130 lines of a second JSON parser required to agree with encoding/json forever. elps#412 tracks removing the redundant work instead. Ceiling 9% allows 233 allocs/op against the measured 231; a second regression landing on this benchmark still reds the build.
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | B/op | 14 | 2027-02-28 | elps#412 elps#410 | The same 17 allocations as the allocs/op waiver above, weighed instead of counted: 10.05Ki -> 11.30Ki (+12.45%, p=0.000 n=10), ~1.25 KiB of marshalled bytes held while the native round-trip is validated. B/op is an allocation metric and so is judged against the 5% allocation gate, not the 15% timing one -- waiving the count alone would have left the build red on this row. Same fix, same tracking issue, same expiry: elps#412 removes the redundant marshal and both entries go with it. Ceiling 14% against a measured 12.45%.

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -521,6 +521,182 @@ assert_exit 2 "missing file fails with the same 'unusable' code as the gate" \
 	"$ARMS" "${ARMS_TMP}/does-not-exist.txt" "${ARMS_TMP}/pr.txt"
 
 echo
+echo "== extracted workflow bodies: bench-gate-fail ============================"
+
+# These four scripts were `run: |` blocks in .github/workflows/benchmark.yml.
+# Inline bash is not syntax-checked, not shellchecked and not testable -- which
+# is exactly how a gate stayed dead for 473 runs. Now that they are files, the
+# discovery loop at the bottom lints them; this section exercises the LOGIC.
+
+GATE_FAIL="${SCRIPT_DIR}/bench-gate-fail.sh"
+
+# The three-way split is the whole point of this script, and the third branch is
+# the subtle one: an exit code the gate never produces means it reached NO
+# verdict, and calling that "regressions detected" (which this branch used to
+# do) sends the reader hunting a performance problem that does not exist.
+assert_exit 1 "bench-gate-fail: always fails the build" \
+	env GATE_STATUS=1 bash "$GATE_FAIL"
+assert_contains "::error::Benchmark regressions detected (gate exit 1)" \
+	"bench-gate-fail: exit 1 is reported as a measured regression" \
+	env GATE_STATUS=1 bash "$GATE_FAIL"
+assert_contains "::error::The benchmark comparison could not be interpreted (gate exit 2)" \
+	"bench-gate-fail: exit 2 is reported as uninterpretable, not as a regression" \
+	env GATE_STATUS=2 bash "$GATE_FAIL"
+assert_exit 1 "bench-gate-fail: an unrecognised code still fails" \
+	env GATE_STATUS=127 bash "$GATE_FAIL"
+assert_contains "did not run to completion (exit 127)" \
+	"bench-gate-fail: exit 127 is reported as 'no verdict reached'" \
+	env GATE_STATUS=127 bash "$GATE_FAIL"
+assert_not_contains "regressions detected" \
+	"bench-gate-fail: the no-verdict branch does NOT claim a regression" \
+	env GATE_STATUS=127 bash "$GATE_FAIL"
+# An empty or absent verdict must still be legible in the log rather than
+# rendering as an empty pair of parentheses.
+assert_contains "exit <unset>" \
+	"bench-gate-fail: an empty verdict prints <unset>" \
+	env GATE_STATUS= bash "$GATE_FAIL"
+assert_contains "exit <unset>" \
+	"bench-gate-fail: an UNSET verdict prints <unset> (not an unbound-variable crash)" \
+	env -u GATE_STATUS bash "$GATE_FAIL"
+
+echo "== extracted workflow bodies: require-jobs-succeeded ====================="
+
+REQ_JOBS="${SCRIPT_DIR}/require-jobs-succeeded.sh"
+
+# `success` is the ONLY pass. This is the body of the single job branch
+# protection requires, so each of the non-success results has to fail it --
+# a skipped or cancelled required check otherwise reads as green.
+assert_exit 0 "require-jobs: all success passes" \
+	env RESULTS='success success success' bash "$REQ_JOBS"
+assert_exit 1 "require-jobs: a failed job fails the aggregate" \
+	env RESULTS='success failure success' bash "$REQ_JOBS"
+assert_exit 1 "require-jobs: a SKIPPED job fails the aggregate" \
+	env RESULTS='success skipped success' bash "$REQ_JOBS"
+assert_exit 1 "require-jobs: a CANCELLED job fails the aggregate" \
+	env RESULTS='success cancelled' bash "$REQ_JOBS"
+assert_contains "::error::A job in this workflow did not succeed" \
+	"require-jobs: emits the ::error:: annotation naming the results" \
+	env RESULTS='success failure' bash "$REQ_JOBS"
+
+echo "== extracted workflow bodies: bench-compare =============================="
+
+BENCH_COMPARE_SH="${SCRIPT_DIR}/bench-compare.sh"
+
+# A sandbox mimicking the workflow's two-tree layout: $GITHUB_WORKSPACE/pr
+# holding stub gate scripts, and a working directory holding the two arms.
+# Stubs, not the real gate -- this section tests bench-compare.sh's plumbing
+# (branching, $GITHUB_OUTPUT, annotations), and benchstat-gate.sh's own verdict
+# logic is already covered by the fixture sections above.
+make_compare_sandbox() {
+	local dir="$1" arms_rc="$2" gate_rc="$3"
+	mkdir -p "${dir}/pr/scripts" "${dir}/work" "${dir}/bin"
+	{
+		echo '#!/usr/bin/env bash'
+		echo "echo 'stub arms-check output'"
+		echo "exit ${arms_rc}"
+	} > "${dir}/pr/scripts/bench-arms-check.sh"
+	{
+		echo '#!/usr/bin/env bash'
+		# Two leading spaces: the waiver extraction greps '^  (WAIVED|...)'.
+		echo "echo '  WAIVED      pkg B/op Encode-2 delta=+12.45% accepted: ceiling 14%'"
+		echo "echo 'stub gate report'"
+		echo "exit ${gate_rc}"
+	} > "${dir}/pr/scripts/benchstat-gate.sh"
+	{
+		echo '#!/usr/bin/env bash'
+		echo "echo 'stub benchstat table'"
+	} > "${dir}/bin/benchstat"
+	chmod +x "${dir}/pr/scripts/bench-arms-check.sh" \
+		"${dir}/pr/scripts/benchstat-gate.sh" "${dir}/bin/benchstat"
+	printf 'baseline rows\n' > "${dir}/work/bench-baseline.txt"
+	printf 'current rows\n' > "${dir}/work/bench-current.txt"
+}
+
+# compare_case <arms-rc> <gate-rc> [mode] -> prints the script's stdout, then
+# its exit status, then whatever it wrote to $GITHUB_OUTPUT, so a single
+# assertion can inspect any of the three.
+compare_case() {
+	local arms_rc="$1" gate_rc="$2" mode="${3:-normal}"
+	local dir rc
+	dir="$(mktemp -d)"
+	make_compare_sandbox "$dir" "$arms_rc" "$gate_rc"
+	case "$mode" in
+		missing-scripts) rm -f "${dir}/pr/scripts/benchstat-gate.sh" \
+			"${dir}/pr/scripts/bench-arms-check.sh" ;;
+		empty-baseline) : > "${dir}/work/bench-baseline.txt" ;;
+	esac
+	(
+		cd "${dir}/work" || exit 99
+		PATH="${dir}/bin:${PATH}" \
+			GITHUB_WORKSPACE="$dir" \
+			GITHUB_OUTPUT="${dir}/gh-output.txt" \
+			BENCH_COUNT=10 \
+			bash "$BENCH_COMPARE_SH"
+	)
+	rc=$?
+	echo "__EXIT__ ${rc}"
+	echo "__GITHUB_OUTPUT__"
+	cat "${dir}/gh-output.txt" 2>/dev/null
+	rm -rf "$dir"
+}
+
+# Every branch must exit 0: this script REPORTS a verdict via gate_status, and
+# bench-gate-fail.sh is the only thing allowed to turn that into a red build.
+# A non-zero exit here would abort the step before the PR comment is assembled.
+for case_args in "0 0 normal" "0 1 normal" "0 2 normal" "1 0 normal" \
+	"0 0 missing-scripts" "0 0 empty-baseline"; do
+	# Deliberate word splitting of the case tuple into three arguments.
+	# shellcheck disable=SC2086
+	assert_contains "__EXIT__ 0" \
+		"bench-compare: exits 0 so the PR comment is always assembled (${case_args})" \
+		compare_case $case_args
+done
+
+# The gate's verdict must reach $GITHUB_OUTPUT verbatim -- that value is what
+# the workflow's `if:` and bench-gate-fail.sh both key on.
+assert_contains "gate_status=0" "bench-compare: a clean gate reports gate_status=0" \
+	compare_case 0 0
+assert_contains "gate_status=1" "bench-compare: a regression reports gate_status=1" \
+	compare_case 0 1
+assert_contains "gate_status=2" "bench-compare: an uninterpretable gate reports gate_status=2" \
+	compare_case 0 2
+assert_contains "gate_status=127" \
+	"bench-compare: an unrecognised gate exit is passed through, not flattened" \
+	compare_case 0 127
+assert_contains "it did not run to completion" \
+	"bench-compare: warns when the gate exits an unrecognised code" \
+	compare_case 0 127
+
+# The three "could not run" branches each name their own cause. All report
+# gate_status=2, so only the annotation distinguishes them.
+assert_contains "::error::benchmark gate scripts missing from the PR checkout" \
+	"bench-compare: a missing gate script is named, not reported as a regression" \
+	compare_case 0 0 missing-scripts
+assert_contains "gate_status=2" \
+	"bench-compare: a missing gate script reports gate_status=2" \
+	compare_case 0 0 missing-scripts
+assert_contains "::error::bench-baseline.txt is empty" \
+	"bench-compare: an empty base arm fails loudly rather than degrading" \
+	compare_case 0 0 empty-baseline
+assert_not_contains "gate_status=0" \
+	"bench-compare: an empty base arm never reports a pass" \
+	compare_case 0 0 empty-baseline
+assert_contains "::error::The two benchmark arms are not comparable" \
+	"bench-compare: incomparable arms are named by the pre-flight" \
+	compare_case 1 0
+assert_not_contains "gate_status=0" \
+	"bench-compare: incomparable arms never report a pass" \
+	compare_case 1 0
+
+# A waived row that is only visible to whoever expands a <details> block is an
+# accepted regression nobody reviews. It must be surfaced ABOVE the fold.
+assert_contains "### Reviewed waivers" \
+	"bench-compare: a WAIVED row is lifted out of the collapsed section" \
+	compare_case 0 0
+assert_contains "n=10 each." \
+	"bench-compare: BENCH_COUNT reaches the comment footer from the environment" \
+	compare_case 0 0
+
 echo "== workflow shape guards ================================================="
 
 BENCH_WF="${REPO_ROOT}/.github/workflows/benchmark.yml"
@@ -546,10 +722,51 @@ print(" ".join(hits))
 PY
 }
 
-if [ -n "$(invoked_in "$BENCH_WF" 'scripts/benchstat-gate.sh')" ]; then
-	ok "benchmark.yml INVOKES scripts/benchstat-gate.sh (not just mentions it)"
+# invoked_in_any <script-path> <file>... -> non-comment hits across all files
+#
+# The benchmark job's step bodies were moved out of `run: |` blocks and into
+# scripts/bench-*.sh, so the invocations these guards anchor on no longer live
+# in the YAML. The guards follow them into the extracted scripts rather than
+# being deleted: the property being protected is "this logic is still wired
+# into CI", not "this string appears in a .yml file". BENCH_PLUMBING is the
+# workflow plus every script it calls, so a reinline, a deletion or an orphaned
+# script all still fail.
+invoked_in_any() {
+	local needle="$1"
+	shift
+	local f hits all=""
+	for f in "$@"; do
+		[ -f "$f" ] || continue
+		hits="$(invoked_in "$f" "$needle")"
+		[ -n "$hits" ] && all="${all} ${hits}"
+	done
+	echo "$all"
+}
+
+BENCH_COMPARE="${SCRIPT_DIR}/bench-compare.sh"
+BENCH_RUN_ARMS="${SCRIPT_DIR}/bench-run-arms.sh"
+BENCH_GATE_FAIL="${SCRIPT_DIR}/bench-gate-fail.sh"
+REQUIRE_JOBS="${SCRIPT_DIR}/require-jobs-succeeded.sh"
+BENCH_PLUMBING=("$BENCH_WF" "$BENCH_COMPARE" "$BENCH_RUN_ARMS" "$BENCH_GATE_FAIL" "$REQUIRE_JOBS")
+
+# Each extracted script must still be CALLED from the workflow. Without this,
+# deleting the `run:` line would leave a perfectly clean, perfectly linted
+# script that nothing executes -- the same "green because it stopped looking"
+# shape as the dead grep, one level up.
+for s in bench-run-arms.sh bench-compare.sh bench-gate-fail.sh require-jobs-succeeded.sh; do
+	if [ ! -f "${SCRIPT_DIR}/${s}" ]; then
+		bad "scripts/${s} is missing — the benchmark workflow calls it"
+	elif [ -n "$(invoked_in "$BENCH_WF" "scripts/${s}")" ]; then
+		ok "benchmark.yml INVOKES scripts/${s} (extracted body still wired in)"
+	else
+		bad "benchmark.yml does not invoke scripts/${s} — extracted body orphaned or reinlined"
+	fi
+done
+
+if [ -n "$(invoked_in_any 'scripts/benchstat-gate.sh' "${BENCH_PLUMBING[@]}")" ]; then
+	ok "the benchmark plumbing INVOKES scripts/benchstat-gate.sh (not just mentions it)"
 else
-	bad "benchmark.yml no longer invokes scripts/benchstat-gate.sh — logic reinlined or removed?"
+	bad "nothing in the benchmark plumbing invokes scripts/benchstat-gate.sh — logic reinlined or removed?"
 fi
 
 # The waiver file the gate reads by default must exist in the repository, or
@@ -565,11 +782,11 @@ fi
 # nobody reviews. The gate's report must reach the PR comment, which means the
 # workflow has to capture it and put it in the comment body -- two halves, both
 # checkable, and the failure of either is invisible from the outside.
-gate_report_hits="$(invoked_in "$BENCH_WF" 'gate-report.txt')"
+gate_report_hits="$(invoked_in_any 'gate-report.txt' "${BENCH_PLUMBING[@]}")"
 if [ "$(echo "$gate_report_hits" | wc -w)" -ge 2 ]; then
-	ok "benchmark.yml captures the gate report AND feeds it into the PR comment"
+	ok "the benchmark plumbing captures the gate report AND feeds it into the PR comment"
 else
-	bad "benchmark.yml does not carry the gate report into the PR comment — a WAIVED row would be visible only to whoever opens the job log"
+	bad "the benchmark plumbing does not carry the gate report into the PR comment — a WAIVED row would be visible only to whoever opens the job log"
 fi
 
 # The dead pattern must never come back, in any workflow. Match an INVOCATION,
@@ -659,10 +876,10 @@ else
 	bad "benchmark.yml does not pin GOMAXPROCS — a runner size change would silently unpair every benchmark"
 fi
 
-if [ -n "$(invoked_in "$BENCH_WF" 'scripts/bench-arms-check.sh')" ]; then
-	ok "benchmark.yml INVOKES scripts/bench-arms-check.sh before comparing"
+if [ -n "$(invoked_in_any 'scripts/bench-arms-check.sh' "${BENCH_PLUMBING[@]}")" ]; then
+	ok "the benchmark plumbing INVOKES scripts/bench-arms-check.sh before comparing"
 else
-	bad "benchmark.yml does not run the arm comparability pre-flight — an unpairable comparison would report only its symptom"
+	bad "the benchmark plumbing does not run the arm comparability pre-flight — an unpairable comparison would report only its symptom"
 fi
 
 # A job that relocates its checkout with `path:` has NOTHING from the
@@ -727,6 +944,69 @@ case "$relocated" in
 	*)
 		bad "root-relative repo paths inside a job whose checkout is relocated (these exit 127, not a regression):"
 		echo "$relocated" | sed 's/^/        | /'
+		;;
+esac
+
+# A job that RUNS a script from scripts/ must CHECK THE REPOSITORY OUT, or the
+# file is simply not there and the step exits 127 -- which this workflow has
+# already once reported as "Benchmark regressions detected", a real-looking
+# failure with an entirely fictional cause.
+#
+# This is not hypothetical bookkeeping: the `required` job carried its assertion
+# as inline bash and so needed no checkout at all. Moving that body into
+# scripts/require-jobs-succeeded.sh made a checkout mandatory, and nothing else
+# in this file would have noticed it missing -- the aggregate required check
+# would simply have gone red on every PR with a 127.
+nocheckout="$(python3 - "$REPO_ROOT" <<'PY_INNER'
+import glob, os, re, sys
+
+root = sys.argv[1]
+try:
+    import yaml
+except ImportError:
+    print("__SKIP__ pyyaml unavailable")
+    sys.exit(0)
+
+# Any reference to a repo script, however it is spelled: root-relative
+# (`scripts/x.sh`, `./scripts/x.sh`) or via a relocated checkout
+# (`${GITHUB_WORKSPACE}/pr/scripts/x.sh`). All of them need the repo present.
+REF = re.compile(r"(?:^|[\s;&|(\"'/])(?:\./)?scripts/[\w.-]+\.(?:sh|cjs)", re.M)
+
+hits = []
+for f in sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.y*ml"))):
+    base = os.path.basename(f)
+    try:
+        doc = yaml.safe_load(open(f))
+    except Exception:  # noqa: BLE001 -- the YAML-parse guard owns this
+        continue
+    if not isinstance(doc, dict):
+        continue
+    for job_id, job in (doc.get("jobs") or {}).items():
+        steps = job.get("steps") or []
+        has_checkout = any("actions/checkout" in (st.get("uses") or "") for st in steps)
+        if has_checkout:
+            continue
+        for st in steps:
+            run = st.get("run")
+            if not isinstance(run, str):
+                continue
+            # Drop shell comments so a block that DOCUMENTS a path is not
+            # mistaken for one that invokes it.
+            code = "\n".join(
+                line[: m.start()] if (m := re.search(r"(?:^|\s)#", line)) else line
+                for line in run.splitlines()
+            )
+            for m in REF.finditer(code):
+                hits.append(f"{base}: job {job_id!r} runs {m.group(0).strip()} with no actions/checkout")
+print("\n".join(sorted(set(hits))))
+PY_INNER
+)"
+case "$nocheckout" in
+	__SKIP__*) echo "SKIP  script-without-checkout guard ($nocheckout)" ;;
+	"") ok "every job that runs a scripts/ helper also checks the repository out" ;;
+	*)
+		bad "a job runs a repo script without checking the repo out (the step exits 127, not a verdict):"
+		echo "$nocheckout" | sed 's/^/        | /'
 		;;
 esac
 

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -209,6 +209,154 @@ assert_exit 0 "with only the ALLOCATION gate raised, the live table passes" \
 	env BENCH_ALLOC_THRESHOLD_PCT=10 "$GATE" "${TESTDATA}/benchstat-alloc-regression-live.txt"
 
 echo
+echo "== benchstat-gate: reviewed waivers ======================================"
+
+# A waiver is a per-row exception, declared in scripts/benchstat-waivers.txt and
+# reviewed in the diff that needs it. It is the one construct in this gate whose
+# whole job is to make something PASS, so it is the one that most needs proving
+# it cannot make the wrong thing pass. Everything here is driven against
+# benchstat-libjson-encode-411.txt -- the REAL comparison from PR #411, verbatim
+# from the workflow's own PR comment -- rather than a synthetic table, because a
+# waiver that only works on a fixture written to suit it proves nothing.
+WAIVED_FIXTURE="${TESTDATA}/benchstat-libjson-encode-411.txt"
+
+# The before half of the round trip. With waivers switched off, the real run has
+# TWO rows at or above a gate. Note that this is not the "one failing row" the
+# change was described as: B/op is an ALLOCATION metric, judged against the 5%
+# allocation gate rather than the 15% timing one, and +12.45% is over it.
+assert_exit 1 "PR #411's REAL benchstat output fires the gate with no waivers" \
+	env BENCH_WAIVERS= "$GATE" "$WAIVED_FIXTURE"
+assert_contains "+7.94%" "the allocs/op row is named when unwaived" \
+	env BENCH_WAIVERS= "$GATE" "$WAIVED_FIXTURE"
+assert_contains "+12.45%" "the B/op row is named too — it is over the allocation gate as well" \
+	env BENCH_WAIVERS= "$GATE" "$WAIVED_FIXTURE"
+
+# The after half: the waivers this repository actually ships, with no env
+# override at all, make that same comparison pass. This is the assertion that
+# keeps scripts/benchstat-waivers.txt honest -- it fails if the file is deleted,
+# emptied, malformed, or edited so it no longer covers what it claims to.
+assert_exit 0 "the SHIPPED waiver file makes PR #411's real comparison pass" \
+	"$GATE" "$WAIVED_FIXTURE"
+
+# ...and it passes because it was WAIVED, not because the gate stopped looking.
+# The row must still appear, with its delta, its ceiling and its issue.
+# Anchored on the per-ROW marker, not the bare word: the summary line already
+# says "row(s) WAIVED", so a substring check for "WAIVED" stays green even after
+# the per-row lines are deleted -- which is exactly the regression that matters.
+assert_contains "WAIVED      github.com/luthersystems/elps/lisp/lisplib/libjson" \
+	"a waived row is still reported by name, not silently dropped" \
+	"$GATE" "$WAIVED_FIXTURE"
+assert_contains "+7.94%" "the waived row still carries its measured delta" \
+	"$GATE" "$WAIVED_FIXTURE"
+assert_contains "elps#412" "the waived row names its tracking issue in the report" \
+	"$GATE" "$WAIVED_FIXTURE"
+assert_contains "row(s) WAIVED" "the summary line counts the waivers" \
+	"$GATE" "$WAIVED_FIXTURE"
+
+# NARROWNESS. A waiver covers one package, one benchmark, one metric column.
+# Waiving allocs/op alone must leave B/op of the SAME benchmark failing --
+# otherwise "per-row" is a description rather than a property.
+assert_exit 1 "waiving allocs/op does NOT waive B/op of the same benchmark" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-libjson-allocs.txt" "$GATE" "$WAIVED_FIXTURE"
+assert_contains "B/op" "the un-waived neighbouring metric is the row that fails" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-libjson-allocs.txt" "$GATE" "$WAIVED_FIXTURE"
+# Right benchmark, right metric, WRONG package: must not reach across packages.
+assert_exit 1 "a waiver for another package does not reach libjson" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-wrong-pkg.txt" "$GATE" "$WAIVED_FIXTURE"
+# And the control for the two above: with both columns waived it does pass, so
+# the failures above are the narrowness and not some unrelated breakage.
+assert_exit 0 "with both allocation columns waived, the same table passes" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-libjson-both.txt" "$GATE" "$WAIVED_FIXTURE"
+
+# BOUNDEDNESS. The ceiling is what makes a waiver an accepted COST rather than a
+# blessed benchmark: the moment the regression grows past what was reviewed, it
+# fails again.
+assert_exit 1 "a regression that EXCEEDS its waiver ceiling fails" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-libjson-tight-ceiling.txt" "$GATE" "$WAIVED_FIXTURE"
+assert_contains "EXCEEDS its waiver ceiling" \
+	"outgrowing a waiver says so, rather than reading as a fresh regression" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-libjson-tight-ceiling.txt" "$GATE" "$WAIVED_FIXTURE"
+
+# EXPIRY. Past its date a waiver stops suppressing and the row is judged
+# normally again, so the decision is re-made rather than inherited.
+assert_exit 1 "an EXPIRED waiver no longer suppresses its row" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-expired.txt" "$GATE" "$WAIVED_FIXTURE"
+assert_contains "WAIVER EXPIRED" "an expired waiver says why the row came back" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-expired.txt" "$GATE" "$WAIVED_FIXTURE"
+# The same proof against the waivers this repo actually ships: wind the clock
+# past their expiry and PR #411's comparison reds again. Without this, "expires"
+# could be a field nothing reads.
+assert_exit 1 "the SHIPPED waivers genuinely expire (clock wound past the date)" \
+	env BENCH_WAIVER_TODAY=2099-01-01 "$GATE" "$WAIVED_FIXTURE"
+
+# JUSTIFICATION. A waiver with no tracking reference is a threshold increase
+# with better manners; the gate must refuse to run rather than honour it. Note
+# the exit code: 2, the same "cannot be interpreted" hard failure as an
+# unreadable benchstat table, because a waiver list that does not parse must
+# never be treated as an empty one.
+assert_exit 2 "a waiver with NO issue reference is rejected" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-no-issue.txt" "$GATE" "$WAIVED_FIXTURE"
+assert_contains "not a tracking reference" "the rejection says what is missing" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-no-issue.txt" "$GATE" "$WAIVED_FIXTURE"
+
+# Every other malformation is the same hard failure, and each is NAMED with its
+# line number -- a waiver that silently fails to parse is a regression nobody is
+# told about.
+assert_exit 2 "malformed waiver entries are refused, not skipped" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-malformed.txt" "$GATE" "$WAIVED_FIXTURE"
+for want in "expected 7 |-separated fields" "is not a positive percentage" \
+	"is not a YYYY-MM-DD date" "reason is missing or too short" \
+	"empty pkg field"; do
+	assert_contains "$want" "malformed waiver diagnosed: ${want}" \
+		env BENCH_WAIVERS="${TESTDATA}/waivers-malformed.txt" "$GATE" "$WAIVED_FIXTURE"
+done
+
+# `go test` appends -<GOMAXPROCS> to every benchmark name, so a waiver written
+# with the suffix would silently unbind the day `runs-on` or the GOMAXPROCS pin
+# changes -- the single failure mode this repository has been bitten by most
+# (see the GOMAXPROCS notes in benchmark.yml and bench-arms-check.sh). Rejected
+# at parse time rather than left to fail open years later.
+assert_exit 2 "a waiver naming Encode-2 (with the GOMAXPROCS suffix) is rejected" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-gomaxprocs-suffix.txt" "$GATE" "$WAIVED_FIXTURE"
+assert_contains "GOMAXPROCS" "the suffix rejection explains the trap" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-gomaxprocs-suffix.txt" "$GATE" "$WAIVED_FIXTURE"
+
+# An explicitly-named waiver file that is not there is an error. Silently
+# adjudicating with no waivers would be the strict direction, but it would also
+# mean a typo'd path reads as "no waivers configured".
+assert_exit 2 "BENCH_WAIVERS pointing at a missing file is an error" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-does-not-exist.txt" "$GATE" "$WAIVED_FIXTURE"
+
+# STALENESS. A waiver that protects nothing must not rot quietly: the benchmark
+# it names was renamed or removed, so it is dead weight that still looks like
+# coverage.
+assert_contains "WAIVER-STALE" "a waiver whose benchmark no longer exists is REPORTED" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-stale.txt" "$GATE" "$WAIVED_FIXTURE"
+assert_contains "WAIVER-STALE" "a waiver aimed at the wrong package is reported as stale too" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-wrong-pkg.txt" "$GATE" "$WAIVED_FIXTURE"
+# ...and the softer half: the row is there and simply is not regressing, which
+# is the signal to delete the entry rather than carry it forever.
+assert_contains "waiver-unused" "a waiver whose row is no longer regressing is REPORTED" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-unused.txt" "$GATE" "$WAIVED_FIXTURE"
+# Reporting a stale waiver must not, by itself, turn a clean comparison red --
+# otherwise a renamed benchmark reds every PR until someone edits a file, and
+# the pressure is to delete the mechanism rather than the entry.
+assert_exit 0 "a stale waiver is reported but does not fail an otherwise clean run" \
+	env BENCH_WAIVERS="${TESTDATA}/waivers-stale.txt" "$GATE" "${TESTDATA}/benchstat-clean-ci.txt"
+
+# THE HOLE THIS COULD HAVE BEEN. The shipped waiver file must not rescue any of
+# the fixtures the gate is supposed to fail on. If a waiver ever widens into
+# something that matches broadly, this is where it shows up.
+for fx in benchstat-regression-new benchstat-regression-old benchstat-task-sample \
+	benchstat-alloc-regression benchstat-alloc-regression-live \
+	benchstat-bps-regression benchstat-noisy-sandbox; do
+	assert_exit 1 "the shipped waivers do NOT rescue ${fx}" \
+		"$GATE" "${TESTDATA}/${fx}.txt"
+done
+assert_exit 2 "the shipped waivers do NOT turn an uninterpretable table green" \
+	"$GATE" "${TESTDATA}/benchstat-crash.txt"
+
+echo
 echo "== benchstat-gate: the threshold is the only thing holding it back ======="
 
 # Proves the parser genuinely SEES the real comparison's significant deltas and
@@ -402,6 +550,26 @@ if [ -n "$(invoked_in "$BENCH_WF" 'scripts/benchstat-gate.sh')" ]; then
 	ok "benchmark.yml INVOKES scripts/benchstat-gate.sh (not just mentions it)"
 else
 	bad "benchmark.yml no longer invokes scripts/benchstat-gate.sh — logic reinlined or removed?"
+fi
+
+# The waiver file the gate reads by default must exist in the repository, or
+# every waiver silently stops applying. That direction is the strict one, so it
+# does not fail a build -- which is precisely why nothing else would notice.
+if [ -f "${SCRIPT_DIR}/benchstat-waivers.txt" ]; then
+	ok "scripts/benchstat-waivers.txt exists (the gate's default waiver list)"
+else
+	bad "scripts/benchstat-waivers.txt is missing — waivers would silently stop applying"
+fi
+
+# A waived row that only ever appears in the job log is an accepted regression
+# nobody reviews. The gate's report must reach the PR comment, which means the
+# workflow has to capture it and put it in the comment body -- two halves, both
+# checkable, and the failure of either is invisible from the outside.
+gate_report_hits="$(invoked_in "$BENCH_WF" 'gate-report.txt')"
+if [ "$(echo "$gate_report_hits" | wc -w)" -ge 2 ]; then
+	ok "benchmark.yml captures the gate report AND feeds it into the PR comment"
+else
+	bad "benchmark.yml does not carry the gate report into the PR comment — a WAIVED row would be visible only to whoever opens the job log"
 fi
 
 # The dead pattern must never come back, in any workflow. Match an INVOCATION,

--- a/scripts/require-jobs-succeeded.sh
+++ b/scripts/require-jobs-succeeded.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Aggregate gate: assert that EVERY upstream job in the workflow succeeded.
+#
+# Extracted verbatim from the "Assert every job in this workflow succeeded" step
+# of the `required` job in .github/workflows/benchmark.yml so the logic is
+# syntax-checked, shellchecked and testable by scripts/ci-gates-test.sh.
+#
+# Branch protection matches a required status check by NAME, so the workflow
+# has exactly one aggregate job whose name never changes and which `needs:`
+# every other job. This is the body of that job. `success` is the ONLY pass:
+# `failure`, `cancelled` and `skipped` all mean the work was not demonstrably
+# done, and a skipped required check reads as green rather than red.
+#
+# Inputs (env):
+#   RESULTS   space-separated job results, from `${{ join(needs.*.result, ' ') }}`
+#
+# Exits 0 if every result is `success`, 1 otherwise.
+#
+# Run locally as:  RESULTS='success failure' scripts/require-jobs-succeeded.sh
+set -euo pipefail
+
+# Sourced from the environment rather than being interpolated. `-` (not `:-`)
+# so an unset RESULTS stays an empty string under `set -u`, preserving the
+# original step's behaviour exactly.
+RESULTS="${RESULTS-}"
+
+echo "upstream job results: ${RESULTS}"
+rc=0
+# Unquoted on purpose: this is the one place word splitting is the point --
+# RESULTS is a space-separated list of job results.
+# shellcheck disable=SC2086
+for r in ${RESULTS}; do
+  # success is the ONLY pass. failure, cancelled and skipped all mean
+  # the work was not demonstrably done.
+  [ "$r" = "success" ] || rc=1
+done
+if [ "$rc" -ne 0 ]; then
+  echo "::error::A job in this workflow did not succeed (results: ${RESULTS}). Open the individual jobs above."
+  exit 1
+fi
+echo "All jobs in this workflow succeeded."

--- a/scripts/testdata/benchstat-libjson-encode-411.txt
+++ b/scripts/testdata/benchstat-libjson-encode-411.txt
@@ -1,0 +1,291 @@
+# The REAL benchstat comparison from luthersystems/elps PR #411
+# (claude/fix-410-native-roundtrip @ 74c447d), copied verbatim out of the
+# benchmark workflow's PR comment. This is the run that fired the gate for the
+# first time on a consciously-accepted regression, and it is the fixture the
+# waiver mechanism is proved against.
+#
+# Run through the gate with waivers switched off, TWO rows in the whole
+# comparison sit at or above a gate -- both of them allocation columns of the
+# same benchmark, both judged against BENCH_ALLOC_THRESHOLD_PCT (5):
+#
+#     Encode-2  B/op       10.05Ki -> 11.30Ki  +12.45% (p=0.000 n=10)
+#     Encode-2  allocs/op    214.0 ->   231.0   +7.94% (p=0.000 n=10)
+#
+# The same 17 extra allocations, ~1.25 KiB of them, counted and weighed. Both
+# are waived in scripts/benchstat-waivers.txt, each with its own ceiling.
+#
+# The third column of the same benchmark is NOT waived:
+#
+#     Encode-2  sec/op     18.63u -> 20.68u   +11.00% (p=0.000 n=10)
+#
+# It moves, and significantly, but its gate is the 15% timing threshold and it
+# is under it. Leaving it unwaived keeps the timing cost of this change watched
+# at full strength.
+#
+# Everything else in the run is flat: every row in lisp and rdparser is "~" or
+# far under gate, and every realistic JSON benchmark -- Package/dump-object,
+# dump-array, dump-nested, dump-github -- is unchanged on all three metrics,
+# which is the evidence that the cost is confined to the microbenchmark whose
+# fixtures contain natives.
+goos: linux
+goarch: arm64
+pkg: github.com/luthersystems/elps/lisp
+                             │     base     │                 pr                  │
+                             │    sec/op    │    sec/op     vs base               │
+EnvGet-2                        15.26m ± 9%   15.18m ±  6%       ~ (p=0.912 n=10)
+EnvFunCallBuiltin-2             886.4µ ± 6%   894.6µ ±  5%       ~ (p=1.000 n=10)
+EnvFunCallRecursion-2           8.378m ± 4%   8.437m ±  5%       ~ (p=0.796 n=10)
+EnvFunCallTailRec-2             3.526m ± 4%   3.473m ±  5%       ~ (p=0.247 n=10)
+EnvFunCallPos-2                 1.698m ± 3%   1.698m ±  4%       ~ (p=0.853 n=10)
+EnvFunCallKey-2                 1.993m ± 3%   1.960m ±  6%       ~ (p=0.529 n=10)
+EnvFunCallOpt-2                 1.686m ± 6%   1.696m ±  3%       ~ (p=0.393 n=10)
+EnvFunCallVar-2                 2.227m ± 3%   2.197m ±  3%       ~ (p=0.165 n=10)
+FormatStringSimple-2            696.2µ ± 3%   687.9µ ±  4%       ~ (p=0.529 n=10)
+FormatStringMultiple-2          751.6µ ± 3%   754.1µ ±  3%       ~ (p=0.481 n=10)
+FormatStringNoPlaceholders-2    636.9µ ± 1%   641.6µ ±  2%       ~ (p=0.280 n=10)
+FormatStringManyTokens-2       1012.3µ ± 2%   998.1µ ±  2%       ~ (p=0.218 n=10)
+FormatStringMixed-2             915.0µ ± 2%   912.2µ ±  5%       ~ (p=0.796 n=10)
+FormatStringPositional-2        785.4µ ± 3%   807.3µ ±  3%  +2.78% (p=0.023 n=10)
+FormatStringConcat-2            710.4µ ± 3%   713.7µ ±  2%       ~ (p=0.579 n=10)
+MacroDefun-2                    34.10µ ± 3%   34.11µ ±  4%       ~ (p=0.971 n=10)
+String/int-2                    10.92n ± 0%   10.94n ±  0%  +0.18% (p=0.001 n=10)
+String/string-2                 259.1n ± 0%   258.6n ±  1%       ~ (p=0.578 n=10)
+String/list-2                   237.1n ± 2%   231.8n ±  4%       ~ (p=0.149 n=10)
+String/wide-2                   1.264µ ± 1%   1.271µ ±  2%       ~ (p=0.565 n=10)
+String/map-2                    1.373µ ± 3%   1.362µ ±  3%       ~ (p=0.670 n=10)
+String/vector-2                 1.710µ ± 4%   1.707µ ±  4%       ~ (p=0.952 n=10)
+String/nested-2                 2.857µ ± 2%   2.874µ ±  3%       ~ (p=0.869 n=10)
+String/deep-2                   4.963µ ± 5%   4.872µ ±  3%       ~ (p=0.631 n=10)
+Equal/int-2                     3.997n ± 2%   4.073n ±  1%  +1.89% (p=0.011 n=10)
+Equal/string-2                  5.252n ± 1%   5.293n ±  1%       ~ (p=0.089 n=10)
+Equal/list-2                    20.79n ± 1%   20.68n ±  1%       ~ (p=0.147 n=10)
+Equal/wide-2                    288.9n ± 0%   288.9n ±  0%       ~ (p=0.493 n=10)
+Equal/map-2                     1.213µ ± 7%   1.189µ ± 12%       ~ (p=0.218 n=10)
+Equal/vector-2                  1.249µ ± 8%   1.284µ ±  4%       ~ (p=0.469 n=10)
+Equal/nested-2                  1.370µ ± 6%   1.387µ ±  5%       ~ (p=1.000 n=10)
+Equal/deep-2                    401.9n ± 1%   403.1n ±  0%       ~ (p=0.324 n=10)
+EqualDistinct/int-2             4.064n ± 0%   4.081n ±  1%  +0.41% (p=0.007 n=10)
+EqualDistinct/string-2          5.314n ± 1%   5.298n ±  0%  -0.31% (p=0.030 n=10)
+EqualDistinct/list-2            20.73n ± 1%   20.71n ±  0%       ~ (p=0.985 n=10)
+EqualDistinct/wide-2            291.6n ± 0%   291.6n ±  1%       ~ (p=0.617 n=10)
+EqualDistinct/map-2             1.234µ ± 3%   1.208µ ± 10%       ~ (p=0.529 n=10)
+EqualDistinct/vector-2          1.286µ ± 3%   1.262µ ± 11%       ~ (p=0.592 n=10)
+EqualDistinct/nested-2          1.358µ ± 6%   1.380µ ±  9%       ~ (p=0.469 n=10)
+EqualDistinct/deep-2            402.5n ± 0%   403.1n ±  0%       ~ (p=0.362 n=10)
+geomean                         7.080µ        7.074µ        -0.08%
+
+                             │      base      │                  pr                   │
+                             │      B/op      │     B/op      vs base                 │
+EnvGet-2                       10.20Mi ± 0%     10.20Mi ± 0%       ~ (p=0.065 n=10)
+EnvFunCallBuiltin-2            829.4Ki ± 0%     829.4Ki ± 0%       ~ (p=0.141 n=10)
+EnvFunCallRecursion-2          3.768Mi ± 0%     3.768Mi ± 0%       ~ (p=0.229 n=10)
+EnvFunCallTailRec-2            3.454Mi ± 0%     3.454Mi ± 0%  +0.00% (p=0.016 n=10)
+EnvFunCallPos-2                1.813Mi ± 0%     1.813Mi ± 0%       ~ (p=0.423 n=10)
+EnvFunCallKey-2                1.889Mi ± 0%     1.889Mi ± 0%       ~ (p=0.147 n=10)
+EnvFunCallOpt-2                1.813Mi ± 0%     1.813Mi ± 0%       ~ (p=0.052 n=10)
+EnvFunCallVar-2                2.385Mi ± 0%     2.385Mi ± 0%       ~ (p=0.492 n=10)
+FormatStringSimple-2           727.9Ki ± 0%     727.9Ki ± 0%       ~ (p=1.000 n=10) ¹
+FormatStringMultiple-2         798.2Ki ± 0%     798.2Ki ± 0%       ~ (p=0.474 n=10)
+FormatStringNoPlaceholders-2   696.6Ki ± 0%     696.6Ki ± 0%       ~ (p=1.000 n=10)
+FormatStringManyTokens-2       1.008Mi ± 0%     1.008Mi ± 0%       ~ (p=1.000 n=10)
+FormatStringMixed-2            817.7Ki ± 0%     817.7Ki ± 0%  -0.00% (p=0.035 n=10)
+FormatStringPositional-2       798.2Ki ± 0%     798.2Ki ± 0%       ~ (p=1.000 n=10)
+FormatStringConcat-2           727.9Ki ± 0%     727.9Ki ± 0%       ~ (p=1.000 n=10) ¹
+MacroDefun-2                   33.30Ki ± 0%     33.30Ki ± 0%       ~ (p=0.271 n=10)
+String/int-2                     0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
+String/string-2                  64.00 ± 0%       64.00 ± 0%       ~ (p=1.000 n=10) ¹
+String/list-2                    101.0 ± 0%       101.0 ± 0%       ~ (p=1.000 n=10) ¹
+String/wide-2                    640.0 ± 0%       640.0 ± 0%       ~ (p=1.000 n=10) ¹
+String/map-2                   1.258Ki ± 0%     1.258Ki ± 0%       ~ (p=1.000 n=10) ¹
+String/vector-2                1.547Ki ± 0%     1.547Ki ± 0%       ~ (p=1.000 n=10) ¹
+String/nested-2                3.258Ki ± 0%     3.258Ki ± 0%       ~ (p=1.000 n=10) ¹
+String/deep-2                  6.922Ki ± 0%     6.922Ki ± 0%       ~ (p=1.000 n=10) ¹
+Equal/int-2                      0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
+Equal/string-2                   0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
+Equal/list-2                     0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
+Equal/wide-2                     0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
+Equal/map-2                    1.938Ki ± 0%     1.938Ki ± 0%       ~ (p=1.000 n=10) ¹
+Equal/vector-2                 1.938Ki ± 0%     1.938Ki ± 0%       ~ (p=1.000 n=10) ¹
+Equal/nested-2                 1.938Ki ± 0%     1.938Ki ± 0%       ~ (p=1.000 n=10) ¹
+Equal/deep-2                     0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/int-2              0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/string-2           0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/list-2             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/wide-2             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/map-2            1.938Ki ± 0%     1.938Ki ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/vector-2         1.938Ki ± 0%     1.938Ki ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/nested-2         1.938Ki ± 0%     1.938Ki ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/deep-2             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
+geomean                                     ²                 -0.00%                ²
+¹ all samples are equal
+² summaries must be >0 to compute geomean
+
+                             │     base      │                  pr                  │
+                             │   allocs/op   │  allocs/op   vs base                 │
+EnvGet-2                       128.0k ± 0%     128.0k ± 0%       ~ (p=1.000 n=10)
+EnvFunCallBuiltin-2            8.015k ± 0%     8.015k ± 0%       ~ (p=1.000 n=10) ¹
+EnvFunCallRecursion-2          40.08k ± 0%     40.08k ± 0%       ~ (p=1.000 n=10) ¹
+EnvFunCallTailRec-2            44.07k ± 0%     44.07k ± 0%       ~ (p=1.000 n=10) ¹
+EnvFunCallPos-2                22.06k ± 0%     22.06k ± 0%       ~ (p=1.000 n=10) ¹
+EnvFunCallKey-2                23.06k ± 0%     23.06k ± 0%       ~ (p=1.000 n=10) ¹
+EnvFunCallOpt-2                22.06k ± 0%     22.06k ± 0%       ~ (p=1.000 n=10) ¹
+EnvFunCallVar-2                29.06k ± 0%     29.06k ± 0%       ~ (p=1.000 n=10) ¹
+FormatStringSimple-2           9.015k ± 0%     9.015k ± 0%       ~ (p=1.000 n=10) ¹
+FormatStringMultiple-2         9.015k ± 0%     9.015k ± 0%       ~ (p=1.000 n=10) ¹
+FormatStringNoPlaceholders-2   8.015k ± 0%     8.015k ± 0%       ~ (p=1.000 n=10) ¹
+FormatStringManyTokens-2       9.015k ± 0%     9.015k ± 0%       ~ (p=1.000 n=10) ¹
+FormatStringMixed-2            10.02k ± 0%     10.02k ± 0%       ~ (p=1.000 n=10) ¹
+FormatStringPositional-2       9.015k ± 0%     9.015k ± 0%       ~ (p=1.000 n=10) ¹
+FormatStringConcat-2           9.015k ± 0%     9.015k ± 0%       ~ (p=1.000 n=10) ¹
+MacroDefun-2                    475.0 ± 0%      475.0 ± 0%       ~ (p=1.000 n=10) ¹
+String/int-2                    0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
+String/string-2                 2.000 ± 0%      2.000 ± 0%       ~ (p=1.000 n=10) ¹
+String/list-2                   4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=10) ¹
+String/wide-2                   4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=10) ¹
+String/map-2                    25.00 ± 0%      25.00 ± 0%       ~ (p=1.000 n=10) ¹
+String/vector-2                 30.00 ± 0%      30.00 ± 0%       ~ (p=1.000 n=10) ¹
+String/nested-2                 49.00 ± 0%      49.00 ± 0%       ~ (p=1.000 n=10) ¹
+String/deep-2                   82.00 ± 0%      82.00 ± 0%       ~ (p=1.000 n=10) ¹
+Equal/int-2                     0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
+Equal/string-2                  0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
+Equal/list-2                    0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
+Equal/wide-2                    0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
+Equal/map-2                     26.00 ± 0%      26.00 ± 0%       ~ (p=1.000 n=10) ¹
+Equal/vector-2                  26.00 ± 0%      26.00 ± 0%       ~ (p=1.000 n=10) ¹
+Equal/nested-2                  26.00 ± 0%      26.00 ± 0%       ~ (p=1.000 n=10) ¹
+Equal/deep-2                    0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/int-2             0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/string-2          0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/list-2            0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/wide-2            0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/map-2             26.00 ± 0%      26.00 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/vector-2          26.00 ± 0%      26.00 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/nested-2          26.00 ± 0%      26.00 ± 0%       ~ (p=1.000 n=10) ¹
+EqualDistinct/deep-2            0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
+geomean                                    ²                +0.00%                ²
+¹ all samples are equal
+² summaries must be >0 to compute geomean
+
+pkg: github.com/luthersystems/elps/lisp/lisplib/libjson
+                              │    base     │                  pr                  │
+                              │   sec/op    │    sec/op     vs base                │
+Encode-2                        18.63µ ± 3%   20.68µ ± 11%  +11.00% (p=0.000 n=10)
+Encode_stringNumbers-2          2.703µ ± 3%   2.688µ ±  3%        ~ (p=0.101 n=10)
+Package/$load-2                 1.287m ± 1%   1.288m ±  2%        ~ (p=0.796 n=10)
+Package/load-object-2           2.208m ± 6%   2.228m ±  2%        ~ (p=0.247 n=10)
+Package/load-array-2            2.873m ± 4%   2.859m ±  3%        ~ (p=0.579 n=10)
+Package/load-nested-2           3.319m ± 2%   3.335m ±  2%        ~ (p=0.684 n=10)
+Package/load-github-2           67.18m ± 1%   66.91m ±  1%        ~ (p=0.631 n=10)
+Package/get-nested-baseline-2   46.56m ± 1%   46.93m ±  1%        ~ (p=0.123 n=10)
+Package/dump-object-2           1.880m ± 4%   1.900m ±  5%        ~ (p=0.481 n=10)
+Package/dump-array-2            1.049m ± 1%   1.051m ±  3%        ~ (p=0.971 n=10)
+Package/dump-nested-2           2.922m ± 2%   2.971m ±  5%        ~ (p=0.481 n=10)
+Package/dump-github-2           45.88m ± 2%   46.19m ±  1%        ~ (p=0.218 n=10)
+EncodeNativeSmall-2                           1.322µ ±  3%
+EncodeNativeLarge-2                           89.32µ ±  2%
+geomean                         1.796m        875.1µ         +1.24%
+
+                              │     base     │                   pr                   │
+                              │     B/op     │     B/op      vs base                  │
+Encode-2                        10.05Ki ± 0%   11.30Ki ± 0%  +12.45% (p=0.000 n=10)
+Encode_stringNumbers-2          1.297Ki ± 0%   1.297Ki ± 0%        ~ (p=1.000 n=10) ¹
+Package/$load-2                 949.1Ki ± 0%   949.1Ki ± 0%   -0.00% (p=0.033 n=10)
+Package/load-object-2           1.437Mi ± 0%   1.437Mi ± 0%        ~ (p=0.299 n=10)
+Package/load-array-2            2.223Mi ± 0%   2.223Mi ± 0%        ~ (p=0.403 n=10)
+Package/load-nested-2           2.147Mi ± 0%   2.147Mi ± 0%        ~ (p=0.925 n=10)
+Package/load-github-2           32.73Mi ± 0%   32.73Mi ± 0%        ~ (p=0.751 n=10)
+Package/get-nested-baseline-2   34.61Mi ± 0%   34.61Mi ± 0%        ~ (p=0.383 n=10)
+Package/dump-object-2           1.735Mi ± 0%   1.735Mi ± 0%        ~ (p=0.784 n=10)
+Package/dump-array-2            807.5Ki ± 0%   807.5Ki ± 0%        ~ (p=1.000 n=10)
+Package/dump-nested-2           2.835Mi ± 0%   2.835Mi ± 0%        ~ (p=0.512 n=10)
+Package/dump-github-2           51.03Mi ± 0%   51.03Mi ± 0%        ~ (p=0.227 n=10)
+EncodeNativeSmall-2                              848.0 ± 0%
+EncodeNativeLarge-2                            45.51Ki ± 0%
+geomean                         1.271Mi        610.4Ki        +0.98%
+¹ all samples are equal
+
+                              │    base     │                  pr                  │
+                              │  allocs/op  │  allocs/op   vs base                 │
+Encode-2                         214.0 ± 0%    231.0 ± 0%  +7.94% (p=0.000 n=10)
+Encode_stringNumbers-2           30.00 ± 0%    30.00 ± 0%       ~ (p=1.000 n=10) ¹
+Package/$load-2                 23.01k ± 0%   23.01k ± 0%       ~ (p=1.000 n=10)
+Package/load-object-2           25.03k ± 0%   25.03k ± 0%       ~ (p=1.000 n=10) ¹
+Package/load-array-2            41.03k ± 0%   41.03k ± 0%       ~ (p=1.000 n=10) ¹
+Package/load-nested-2           39.03k ± 0%   39.03k ± 0%       ~ (p=1.000 n=10) ¹
+Package/load-github-2           457.0k ± 0%   457.0k ± 0%       ~ (p=1.000 n=10)
+Package/get-nested-baseline-2   504.1k ± 0%   504.1k ± 0%       ~ (p=0.400 n=10)
+Package/dump-object-2           23.04k ± 0%   23.04k ± 0%       ~ (p=1.000 n=10) ¹
+Package/dump-array-2            10.03k ± 0%   10.03k ± 0%       ~ (p=1.000 n=10) ¹
+Package/dump-nested-2           37.06k ± 0%   37.06k ± 0%       ~ (p=1.000 n=10) ¹
+Package/dump-github-2           387.5k ± 0%   387.5k ± 0%       ~ (p=0.370 n=10)
+EncodeNativeSmall-2                            17.00 ± 0%
+EncodeNativeLarge-2                           1.159k ± 0%
+geomean                         20.17k        9.973k       +0.64%
+¹ all samples are equal
+
+pkg: github.com/luthersystems/elps/parser/rdparser
+                                       │    base     │                 pr                 │
+                                       │   sec/op    │   sec/op     vs base               │
+Parser/approx.lisp-2                     187.0µ ± 4%   187.6µ ± 2%       ~ (p=0.796 n=10)
+Parser/complex.lisp-2                    530.9µ ± 4%   539.3µ ± 3%       ~ (p=0.481 n=10)
+Parser/diff.lisp-2                       222.6µ ± 1%   222.6µ ± 2%       ~ (p=0.971 n=10)
+Parser/scheme-math.lisp-2                1.240m ± 2%   1.264m ± 2%  +1.89% (p=0.035 n=10)
+Parser/sicp.lisp-2                       843.4µ ± 2%   849.8µ ± 2%       ~ (p=0.280 n=10)
+Parser/stream.lisp-2                     735.5µ ± 2%   728.8µ ± 1%       ~ (p=0.190 n=10)
+ParserFaultTolerant/approx.lisp-2        184.3µ ± 2%   183.2µ ± 2%       ~ (p=0.631 n=10)
+ParserFaultTolerant/complex.lisp-2       536.4µ ± 1%   534.2µ ± 2%       ~ (p=0.393 n=10)
+ParserFaultTolerant/diff.lisp-2          219.9µ ± 3%   220.2µ ± 2%       ~ (p=0.436 n=10)
+ParserFaultTolerant/scheme-math.lisp-2   1.252m ± 1%   1.265m ± 2%       ~ (p=0.436 n=10)
+ParserFaultTolerant/sicp.lisp-2          835.8µ ± 2%   843.2µ ± 1%       ~ (p=0.190 n=10)
+ParserFaultTolerant/stream.lisp-2        731.3µ ± 2%   741.7µ ± 1%       ~ (p=0.218 n=10)
+geomean                                  506.2µ        508.7µ       +0.51%
+
+                                       │     base     │                  pr                   │
+                                       │     B/op     │     B/op      vs base                 │
+Parser/approx.lisp-2                     239.5Ki ± 0%   239.5Ki ± 0%       ~ (p=1.000 n=10)
+Parser/complex.lisp-2                    464.4Ki ± 0%   464.4Ki ± 0%       ~ (p=0.164 n=10)
+Parser/diff.lisp-2                       269.3Ki ± 0%   269.3Ki ± 0%       ~ (p=1.000 n=10)
+Parser/scheme-math.lisp-2                907.5Ki ± 0%   907.5Ki ± 0%       ~ (p=0.312 n=10)
+Parser/sicp.lisp-2                       680.9Ki ± 0%   680.9Ki ± 0%       ~ (p=0.056 n=10)
+Parser/stream.lisp-2                     593.3Ki ± 0%   593.3Ki ± 0%       ~ (p=0.148 n=10)
+ParserFaultTolerant/approx.lisp-2        239.5Ki ± 0%   239.5Ki ± 0%       ~ (p=1.000 n=10)
+ParserFaultTolerant/complex.lisp-2       464.4Ki ± 0%   464.4Ki ± 0%       ~ (p=0.975 n=10)
+ParserFaultTolerant/diff.lisp-2          269.3Ki ± 0%   269.3Ki ± 0%       ~ (p=1.000 n=10) ¹
+ParserFaultTolerant/scheme-math.lisp-2   907.5Ki ± 0%   907.5Ki ± 0%       ~ (p=1.000 n=10)
+ParserFaultTolerant/sicp.lisp-2          680.9Ki ± 0%   680.9Ki ± 0%       ~ (p=0.729 n=10)
+ParserFaultTolerant/stream.lisp-2        593.3Ki ± 0%   593.3Ki ± 0%       ~ (p=0.637 n=10)
+geomean                                  471.5Ki        471.5Ki       +0.00%
+¹ all samples are equal
+
+                                       │    base     │                  pr                  │
+                                       │  allocs/op  │  allocs/op   vs base                 │
+Parser/approx.lisp-2                     3.565k ± 0%   3.565k ± 0%       ~ (p=1.000 n=10) ¹
+Parser/complex.lisp-2                    10.79k ± 0%   10.79k ± 0%       ~ (p=1.000 n=10) ¹
+Parser/diff.lisp-2                       4.233k ± 0%   4.233k ± 0%       ~ (p=1.000 n=10) ¹
+Parser/scheme-math.lisp-2                24.86k ± 0%   24.86k ± 0%       ~ (p=1.000 n=10) ¹
+Parser/sicp.lisp-2                       16.70k ± 0%   16.70k ± 0%       ~ (p=1.000 n=10) ¹
+Parser/stream.lisp-2                     14.63k ± 0%   14.63k ± 0%       ~ (p=1.000 n=10) ¹
+ParserFaultTolerant/approx.lisp-2        3.565k ± 0%   3.565k ± 0%       ~ (p=1.000 n=10) ¹
+ParserFaultTolerant/complex.lisp-2       10.79k ± 0%   10.79k ± 0%       ~ (p=1.000 n=10) ¹
+ParserFaultTolerant/diff.lisp-2          4.233k ± 0%   4.233k ± 0%       ~ (p=1.000 n=10) ¹
+ParserFaultTolerant/scheme-math.lisp-2   24.86k ± 0%   24.86k ± 0%       ~ (p=1.000 n=10) ¹
+ParserFaultTolerant/sicp.lisp-2          16.70k ± 0%   16.70k ± 0%       ~ (p=1.000 n=10) ¹
+ParserFaultTolerant/stream.lisp-2        14.63k ± 0%   14.63k ± 0%       ~ (p=1.000 n=10) ¹
+geomean                                  9.982k        9.982k       +0.00%
+¹ all samples are equal
+
+                                       │     base     │                 pr                  │
+                                       │     B/s      │     B/s       vs base               │
+Parser/approx.lisp-2                     8.903Mi ± 4%   8.874Mi ± 2%       ~ (p=0.781 n=10)
+Parser/complex.lisp-2                    9.556Mi ± 4%   9.403Mi ± 3%       ~ (p=0.469 n=10)
+Parser/diff.lisp-2                       7.601Mi ± 1%   7.601Mi ± 2%       ~ (p=0.955 n=10)
+Parser/scheme-math.lisp-2                9.284Mi ± 2%   9.117Mi ± 1%  -1.80% (p=0.037 n=10)
+Parser/sicp.lisp-2                       8.202Mi ± 2%   8.140Mi ± 2%       ~ (p=0.270 n=10)
+Parser/stream.lisp-2                     9.227Mi ± 2%   9.308Mi ± 2%       ~ (p=0.210 n=10)
+ParserFaultTolerant/approx.lisp-2        9.027Mi ± 2%   9.084Mi ± 2%       ~ (p=0.617 n=10)
+ParserFaultTolerant/complex.lisp-2       9.456Mi ± 1%   9.494Mi ± 2%       ~ (p=0.404 n=10)
+ParserFaultTolerant/diff.lisp-2          7.691Mi ± 3%   7.687Mi ± 2%       ~ (p=0.481 n=10)
+ParserFaultTolerant/scheme-math.lisp-2   9.193Mi ± 1%   9.103Mi ± 2%       ~ (p=0.468 n=10)
+ParserFaultTolerant/sicp.lisp-2          8.278Mi ± 2%   8.206Mi ± 1%       ~ (p=0.196 n=10)
+ParserFaultTolerant/stream.lisp-2        9.279Mi ± 2%   9.151Mi ± 1%       ~ (p=0.209 n=10)
+geomean                                  8.783Mi        8.739Mi       -0.49%

--- a/scripts/testdata/waivers-expired.txt
+++ b/scripts/testdata/waivers-expired.txt
@@ -1,0 +1,5 @@
+# Self-test fixture: correctly formed, but past its expiry date. An expired
+# waiver stops suppressing; the row is judged normally again and the report says
+# why, so the decision has to be re-made rather than inherited.
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | 9 | 2020-01-01 | elps#412 | accepted native round-trip validation cost, tracked for removal
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | B/op | 14 | 2020-01-01 | elps#412 | the same 17 allocations weighed instead of counted

--- a/scripts/testdata/waivers-gomaxprocs-suffix.txt
+++ b/scripts/testdata/waivers-gomaxprocs-suffix.txt
@@ -1,0 +1,5 @@
+# Self-test fixture: benchmark written WITH the -<GOMAXPROCS> suffix `go test`
+# appends. Accepting it would create a waiver that silently unbinds the day the
+# runner or the GOMAXPROCS pin changes, which is this repository's most-repeated
+# failure. It is a hard error instead.
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode-2 | allocs/op | 9 | 2099-01-01 | elps#412 | suffix written by hand, which is the trap

--- a/scripts/testdata/waivers-libjson-allocs.txt
+++ b/scripts/testdata/waivers-libjson-allocs.txt
@@ -1,0 +1,6 @@
+# Self-test fixture: the narrow, well-formed waiver. Covers ONE package, ONE
+# benchmark and ONE metric column of the run in
+# benchstat-libjson-encode-411.txt -- deliberately NOT the B/op column of the
+# same benchmark, so the "a waiver does not spill onto the neighbouring metric"
+# assertion has something to prove.
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | 9 | 2099-01-01 | elps#412 | accepted native round-trip validation cost, tracked for removal

--- a/scripts/testdata/waivers-libjson-both.txt
+++ b/scripts/testdata/waivers-libjson-both.txt
@@ -1,0 +1,6 @@
+# Self-test fixture: both allocation columns of libjson BenchmarkEncode, which
+# is what it actually takes to make the PR #411 comparison pass. Mirrors
+# scripts/benchstat-waivers.txt but with a far-future expiry so the assertions
+# do not start failing on a date.
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | 9 | 2099-01-01 | elps#412 | accepted native round-trip validation cost, tracked for removal
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | B/op | 14 | 2099-01-01 | elps#412 | the same 17 allocations weighed instead of counted, tracked for removal

--- a/scripts/testdata/waivers-libjson-tight-ceiling.txt
+++ b/scripts/testdata/waivers-libjson-tight-ceiling.txt
@@ -1,0 +1,6 @@
+# Self-test fixture: a waiver on the right row whose CEILING is below the
+# measured move (+7.94% against a 5% ceiling). A waiver that has been outgrown
+# must fail again -- that is the whole difference between bounding a cost and
+# blessing a benchmark.
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | 5 | 2099-01-01 | elps#412 | ceiling deliberately below the measured move
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | B/op | 14 | 2099-01-01 | elps#412 | the same 17 allocations weighed instead of counted

--- a/scripts/testdata/waivers-malformed.txt
+++ b/scripts/testdata/waivers-malformed.txt
@@ -1,0 +1,10 @@
+# Self-test fixture: assorted malformed entries. Every one of them must be named
+# and must make the gate exit 2 -- a waiver list that cannot be read must never
+# be treated as an empty one.
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | 9 | 2099-01-01 | elps#412
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | | 2099-01-01 | elps#412 | no ceiling at all
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | lots | 2099-01-01 | elps#412 | ceiling is not a number
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | 9 | soon | elps#412 | expiry is not a date
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | 9 | 2099-01-01 | see slack | it is tracked somewhere honest
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | 9 | 2099-01-01 | elps#412 | ok
+ | Encode | allocs/op | 9 | 2099-01-01 | elps#412 | no package named at all

--- a/scripts/testdata/waivers-no-issue.txt
+++ b/scripts/testdata/waivers-no-issue.txt
@@ -1,0 +1,4 @@
+# Self-test fixture: no tracking reference. A waiver nobody is obliged to come
+# back to is a threshold increase with better manners, so the gate must refuse
+# to run rather than quietly honour it.
+github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | 9 | 2099-01-01 | | accepted for now, we will look at it eventually

--- a/scripts/testdata/waivers-stale.txt
+++ b/scripts/testdata/waivers-stale.txt
@@ -1,0 +1,4 @@
+# Self-test fixture: a waiver whose benchmark appears nowhere in the comparison
+# (renamed, deleted, or a typo). It protects nothing while looking like it does,
+# so it must be REPORTED on every run rather than rotting silently.
+github.com/luthersystems/elps/lisp/lisplib/libjson | EncodeRenamedAwayLongAgo | allocs/op | 9 | 2099-01-01 | elps#412 | points at a benchmark that no longer exists

--- a/scripts/testdata/waivers-unused.txt
+++ b/scripts/testdata/waivers-unused.txt
@@ -1,0 +1,5 @@
+# Self-test fixture: a waiver whose row IS present in the comparison and is not
+# regressing (Package/dump-github allocs/op is flat at 387.5k in the PR #411
+# run). The waiver is doing nothing, which is the signal to delete it -- so it
+# must be reported, not silently carried forever.
+github.com/luthersystems/elps/lisp/lisplib/libjson | Package/dump-github | allocs/op | 9 | 2099-01-01 | elps#412 | a waiver that is no longer needed

--- a/scripts/testdata/waivers-wrong-pkg.txt
+++ b/scripts/testdata/waivers-wrong-pkg.txt
@@ -1,0 +1,4 @@
+# Self-test fixture: right benchmark and metric, WRONG package. A waiver must
+# not reach across packages, so this must leave the libjson rows failing -- and
+# be reported as stale, since it matched nothing.
+github.com/luthersystems/elps/lisp | Encode | allocs/op | 9 | 2099-01-01 | elps#412 | wrong package on purpose


### PR DESCRIPTION
## Why

The benchmark gate has fired for the first time on a regression that is **real, understood and deliberately accepted** (libjson `BenchmarkEncode`, #411), and there was no way to say "yes, we know, here is why".

The two knobs that existed are both wrong. `BENCH_REGRESSION_THRESHOLD_PCT` and `BENCH_ALLOC_THRESHOLD_PCT` are per-metric-class **noise floors** derived from measurement; raising one to accept a single benchmark blinds every other benchmark in the repo to the same magnitude of move, permanently and silently. Skipping the gate is worse. Both recreate the exact defect this gate was written to fix — the inline `grep -E '^\S.*\+$'` that could not match any benchstat line and reported success across 473 runs.

**Neither threshold is changed here, and no blanket skip is added.** The gate keeps failing on everything it currently fails on; there is a self-test case for each of those fixtures asserting the shipped waivers do not rescue them.

## What

`scripts/benchstat-waivers.txt`, one entry per line:

```
pkg | benchmark | metric | ceiling | expires | issue | reason
```

- **Per row.** Package, benchmark and metric matched *exactly*. A waiver cannot reach another row, another metric or another package. The benchmark is written **without** the `-` suffix `go test` appends — the gate strips it from the row and *rejects* a waiver that carries one. That suffix follows the runner, so `Encode-2` would unbind the day `runs-on` changed, silently, which is this repo's most-repeated failure mode.
- **Bounded.** Each entry records a **ceiling percentage**. Past it the row fails again, so a waiver prices a cost rather than blessing a benchmark. (Percentage, because that is the unit benchstat reports and the unit the thresholds are already in — a reviewer can compare the two without arithmetic.)
- **Justified.** A reason and a tracking reference are mandatory. An entry missing either — or malformed in any other way — is a hard **exit 2**, the same "cannot be interpreted" failure as an unreadable benchstat table. A waiver list that does not parse must never read as an empty one.
- **Expiring.** Past its date a waiver stops suppressing and the row is judged normally again. A **date** rather than "the issue must still be open": the gate has to stay hermetic — runnable offline, from the self-test, with no network and no token — and an open-issue check would make a green build depend on GitHub being reachable and on a token that fork PRs do not have. The issue is recorded so a human can check it; the date is what the machine can check honestly.
- **Visible.** A waived row is still parsed, still counted, and still printed — as `WAIVED`, with its delta, ceiling and issue — in the job log **and** in the PR comment, which now carries the gate report and surfaces waiver lines *outside* the collapsed `<details>`. The waiver changes the verdict, never the visibility.
- **Non-rotting.** Waivers that match nothing are reported on every run: `WAIVER-STALE` when the package is in the comparison and the row is not (renamed benchmark, typo — protecting nothing while looking like it is), `waiver-unused` when the row is there and no longer regressing (delete the entry).

## ⚠️ Two entries, not one — please read this bit

The regression was scoped as a single failing row, `allocs/op` at +7.94%. **It is not.** Running the gate over #411's actual benchstat output with waivers off reports **two** rows at or above a gate:

```
Encode-2  B/op       10.05Ki -> 11.30Ki  +12.45% (p=0.000 n=10)   gate 5%
Encode-2  allocs/op    214.0 ->   231.0   +7.94% (p=0.000 n=10)   gate 5%
```

`B/op` is an **allocation** metric, so it is judged against `BENCH_ALLOC_THRESHOLD_PCT` (5), not the 15% timing threshold. At +12.45% it is over.

They are one cost measured two ways — the same 17 extra allocations, ~1.25 KiB of them. Waiving only the count would have produced a waiver that does not work: the build stays red on a row nobody reviewed, and the natural next move is to widen the allocation threshold, which is exactly the outcome this mechanism exists to prevent. So both are waived, each with its own ceiling, each nameable in review.

`sec/op` (+11.00%, p=0.000) is **not** waived — it is under its own 15% gate and needs nothing, so the timing cost of #411 stays watched at full strength.

## The waiver added

| pkg | benchmark | metric | ceiling | expires | issue |
|---|---|---|---|---|---|
| `.../lisp/lisplib/libjson` | `Encode` | `allocs/op` | 9% | 2027-02-28 | elps#412 elps#410 |
| `.../lisp/lisplib/libjson` | `Encode` | `B/op` | 14% | 2027-02-28 | elps#412 elps#410 |

Ceilings sit just above the measured values (+7.94% → 9%, allowing 233 allocs/op against the measured 231; +12.45% → 14%). A second regression landing on this benchmark still reds the build.

Why it is accepted, in full in the file: #411 fixes #410, where `Dump` could emit a document `Load` refuses; the fix marshals each native value and validates the bytes it produced. 3 of `BenchmarkEncode`'s 36 `stdEncodeTests` rows are `lisp.Value(map[string]interface{}{...})`, i.e. natives, so this **microbenchmark** pays the check while documents without natives pay nothing — every realistic JSON row (`Package/dump-object`, `dump-array`, `dump-nested`, `dump-github`) is flat on all three metrics, and everything in `lisp` and `rdparser` is `~`. A hand-rolled scanner restoring allocation parity was built and measured: an end-to-end substrate benchmark (interleaved, n=12) could not distinguish it from the decode on any of that repo's 20 rows, and it cost ~130 lines of a second JSON parser required to agree with `encoding/json` forever. **elps#412** tracks removing the redundant work instead; when it lands, both entries go with it.

## Verification

`scripts/testdata/benchstat-libjson-encode-411.txt` is #411's real benchstat output, verbatim from the workflow's own PR comment. Everything below is driven against it rather than a fixture written to suit the mechanism.

**Before / after round trip:**

```
$ BENCH_WAIVERS= scripts/benchstat-gate.sh scripts/testdata/benchstat-libjson-encode-411.txt
  REGRESSION  .../libjson  B/op       Encode-2  delta=+12.45% p=0.000 (gate 5%)
  REGRESSION  .../libjson  allocs/op  Encode-2  delta=+7.94%  p=0.000 (gate 5%)
  ... 23 delta row(s) + 191 no-change row(s); 9 significant; 2 at or above the gate.
EXIT=1

$ scripts/benchstat-gate.sh scripts/testdata/benchstat-libjson-encode-411.txt
  WAIVED  .../libjson  B/op       Encode-2  delta=+12.45% p=0.000 (gate 5%) accepted: ceiling 14%, expires 2027-02-28, elps#412 elps#410
  WAIVED  .../libjson  allocs/op  Encode-2  delta=+7.94%  p=0.000 (gate 5%) accepted: ceiling 9%,  expires 2027-02-28, elps#412 elps#410
  ... 9 significant move(s) in the bad direction; 0 at or above the gate.
  ... 2 reviewed waiver(s) loaded; 2 row(s) WAIVED (measured, reported, and excluded from the verdict), 0 stale, 0 unused, 0 expired.
EXIT=0
```

Pre-existing known-regression fixture, with the shipped waivers loaded — still fires:

```
$ scripts/benchstat-gate.sh scripts/testdata/benchstat-alloc-regression-live.txt
  REGRESSION  .../lisp  B/op  EnvFunCallRecursion-4  delta=+8.44% p=0.008 (gate 5%)
EXIT=1
```

**Self-test — `bash scripts/ci-gates-test.sh` → `141 passed, 0 failed`** (was 101). New cases:

- #411's real output fires with no waivers; both offending rows named
- the **shipped** waiver file makes that same comparison pass, with no env override
- a waived row is still reported *by name* (anchored on the per-row marker, not the bare word — the summary line says "row(s) WAIVED", so a substring check would survive deleting the per-row lines), with its delta and its issue
- waiving `allocs/op` does **not** waive `B/op` of the same benchmark; a waiver for another package does not reach libjson; control: with both waived it passes
- a regression exceeding its ceiling fails, and says `EXCEEDS its waiver ceiling`
- an expired waiver stops suppressing and says why — plus the **shipped** waivers proved to genuinely expire by winding `BENCH_WAIVER_TODAY` past their date
- a waiver with no issue reference is **rejected** (exit 2); so are all six other malformations, each named with its line number; so is a benchmark written with the `-2` suffix
- `BENCH_WAIVERS` pointing at a missing file is an error
- stale and unused waivers are reported — and a stale waiver does *not*, by itself, red an otherwise clean run
- the shipped waivers rescue **none** of the seven regression fixtures, and do not turn `benchstat-crash.txt` green
- workflow-shape guards: the default waiver file exists, and the workflow both captures the gate report and feeds it into the PR comment

Every one of these was checked by **mutation** — the gate was deliberately broken seven ways (ceiling ignored, metric ignored when matching, package-only matching, expiry ignored, malformed waivers skipped instead of fatal, waived rows dropped from the report, stale/unused reporting removed) and each mutation watched failing the suite. One assertion was strengthened as a result: `assert_contains "WAIVED"` survived deleting the per-row line, so it is now anchored on the full row prefix.

**Other gates:** `go build ./...`, `go vet ./...`, `go test -count=1 ./...`, `golangci-lint run ./...` (`0 issues`), `bash scripts/confidentiality-guard.sh` (clean), `shellcheck -S warning scripts/*.sh` (clean; CI runs it via the `gates` job).

## Incidental fix

The gate now ignores `#` comment lines. benchstat never emits one, but the fixtures in `scripts/testdata/` are annotated with the history of the run they capture, and those annotations *quote* benchstat rows — p-values and all. Without this, a fixture's own explanation is adjudicated as data: the new fixture's header produced four phantom comparison rows, one of them a `below-gate` verdict on a sentence. The pinned counts on `benchstat-clean-ci.txt` are unaffected (it carries no comments).

## Note for reviewers

**#411 is blocked on this.** Its benchmark check cannot go green until this waiver is present on `main` — the gate is invoked from the PR's own tree, but the waiver has to be a reviewed, merged decision rather than something #411 adds to itself. Merge this first, then rebase/re-run #411.

This change is deliberately on its own branch off `main` so the gate mechanism is reviewable independently of the fix that needs it.

---

## Follow-up commit: inline bash moved out of `benchmark.yml` (`64f26b6`)

`benchmark.yml` carried **207 lines of bash across four `run: |` blocks** — by far the most in this repo. Inline bash is not syntax-checked, not shellchecked and not testable, which is exactly how the gate above stayed dead for 473 runs. Each block is now a script and the YAML is a thin call, matching `govulncheck-scheduled.yml`, which already carries no inline bash at all. `benchmark.yml` is now at **zero** inline blocks over three lines.

| new script | extracted from (step) | lines |
|---|---|---|
| `scripts/bench-run-arms.sh` | `Run benchmarks (both arms, interleaved)` | 11 |
| `scripts/bench-compare.sh` | `Compare with benchstat` | 167 |
| `scripts/bench-gate-fail.sh` | `Fail on regressions` | 17 |
| `scripts/require-jobs-succeeded.sh` | `Assert every job in this workflow succeeded` | 12 |

**This is a move, not a rewrite.** Diffing each extracted body against the original YAML block, the *only* changes are `${{ }}` template expansions becoming environment reads:

- `${{ env.BENCH_COUNT }}` → `${BENCH_COUNT}` (2 sites in `bench-run-arms.sh`, 1 in `bench-compare.sh`)
- `status='${{ steps.benchstat.outputs.gate_status }}'` → `status="${GATE_STATUS-}"`
- `RESULTS="${RESULTS-}"` sourced explicitly

`bench-compare.sh`'s 165-line body has **one** changed line. No threshold, no `::error::`/`::notice::` text, no exit code, and nothing written to `$GITHUB_OUTPUT` was touched; `scripts/benchstat-gate.sh` is not modified at all. `set -euo pipefail` reproduces the original flags exactly — Actions runs `run:` bodies under `bash -e`, on top of which these blocks already set `-uo pipefail`.

### One structural change, deliberately not silent

The `required` job **now checks the repository out**. It previously had no checkout at all, because its assertion was inline and needed nothing from the repo; an extracted script has to exist before it can run. This adds a failure mode that did not exist before — a checkout that does not complete now fails the required check. It is the only non-bit-identical change in the commit, and easy to revert on its own if you would rather that job stayed self-contained.

### Gate coverage follows the logic, not the file

Three shape guards anchored on invocations that lived in `benchmark.yml` and have now moved into `bench-compare.sh`. Rather than delete them, they search the workflow **plus the scripts it calls**, so a reinline, a deletion or an orphaned script all still fail. Each was verified by **negative control** — mutated, watched go red, restored:

- removing the `bench-compare.sh` call from the YAML → `does not invoke scripts/bench-compare.sh`
- blanking the gate/arms invocations inside `bench-compare.sh` → all three plumbing guards fire
- removing the new checkout → the new no-checkout guard fires

New guards: the workflow must still invoke each of the four scripts, and **no job may run a `scripts/` helper without checking the repository out** — the exact trap the `required` job just walked into, which nothing would otherwise have caught.

### Verification

- `bash scripts/ci-gates-test.sh` → **210 passed, 0 failed** (was 169). +32 fixture assertions covering the extracted logic, +4 invocation guards, +1 no-checkout guard, +4 `bash -n`.
- Waiver round-trip re-run, all four unchanged: shipped waivers → exit 0, both rows `WAIVED`; comment-only file → exit 1, both `REGRESSION`; tight ceiling → exit 1, `EXCEEDS its waiver ceiling`; expired → exit 1, `WAIVER EXPIRED`.
- `shellcheck -S warning scripts/*.sh` and `bash -n` clean on all 14 scripts.
- Structural YAML diff against `9af5336` using a loader that **rejects duplicate keys**: top-level `name`/`on`/`concurrency`/`env`/`permissions` identical, job ids identical, every `runs-on`/`needs`/`if`/`id`/`uses`/`env` identical. The only differences are the `run:` bodies, the new `GATE_STATUS` env on `Fail on regressions`, and the new checkout step.
- `actionlint` clean. Worth noting: `actionlint` with its shellcheck integration reported **3 findings inside the old inline block and none now** — those findings were unreachable by any gate the repo runs, which is the point.

Remaining inline bash elsewhere, for a possible follow-up: `elps.yml` (22 lines), `tree-sitter.yml` (12), `govulncheck.yml` (12), `fuzz.yml` (8), `vscode-publish.yml` (5). Of that, the 12-line `Assert every job in this workflow succeeded` block is **byte-identical in `elps.yml`, `tree-sitter.yml` and `govulncheck.yml`** — `scripts/require-jobs-succeeded.sh` is a drop-in for all three, and would remove 36 of those 59 lines. Each of those three `required` jobs also lacks a checkout, so the new guard will catch the same trap if anyone adopts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA