### PR TITLE
docs: call out the JSON integer-precision footgun (#350)

### DIFF
--- a/docs/func.md
+++ b/docs/func.md
@@ -32,6 +32,93 @@ elps> (to-string (json:dump-bytes (sorted-map "K" "V")))
 "{\"K\":\"V\"}"
 ```
 
+## `json:load-string`
+
+Parses a JSON string into ELPS values.  JSON objects become sorted-maps, JSON
+arrays become arrays, and strings, numbers, booleans and `null` map naturally.
+
+```Lisp
+elps> (json:load-string "{\"K\":\"V\"}")
+(sorted-map "K" "V")
+elps> (json:load-string "[1, 2.5, true, null]")
+(vector 1 2.5 true ())
+```
+
+**WARNING**: by default *every* JSON number decodes as a float, and a float
+carries only 53 bits of integer precision, so an integer larger than 2^53 is
+silently rounded on the way in.
+
+```Lisp
+elps> (json:dump-string (json:load-string "9007199254740993"))
+"9007199254740992"
+elps> (json:dump-string (json:load-string "9223372036854775807"))
+"9223372036854776000"
+```
+
+Nothing reports this.  The rounded value still compares `=` to the integer it
+was meant to be, so a program can read a corrupted identifier, check it against
+the value it expected, match, and carry on.  Pass `:exact-integers true` to
+decode integer-shaped numbers as ints instead:
+
+```Lisp
+elps> (json:dump-string (json:load-string "9007199254740993" :exact-integers true))
+"9007199254740993"
+elps> (json:dump-string (json:load-string "9223372036854775807" :exact-integers true))
+"9223372036854775807"
+```
+
+The option changes more than the large numbers, and a document that used to
+load can now raise `json:integer-range-error`.  Read [JSON numbers and integer
+precision](lang.md#json-numbers-and-integer-precision) before turning it on.
+
+The `:string-numbers` keyword decodes every JSON number as a string holding its
+literal text.  It takes precedence over `:exact-integers` when both are given.
+
+## `json:load-bytes`
+
+Like `json:load-string`, but takes bytes rather than a string.  It accepts the
+same `:exact-integers` and `:string-numbers` keywords, and carries the same
+number-precision [warning](#json-load-string).
+
+```Lisp
+elps> (json:load-bytes (to-bytes "{\"K\":\"V\"}"))
+(sorted-map "K" "V")
+elps> (json:load-bytes (to-bytes "9007199254740993"))
+9.007199254740992e+15
+elps> (json:load-bytes (to-bytes "9007199254740993") :exact-integers true)
+9007199254740993
+```
+
+## `json:load-message`
+
+Parses a native JSON message object (`json.RawMessage`, as produced by
+`json:dump-message`) into ELPS values.  It accepts the same keywords as
+`json:load-string` and carries the same number-precision
+[warning](#json-load-string).
+
+```Lisp
+elps> (json:load-message (json:dump-message 9007199254740993))
+9.007199254740992e+15
+elps> (json:load-message (json:dump-message 9007199254740993) :exact-integers true)
+9007199254740993
+```
+
+## `json:use-exact-integers`
+
+Sets the default `:exact-integers` mode for the JSON serializer, so every later
+load that passes no explicit keyword uses it.  Returns nil.
+
+```Lisp
+elps> (progn (json:use-exact-integers true) (type (json:load-string "3")))
+'int
+```
+
+This is a process-wide switch and it changes the type of every number in every
+document the process loads.  Prefer the per-call `:exact-integers` keyword
+unless you have read [JSON numbers and integer
+precision](lang.md#json-numbers-and-integer-precision) and want the whole
+process migrated at once.
+
 ## `string:lowercase`
 
 Convert letters in a string to lowercase

--- a/docs/lang.md
+++ b/docs/lang.md
@@ -54,6 +54,12 @@ so `:1` is only useful as data.
 Numbers can be either int or floating point and will be converted between the
 two forms as necessary.
 
+A float carries only 53 bits of integer precision, which matters when numbers
+arrive from outside the program: `json:load-string` and its siblings decode
+every JSON number as a float by default and silently round integers above
+2^53.  See [JSON numbers and integer
+precision](#json-numbers-and-integer-precision).
+
 ### Strings
 
 Strings are a sequence of utf-8 text delimited by double quotes `"`.  Strings
@@ -623,6 +629,230 @@ associates the type symbol with user data which can be any value.
 The core language only provides low-level functionality for defining and
 working with custom types.  For the time being it is left it up to the
 application to create more powerful abstractions over typed data.
+
+### JSON numbers and integer precision
+
+**By default `json:load-string`, `json:load-bytes` and `json:load-message`
+decode every JSON number as a float, and silently round any integer larger
+than 2^53.**  This is the single sharpest edge in the standard library, so it
+gets a section of its own.
+
+A float carries 53 bits of integer precision.  Above that the nearest
+representable float is not the integer in the document, and the difference is
+not reported anywhere:
+
+```lisp
+elps> (json:dump-string (json:load-string "9007199254740993"))
+"9007199254740992"
+elps> (json:dump-string (json:load-string "9223372036854775807"))
+"9223372036854776000"
+```
+
+The first has drifted by 1.  The second — an int64 maximum, the shape of a
+great many machine-generated identifiers — has drifted by 193, and is no
+longer even an int64.
+
+What makes this a footgun rather than a rounding error is that **nothing
+signals**.  The corrupted value still compares `=` to the integer it was
+supposed to be, so a program can read a corrupted identifier, check it against
+the value it expected, match, and carry on:
+
+```lisp
+elps> (= 9007199254740993 (json:load-string "9007199254740993"))
+true
+elps> (= (json:load-string "9007199254740993") (json:load-string "9007199254740992"))
+true
+```
+
+Two *different* documents are indistinguishable once loaded.  The only thing
+that gives it away is the type, and only if you go looking:
+
+```lisp
+elps> (type (json:load-string "1"))
+'float
+```
+
+#### Opting in with `:exact-integers`
+
+Every `json:load*` function takes an `:exact-integers` keyword.  With it, a
+JSON number **written as an integer** — no `.`, no exponent — decodes to a
+lisp int holding its exact value:
+
+```lisp
+elps> (json:dump-string (json:load-string "9007199254740993" :exact-integers true))
+"9007199254740993"
+elps> (json:dump-string (json:load-string "9223372036854775807" :exact-integers true))
+"9223372036854775807"
+elps> (= (json:load-string "9007199254740993" :exact-integers true)
+         (json:load-string "9007199254740992" :exact-integers true))
+false
+elps> (json:dump-string
+        (json:load-string "{\"id\": 9007199254740993}" :exact-integers true))
+"{\"id\":9007199254740993}"
+```
+
+The rule is **syntactic**: it looks at how the number is written, never at the
+value it denotes.  That is deliberate.  A rule that depends only on the bytes
+of a document gives every reader of those bytes the same answer, without
+depending on shared floating-point behaviour — which is the property that
+matters where this package decodes replicated state.
+
+#### It changes more than the large numbers
+
+`:exact-integers` is not a fix that applies only to the values that were
+broken.  *Every* integer-shaped number in the document becomes an int, down to
+`3`:
+
+```lisp
+elps> (type (get (json:load-string "{\"count\": 3}") "count"))
+'float
+elps> (type (get (json:load-string "{\"count\": 3}" :exact-integers true) "count"))
+'int
+```
+
+So `(type x)`, `int?`, `float?`, `to-string` and anything that requires an
+integer all change with it:
+
+```lisp
+elps> (int? (json:load-string "3" :exact-integers true))
+true
+elps> (float? (json:load-string "3" :exact-integers true))
+false
+elps> (to-string (json:load-string "9007199254740993"))
+"9.007199254740992e+15"
+elps> (to-string (json:load-string "9007199254740993" :exact-integers true))
+"9007199254740993"
+```
+
+Some of that is code that starts working.  `nth` rejects a float index, so an
+index read out of a JSON document is unusable today and usable under the
+option:
+
+```lisp
+elps> (nth (vector "a" "b" "c") (json:load-string "1"))
+error: lisp:nth: second argument is not an integer: float
+elps> (nth (vector "a" "b" "c") (json:load-string "1" :exact-integers true))
+"b"
+```
+
+Some of it is code that starts failing, which is the point of the next
+section.
+
+#### Oversized literals fail loudly
+
+Under the option an integer literal too large for a lisp int is an error —
+the catchable condition `json:integer-range-error` — instead of a rounded
+float.  A document that loaded before can now fail:
+
+```lisp
+elps> (json:dump-string (json:load-string "9223372036854775808"))
+"9223372036854776000"
+elps> (json:load-string "9223372036854775808" :exact-integers true)
+error: json:integer-range-error: json:load-string: json integer does not fit in a lisp int: 9223372036854775808
+```
+
+That is deliberate: a value elps cannot hold should say so rather than become
+a different value.  Handle it like any other condition:
+
+```lisp
+elps> (handler-bind ([json:integer-range-error (lambda (c &rest args) (list c args))])
+        (json:load-string "{\"id\": 9223372036854775808}" :exact-integers true))
+'('json:integer-range-error '("json integer does not fit in a lisp int: 9223372036854775808"))
+```
+
+Malformed input is still catchable as `json:syntax-error` under the option, so
+an existing `handler-bind` does not quietly stop firing.
+
+#### Numbers with a fraction or an exponent are unchanged
+
+The syntactic rule means anything written with a `.` or an `e` is untouched
+and still decodes as a float, exactly as it does by default:
+
+```lisp
+elps> (type (json:load-string "1.5" :exact-integers true))
+'float
+elps> (type (json:load-string "1.0" :exact-integers true))
+'float
+elps> (type (json:load-string "1e2" :exact-integers true))
+'float
+elps> (json:dump-string (json:load-string "-0" :exact-integers true))
+"-0"
+```
+
+`-0` is excluded on purpose so that it keeps re-serializing as `-0` rather
+than as `0`.
+
+#### Two edges worth knowing
+
+**Exponent form normalizes on a dump.**  Because the rule is syntactic and
+`json:dump` renders float text in its own normal form, a number written as
+`100e7` loads as a float, dumps as plain digits, and a *re-read* of that
+output makes it an int:
+
+```lisp
+elps> (type (json:load-string "100e7" :exact-integers true))
+'float
+elps> (json:dump-string (json:load-string "100e7" :exact-integers true))
+"1000000000"
+elps> (type (json:load-string "1000000000" :exact-integers true))
+'int
+```
+
+The value is correct at every step and stable from the second read onwards;
+what changed is the document, not the value, and every node reading the same
+bytes still agrees.  Machine-generated JSON does not hit this — Go,
+JavaScript and Python all render `1e9` as plain digits — so it is a footgun
+for hand-written JSON inside a phylum, not a data-loss risk.
+
+**An oversized literal is accepted when it is already canonical float text.**
+This is the one exception to the range error above:
+
+```lisp
+elps> (type (json:load-string "10000000000000000000" :exact-integers true))
+'float
+elps> (json:dump-string (json:load-string "10000000000000000000" :exact-integers true))
+"10000000000000000000"
+elps> (json:dump-string 1e19)
+"10000000000000000000"
+```
+
+elps renders every float between 2^63 and 1e21 as plain digits, so without
+this exception a program holding an ordinary float of `1e19` could dump its
+state and then be unable to read it back.  Nothing is discarded, so nothing is
+hidden.  A literal that is *not* canonical float text still fails loudly —
+`9223372036854775808` is rejected, as shown above.
+
+#### `:string-numbers` still wins
+
+When both keywords are given, `:string-numbers` takes precedence, so a caller
+already using it sees no change at all:
+
+```lisp
+elps> (type (json:load-string "9007199254740993" :string-numbers true :exact-integers true))
+'string
+elps> (json:load-string "9007199254740993" :string-numbers true :exact-integers true)
+"9007199254740993"
+```
+
+#### Why it is opt-in
+
+Turning this on by default would change `(type x)` for every integer in every
+document at once.  Two nodes running different elps versions would then
+disagree about what the same bytes *mean* — one seeing `'float` where the
+other sees `'int` — which is exactly the kind of divergence a replicated
+system cannot absorb.  A per-call-site keyword lets a program migrate one call
+at a time and observe each change; `json:use-exact-integers` flips the default
+for a whole process once that migration is done.
+
+**Practical advice.**  If a document can carry a number above 2^53 — an
+account number, a nanosecond timestamp, a snowflake id — either turn
+`:exact-integers` on at that call site, or carry the value as a JSON *string*
+and convert it explicitly:
+
+```lisp
+elps> (to-int (get (json:load-string "{\"id\": \"9007199254740993\"}") "id"))
+9007199254740993
+```
 
 ## Packages
 


### PR DESCRIPTION
Documentation for #350. Docs only — no Go or lisp source is touched.

## Why this is the mitigation, not a nice-to-have

#408's `:exact-integers` is **opt-in**, so the default still silently rounds every JSON integer above 2^53. For everyone who does not opt in, the only thing standing between them and a corrupted identifier is knowing. And `docs/` had **zero** guidance on number precision anywhere: `docs/func.md` documented `json:dump-string` and `json:dump-bytes` and had no `json:load*` entry at all, so there was not even a place a reader would meet the problem.

Repo owner's framing: *"maybe the elps manual/doc/guide needs to really call this out as a footgun."*

## `docs/func.md`

Adds the four missing entries, each with a `**WARNING**` on the default and a link to the full treatment:

- `json:load-string` — the footgun in the position a reader actually arrives at it: two transcripts showing `9007199254740993` → `9007199254740992` and `9223372036854775807` → `9223372036854776000`, why nothing signals, then the `:exact-integers` form.
- `json:load-bytes`, `json:load-message` — same keywords, same warning, back-linked.
- `json:use-exact-integers` — with a note that it is process-wide and the per-call keyword is preferred.

## `docs/lang.md`

New `### JSON numbers and integer precision` at the end of `## Data Structures`, following the shape of the `Sharing, copying and mutation` section from the #373 work. `### Numbers` under Atoms now points at it, since that is where a reader asking "how big can a number be" looks first.

It covers, in this order:

1. **The default silently rounds**, shown before anything else, with the drift of 193 at int64 max named.
2. **The hiding mechanism** — `(= 9007199254740993 (json:load-string "9007199254740993"))` is `true` *and* the two distinct documents `…93` and `…92` compare equal to each other. Only `(type x)` gives it away.
3. **`:exact-integers` opts in**, per call site, and the rule is syntactic — and why that matters for replicated state.
4. **It retypes every integer-shaped number, not only the broken ones.** `{"count":3}` gives an int. `(type x)`, `int?`, `float?`, `to-string` all move. Includes the case where code starts *working*: `nth` rejects a float index today, so a JSON-sourced index is unusable by default and usable under the option.
5. **Oversized literals fail loudly** with the catchable `json:integer-range-error` — documents that used to load can now fail, that being the point — plus the `handler-bind` that catches it, and the note that `json:syntax-error` keeps firing.
6. **Fraction/exponent forms are unchanged** — `1.5`, `1.0`, `1e2`, `-0`, with `-0`'s exclusion explained.
7. **The exponent-form asymmetry, stated honestly.** `100e7` loads as a float, dumps as `1000000000`, and a re-read makes it an int. Value-correct and stable from the second read; the document changed, not the value. Framed as a phylum-authoring footgun, with the note that Go, JavaScript and Python all render `1e9` as plain digits so machine-generated JSON does not hit it.
8. **The canonical-float exception**, with why it is required rather than a wart: elps renders every float in [2^63, 1e21) as plain digits, so without it a program could dump state it cannot read back. `9223372036854775808` is not canonical text and still fails.
9. **`:string-numbers` takes precedence.**
10. **Why it is opt-in** — flipping it changes `(type x)` for every integer in every document at once, so two nodes on different versions would disagree about what the same bytes mean. Per-call-site opt-in allows incremental migration.
11. **Practical advice**: above 2^53, either turn the option on at that call site or carry the value as a JSON string and convert it explicitly.

## Every transcript was executed

No `elps>` block here was written from reasoning. A binary was built from this branch (`go build -o elps .`), every expression was run through `./elps repl`, the real output pasted, and the binary deleted before committing. That includes the two error transcripts (`lisp:nth` on a float index, and `json:integer-range-error`), the multi-line forms, and the `1e19` canonical-text demonstration. The transcripts also match what `libjson_integer_test.lisp` asserts, which is the second check on them.

## Gates

`go build ./...`, `go vet ./...`, `go test -count=1 ./...`, `elps fmt -l ./...` (clean, binary deleted after), `golangci-lint run ./...` (**0 issues**), `confidentiality-guard.sh` (clean, after `git add`), `ci-gates-test.sh` (**210 passed / 0 failed**), `elps doc -m` ("All functions and exports are documented").

Originally stacked on #408; retargeted to `main` now that #408 has merged.