### PR TITLE
Stop re-validating libjson's own output on every dump-message (#412)

### DIFF
--- a/lisp/lisplib/libjson/encode.go
+++ b/lisp/lisplib/libjson/encode.go
@@ -42,11 +42,77 @@ func (e encodeInvalidNumberError) Error() string {
 // more word rounds the encoder up to the next size class, and every document
 // in the process -- almost none of which have anything to do with cycles --
 // pays the 16 bytes.  TestEncoderFitsItsSizeClass pins the size.
+//
+// What costs nothing is a bool.  stringNums leaves seven bytes of tail padding
+// before the struct rounds up to 112, so the two flags below sit in padding
+// the encoder was already paying for, and the size is unchanged --
+// TestEncoderFitsItsSizeClass would catch it if that ever stopped being true.
+// A WORD is what the paragraph above is about, and a word is still charged in
+// full.
 type encoder struct {
 	buf bytes.Buffer
 
 	scratch    [64]byte
 	stringNums bool
+
+	// nestedDeep and wroteNative record the two ways the bytes this encoder
+	// produces can fall outside what it is able to vouch for.  Both are read
+	// once, by loadableBytes, after the document is finished.
+	nestedDeep  bool
+	wroteNative bool
+}
+
+// loadableBytes reports whether this package can vouch, without reading them
+// back, that the bytes this encoder just wrote will load.
+//
+// The claim is exactly the FuzzDumpJSON invariant -- whatever Dump emits, Load
+// must accept -- so it is continuously tested rather than asserted here.  It
+// is not unconditional, though, which is the whole reason this function
+// exists.  Every number in the output was written by encodeInt or encodeFloat,
+// which refuse anything a float64 cannot carry, so the elps#410 literal cannot
+// appear; every string was written by encodeString, which escapes what
+// encoding/json escapes.  That leaves two gaps, and this reports the absence
+// of both:
+//
+//   - nestedDeep.  Nothing bounds how deep a lisp value nests, and
+//     encoding/json's DECODER stops at 10000, so a document nested deeper than
+//     that is one Dump writes and Load refuses.  That gap is real and predates
+//     this function -- `json:dump` of a 10001-deep value has always produced
+//     bytes `json:load` rejects -- and nothing here closes it; this only
+//     declines to make a claim about such a document.  The bound used is the
+//     counting pass's own: a document the counting pass finished nests less
+//     than encodeGuardDepth, two orders of magnitude inside the decoder's
+//     limit.  That is a much cheaper thing to know than the exact depth, and
+//     it covers every document anyone actually writes.
+//
+//   - wroteNative.  A native's bytes are not this encoder's.  checkLoadable
+//     clears them in isolation, but nesting composes: a native holding a
+//     10000-deep document, embedded in a two-deep lisp value, yields 10002.
+//     So a document that embedded any native at all is not vouched for --
+//     including one that embedded an ownMessage, which keeps this a statement
+//     about a single encode rather than an induction over a chain of them.
+//     It also covers a case elps#350 introduced after this function was
+//     written: a native can hold a thirty-digit integer literal, which the
+//     default decoder rounds to a float and an :exact-integers load REFUSES.
+//     Foreign number text only reaches a document through a native, so
+//     declining to vouch for a document that holds one closes that too --
+//     TestOwnOutputLoadsWithExactIntegers and FuzzDumpExactIntegers are what
+//     say the remaining, native-free case is safe under that option.
+//
+// Both flags are DEFENCE IN DEPTH rather than the only guard, and this is
+// worth knowing before anyone decides they are dead weight.  Measured, not
+// assumed: json.Marshal compacts whatever a MarshalJSON returns, that
+// compaction applies the same 10000-deep bound the decoder does, and so a
+// too-deep ownMessage is refused by encoding/json before checkLoadable would
+// have run -- with a different error, but refused.  There is at present no
+// document for which flipping these flags to true changes an OUTCOME.  They
+// are kept because the reasoning above is about what this package emits, and
+// leaning the whole exemption on an undocumented depth check inside
+// encoding/json would make a correctness property depend on an implementation
+// detail of another package.  They cost nothing: a document that trips either
+// one is off the hot path by construction.
+func (enc *encoder) loadableBytes() bool {
+	return !enc.nestedDeep && !enc.wroteNative
 }
 
 // encodeGuardDepth is the nesting depth at which the encoder stops assuming
@@ -163,6 +229,7 @@ func (enc *encoder) encode(v *lisp.LVal) error {
 	}
 	// The counting pass abandoned the document partway through, so its output
 	// is a fragment.  Drop it and start the value over.
+	enc.nestedDeep = true
 	enc.buf.Truncate(mark)
 	return enc.encodeValue(v, encodeGuard{path: make(map[*lisp.LVal]struct{}, encodeGuardDepth)})
 }
@@ -269,12 +336,30 @@ func (enc *encoder) encodeLNative(v *lisp.LVal, _ encodeGuard) error {
 }
 
 func (enc *encoder) encodeNative(v interface{}) error {
+	enc.wroteNative = true
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
 	}
-	if err := enc.checkLoadable(b); err != nil {
-		return err
+	// elps#412.  The check below asks whether bytes this package did not
+	// produce can be read back.  An ownMessage is the one native for which
+	// this package DID produce them, and the loadable flag says it produced
+	// them under the conditions loadableBytes checks -- so the answer is
+	// already known, and re-deriving it is duplicated work on substrate's
+	// per-response path, where every JSON-RPC response embeds one.
+	//
+	// The exemption is by TYPE, and the type is unexported with unexported
+	// fields, minted on one line of DumpMessageBuiltin from this package's own
+	// output: there is no expression an embedder can write that puts their
+	// bytes inside one, and none that flips loadable on a message that did not
+	// earn it.  TestEmbedderCannotObtainTheExemption is the guard.
+	//
+	// Nothing else is exempt.  Narrowing to *json.RawMessage instead of to our
+	// own type would be the hole described under checkLoadable.
+	if m, own := v.(*ownMessage); !own || !m.loadable {
+		if err := enc.checkLoadable(b); err != nil {
+			return err
+		}
 	}
 	enc.buf.Write(b)
 	return nil
@@ -342,11 +427,15 @@ func (enc *encoder) encodeNative(v interface{}) error {
 // regression gate cannot detect. Correct by construction wins on the evidence,
 // not by preference.
 //
-// elps#412 is the direction that would actually pay. On that platform's hot
-// path, json:dump-message wraps libjson's OWN output in a json.RawMessage, so
-// this check re-validates bytes this package produced microseconds earlier and
-// structurally cannot fire. Removing the work beats making it faster; do not
-// reach for a faster check before reading that ticket.
+// elps#412 was the direction that actually paid, and it has shipped: on that
+// platform's hot path json:dump-message wrapped libjson's OWN output, so this
+// check re-validated bytes this package had produced microseconds earlier and
+// structurally could not fire. encodeNative now skips it for an ownMessage the
+// encoder vouched for -- 70-78% off the time and up to 99.98% off the
+// allocations of an envelope carrying one. Removing the work beat making it
+// faster, which is the thing to remember before reaching for a faster check:
+// the remaining callers are bytes this package did NOT write, and for those
+// the decode is the point.
 //
 // # Other designs tried and rejected, recorded so they are not retried blind
 //

--- a/lisp/lisplib/libjson/fuzz_test.go
+++ b/lisp/lisplib/libjson/fuzz_test.go
@@ -210,6 +210,110 @@ func FuzzDumpJSON(f *testing.F) {
 	})
 }
 
+// FuzzDumpExactIntegers is FuzzDumpJSON's invariant -- whatever Dump emits,
+// Load must accept -- asked of the :exact-integers decoder instead of the
+// default one.
+//
+// It exists because of elps#412.  That change lets encodeNative skip the
+// elps#410 loadability check for libjson's own output, and the licence for the
+// skip is exactly this invariant.  FuzzDumpJSON tests it in both
+// string-numbers modes and in neither exact-integers mode, so before elps#412
+// the gap was theoretical; afterwards it is the premise of a check that no
+// longer runs.  A premise a fuzz target does not cover is an assumption, and
+// the whole point of the ticket was to settle these rather than assume them.
+//
+// The mode can refuse a number the default accepts -- that is what elps#350
+// bought -- so the risk is real rather than notional: it would take one
+// integer literal libjson emits and :exact-integers rejects to make
+// encoder.loadableBytes vouch for a document that does not load.  There is an
+// argument that it cannot happen (loadNumber falls back to a float only when
+// the literal is ALREADY appendJSONFloat's rendering, and appendJSONFloat is
+// the only float rendering this package emits, so the two sides cannot drift),
+// and TestOwnOutputLoadsWithExactIntegers pins the boundaries that argument
+// turns on.  This is the part that does not depend on the argument being
+// complete.
+//
+// Documents holding a NATIVE are out of scope here, as they are for
+// loadableBytes: a native's bytes are not this encoder's, they can hold a
+// thirty-digit integer this mode refuses, and that is precisely why
+// encoder.wroteNative exists.  fuzzval mints natives, so those runs are
+// skipped rather than asserted -- the target would otherwise report the
+// carve-out as a bug.
+func FuzzDumpExactIntegers(f *testing.F) {
+	for _, seed := range fuzzval.Seeds() {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		env := newJSONEnv(t)
+		gen := fuzzval.New(data, env)
+		v := gen.Value()
+
+		enc, err := libjson.Dump(v, false)
+		if err != nil {
+			return // Refusing a value it cannot represent is correct.
+		}
+		if containsNative(v) {
+			return // encoder.wroteNative: not vouched for, by design.
+		}
+
+		opts := libjson.LoadOpts{ExactIntegers: true}
+		back := libjson.LoadWith(enc, opts)
+		if back == nil {
+			t.Fatalf("LoadWith returned a nil LVal for Dump's output\n--- encoded ---\n%s", enc)
+		}
+		if back.Type == lisp.LError {
+			t.Fatalf("the :exact-integers decoder rejected Dump's own output: %s\n--- encoded ---\n%s\n--- value ---\n%s",
+				back, enc, v)
+		}
+
+		// And it is stable, for the same reason FuzzLoadExactIntegers asserts
+		// stability from the second decode: this mode's integer test is
+		// syntactic, and Dump normalises a float's text.
+		reenc, err := libjson.Dump(back, false)
+		if err != nil {
+			t.Fatalf("Dump rejected the value its own output decoded to: %v\n--- encoded ---\n%s", err, enc)
+		}
+		again := libjson.LoadWith(reenc, opts)
+		if again == nil || again.Type == lisp.LError {
+			t.Fatalf("the :exact-integers decoder rejected the re-encoded output: %v\n--- re-encoded ---\n%s", again, reenc)
+		}
+		if got, want := again.String(), back.String(); got != want {
+			t.Fatalf("the value drifted across a second round trip\n--- first decode ---\n%s\n--- second decode ---\n%s\n--- encoded ---\n%s",
+				want, got, enc)
+		}
+	})
+}
+
+// containsNative reports whether v holds a native anywhere, which is the
+// condition encoder.wroteNative records.  Depth is bounded by
+// lisp.NewCycleGuard's own limit rather than by a count here, because a
+// generated value can contain itself.
+func containsNative(v *lisp.LVal) bool {
+	found := false
+	seen := make(map[*lisp.LVal]bool)
+	var walk func(*lisp.LVal, int)
+	walk = func(v *lisp.LVal, depth int) {
+		if v == nil || found || depth > 64 || seen[v] {
+			return
+		}
+		seen[v] = true
+		if v.Type == lisp.LNative {
+			found = true
+			return
+		}
+		for _, c := range v.Cells {
+			walk(c, depth+1)
+		}
+		if v.Type == lisp.LSortMap {
+			for _, k := range v.MapKeys().Cells {
+				walk(v.MapGet(k), depth+1)
+			}
+		}
+	}
+	walk(v, 0)
+	return found
+}
+
 // newJSONEnv exists only so the generator can build tagged-values, which need
 // an LEnv to stamp a source location. libjson itself is package-level.
 func newJSONEnv(tb testing.TB) *lisp.LEnv {

--- a/lisp/lisplib/libjson/json.go
+++ b/lisp/lisplib/libjson/json.go
@@ -54,16 +54,19 @@ func Builtins(s *Serializer) []*libutil.Builtin {
 	return []*libutil.Builtin{
 		libutil.FunctionDoc("message-bytes", lisp.Formals("json-message"), s.MessageBytesBuiltin,
 			`Extracts the raw byte content from a native JSON message object
-			(json.RawMessage). Returns a bytes value. Use this to get the
+			(one produced by dump-message, or a json.RawMessage supplied by
+			an embedder). Returns a bytes value. Use this to get the
 			underlying bytes of a message for further processing.`),
 		libutil.FunctionDoc("dump-message", lisp.Formals("object", lisp.KeyArgSymbol, "string-numbers"), s.DumpMessageBuiltin,
 			`Serializes an ELPS value to a native JSON message object
-			(json.RawMessage) suitable for embedding in Go structures.
-			The :string-numbers keyword controls whether numbers are
-			serialized as JSON strings (default: serializer setting).`),
+			suitable for embedding in Go structures, and in a value passed
+			back to dump. The :string-numbers keyword controls whether
+			numbers are serialized as JSON strings (default: serializer
+			setting).`),
 		libutil.FunctionDoc("load-message", lisp.Formals("json-message", lisp.KeyArgSymbol, "string-numbers", "exact-integers"), s.LoadMessageBuiltin,
-			`Parses a native JSON message object (json.RawMessage) into
-			ELPS values. The :string-numbers keyword controls whether
+			`Parses a native JSON message object (one produced by
+			dump-message, or a json.RawMessage supplied by an embedder)
+			into ELPS values. The :string-numbers keyword controls whether
 			JSON numbers are returned as strings (default: serializer
 			setting). The :exact-integers keyword controls whether JSON
 			integer literals are returned as ints rather than floats
@@ -453,11 +456,76 @@ func (s *Serializer) loadOpts(env *lisp.LEnv, stringNums, exactInts *lisp.LVal) 
 
 // Dump serializes v as JSON and returns any error.
 func (s *Serializer) Dump(v *lisp.LVal, stringNums bool) ([]byte, error) {
+	b, _, err := s.dump(v, stringNums)
+	return b, err
+}
+
+// dump serializes v and reports, alongside the bytes, whether this package can
+// vouch that they load back -- see encoder.loadableBytes.  It is the only
+// producer of that verdict, and DumpMessageBuiltin is its only consumer.
+func (s *Serializer) dump(v *lisp.LVal, stringNums bool) (b []byte, loadable bool, err error) {
 	enc := newEncoder(stringNums)
 	if err := enc.encode(v); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return enc.bytes(), nil
+	return enc.bytes(), enc.loadableBytes(), nil
+}
+
+// ownMessage is a JSON message this package produced: the value behind
+// `json:dump-message`.
+//
+// It exists so encodeNative can tell libjson's own output apart from an
+// embedder's bytes and skip the elps#410 loadability check on the former,
+// which is elps#412.  The whole design of the type is that separation:
+//
+//   - Unexported, with an unexported field, and every method on it is
+//     read-only.  There is no exported constructor, no exported field to
+//     assign through, and no exported type an embedder can convert from.  A
+//     value of it cannot be named outside this package, so it cannot be
+//     built, embedded, or reflected into with SetBytes.
+//
+//   - Minted on exactly one line -- DumpMessageBuiltin, below -- from bytes
+//     Serializer.dump just wrote, carrying that call's own loadable verdict.
+//     Nothing else in the package constructs one.
+//
+// loadable is carried per value rather than being implied by the type because
+// libjson's output is not unconditionally loadable (see
+// encoder.loadableBytes).  Minting the type only when it happens to be true
+// would make `json:dump-message` return one Go type for shallow documents and
+// another for deep ones, which is a far nastier trap for a consumer than a
+// single type that is honest about what it knows.
+type ownMessage struct {
+	msg      json.RawMessage
+	loadable bool
+}
+
+// MarshalJSON returns the message verbatim, as json.RawMessage does.  The
+// method is what makes json.Marshal emit the bytes rather than a struct, and
+// it hands out the slice the same way json.RawMessage.MarshalJSON does -- the
+// caller is encodeNative, which only writes it out.
+//
+// json.RawMessage substitutes "null" for a nil receiver; there is no such case
+// to reproduce here.  The one mint site takes msg from Serializer.dump, which
+// returns bytes or an error, never a nil slice with no error.
+func (m *ownMessage) MarshalJSON() ([]byte, error) { return m.msg, nil }
+
+var _ json.Marshaler = (*ownMessage)(nil)
+
+// jsonMessage returns the bytes behind a `json:dump-message` native, in either
+// of the shapes one can have.
+//
+// *json.RawMessage is still accepted because it is what an embedder building a
+// message on the Go side has always passed in, and elps#412 is not a reason to
+// stop reading those.  It is only the WRITE side -- which type gets the
+// loadability exemption -- that distinguishes the two.
+func jsonMessage(v interface{}) (json.RawMessage, bool) {
+	switch m := v.(type) {
+	case *ownMessage:
+		return m.msg, true
+	case *json.RawMessage:
+		return *m, true
+	}
+	return nil, false
 }
 
 func (s *Serializer) MessageBytesBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
@@ -465,43 +533,59 @@ func (s *Serializer) MessageBytesBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.
 	if lmsg.Type != lisp.LNative {
 		return env.Errorf("argument is not a raw json-message: %v", lmsg.Type)
 	}
-	msg, ok := lmsg.Native.(*json.RawMessage)
+	msg, ok := jsonMessage(lmsg.Native)
 	if !ok {
-		return env.Errorf("argument is not a raw json-message: %v", msg)
+		return errNotAMessage(env)
 	}
-	return lisp.Bytes([]byte(*msg))
+	return lisp.Bytes([]byte(msg))
+}
+
+// errNotAMessage reports a native that is not a json-message.
+//
+// The message names no value, which is not an oversight: the code this
+// replaced formatted the nil result of a failed type assertion, so it has
+// always read "... json-message: <nil>", and an error string is observable
+// from lisp.  Kept byte for byte rather than improved, so that elps#412
+// changes nothing a program can see.
+func errNotAMessage(env *lisp.LEnv) *lisp.LVal {
+	return env.Errorf("argument is not a raw json-message: %v", (*json.RawMessage)(nil))
 }
 
 func (s *Serializer) DumpMessageBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
-	val := s.DumpBytesBuiltin(env, args)
-	if val.Type == lisp.LError {
-		return val
+	b, loadable, lerr := s.dumpBuiltin(env, args)
+	if lerr != nil {
+		return lerr
 	}
-	if val.Type != lisp.LBytes {
-		return env.Errorf("internal error: unexpected value type from JSON dump: %v", val.Type)
-	}
-	b := val.Bytes()
-	msg := (*json.RawMessage)(&b)
-	var _ json.Marshaler = msg
-	return lisp.Native(msg)
+	return lisp.Native(&ownMessage{msg: b, loadable: loadable})
 }
 
 func (s *Serializer) DumpBytesBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+	b, _, lerr := s.dumpBuiltin(env, args)
+	if lerr != nil {
+		return lerr
+	}
+	return lisp.Bytes(b)
+}
+
+// dumpBuiltin is the argument handling `json:dump-bytes` and
+// `json:dump-message` share, returning the loadable verdict only the latter
+// uses.  A non-nil third result is the error LVal to return.
+func (s *Serializer) dumpBuiltin(env *lisp.LEnv, args *lisp.LVal) ([]byte, bool, *lisp.LVal) {
 	obj, stringNums := args.ReqArg(env, 0), args.KeyArg(1)
 	if obj.Type == lisp.LError {
-		return obj
+		return nil, false, obj
 	}
 	if stringNums.IsNil() {
 		stringNums = s.useStringNumbers(env)
 		if stringNums.Type == lisp.LError {
-			return stringNums
+			return nil, false, stringNums
 		}
 	}
-	b, err := s.Dump(obj, lisp.True(stringNums))
+	b, loadable, err := s.dump(obj, lisp.True(stringNums))
 	if err != nil {
-		return env.Error(err)
+		return nil, false, env.Error(err)
 	}
-	return lisp.Bytes(b)
+	return b, loadable, nil
 }
 
 func (s *Serializer) LoadMessageBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
@@ -512,11 +596,11 @@ func (s *Serializer) LoadMessageBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.L
 	if lmsg.Type != lisp.LNative {
 		return env.Errorf("argument is not a raw json-message: %v", lmsg.Type)
 	}
-	msg, ok := lmsg.Native.(*json.RawMessage)
+	msg, ok := jsonMessage(lmsg.Native)
 	if !ok {
-		return env.Errorf("argument is not a raw json-message: %v", msg)
+		return errNotAMessage(env)
 	}
-	return s.LoadBytesBuiltin(env, lisp.SExpr([]*lisp.LVal{lisp.Bytes([]byte(*msg)), stringNums, exactInts}))
+	return s.LoadBytesBuiltin(env, lisp.SExpr([]*lisp.LVal{lisp.Bytes([]byte(msg)), stringNums, exactInts}))
 }
 
 func (s *Serializer) LoadBytesBuiltin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {

--- a/lisp/lisplib/libjson/nativebench_test.go
+++ b/lisp/lisplib/libjson/nativebench_test.go
@@ -50,13 +50,18 @@ import (
 // are small (177 encodes across the whole suite, mean 25 bytes, largest 487),
 // and a per-byte difference on bytes there are few of does not clear the noise
 // floor of the gate that would have to defend it. See the comment on
-// encoder.checkLoadable in encode.go for the full reasoning, and elps#412 for
-// the change that would actually remove this cost instead of shrinking it.
+// encoder.checkLoadable in encode.go for the full reasoning.
+//
+// elps#412 has since shipped the change that removes the cost instead of
+// shrinking it, and these two rows are exactly where it does NOT apply: the
+// exemption is for libjson's own output, and benchNative encodes an EMBEDDER's
+// *json.RawMessage. Both rows are flat across it, deliberately. The rows that
+// move are BenchmarkEncodeOwnMessage* in own_message_bench_test.go.
 //
 // So these benchmarks are not a regression report to be explained away. They
-// are the standing price of the invariant, kept measurable so that elps#412 --
-// or any future attempt at a cheaper check -- has a number to beat and a place
-// to prove it.
+// are the standing price of the invariant on the values that still pay it,
+// kept measurable so that any future attempt at a cheaper check has a number
+// to beat and a place to prove it.
 //
 // The stringNumbers row is flat for a mundane reason, stated here so it is not
 // misread as evidence the check is free in that mode:

--- a/lisp/lisplib/libjson/own_message_bench_test.go
+++ b/lisp/lisplib/libjson/own_message_bench_test.go
@@ -1,0 +1,96 @@
+// Copyright © 2018 The ELPS authors
+
+package libjson_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libjson"
+)
+
+// The `json:dump-message` path had no benchmark before elps#412, which is why
+// elps#411 could ship a check on it costed only by proxy.  BenchmarkEncode
+// prices natives that are Go maps, and BenchmarkEncodeNative* prices an
+// embedder's *json.RawMessage; neither is libjson's own output, and neither
+// moves when the elps#412 exemption is applied or removed.
+//
+// This one is the shape the downstream platform actually runs: a JSON-RPC
+// envelope whose "result" member is the native `json:dump-message` returned,
+// serialized by a second Dump.  That is one re-validated native per response,
+// structurally -- not an occasional path.
+//
+// The three sizes are the ticket's, and the reason there are three is that the
+// cost being removed is per-BYTE, not per-call: the check decodes the whole
+// message into an interface{} and throws it away, so it allocates in
+// proportion to the document.  A single small row would understate it by two
+// orders of magnitude and invite the conclusion that elps#412 is noise.
+//
+// The payload is deliberately ordinary -- strings, ints, floats, nesting -- so
+// the row measures the envelope encode and not some pathological document.
+func benchOwnMessage(b *testing.B, rows int, wantBytes int) {
+	b.Helper()
+	env := newJSONEnv(b)
+	s := libjson.DefaultSerializer()
+
+	payload := lisp.SortedMap()
+	items := make([]*lisp.LVal, rows)
+	for i := range rows {
+		row := lisp.SortedMap()
+		row.MapSet("id", lisp.Int(1000000+i))
+		row.MapSet("name", lisp.String(fmt.Sprintf("record number %d", i)))
+		row.MapSet("score", lisp.Float(1.5))
+		row.MapSet("tags", lisp.QExpr([]*lisp.LVal{
+			lisp.String("alpha"), lisp.String("beta"), lisp.String("gamma"),
+		}))
+		items[i] = row
+	}
+	payload.MapSet("items", lisp.QExpr(items))
+	payload.MapSet("count", lisp.Int(rows))
+
+	msg := s.DumpMessageBuiltin(env, lisp.SExpr([]*lisp.LVal{payload, lisp.Nil()}))
+	if msg.Type == lisp.LError {
+		b.Fatalf("json:dump-message: %v", msg)
+	}
+	// The size is pinned, not logged.  These rows only mean anything as a
+	// series -- small, medium, large -- and a payload that quietly drifted an
+	// order of magnitude would still produce a plausible-looking table.
+	size := s.MessageBytesBuiltin(env, lisp.SExpr([]*lisp.LVal{msg}))
+	if size.Type == lisp.LError {
+		b.Fatalf("json:message-bytes: %v", size)
+	}
+	if got := len(size.Bytes()); got < wantBytes*9/10 || got > wantBytes*11/10 {
+		b.Fatalf("payload is %d bytes, expected about %d: this row no longer "+
+			"measures the size class its name claims", got, wantBytes)
+	}
+
+	// The envelope shirocore builds around every response.
+	envelope := lisp.SortedMap()
+	envelope.MapSet("jsonrpc", lisp.String("2.0"))
+	envelope.MapSet("id", lisp.Int(1))
+	envelope.MapSet("result", msg)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := libjson.Dump(envelope, false); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkEncodeOwnMessageSmall is a response of a few hundred bytes, the
+// size the downstream platform's own instrumentation reports today (mean 25 B,
+// max 487 B across its whole suite).  It is the row that says whether
+// elps#412 is worth anything at current traffic.
+func BenchmarkEncodeOwnMessageSmall(b *testing.B) { benchOwnMessage(b, 7, 570) }
+
+// BenchmarkEncodeOwnMessageMedium is roughly 14 KB, the middle row of
+// elps#412's table.
+func BenchmarkEncodeOwnMessageMedium(b *testing.B) { benchOwnMessage(b, 172, 14600) }
+
+// BenchmarkEncodeOwnMessageLarge is roughly 295 KB, the top row: a phylum that
+// has started returning large opaque blobs.  The point of keeping it is that
+// the saving must be shown to SCALE, not merely to exist.
+func BenchmarkEncodeOwnMessageLarge(b *testing.B) { benchOwnMessage(b, 3410, 295000) }

--- a/lisp/lisplib/libjson/own_message_internal_test.go
+++ b/lisp/lisplib/libjson/own_message_internal_test.go
@@ -1,0 +1,166 @@
+// Copyright © 2018 The ELPS authors
+
+package libjson
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExemptionRidesOnTheFlag proves elps#412's skip is real, and that it is
+// the loadable flag rather than the type alone that arms it.
+//
+// It is the one test that can: from outside the package there is no way to
+// build an ownMessage holding bytes the check would refuse -- that is the
+// whole point of TestEmbedderCannotObtainTheExemption -- so from outside, an
+// exemption that had quietly stopped being applied would look identical to one
+// that worked.  Every observable of a correct skip is "nothing changed".
+//
+// The payload is the elps#410 literal: syntactically valid JSON that
+// json.Marshal is happy to pass through and that the decoder refuses, so it
+// separates the two layers cleanly.  Nesting would not -- encoding/json's own
+// compaction catches that before checkLoadable is reached, and the row would
+// pass whether or not the skip existed.
+//
+// These bytes are a fiction: no encoder in this package can emit 1E1000, since
+// encodeFloat and encodeInt both refuse anything a float64 cannot carry.  The
+// fiction is deliberate.  The test asks what the exemption DOES, not whether
+// its premise holds; FuzzDumpJSON is what holds the premise.
+func TestExemptionRidesOnTheFlag(t *testing.T) {
+	const unloadable = "1E1000"
+
+	envelope := func(native interface{}) *lisp.LVal {
+		m := lisp.SortedMap()
+		m.MapSet("result", lisp.Native(native))
+		return m
+	}
+
+	t.Run("vouched, so the check is skipped", func(t *testing.T) {
+		b, err := Dump(envelope(&ownMessage{msg: json.RawMessage(unloadable), loadable: true}), false)
+		require.NoError(t, err, "the exemption is not being applied -- elps#412 is inert")
+		assert.Equal(t, `{"result":`+unloadable+`}`, string(b))
+
+		// And the skip really did skip something: the same bytes are refused
+		// when they are not exempt.  Without this the row above could pass
+		// because the check had stopped working for everyone.
+		assert.Equal(t, lisp.LError, Load(b, false).Type,
+			"premise broken: these bytes load, so nothing was skipped")
+	})
+
+	t.Run("not vouched, so the check runs", func(t *testing.T) {
+		_, err := Dump(envelope(&ownMessage{msg: json.RawMessage(unloadable), loadable: false}), false)
+		require.Error(t, err, "an unvouched ownMessage was waved through on its type alone")
+		assert.Contains(t, err.Error(), "unable to encode native value")
+	})
+
+	t.Run("an embedder's RawMessage is never exempt", func(t *testing.T) {
+		raw := json.RawMessage(unloadable)
+		_, err := Dump(envelope(&raw), false)
+		require.Error(t, err, "elps#410 reopened for embedder bytes")
+		assert.Contains(t, err.Error(), "unable to encode native value")
+	})
+}
+
+// TestOwnMessageHasOneMintSite is the structural half of "it cannot leak".
+//
+// TestEmbedderCannotObtainTheExemption shows no embedder VALUE can reach the
+// type today.  That argument rests on there being exactly one place the type
+// is constructed, from this package's own output -- a second composite literal
+// somewhere, fed from a builtin's argument, would defeat it without failing
+// any behavioural test written against the sites that exist now.
+//
+// So this counts them, in the package's non-test sources.  A new one is not
+// forbidden; it is required to come with a reason and an updated count, which
+// is what puts it in front of a reviewer.
+func TestOwnMessageHasOneMintSite(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err)
+	require.Contains(t, pkgs, "libjson")
+
+	var sites []string
+	ast.Inspect(pkgs["libjson"], func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		if id, ok := lit.Type.(*ast.Ident); ok && id.Name == "ownMessage" {
+			sites = append(sites, fset.Position(lit.Pos()).String())
+		}
+		return true
+	})
+
+	assert.Len(t, sites, 1,
+		"ownMessage is constructed at %v; the elps#412 exemption is only as "+
+			"narrow as the set of places that can mint one, so a new site "+
+			"needs review rather than a bumped count", sites)
+}
+
+// TestOwnOutputLoadsWithExactIntegers settles the question elps#350 raised for
+// elps#412: whether encoder.loadableBytes vouches for documents that a load
+// with :exact-integers would refuse.
+//
+// It could.  That mode is allowed to REJECT an integer literal -- one too
+// large for a lisp int is an error there and a rounded float by default -- and
+// the elps#410 check that elps#412 skips never tested that mode either
+// (checkLoadable decodes with the encoder's string-numbers setting and nothing
+// else).  So a number libjson emits and :exact-integers refuses would be a
+// third carve-out alongside nestedDeep and wroteNative.
+//
+// It is not one, and the reason is structural rather than lucky: loadNumber
+// takes a float for an over-large integer literal in exactly one case, when
+// the literal is ALREADY appendJSONFloat's rendering of that float, and
+// appendJSONFloat is the only float rendering this package emits.  The two
+// sides cannot drift because they are the same function.
+//
+// These are the boundaries that argument turns on -- either side of the int
+// range, either side of the exponent-form cutoff, and the integral floats in
+// between, which are the values that render as bare digits and so take the
+// integer path.  FuzzDumpExactIntegers covers the space around them.
+func TestOwnOutputLoadsWithExactIntegers(t *testing.T) {
+	s := DefaultSerializer()
+	for _, tc := range []struct {
+		name string
+		v    *lisp.LVal
+	}{
+		{"int max", lisp.Int(math.MaxInt)},
+		{"int min", lisp.Int(math.MinInt)},
+		{"float 2^63, one past int max", lisp.Float(9223372036854775808)},
+		{"float -2^63-1024, one past int min", lisp.Float(-9223372036854776832)},
+		{"float 1e19, plain digits", lisp.Float(1e19)},
+		{"float 1e20, the last plain-digit decade", lisp.Float(1e20)},
+		{"float 1e21, the first exponent-form decade", lisp.Float(1e21)},
+		{"float 1e-6, the small-end cutoff", lisp.Float(1e-6)},
+		{"float 1e-7, exponent form", lisp.Float(1e-7)},
+		{"float 2.0, integral and small", lisp.Float(2)},
+		{"float -0", lisp.Float(math.Copysign(0, -1))},
+		{"max float64", lisp.Float(math.MaxFloat64)},
+		{"2^53+1 as a float", lisp.Float(9007199254740993)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// The document is the one substrate builds: the value inside the
+			// envelope json:dump-message produces.
+			b, loadable, err := s.dump(tc.v, false)
+			require.NoError(t, err)
+			require.True(t, loadable,
+				"the encoder declined to vouch for %s, so this row proves nothing", b)
+
+			got := LoadWith(b, LoadOpts{ExactIntegers: true})
+			require.NotEqual(t, lisp.LError, got.Type,
+				"loadableBytes vouched for %s, which the :exact-integers "+
+					"decoder refuses: %v -- that is a third carve-out", b, got)
+		})
+	}
+}

--- a/lisp/lisplib/libjson/own_message_test.go
+++ b/lisp/lisplib/libjson/own_message_test.go
@@ -1,0 +1,370 @@
+// Copyright © 2018 The ELPS authors
+
+package libjson_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/token"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/elpstest"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libjson"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newLispEnv returns an environment with the standard library loaded, so these
+// tests reach `json:dump-message` through the builtin rather than through a Go
+// shortcut a lisp program could not take.
+func newLispEnv(t testing.TB) *lisp.LEnv {
+	t.Helper()
+	r := &elpstest.Runner{}
+	t.Cleanup(r.Close)
+	env, err := r.NewEnv(t)
+	require.NoError(t, err)
+	return env
+}
+
+func evalIn(t testing.TB, env *lisp.LEnv, src string) *lisp.LVal {
+	t.Helper()
+	v := env.LoadString("own-message-test", src)
+	require.NotEqual(t, lisp.LError, v.Type, "evaluating %s: %v", src, v)
+	return v
+}
+
+// dumpMessage calls the builtin directly.  It is the same mint site
+// `json:dump-message` reaches, which is the point: there must be exactly one,
+// and a test that built the value another way would not be testing it.
+func dumpMessage(t testing.TB, env *lisp.LEnv, v *lisp.LVal) *lisp.LVal {
+	t.Helper()
+	s := libjson.DefaultSerializer()
+	msg := s.DumpMessageBuiltin(env, lisp.SExpr([]*lisp.LVal{v, lisp.Nil()}))
+	require.NotEqual(t, lisp.LError, msg.Type, "json:dump-message: %v", msg)
+	return msg
+}
+
+func messageBytes(t testing.TB, env *lisp.LEnv, msg *lisp.LVal) []byte {
+	t.Helper()
+	s := libjson.DefaultSerializer()
+	b := s.MessageBytesBuiltin(env, lisp.SExpr([]*lisp.LVal{msg}))
+	require.NotEqual(t, lisp.LError, b.Type, "json:message-bytes: %v", b)
+	return b.Bytes()
+}
+
+// TestDumpMessageIsExemptFromTheLoadabilityCheck pins elps#412's mechanism at
+// the only level it is visible: which type the exemption is keyed on.
+//
+// Nothing about the OUTPUT changes when the check is skipped -- that is the
+// whole point -- so a test comparing bytes would pass whether or not the
+// exemption existed.  What this holds instead is that the mint site produced
+// the exempt shape, and that the shape is one nothing outside this package can
+// build: TestEmbedderCannotObtainTheExemption holds the other half.
+func TestDumpMessageIsExemptFromTheLoadabilityCheck(t *testing.T) {
+	env := newLispEnv(t)
+	msg := evalIn(t, env, `(json:dump-message (sorted-map "a" 1 "b" (vector 1 2 3)))`)
+	require.Equal(t, lisp.LNative, msg.Type)
+
+	if _, isRaw := msg.Native.(*json.RawMessage); isRaw {
+		t.Fatal("json:dump-message still returns a *json.RawMessage, so the " +
+			"exemption cannot be keyed on the type -- elps#412 is not implemented")
+	}
+	require.Equal(t, "*libjson.ownMessage", fmt.Sprintf("%T", msg.Native),
+		"the exempt type moved; the leak-prevention tests below name this")
+
+	// Opaque by construction, checked rather than asserted.  An exported type
+	// name would let an embedder build one outright; an exported field would
+	// let them reflect a payload into an existing one with SetBytes, which
+	// needs no unsafe and no cooperation from this package.
+	rt := reflect.TypeOf(msg.Native).Elem()
+	assert.False(t, token.IsExported(rt.Name()), "the exempt type is exported")
+	rv := reflect.ValueOf(msg.Native).Elem()
+	for i := range rt.NumField() {
+		f := rt.Field(i)
+		assert.False(t, f.IsExported(), "field %s of the exempt type is exported", f.Name)
+		assert.False(t, rv.Field(i).CanSet(), "field %s is settable through reflection", f.Name)
+	}
+}
+
+// TestEmbedderCannotObtainTheExemption is the guard on elps#412's one real
+// risk.  An exemption that leaks reopens elps#410 SILENTLY, which is worse
+// than the bug it started from: the original at least announced itself the
+// moment json:load saw the document.
+//
+// The rows are the two independent ways a native carries bytes Load refuses --
+// the out-of-range literal and nesting past the decoder's limit -- in every
+// shape an embedder actually has: a *json.RawMessage, a json.RawMessage value,
+// and the same bytes behind a struct field.  None of them can become an
+// ownMessage.  This is what fails if that stops being true: an exported
+// constructor, an exported field, or a second mint site fed from an argument.
+//
+// The two kinds of bytes are refused by DIFFERENT layers, and wantErr records
+// which.  That distinction is not decoration -- it is the measurement of how
+// much work the elps#410 check is really doing:
+//
+//   - The out-of-range literal is syntactically valid JSON, so json.Marshal
+//     passes it through untouched and only checkLoadable, which decodes,
+//     catches it.  That is the gap the check exists for, and the only one it
+//     is the sole guard on.
+//
+//   - Nesting past the limit is caught EARLIER, by encoding/json itself:
+//     json.Marshal compacts whatever MarshalJSON returns, and that compaction
+//     applies the same 10000-deep bound the decoder does.  checkLoadable never
+//     sees those bytes.
+func TestEmbedderCannotObtainTheExemption(t *testing.T) {
+	deep := json.RawMessage(strings.Repeat("[", 10001) + "1" + strings.Repeat("]", 10001))
+	outOfRange := json.RawMessage("1E1000")
+
+	// The elps#410 error: the loadability check refused the bytes.
+	const byTheCheck = "unable to encode native value"
+	// encoding/json refused them first, so the check never ran.
+	const byEncodingJSON = "exceeded max depth"
+
+	cases := []struct {
+		name    string
+		v       interface{}
+		wantErr string
+	}{
+		{"pointer to RawMessage, out-of-range number", &outOfRange, byTheCheck},
+		{"RawMessage value, out-of-range number", outOfRange, byTheCheck},
+		{"RawMessage in a struct field, out-of-range number", struct {
+			P json.RawMessage `json:"p"`
+		}{outOfRange}, byTheCheck},
+		{"pointer to RawMessage, nested past the decoder's limit", &deep, byEncodingJSON},
+		{"RawMessage value, nested past the decoder's limit", deep, byEncodingJSON},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := lisp.Native(tc.v)
+			require.NotEqual(t, "*libjson.ownMessage", fmt.Sprintf("%T", v.Native),
+				"an embedder value reached the exempt type")
+
+			// Refused at the root, exactly as before elps#412...
+			if enc, err := libjson.Dump(v, false); err == nil {
+				t.Fatalf("Dump emitted %.80s, which Load rejects -- elps#410 reopened", enc)
+			} else if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("refused, but not by the layer that should have refused it: "+
+					"want an error containing %q, got %v", tc.wantErr, err)
+			}
+
+			// ...and refused inside an envelope, which is the row that
+			// matters.  The exemption is applied during a walk, so a value
+			// that escaped it in a container and not at the root would be a
+			// hole nothing else here catches.
+			envelope := lisp.SortedMap()
+			envelope.MapSet("jsonrpc", lisp.String("2.0"))
+			envelope.MapSet("result", v)
+			if enc, err := libjson.Dump(envelope, false); err == nil {
+				t.Fatalf("Dump emitted %.80s inside an envelope -- elps#410 reopened", enc)
+			}
+		})
+	}
+}
+
+// TestDumpMessageOfAnUnvouchedDocumentIsStillRefused is the other half of the
+// seal, and the reason the exemption is not the type alone.
+//
+// `json:dump-message` mints an ownMessage for every document, so the skip
+// rides on the loadable flag the encoder set rather than on who called it.
+// These are the two documents libjson writes and libjson will not read back,
+// so these are the two for which the flag is false.  The gap itself predates
+// elps#412 -- `json:dump` of either value produces the same bytes today, and
+// always has -- but elps#412 must not make it SILENT by waving a document
+// through on the strength of its author.
+//
+// What refuses them, as TestEmbedderCannotObtainTheExemption also records, is
+// encoding/json rather than checkLoadable: both rows fail because they nest
+// past the limit, and json.Marshal compacts a MarshalJSON result against that
+// same limit before this package gets a word in.  So these rows hold the
+// OUTCOME -- an unvouched document does not get written -- and not the
+// mechanism.  The mechanism, that a false flag really does re-arm the check,
+// is only reachable from inside the package; TestExemptionRidesOnTheFlag in
+// own_message_internal_test.go holds it.
+func TestDumpMessageOfAnUnvouchedDocumentIsStillRefused(t *testing.T) {
+	env := newLispEnv(t)
+
+	t.Run("nested past the decoder's limit", func(t *testing.T) {
+		payload := lisp.Int(1)
+		for range 10001 {
+			m := lisp.SortedMap()
+			m.MapSet("k", payload)
+			payload = m
+		}
+		msg := dumpMessage(t, env, payload)
+
+		// Premise: these really are bytes Load refuses.  Without it the row
+		// could pass because the document is fine.
+		require.Equal(t, lisp.LError, libjson.Load(messageBytes(t, env, msg), false).Type,
+			"premise broken: Load accepts the document, so the row proves nothing")
+
+		envelope := lisp.SortedMap()
+		envelope.MapSet("result", msg)
+		enc, err := libjson.Dump(envelope, false)
+		require.Error(t, err, "Dump emitted %.80s, which Load rejects", enc)
+		assert.Contains(t, err.Error(), "exceeded max depth")
+	})
+
+	t.Run("assembled over an embedder's native", func(t *testing.T) {
+		// A two-deep lisp value whose only content is an embedder's native.
+		// The native's own bytes clear checkLoadable in isolation -- they are
+		// exactly at the decoder's limit -- but nesting COMPOSES, so what
+		// json:dump-message produces is one level past it.  A rule that
+		// vouched for output merely because libjson assembled it would wave
+		// this through.
+		deep := json.RawMessage(strings.Repeat("[", 10000) + "1" + strings.Repeat("]", 10000))
+		require.NotEqual(t, lisp.LError, libjson.Load(deep, false).Type,
+			"premise broken: the native alone must load, or the check refuses it first")
+
+		payload := lisp.SortedMap()
+		payload.MapSet("k", lisp.Native(&deep))
+		msg := dumpMessage(t, env, payload)
+
+		require.Equal(t, lisp.LError, libjson.Load(messageBytes(t, env, msg), false).Type,
+			"premise broken: the composed document loads, so the row proves nothing")
+
+		envelope := lisp.SortedMap()
+		envelope.MapSet("result", msg)
+		enc, err := libjson.Dump(envelope, false)
+		require.Error(t, err, "Dump emitted %.80s, which Load rejects", enc)
+	})
+}
+
+// TestDumpMessageOutputIsUnchanged is the byte-level half of "invisible".
+//
+// The exemption removes a READ of the marshalled bytes and nothing else: the
+// bytes still go through json.Marshal, so compaction and HTML escaping are the
+// same code they were.  This holds that -- an ownMessage in a document and the
+// identical bytes as an embedder's *json.RawMessage in the same document must
+// serialize the same way, in both number modes, including the characters
+// encoding/json escapes on the way through.
+func TestDumpMessageOutputIsUnchanged(t *testing.T) {
+	env := newLispEnv(t)
+
+	m := lisp.SortedMap()
+	m.MapSet("a", lisp.Int(1))
+	m.MapSet("html", lisp.String("<&>"))
+
+	payloads := []*lisp.LVal{
+		lisp.String("plain"),
+		lisp.Int(42),
+		lisp.Float(1.5),
+		lisp.Nil(),
+		lisp.QExpr([]*lisp.LVal{lisp.Int(1), lisp.String("two")}),
+		lisp.String(`<script>&"\` + "\n  "),
+		lisp.Bytes([]byte{0, 1, 2, 250}),
+		m,
+	}
+
+	for i, payload := range payloads {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			own := dumpMessage(t, env, payload)
+			raw := json.RawMessage(messageBytes(t, env, own))
+
+			for _, stringNums := range []bool{false, true} {
+				envOwn := lisp.SortedMap()
+				envOwn.MapSet("result", own)
+				envRaw := lisp.SortedMap()
+				envRaw.MapSet("result", lisp.Native(&raw))
+
+				gotOwn, err := libjson.Dump(envOwn, stringNums)
+				require.NoError(t, err)
+				gotRaw, err := libjson.Dump(envRaw, stringNums)
+				require.NoError(t, err)
+				assert.Equal(t, string(gotRaw), string(gotOwn),
+					"stringNums=%v: the exemption changed the bytes", stringNums)
+
+				// And whatever it wrote, Load must still take back.
+				assert.NotEqual(t, lisp.LError, libjson.Load(gotOwn, stringNums).Type)
+			}
+		})
+	}
+}
+
+// TestOwnMessageIsInvisibleFromLisp records what a lisp program can see of
+// elps#412, which is the property the change was asked to have.  Each
+// observation is checked against the documented behaviour rather than against
+// a golden blob, so the test says what is preserved instead of merely that
+// something did not move.
+//
+// The one thing NOT preserved is recorded here so it is not met by surprise:
+// the value's PRINTED form embeds the Go type, so `#<native value:
+// *json.RawMessage>` becomes `#<native value: *libjson.ownMessage>`.  That is
+// the rendering LVal.String gives every native, it is reachable from lisp
+// through format-string and debug-print, and nothing on this side can change
+// it -- %T prints the concrete type.  Asserted below so the change is pinned
+// rather than implied.
+func TestOwnMessageIsInvisibleFromLisp(t *testing.T) {
+	env := newLispEnv(t)
+	evalIn(t, env, `(set 'm (json:dump-message (sorted-map "a" 1 "b" (vector 1 2 3))))`)
+
+	for _, tc := range []struct {
+		expr string
+		want string
+	}{
+		{`(type m)`, "native"},
+		{`(to-string (json:message-bytes m))`, `{"a":1,"b":[1,2,3]}`},
+		{`(json:dump-string (json:load-message m))`, `{"a":1,"b":[1,2,3]}`},
+		{`(json:dump-string (sorted-map "env" m))`, `{"env":{"a":1,"b":[1,2,3]}}`},
+		{`(format-string "{}" (nil? m))`, "false"},
+		{`(format-string "{}" (bytes? m))`, "false"},
+		{`(format-string "{}" (sorted-map? m))`, "false"},
+		{`(format-string "{}" (json:message-bytes (json:dump-message m)))`,
+			`#<bytes 123 34 97 34 58 49 44 34 98 34 58 91 49 44 50 44 51 93 125>`},
+
+		// The one visible difference, pinned rather than hidden.
+		{`(format-string "{}" m)`, "#<native value: *libjson.ownMessage>"},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			got := evalIn(t, env, tc.expr)
+			assert.Equal(t, tc.want, got.Str)
+		})
+	}
+}
+
+// TestMessageAccessorsStillTakeAnEmbeddersRawMessage holds the compatibility
+// half of the type change.  json:message-bytes and json:load-message asserted
+// on *json.RawMessage before elps#412, so an embedder handing one to lisp for
+// those builtins to read is a supported thing to do, and the new type must not
+// cost them that.
+func TestMessageAccessorsStillTakeAnEmbeddersRawMessage(t *testing.T) {
+	env := newLispEnv(t)
+	s := libjson.DefaultSerializer()
+
+	payload := lisp.SortedMap()
+	payload.MapSet("a", lisp.Int(1))
+	raw := json.RawMessage(`{"a":1}`)
+
+	for _, tc := range []struct {
+		name string
+		v    *lisp.LVal
+	}{
+		{"embedder RawMessage", lisp.Native(&raw)},
+		{"json:dump-message", dumpMessage(t, env, payload)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, `{"a":1}`, string(messageBytes(t, env, tc.v)))
+			loaded := s.LoadMessageBuiltin(env, lisp.SExpr([]*lisp.LVal{tc.v, lisp.Nil()}))
+			require.NotEqual(t, lisp.LError, loaded.Type, "json:load-message: %v", loaded)
+			assert.Equal(t, lisp.LSortMap, loaded.Type)
+		})
+	}
+
+	// A native that is not a message at all is still refused, with the error
+	// text it has always had.
+	for _, name := range []string{"message-bytes", "load-message"} {
+		t.Run(name+" on a non-message native", func(t *testing.T) {
+			args := lisp.SExpr([]*lisp.LVal{lisp.Native(42), lisp.Nil()})
+			got := s.MessageBytesBuiltin(env, args)
+			if name == "load-message" {
+				got = s.LoadMessageBuiltin(env, args)
+			}
+			require.Equal(t, lisp.LError, got.Type)
+			assert.Contains(t, got.String(), "argument is not a raw json-message: <nil>")
+		})
+	}
+}


### PR DESCRIPTION
Closes #412. Follow-up to #410 / #411.

## What it does

`json:dump-message` wraps bytes libjson wrote microseconds earlier. When that native is later encoded — which is exactly what happens on substrate's per-response path, where `shirocore.lisp:634` builds every JSON-RPC response as `"result" (json:dump-message result)` and `route-failure` adds a second — the #410 loadability check decodes the whole thing again to answer a question this package already knows the answer to.

The check exists for bytes libjson did **not** produce. This exempts the one native for which it did.

- New unexported `ownMessage{msg json.RawMessage; loadable bool}`, minted on exactly one line of `DumpMessageBuiltin` from `Serializer.dump`'s output, carrying that call's own loadability verdict.
- `encodeNative` skips `checkLoadable` for `*ownMessage` with `loadable == true`, and for nothing else.
- `encoder` gains `nestedDeep` and `wroteNative`, the two ways libjson's output can fall outside what it can vouch for. Both fit in the tail padding `stringNums` already left, so the struct stays in its 112-byte size class — `TestEncoderFitsItsSizeClass` passes unchanged (measured: `sizeof(encoder) = 112`, same as base).
- `json:message-bytes` and `json:load-message` accept an `ownMessage` and an embedder's `*json.RawMessage` alike. The read side is unchanged, including the error text for a non-message native.

## Measurement

Interleaved arms (alternating every round, the same scheme as `scripts/bench-run-arms.sh`), n=12, `-benchtime=100ms`, GOMAXPROCS=4, compared with benchstat. Base is this PR's merge base, `ab0686d`, carrying the same new benchmark file so the arms are comparable.

The three `EncodeOwnMessage` benchmarks are **new**: this path had no benchmark at all, which is how #411 came to be costed only by proxy. Payload sizes reproduce #412's table and are pinned in the benchmark, so a row cannot quietly stop measuring its size class.

| row | payload | sec/op | B/op | allocs/op |
|---|---|---|---|---|
| EncodeOwnMessageSmall | 570 B | −71.68% (p=0.000) | −67.23% (p=0.000) | 186 → 17, −90.86% (p=0.000) |
| EncodeOwnMessageMedium | 14.6 KB | −75.21% (p=0.000) | −77.50% (p=0.000) | 3822 → 17, −99.56% (p=0.000) |
| EncodeOwnMessageLarge | 295 KB | −77.81% (p=0.000) | −79.44% (p=0.000) | 75071 → 18, −99.98% (p=0.000) |

The saving scales, as #412 predicted: the check decoded the whole message into an `interface{}` and threw it away, so it allocated in proportion to the document. It is now a constant 17-18 allocations regardless of payload size.

Everything else is flat, including the rows that should be:

- `Encode`: `~` on time (p=0.630), and **231.0 → 231.0 allocs/op, all samples equal**. Its natives are Go maps built by `lisp.Value`, not libjson output, so they are not exempt.
- `EncodeNativeSmall` / `EncodeNativeLarge`: `~` on all three metrics, `1.159k → 1.159k` allocs, all samples equal. These encode an embedder's `*json.RawMessage`, which is deliberately still checked.
- All `Package/*`, `Load/*`, `LoadIntegers/*`, `Encode_stringNumbers`: `~`.

**Detection floor, stated honestly.** This box is noisy on timing: baseline relative deviations run from ±7% to ±52% depending on the row, so with n=12 the practical floor for a timing claim is roughly 15–25%. Every timing delta claimed above is 70%+ and lands at p=0.000; every timing row not claimed is reported as `~`, and I am **not** claiming those are exactly zero — only that they are indistinguishable at this n on this hardware. The allocation columns are the load-bearing evidence: within each arm the per-sample values are identical (±0%), so those numbers are exact rather than estimated.

`scripts/benchstat-gate.sh` over that comparison: **0 significant moves in the bad direction, 0 at or above the gate** (timing 15%, allocation 5%). Nothing trips.

## The three points #412 asked to settle

### Does it leak? No.

The type is unexported, its fields are unexported, there is no exported constructor, and no exported type an embedder can convert from.

- `TestEmbedderCannotObtainTheExemption` drives both kinds of bytes `Load` refuses (the #410 out-of-range literal, and nesting past the decoder's limit) in every shape an embedder actually has — `*json.RawMessage`, a `json.RawMessage` value, and the same bytes behind a struct field — at the document root **and** inside an envelope. None reaches the exempt type; none gets written.
- It also records *which layer* refuses each, because that turned out to matter (see the last section).
- `TestDumpMessageIsExemptFromTheLoadabilityCheck` additionally walks the type by reflection and asserts the type name is unexported, every field is unexported, and no field is settable through reflection — `SetBytes` on an exported field would need no `unsafe` and no cooperation from this package.
- `TestOwnMessageHasOneMintSite` parses the package's non-test sources and counts `ownMessage` composite literals. The leak argument rests on there being exactly one, fed from this package's own output; a second one added later would defeat it without failing any behavioural test. This makes that a reviewable event.
- `TestExemptionRidesOnTheFlag` (package-internal) is the one test that can prove the skip is *real*: from outside the package every observable of a correct skip is "nothing changed", so an exemption that had quietly stopped being applied would be invisible. It builds an `ownMessage` holding `1E1000` and shows the document is emitted with `loadable: true` and refused with `loadable: false`, and that the same bytes as an embedder's `*json.RawMessage` are always refused.

### Is it observable? `(type x)` does not change.

Settled empirically, running the same script under a binary built from `ab0686d` and one built from this branch:

```
                             BEFORE                          AFTER
(type m)                     'native                         'native
(json:message-bytes m)       {"a":1,"b":[1,2,3]}             same
(json:load-message m)        {"a":1,"b":[1,2,3]}             same
(json:dump-string {env: m})  {"env":{"a":1,"b":[1,2,3]}}     same
(nil? m) (bytes? m)          false false                     same
```

#412 assumed `(type x)` would differ. It does not, and the reason is structural rather than lucky: `GetType` maps every `LNative` to the symbol `native` regardless of the Go type behind it. The requested property — "this should be an invisible optimisation" — holds for `(type ...)`.

**One thing does change, and it is not hidden.** `LVal.String` renders a native with `%T`, so the printed form goes from `#<native value: *json.RawMessage>` to `#<native value: *libjson.ownMessage>`. That is reachable from lisp via `format-string` and `debug-print`. It cannot be avoided by any type-keyed exemption — `%T` prints the concrete type — and `TestOwnMessageIsInvisibleFromLisp` asserts it so it is pinned rather than discovered later.

Checked against substrate rather than assumed:

- No Go-side `*json.RawMessage` type assertion on an elps native anywhere in substrate. The `.Native.(...)` assertions there are `*bptree.BPlusTree`, `time.Time`, `Date`, `decimal.Decimal` and `PreheatFinalizer`.
- No lisp-side `(type ...)` check on a `dump-message` result.
- One comment in `e2e/sample-network/phylum_a/migration.lisp` mentions the `#<native value: ...>` rendering, but as a general statement that natives render opaquely — it does not match on the type name.

Substrate's suite, run against an elps pinned to this branch: **39 packages pass**, including `internal/substrate/shirocore` (23.6s), `shiro/tests`, `shiro/preheat` and every `libcc/*`. Two packages fail — `cmd/shirotester/cmd` (`TestFunctionalTests/TestFile_shiro/init_zip_archive`, `multi-file_request`) and `cmd/substratehcp/stresstest` (`SUBSTRATEHCP_FILE not found in environment`) — and they fail **identically** against an elps built from `ab0686d`, so they are environmental and pre-existing. `shirotester functional-tests` was run from inside the fixture directory with relative paths (`jsonrpc_test.yaml`, `batch_test.yaml`, `mxf_test.yaml`, `app_control_test.yaml`): all PASS, and `--verbose` confirms real test cases executed rather than the silent no-op an absolute path can produce.

### Does it stay true? Yes, and #350 needed checking.

The skip's licence is the `FuzzDumpJSON` invariant — whatever `Dump` emits, `Load` accepts. That target covers both string-numbers modes and neither `:exact-integers` mode, and #350 landed a decoder that is **allowed to refuse** a number the default accepts. A single integer literal libjson emits and `:exact-integers` rejects would have made `loadableBytes` vouch for a document that does not load.

It is not a third carve-out, and this was settled empirically rather than by reading:

- `FuzzDumpExactIntegers` (new) asks the same Dump-then-Load question of the `:exact-integers` decoder, over `fuzzval`-generated values, skipping documents that hold a native (which `wroteNative` already declines to vouch for). Run locally for 150s: **470,896 execs, 497 corpus entries, no counterexample.**
- `TestOwnOutputLoadsWithExactIntegers` pins the boundaries the argument turns on — either side of the int range, either side of the exponent-form cutoff, and the integral floats between them that render as bare digits and so take the integer path.
- The reason it holds is structural: `loadNumber` accepts an over-large integer literal as a float in exactly one case, when the literal is *already* `appendJSONFloat`'s rendering of that float, and `appendJSONFloat` is the only float rendering this package emits. The two sides cannot drift because they are the same function. #350's own comment says as much; this now tests it.
- Foreign number text — a thirty-digit id, say — only reaches a document through a native, and `wroteNative` already covers that.

The fuzz budget still fits: 26 targets, largest shard 5, 60 minutes required against a 60-minute timeout.

## Two findings that contradict assumptions in the tickets

**1. The deep-nesting carve-out is not carried by `checkLoadable`.** `json.Marshal` compacts whatever `MarshalJSON` returns, and that compaction applies the same 10000-deep bound the decoder does — so a too-deep message is refused by `encoding/json` *before* `checkLoadable` would have run, with a different error but refused all the same. There is at present no document for which flipping `nestedDeep` or `wroteNative` to true changes an outcome; they only change which error you get. Two tests inherited from the draft asserted the #410 error text on those rows and were simply wrong; they now assert the layer that really refuses, and say why the distinction matters. The flags are kept as defence in depth, so the exemption does not rest on an undocumented implementation detail of another package, and they cost nothing — a document that trips either is off the hot path by construction. This is documented on `loadableBytes`.

**2. The #413 waiver cannot be removed by this change, and #413 already said so.** `BenchmarkEncode`'s three native rows are `lisp.Value(map[string]interface{}{...})` — Go maps, not libjson output — so they are not exempt and did not move (231.0 → 231.0 allocs/op, all samples equal). The waiver text in `scripts/benchstat-waivers.txt` claims "elps#412 removes the redundant marshal and both entries go with it", which is wrong; #413's own body is correct and says #412 "does not close this issue on its own".

There is a separate, real reason the waiver is now dead, which I am reporting rather than acting on: the benchmark job compares a PR against `github.event.pull_request.base.sha`, #411 is in `main`, so both arms of every future comparison pay the check and the row is permanently flat. The gate says so itself on this PR's own comparison — `waiver-unused ... the waiver can be deleted`, twice — and while it stands it holds this benchmark's allocation gate open at 9% and 14% instead of the repository's 5%.

I did not delete it here. Doing so breaks six assertions in `scripts/ci-gates-test.sh` that #414 wrote deliberately to pin the *shipped* file ("the SHIPPED waiver file makes PR #411's real comparison pass", "the SHIPPED waivers genuinely expire", and the four that check a waived row is reported by name with its delta and issue). Rewriting those onto the existing `scripts/testdata/waivers-libjson-*.txt` fixtures is a small change, but it is a redesign of #414's self-test in service of #413's decision, and this PR does not change the benchmark those waivers cover. It belongs in #413.

## Gates

All from the worktree root, on the final tree:

- `go build ./...`, `go vet ./...` — clean
- `go test -count=1 ./...` — all pass
- `go test -race ./lisp/...` — all pass, 0 data races
- `golangci-lint run ./...` — 0 issues
- `elps fmt -l ./...` — clean (binary built, run, and deleted before commit)
- `elps doc -m` — "All functions and exports are documented"
- `./scripts/ci-gates-test.sh` — 210 passed, 0 failed
- `./scripts/confidentiality-guard.sh` — clean (run after `git add`)
- `./scripts/fuzz-budget-check.sh` — the sweep fits with the new target
- `./scripts/benchstat-gate.sh` on the n=12 comparison — 0 regressions

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_