### PR TITLE
libschema: make a validator safe to share across runtimes

### DIFF
--- a/lisp/lisplib/libschema/foreign_constraint_test.go
+++ b/lisp/lisplib/libschema/foreign_constraint_test.go
@@ -191,6 +191,14 @@ func TestWhenRejectsNonMapInput(t *testing.T) {
 // the proof that the exported constructor really produces something the
 // package accepts -- otherwise "we kept the extension point" would be a claim
 // with nothing behind it.
+//
+// NOTE: this test deliberately mints ONE validator and binds it into six
+// separate runtimes. Issue #364 read that as the test misusing the API. It is
+// the other way round: sharing one validator across runtimes is the natural
+// reading of an extension point, so NewValidator was made to support it rather
+// than the test made to avoid it. See multi_runtime_test.go, and the RUNTIME
+// SCOPE section of NewValidator's doc comment. Do not "fix" this to mint one
+// validator per environment -- that would delete the coverage.
 func TestNewValidatorIsAcceptedAsAConstraint(t *testing.T) {
 	even := libschema.NewValidator(lisp.Formals("input"),
 		func(_ *lisp.LEnv, input *lisp.LVal) *lisp.LVal {

--- a/lisp/lisplib/libschema/libschema.go
+++ b/lisp/lisplib/libschema/libschema.go
@@ -6,6 +6,7 @@ package libschema
 import (
 	"fmt"
 	"regexp"
+	"sync/atomic"
 
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/lisplib/internal/libutil"
@@ -350,12 +351,34 @@ func getHandler(env *lisp.LEnv, in *lisp.LVal, name string, constraints []*lisp.
 	return res
 }
 
-var symcounter = 0
+// symcounter names anonymous validators.  It is ATOMIC, and it has to be
+// (issue #364).
+//
+// Every validator this package mints takes its FID from here: NewValidator
+// does, and so does every s: constructor reachable from ordinary ELPS source
+// -- s:int and s:gt each mint one, s:deftype mints another around them.  So
+// two runtimes evaluating schema code on two goroutines both land in
+// GenSymbol, and while it was a plain int++ that was a data race with no Go
+// embedder involvement required.  substrate runs dozens of environments
+// evaluating concurrently, so that is the normal case, not an exotic one.
+//
+// The damage from losing an increment is only a duplicate name in a stack
+// frame; the undefined behaviour of the unsynchronised read-modify-write is
+// the actual defect, and it is why this was invisible for so long.
+//
+// The counter is process-global rather than per-Runtime because NewValidator
+// has no runtime to hang it off: its signature is (formals, fn), and giving it
+// one would be an API break for an extension point whose whole point is that
+// the value it returns is runtime-independent.  Global-and-atomic also gives
+// FIDs that stay distinct across runtimes, which is what you want when reading
+// a stack trace out of a process running many.  lisp.Runtime.gensym is the
+// in-tree precedent for the atomic counter.
+var symcounter atomic.Uint64
 
-// Keep our symbols clean
+// GenSymbol returns a fresh name for an anonymous validator.  It is safe to
+// call from multiple goroutines.
 func GenSymbol() string {
-	symcounter++
-	return fmt.Sprintf("_validation_fun_%d", symcounter)
+	return fmt.Sprintf("_validation_fun_%d", symcounter.Add(1))
 }
 
 // validatorTag is a private zero-size type whose ADDRESS identifies a schema
@@ -444,8 +467,27 @@ func newNamedValidator(name string, formals *lisp.LVal, fn lisp.LBuiltin) *lisp.
 	return markValidator(lisp.FunInPackage(DefaultPackageName, name, formals, fn))
 }
 
+// markValidator stamps the credential onto fun's cells.
+//
+// The cell slice is allocated at EXACTLY its final length, so cap == len.
+// That is the issue #373 clamp applied to an LFun: a slice handed out with
+// spare capacity is a slice something else can append into, and that append
+// writes through into cells the owner still considers its own.  Before the
+// clamp, appending the marker onto the two-cell slice lisp.FunInPackage
+// returns grew the backing array to capacity 4, so every validator carried a
+// spare slot for life; append(v.Cells[:2], x) would have overwritten the
+// marker in place, silently revoking the credential of a value that -- per
+// NewValidator's contract below -- may be shared by every runtime in the
+// process.
+//
+// Nothing does that today.  The clamp is what stops "nothing does that" from
+// being load-bearing, and it is not a cost: one exact-length allocation
+// replaces one grow-on-append allocation, and allocates less.
 func markValidator(fun *lisp.LVal) *lisp.LVal {
-	fun.Cells = append(fun.Cells, validatorMarker)
+	cells := make([]*lisp.LVal, 0, len(fun.Cells)+1)
+	cells = append(cells, fun.Cells...)
+	cells = append(cells, validatorMarker)
+	fun.Cells = cells
 	return fun
 }
 
@@ -471,8 +513,34 @@ func markValidator(fun *lisp.LVal) *lisp.LVal {
 // There is no way to call one with libschema's convention, and the whole point
 // of the marker is that the refusal is a lisp-level error rather than a nil
 // dereference.
+//
+// RUNTIME SCOPE (issue #364): the returned value may be bound into ANY number
+// of lisp.LEnv / lisp.Runtime pairs, including concurrently.  That is the
+// natural reading of an extension point -- build the constraint set once at
+// process start, install it into every environment you create -- and it is now
+// a guarantee rather than something that happened to work:
+//
+//   - NewValidator is itself safe to call from multiple goroutines.
+//   - The returned value owns all of its own state.  The formals are COPIED,
+//     so a caller that keeps its formals list and writes through it later
+//     cannot reach into validators already built from it; and the cell slice
+//     is capacity-clamped, so no append through a view of it can overwrite the
+//     validator credential.
+//   - The interpreter does not write into a validator while running it.
+//     TestSharedValidatorIsNotMutatedByEvaluation pins that, so this line does
+//     not quietly become false.
+//
+// Two obligations stay with the caller, because they cannot be enforced here:
+// fn must be safe to call from multiple goroutines if the validator is shared
+// across them, and any value fn captures is shared on exactly the same terms.
 func NewValidator(formals *lisp.LVal, fn lisp.LBuiltin) *lisp.LVal {
-	return newValidator(formals, fn)
+	// Copy the caller's formals: see RUNTIME SCOPE above.  This is done at
+	// the exported boundary only.  The package-internal callers of
+	// newValidator all build a fresh lisp.Formals(...) inline on the call
+	// and drop the reference immediately, so making the copy unconditional
+	// would put a second allocation on the path every s: constructor takes
+	// -- and buy nothing, since there is no other holder to defend against.
+	return newValidator(formals.Copy(), fn)
 }
 
 // Checks constraints and type for boolean values

--- a/lisp/lisplib/libschema/multi_runtime_test.go
+++ b/lisp/lisplib/libschema/multi_runtime_test.go
@@ -1,0 +1,340 @@
+// Copyright © 2026 The ELPS authors
+
+package libschema_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libschema"
+)
+
+// This file covers issue #364: libschema.NewValidator is the package's
+// exported extension point, and an embedder's natural reading of an extension
+// point is "build the constraint set once at process start, install it into
+// every environment I create". Nothing in the signature said otherwise, and
+// nothing verified that doing so was safe.
+//
+// Three separate properties have to hold for that reading to be correct, and
+// they are covered separately below because they failed differently:
+//
+//  1. Constructing validators must be safe from more than one runtime at once.
+//     This was BROKEN -- see TestValidatorConstructionIsRaceFree.
+//  2. The returned value must own its state, so the caller cannot reach back
+//     into it after the fact. This was BROKEN for the formals -- see
+//     TestNewValidatorOwnsItsFormals -- and for the cell slice's spare
+//     capacity, see TestValidatorCellsCarryNoSpareCapacity.
+//  3. The interpreter must not write into a validator while running it. This
+//     already held; TestSharedValidatorIsNotMutatedByEvaluation is a GUARD
+//     that keeps it holding, not a catch of a live defect.
+
+// evenValidator builds the constraint used throughout this file: a Go-side
+// schema constraint of exactly the shape the doc comment on NewValidator
+// describes.
+func evenValidator() *lisp.LVal {
+	return libschema.NewValidator(lisp.Formals("input"),
+		func(_ *lisp.LEnv, input *lisp.LVal) *lisp.LVal {
+			if input.Type == lisp.LInt && input.Int%2 == 0 {
+				return lisp.Nil()
+			}
+			return lisp.ErrorConditionf(libschema.FailedConstraint, "not even: %v", input)
+		})
+}
+
+// TestValidatorConstructionIsRaceFree is the catch.
+//
+// Every validator this package mints -- through NewValidator, and through
+// every s: constructor reachable from ordinary ELPS source -- took its
+// function ID from GenSymbol, which incremented an unsynchronised
+// package-level int. Two runtimes evaluating schema code on two goroutines
+// therefore raced on that counter, with no Go embedder involvement required:
+// (s:deftype ...) alone is enough.
+//
+// On main this failed under -race with, per goroutine pair:
+//
+//	WARNING: DATA RACE
+//	Read at 0x000000c85f20 by goroutine 10:
+//	  libschema.GenSymbol()  libschema.go:357
+//	  libschema.newValidator()  libschema.go:438
+//	  libschema.builtinGreaterThan()  libschema.go:684
+//	Previous write at 0x000000c85f20 by goroutine 18:
+//	  libschema.GenSymbol()  libschema.go:357
+//	  libschema.newValidator()  libschema.go:438
+//	  libschema.builtinCheckAny()  libschema.go:514
+//
+// The visible damage from losing the race is a duplicate FID, which is only a
+// debugging-output defect. The race itself is not: it is undefined behaviour
+// in an interpreter that substrate runs with dozens of live environments
+// evaluating concurrently.
+//
+// This test is meaningful only under -race. Without it a lost increment
+// produces a duplicate name and nothing observable, which is exactly why the
+// bug survived.
+func TestValidatorConstructionIsRaceFree(t *testing.T) {
+	const nenv = 8
+	const niter = 20
+
+	envs := make([]*lisp.LEnv, nenv)
+	for i := range envs {
+		envs[i] = newSchemaEnv(t)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(nenv)
+	for i := range nenv {
+		go func() {
+			defer wg.Done()
+			for range niter {
+				// Every constructor on this line mints a validator:
+				// s:int and s:gt each call newValidator, and deftype
+				// wraps them in another.
+				res := envs[i].LoadStringContext(context.Background(), "multiruntime",
+					`(s:deftype "T" s:int (s:gt 0)) (s:validate T 4)`)
+				if res.Type == lisp.LError {
+					t.Errorf("runtime %d: %v", i, res)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestNewValidatorConcurrentFromGo is the same race reached through the
+// exported extension point rather than through ELPS source, which is the
+// literal shape issue #364 reports: an embedder minting its constraint set
+// concurrently, or minting one per runtime as its runtime pool fills.
+func TestNewValidatorConcurrentFromGo(t *testing.T) {
+	const n = 16
+	var wg sync.WaitGroup
+	wg.Add(n)
+	ids := make([]string, n)
+	for i := range n {
+		go func() {
+			defer wg.Done()
+			ids[i] = evenValidator().FID()
+		}()
+	}
+	wg.Wait()
+
+	// A lost increment shows up as a duplicate FID. This assertion is a
+	// bonus: the race detector is the real signal, since the counter can
+	// race without losing an increment on any given run.
+	seen := make(map[string]int, n)
+	for i, id := range ids {
+		if prev, dup := seen[id]; dup {
+			t.Errorf("validators %d and %d share FID %q: GenSymbol lost an increment", prev, i, id)
+		}
+		seen[id] = i
+	}
+}
+
+// TestNewValidatorOwnsItsFormals is a catch.
+//
+// NewValidator stored the caller's formals LVal by reference in Cells[0]. A
+// caller that kept the formals around -- which is the natural thing to do
+// when minting a family of constraints that all take one argument, i.e.
+// exactly what every constructor in this package does internally -- could
+// mutate it afterwards and have the mutation land in every validator built
+// from it, in every runtime any of them were bound into.
+//
+// On main this failed with:
+//
+//	formals leaked: validator's formal argument is now "hijacked"
+//
+// The fix is a defensive copy at the exported boundary. It is NOT applied to
+// the package-internal constructor, whose callers all build a fresh formals
+// list inline on the call, so the hot path pays nothing.
+func TestNewValidatorOwnsItsFormals(t *testing.T) {
+	formals := lisp.Formals("input")
+	v := libschema.NewValidator(formals,
+		func(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal { return lisp.Nil() })
+
+	// The caller still holds the formals it passed in and writes through it.
+	formals.Cells[0] = lisp.Symbol("hijacked")
+
+	got := v.Cells[0]
+	if got == formals {
+		t.Fatalf("formals leaked: NewValidator stored the caller's LVal by reference")
+	}
+	if len(got.Cells) != 1 || got.Cells[0].Str != "input" {
+		t.Errorf("formals leaked: validator's formal argument is now %q", got.Cells[0].Str)
+	}
+}
+
+// TestNewValidatorFormalsCopyIsFaithful checks that the defensive copy above
+// reproduces the formals list rather than flattening it. A copy that dropped
+// the control symbols would turn a variadic constraint into a fixed-arity one,
+// which is a worse bug than the leak it was added to close.
+func TestNewValidatorFormalsCopyIsFaithful(t *testing.T) {
+	for _, formals := range []*lisp.LVal{
+		lisp.Formals(),
+		lisp.Formals("input"),
+		lisp.Formals("input", lisp.OptArgSymbol, "extra"),
+		lisp.Formals("input", lisp.VarArgSymbol, "rest"),
+	} {
+		want := formals.String()
+		v := libschema.NewValidator(formals,
+			func(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal { return lisp.Nil() })
+		if got := v.Cells[0].String(); got != want {
+			t.Errorf("formals copy is not faithful: got %s, want %s", got, want)
+		}
+	}
+}
+
+// TestValidatorCellsCarryNoSpareCapacity is a catch, of the same class as
+// issue #373: a slice handed out with spare capacity is a slice something else
+// can append into, and the append writes through into cells the owner still
+// considers its own.
+//
+// A validator's cells are [formals, docstring, marker], built by appending the
+// marker onto the two-cell slice lisp.FunInPackage returns. That append grew
+// the backing array to capacity 4, so the value carried one spare slot for
+// life. Appending onto any view of those cells -- append(v.Cells[:2], x) --
+// would have overwritten the marker in place, silently revoking the validator
+// credential of a value shared by every runtime it was bound into.
+//
+// Nothing does that today. The clamp is what keeps "nothing does that" from
+// being load-bearing, and it costs nothing: allocating the slice at its exact
+// length is one allocation, the same as the append it replaces.
+//
+// On main this failed with:
+//
+//	validator cells carry spare capacity: len=3 cap=4
+func TestValidatorCellsCarryNoSpareCapacity(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		make func(t *testing.T) *lisp.LVal
+	}{
+		{"NewValidator", func(t *testing.T) *lisp.LVal { return evenValidator() }},
+		{"s:make-validator", func(t *testing.T) *lisp.LVal {
+			env := newSchemaEnv(t)
+			v := env.LoadStringContext(context.Background(), "cap", `(s:make-validator "T" s:int)`)
+			if v.Type == lisp.LError {
+				t.Fatalf("s:make-validator: %v", v)
+			}
+			return v
+		}},
+		{"s:gt", func(t *testing.T) *lisp.LVal {
+			env := newSchemaEnv(t)
+			v := env.LoadStringContext(context.Background(), "cap", `(s:gt 0)`)
+			if v.Type == lisp.LError {
+				t.Fatalf("s:gt: %v", v)
+			}
+			return v
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := tc.make(t)
+			if cap(v.Cells) != len(v.Cells) {
+				t.Errorf("validator cells carry spare capacity: len=%d cap=%d",
+					len(v.Cells), cap(v.Cells))
+			}
+		})
+	}
+}
+
+// TestSharedValidatorIsNotMutatedByEvaluation is a GUARD, not a catch: it
+// passes on main.
+//
+// It pins the property issue #364 asks about most directly -- that the
+// interpreter never writes into a validator LFun while running it -- so that
+// the documented "safe to bind into any number of runtimes" guarantee on
+// NewValidator is verified rather than asserted. Without it, the guarantee
+// would be a claim about code in lisp/env.go that nothing in this package
+// notices changing.
+func TestSharedValidatorIsNotMutatedByEvaluation(t *testing.T) {
+	even := evenValidator()
+
+	type snapshot struct {
+		cells   []*lisp.LVal
+		cap     int
+		fid     string
+		pkg     string
+		builtin bool
+	}
+	take := func() snapshot {
+		return snapshot{
+			cells:   append([]*lisp.LVal(nil), even.Cells...),
+			cap:     cap(even.Cells),
+			fid:     even.FID(),
+			pkg:     even.Package(),
+			builtin: even.FunData().Builtin != nil,
+		}
+	}
+	before := take()
+
+	for _, tc := range []struct {
+		src   string
+		valid bool
+	}{
+		{`(s:deftype "T" s:int even?) (s:validate T 4)`, true},
+		{`(s:deftype "T" s:int even?) (s:validate T 5)`, false},
+		{`(s:deftype "T" s:sorted-map (s:has-key "a" even?)) (s:validate T (sorted-map "a" 2))`, true},
+	} {
+		// A FRESH runtime per case: this is the usage the issue reports,
+		// and the point is that the validator survives it unchanged.
+		env := newSchemaEnv(t)
+		if rc := env.PutGlobal(lisp.Symbol("even?"), even); rc.Type == lisp.LError {
+			t.Fatalf("bind: %v", rc)
+		}
+		res := env.LoadStringContext(context.Background(), "shared", tc.src)
+		if got := res.Type != lisp.LError; got != tc.valid {
+			t.Errorf("%s: expected valid=%v, got %v (%v)", tc.src, tc.valid, got, res)
+		}
+	}
+
+	after := take()
+	if len(before.cells) != len(after.cells) {
+		t.Fatalf("cell count changed under evaluation: %d -> %d",
+			len(before.cells), len(after.cells))
+	}
+	for i := range before.cells {
+		if before.cells[i] != after.cells[i] {
+			t.Errorf("cell %d was replaced under evaluation", i)
+		}
+	}
+	if before.cap != after.cap {
+		t.Errorf("cell capacity changed under evaluation: %d -> %d", before.cap, after.cap)
+	}
+	if before.fid != after.fid || before.pkg != after.pkg || !after.builtin {
+		t.Errorf("function data changed under evaluation: %+v -> %+v", before, after)
+	}
+}
+
+// TestSharedValidatorConcurrentAcrossRuntimes drives the reported usage
+// pattern in full: ONE validator built once, bound into many independent
+// runtimes, exercised on many goroutines at once. It is the end-to-end
+// statement of what NewValidator now promises.
+func TestSharedValidatorConcurrentAcrossRuntimes(t *testing.T) {
+	even := evenValidator()
+
+	const nenv = 8
+	const niter = 20
+	envs := make([]*lisp.LEnv, nenv)
+	for i := range envs {
+		envs[i] = newSchemaEnv(t)
+		if rc := envs[i].PutGlobal(lisp.Symbol("even?"), even); rc.Type == lisp.LError {
+			t.Fatalf("bind: %v", rc)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(nenv)
+	for i := range nenv {
+		go func() {
+			defer wg.Done()
+			for range niter {
+				res := envs[i].LoadStringContext(context.Background(), "shared",
+					`(s:deftype "T" s:int even?) (s:validate T 4)`)
+				if res.Type == lisp.LError {
+					t.Errorf("runtime %d: %v", i, res)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #364

`libschema.NewValidator` is the package's exported extension point, and the natural reading of an extension point is "build the constraint set once at process start, install it into every environment I create". Nothing in the signature said otherwise, and nothing checked that doing so worked.

Three properties have to hold for that reading to be correct. Two did not.

## What the issue got right, and what it got wrong

The issue reports the hazard as the returned LFun carrying per-value mutable state that gets shared when the value is bound into two runtimes, and proposes either documenting a single-runtime requirement or returning something safe to share.

Checked against `main` (`ab0686d`), the specific mechanism named in the issue is **latent**. The interpreter does not write into a validator LFun while running it. A probe that binds one validator into three fresh runtimes, runs `s:deftype`/`s:validate`/`s:has-key` against it, and then compares every cell pointer, the cell capacity, the FID, the package and the builtin, finds nothing changed. That probe is now `TestSharedValidatorIsNotMutatedByEvaluation`, and it is labelled a **guard, not a catch** — it passes on `main`.

The issue's *conclusion* is still correct, and two real defects sit underneath it, both found by taking the issue's question seriously and testing it rather than by reading the report. Both are red on `main`.

## Defect 1: the FID counter is a data race (live, red on `main` under `-race`)

```go
var symcounter = 0

func GenSymbol() string {
	symcounter++
	return fmt.Sprintf("_validation_fun_%d", symcounter)
}
```

Every validator this package mints takes its FID from here. `NewValidator` does, and so does every `s:` constructor reachable from **ordinary ELPS source** — `s:int` and `s:gt` each mint one, `s:deftype` mints another around them. So two runtimes evaluating schema code on two goroutines both land in `GenSymbol`, and while it was a plain `int++` that is an unsynchronised read-modify-write.

No Go embedder involvement is required. `(s:deftype "T" s:int (s:gt 0))` alone is enough. Red on `main`:

```
WARNING: DATA RACE
Read at 0x000000c85f20 by goroutine 10:
  libschema.GenSymbol()          libschema.go:357
  libschema.newValidator()       libschema.go:438
  libschema.builtinGreaterThan() libschema.go:684
  ...
  lisp.(*LEnv).LoadStringContext()
Previous write at 0x000000c85f20 by goroutine 18:
  libschema.GenSymbol()          libschema.go:357
  libschema.newValidator()       libschema.go:438
  libschema.builtinCheckAny()    libschema.go:514
  libschema.builtinCheckInt()    libschema.go:820
  libschema.getHandler()         libschema.go:307
  libschema.builtinDefType()     libschema.go:248
```

and through the exported entry point, which is the literal shape #364 describes:

```
WARNING: DATA RACE
Read at 0x000000c87f60 by goroutine 25:
  libschema.GenSymbol()     libschema.go:357
  libschema.newValidator()  libschema.go:438
  libschema.NewValidator()  libschema.go:475
```

Nine distinct race reports across the three concurrency tests on `main`; zero after.

The visible damage from losing an increment is only a duplicate name in a stack frame, which is exactly why this survived — the symptom is a debugging-output blemish, not a wrong answer. The undefined behaviour is the defect, in an interpreter substrate runs with dozens of live environments evaluating concurrently.

## Defect 2: the returned value did not own its state (red on `main`)

**Formals stored by reference.** `NewValidator(formals, fn)` put the caller's `*LVal` straight into `Cells[0]`. A caller that keeps its formals — the natural thing when minting a family of one-argument constraints, i.e. exactly what every constructor in this package does internally — could write through it later and land the write in every validator built from it, in every runtime any of them were bound into. Red on `main`:

```
--- FAIL: TestNewValidatorOwnsItsFormals
    formals leaked: NewValidator stored the caller's LVal by reference
```

**Cells carried spare capacity.** A validator's cells are `[formals, docstring, marker]`, built by appending the marker onto the two-cell slice `lisp.FunInPackage` returns. That append grew the backing array to capacity 4, so every validator carried one spare slot for life. `append(v.Cells[:2], x)` would have overwritten the marker in place — silently revoking the validator credential of a value shared by every runtime it was bound into. This is the #373 class, on an LFun instead of a sequence. Red on `main`, for all three ways to mint one:

```
--- FAIL: TestValidatorCellsCarryNoSpareCapacity
    NewValidator:      validator cells carry spare capacity: len=3 cap=4
    s:make-validator:  validator cells carry spare capacity: len=3 cap=4
    s:gt:              validator cells carry spare capacity: len=3 cap=4
```

## Did #409 already resolve part of this?

**No.** #409's three-index clamp is confined to sequence producers in `lisp/builtins.go` (`slice`, `cdr`, `rest`, and `append`'s input), and its `clampCap` helper is unexported in package `lisp`. Nothing in it reaches an LFun's cells or `lisp/lisplib/`. Verified by reading `1ed498a` — every hunk is in `lisp/builtins.go`.

What #409 did contribute is the house style. Defect 2's capacity half is the same bug in a different container, and it is fixed the same way, which is how it got noticed at all.

## Which fix, and what was rejected

The issue offers three answers. Taken in turn:

**Rejected — document a single-runtime requirement.** This is the cheapest change and the worst outcome. It would make the repository's own demonstration of the extension point (`TestNewValidatorIsAcceptedAsAConstraint`, which binds one validator into six runtimes) into a documented misuse, and it would push a per-runtime constraint-set rebuild onto every embedder to work around two defects that are cheap to just fix. It also does nothing about the race, which is reachable from plain ELPS source with no embedder in sight.

**Rejected — make the validator per-Runtime.** `NewValidator(formals, fn)` has no runtime to hang anything off. Giving it one is an API break for an extension point whose entire value is that what it returns is runtime-independent, and it would not help: the race is in the *constructor's* global counter, not in the value, so a per-runtime value with a global counter still races.

**Chosen — make it genuinely shareable, and verify it.** The three properties are now individually true and individually tested:

1. `symcounter` is `atomic.Uint64`, matching the in-tree precedent `lisp.Runtime.gensym`. It stays process-global for the signature reason above; global-and-atomic also keeps FIDs distinct across runtimes, which is what you want reading a stack trace out of a process running many.
2. The formals are copied, and the cell slice is allocated at exactly its final length. The copy is at the **exported boundary only** — the package-internal `newValidator` callers all build a fresh `lisp.Formals(...)` inline on the call and drop the reference immediately, so the path every `s:` constructor takes pays nothing and there is no other holder to defend against.
3. The "interpreter does not write into a validator" property is pinned by a guard test, so the doc comment does not quietly become false when someone changes `lisp/env.go`.

`NewValidator`'s doc comment gains a RUNTIME SCOPE section stating the guarantee and the two obligations that stay with the caller and cannot be enforced here: `fn` must be goroutine-safe if the validator is shared across goroutines, and anything `fn` captures is shared on the same terms.

`TestNewValidatorIsAcceptedAsAConstraint` is left binding one validator into six runtimes, with a comment saying why. #364 read that as the test misusing the API. It is the other way round — the API was made to support what the test already does — and the comment exists so nobody deletes the coverage to satisfy an ownership checker.

## Tests

| Test | Kind | On `main` |
|---|---|---|
| `TestValidatorConstructionIsRaceFree` | catch | DATA RACE under `-race`, via plain ELPS source |
| `TestNewValidatorConcurrentFromGo` | catch | DATA RACE under `-race`, via the exported API |
| `TestSharedValidatorConcurrentAcrossRuntimes` | catch | DATA RACE under `-race`, end-to-end shape from the issue |
| `TestNewValidatorOwnsItsFormals` | catch | FAIL |
| `TestValidatorCellsCarryNoSpareCapacity` | catch | FAIL (3/3 subtests) |
| `TestNewValidatorFormalsCopyIsFaithful` | guard on the new copy | n/a |
| `TestSharedValidatorIsNotMutatedByEvaluation` | **guard, not a catch** | PASS |

The three race tests are meaningful only under `-race`: a lost increment produces a duplicate name and nothing observable, which is why the bug survived. `TestNewValidatorConcurrentFromGo` additionally asserts FID uniqueness, but the detector is the real signal.

## Neighbourhood audit

Every exported constructor in `lisp/lisplib/` that returns a value an embedder might reasonably bind into more than one Runtime.

**Changed**

- `libschema.NewValidator` — the subject.
- `libschema.GenSymbol` — exported, and the race. Behaviour is unchanged (`_validation_fun_N`); only the synchronisation is.

**Not changed, with reasons**

- `libtesting.NewTestSuite` — returns a `*TestSuite` holding unsynchronised Go maps, so installing one into two runtimes would genuinely race. Left alone because `LoadPackage` already calls it once per env, so the shared-instance path exists only if an embedder deliberately constructs one and installs it twice, and `elps test` is single-runtime. Fixing it means either a mutex on the suite or an explicit doc contract; neither belongs in a libschema PR. Worth its own issue if anyone wants to embed the test framework.
- `libutil.Function` / `libutil.FunctionDoc` (`lisp/lisplib/internal/libutil`) — these build the `*Builtin` entries in the package-level `var builtins` tables, which share one formals `*LVal` across every `LEnv` in the process. That is **issue #363** exactly, tracked, with a fix in flight on PR #374. Deliberately untouched: fixing it here would collide with that branch, and #363 documents that a partial fix measured at the wrong layer is the trap.
- `libjson.DefaultSerializer` / `libjson.Builtins(s)` — safe. Both allocate fresh per call, and `Builtins(s)` is the control case #363 names for getting this right.
- `libjson.Load` / `LoadWith` / `Dump` — return ordinary mutable data trees. Sharing one across runtimes means `assoc!` in one is visible in the other, but that is ELPS value semantics for *any* data value, identical to sharing a literal; it is not a property of these constructors and there is no per-constructor fix.
- `libtime.Time` / `libtime.Duration` — `lisp.Native` wrappers around immutable Go values (`time.Time`, `time.Duration`), no cells. Safe to share.
- `libregexp.BuiltinCompile` — returns a native `*regexp.Regexp`, which is documented goroutine-safe. Safe to share.
- `libhelp.Query*` / `Render*`, all `LoadPackage` functions — take an `*LEnv` and act on it; they return no value an embedder holds across runtimes.

I also swept `lisp/` and `lisp/lisplib/` for other mutable package-level counters of the `symcounter` shape. `symcounter` was the only one; `Runtime.numenv`, `Runtime.numsym` and `Runtime.macroExpSeq` are all per-runtime, and the first two are already atomic.

## Gates

| Gate | Result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test -count=1 ./...` | pass |
| `go test -race ./...` | pass, 0 race reports |
| `golangci-lint run ./...` | 0 issues |
| `elps fmt -l ./...` | clean (binary deleted before commit) |
| `elps doc -m` | "All functions and exports are documented." |
| `./scripts/ci-gates-test.sh` | 210 passed, 0 failed |
| `./scripts/confidentiality-guard.sh` | clean (run after `git add`) |

On `scripts/benchstat-gate.sh`: the changed code is not on any benchmarked path. `go test -bench=. ./lisp/lisplib/libschema/` reports no benchmarks, and no `Benchmark*` or lisp `benchmark` form in the repo constructs a schema validator. Both changed operations are cheap regardless — `markValidator` replaces a grow-on-append allocation with an exact-length one, which is the same allocation count and fewer bytes, and `GenSymbol` gains one atomic add per validator construction, which happens at `deftype` time rather than in the validation path. No waiver needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_