### PR TITLE
Stop the reader emitting nodes macro expansion will write into (#370)

### DIFF
--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -3,6 +3,7 @@
 package analysis
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -727,4 +728,75 @@ func TestExpandMacroDoesNotAliasCallerForm(t *testing.T) {
 				" ExpandMacro must build the macro's argument list the same way"+
 				" LEnv.evalSExprCells does")
 	})
+}
+
+// TestExpandMacroDoesNotRestampCallerSourceLocations is the analyzer-side
+// guard for elps#370, the sibling of #396 above: not the argument ARRAY this
+// time, but the source locations recorded on the caller's nodes.
+//
+// lisp.stampMacroExpansion runs at the end of every MacroCall — the one
+// ExpandMacro makes included — and rewrites LVal.Source on each expanded node
+// whose location is synthetic (nil, or Pos < 0). Macro arguments are not
+// evaluated, so they reach the expansion as the analyzer's own parse-tree
+// nodes; and the reader used to emit two nodes with synthetic locations of its
+// own, the "lisp:function" head behind #' and the nil-source "lisp:expr" head
+// behind #^. Those were nodes the stamp would write into.
+//
+// This is a GUARD, not a catch: it passes on main. The stamp does fire on this
+// path, but its call site is env.Loc, and an expander env that has just
+// finished loading macros is left pointing at lisp.nativeSource — so the write
+// lands the same value the node already held and moves nothing observable. The
+// damage was demonstrable on the lisp side, where the call site is a real
+// location (lisp's TestMacroExpansionDoesNotRestampCallerParseTree, and
+// TestMacroExpansionSharedParseTreeIsRaceFree under -race).
+//
+// It is worth pinning here anyway, because this is where a moved position
+// costs the most. Position information is the analyzer's output — hover
+// ranges, go-to-definition and diagnostics are computed from it — and since
+// #359 the LSP holds this tree across requests in workspaceRefs and expands
+// over it from NumCPU workers. Whether the stamp's call site is real depends
+// on nothing more than which form the expander env last evaluated.
+//
+// The fix is in the reader: rdparser now gives those synthesized heads the
+// real location of the prefix token they stand for, so there is no node left
+// in a parsed form for the stamp to claim.
+func TestExpandMacroDoesNotRestampCallerSourceLocations(t *testing.T) {
+	env := newTestEnv(t)
+	evalSource(t, env, `
+(defmacro ident (x) x)
+(defun target () 1)`)
+
+	// Parsed, not hand-built: the point is that these are READER nodes, and
+	// only the reader produced the synthetic locations at issue.
+	s := token.NewScanner("caller.lisp", strings.NewReader(`(ident #'target)`))
+	exprs, err := rdparser.New(s).ParseProgram()
+	require.NoError(t, err)
+	require.Len(t, exprs, 1)
+	form := exprs[0]
+
+	type located struct{ desc, loc string }
+	var walk func(v *lisp.LVal, path string) []located
+	walk = func(v *lisp.LVal, path string) []located {
+		loc := "<nil>"
+		if v.Source != nil {
+			loc = v.Source.String()
+		}
+		out := []located{{path + "/" + v.Type.String() + " " + v.Str, loc}}
+		for i, c := range v.Cells {
+			out = append(out, walk(c, fmt.Sprintf("%s/%d", path, i))...)
+		}
+		return out
+	}
+
+	before := walk(form, "")
+	expander := &EnvMacroExpander{Env: env}
+	expanded := expander.ExpandMacro(form, lisp.DefaultUserPackage)
+	require.NotNil(t, expanded, "expansion should succeed")
+	after := walk(form, "")
+
+	require.Len(t, after, len(before))
+	for i := range before {
+		assert.Equal(t, before[i].loc, after[i].loc,
+			"expansion moved the source location of %s in the analyzer's parse tree", before[i].desc)
+	}
 }

--- a/lisp/macro_stamp_shared_ast_test.go
+++ b/lisp/macro_stamp_shared_ast_test.go
@@ -1,0 +1,243 @@
+// Copyright © 2026 The ELPS authors
+
+// Shared-parse-tree regression tests for elps#370.
+//
+// stampMacroExpansion walks a macro's expansion and replaces every SYNTHETIC
+// source location -- nil, or Pos < 0, i.e. lisp.nativeSource's "<native code>"
+// -- with the macro's call site, attaching a MacroExpansionInfo as well when a
+// debugger is attached.  Both are writes to *LVal fields.
+//
+// The walk is meant to reach only nodes the macro CREATED.  It reached parser
+// output too, because the reader emitted two nodes with synthetic locations of
+// its own: the "lisp:function" head behind #' and, in the nil-source edge
+// case, the "lisp:expr" head behind #^.  Macro arguments are not evaluated, so
+// a form containing #' arrives at the macro's parameters as the CALLER'S OWN
+// parse-tree nodes and is spliced into the expansion -- and the stamp then
+// wrote into the caller's parse tree.
+//
+// That tree is not private to a single evaluation:
+//
+//   - LEnv.load evaluates the reader's expressions directly.  It does not
+//     copy (lisp.TextLoader does; the Load* entry points do not).
+//   - A function body IS the parse tree it was defined from, re-entered on
+//     every call.
+//   - A *Package -- LFun bodies included -- is shared by pointer across the
+//     per-request environments an embedder derives from one registry.  That is
+//     the same sharing elps#397 turned into "fatal error: concurrent map read
+//     and map write".
+//
+// So two environments expanding the same macro call wrote to one *LVal.Source
+// word with no synchronisation between them.  Before the fix `go test -race`
+// reported it at macro.go:276 (the read) and macro.go:277 (the write).
+//
+// The fix is in the reader: parser/rdparser gives the synthesized #'/#^ heads
+// the real location of the prefix token they stand for, which empties the set
+// of shared nodes the stamp can reach.  parser/rdparser's
+// TestParserEmitsNoSyntheticSourceLocations pins that end; these tests pin the
+// consequence at the end that was corrupted.
+
+package lisp_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+	"github.com/luthersystems/elps/parser/rdparser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dormantDebugger is the cheapest thing that satisfies lisp.Debugger.  Only
+// its presence matters here: macroCall builds a MacroExpansionContext whenever
+// Runtime.Debugger is non-nil, and that context is what stampMacroExpansion
+// turns into a MacroExpansionInfo on every node it claims.  It is never asked
+// to do anything, so every hook is dormant.
+type dormantDebugger struct{}
+
+func (dormantDebugger) IsEnabled() bool                                { return false }
+func (dormantDebugger) OnEval(*lisp.LEnv, *lisp.LVal) bool             { return false }
+func (dormantDebugger) OnFunEntry(*lisp.LEnv, *lisp.LVal, *lisp.LEnv)  {}
+func (dormantDebugger) OnFunReturn(*lisp.LEnv, *lisp.LVal, *lisp.LVal) {}
+func (dormantDebugger) AfterFunCall(*lisp.LEnv) bool                   { return false }
+func (dormantDebugger) OnError(*lisp.LEnv, *lisp.LVal) bool            { return false }
+func (dormantDebugger) WaitIfPaused(*lisp.LEnv, *lisp.LVal) lisp.DebugAction {
+	return lisp.DebugContinue
+}
+
+// stampPrelude defines the smallest macro that reproduces the defect: one that
+// returns its argument unchanged, so the expansion IS the caller's node.
+//
+// Nothing about the macro is exotic.  Any macro that splices an argument into
+// its expansion -- which is what quasiquote/unquote is for, and therefore what
+// nearly every macro does -- puts the caller's nodes in the stamp's path.
+const stampPrelude = `
+(defmacro ident (x) x)
+(defun target () 1)`
+
+// sharedFormSrc is a call to that macro whose argument contains a #' function
+// reference: the form whose head the reader used to leave on "<native code>".
+const sharedFormSrc = `(ident #'target)`
+
+func newStampEnv(t testing.TB) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnvRuntime(&lisp.Runtime{
+		Registry: lisp.NewRegistry(),
+		Stack:    &lisp.CallStack{},
+		Reader:   parser.NewReader(),
+	})
+	require.NotEqual(t, lisp.LError, lisp.InitializeUserEnv(env).Type)
+	env.InPackage(lisp.String(lisp.DefaultUserPackage))
+	require.NotEqual(t, lisp.LError, lisplib.LoadLibrary(env).Type)
+	require.NotEqual(t, lisp.LError, env.InPackage(lisp.String(lisp.DefaultUserPackage)).Type)
+	require.NotEqual(t, lisp.LError, env.LoadString("prelude.lisp", stampPrelude).Type)
+	return env
+}
+
+func parseOneForm(t testing.TB, name, src string) *lisp.LVal {
+	t.Helper()
+	exprs, err := rdparser.NewReader().Read(name, strings.NewReader(src))
+	require.NoError(t, err)
+	require.Len(t, exprs, 1)
+	return exprs[0]
+}
+
+// findSymbol returns the first node named name in v's tree.
+func findSymbol(v *lisp.LVal, name string) *lisp.LVal {
+	if v.Type == lisp.LSymbol && v.Str == name {
+		return v
+	}
+	for _, c := range v.Cells {
+		if got := findSymbol(c, name); got != nil {
+			return got
+		}
+	}
+	return nil
+}
+
+// snapshotSources records the Source pointer of every node in v, keyed by the
+// node pointer, so a later comparison names the node that moved.
+func snapshotSources(v *lisp.LVal, out map[*lisp.LVal]*struct {
+	src  string
+	name string
+},
+) {
+	if v == nil {
+		return
+	}
+	loc := "<nil>"
+	if v.Source != nil {
+		loc = v.Source.String()
+	}
+	out[v] = &struct {
+		src  string
+		name string
+	}{loc, v.Type.String() + " " + v.Str}
+	for _, c := range v.Cells {
+		snapshotSources(c, out)
+	}
+}
+
+// TestMacroExpansionDoesNotRestampCallerParseTree is the deterministic arm.
+//
+// Evaluating a form must not move the positions recorded in it.  Those
+// positions are what every error message, every stack frame, and every LSP
+// range is computed from, and the parse tree outlives the evaluation.
+//
+// Pre-fix this failed on the (lisp:function target) head: "<native code>"
+// became "shared.lisp:1:8", the location of the `ident` call, which is neither
+// where the reference is nor where anything the interpreter synthesised is.
+func TestMacroExpansionDoesNotRestampCallerParseTree(t *testing.T) {
+	env := newStampEnv(t)
+	form := parseOneForm(t, "shared.lisp", sharedFormSrc)
+
+	type entry = struct{ src, name string }
+	before := map[*lisp.LVal]*entry{}
+	snapshotSources(form, before)
+
+	res := env.Eval(form)
+	require.NotEqual(t, lisp.LError, res.Type, "%v", res)
+
+	after := map[*lisp.LVal]*entry{}
+	snapshotSources(form, after)
+
+	require.Len(t, after, len(before))
+	for node, was := range before {
+		now, ok := after[node]
+		require.True(t, ok)
+		assert.Equal(t, was.src, now.src,
+			"evaluation moved the source location of %s in the caller's parse tree", was.name)
+	}
+}
+
+// TestMacroExpansionDoesNotStampMacroExpansionInfo is the other half of the
+// same write.  With a debugger attached the stamp also allocates a
+// MacroExpansionInfo onto each node it claims, which is a second field written
+// into the shared tree -- and one that makes the node report itself to the
+// debugger as macro-generated when the user wrote it by hand.
+func TestMacroExpansionDoesNotStampMacroExpansionInfo(t *testing.T) {
+	env := newStampEnv(t)
+	env.Runtime.Debugger = dormantDebugger{}
+	form := parseOneForm(t, "shared.lisp", sharedFormSrc)
+	head := findSymbol(form, "lisp:function")
+	require.NotNil(t, head, "the #' head should be in the parse tree")
+
+	res := env.Eval(form)
+	require.NotEqual(t, lisp.LError, res.Type, "%v", res)
+
+	assert.Nil(t, head.MacroExpansion,
+		"macro expansion attached MacroExpansionInfo to a node the reader produced")
+}
+
+// TestMacroExpansionSharedParseTreeIsRaceFree is the concurrency arm, and the
+// one that reproduces the defect as reported.  It is meaningful only under
+// `go test -race`; without it the two goroutines simply both write the same
+// word and the test passes either way.
+//
+// Two INDEPENDENT environments -- separate runtimes, separate registries,
+// separate stacks -- evaluate the same parsed forms.  Nothing is shared
+// between them except the AST, which is exactly the embedder shape the issue
+// describes: a parse cache handing one tree to per-request environments.
+//
+// Each form is used once.  The write settles (a node that has acquired a real
+// location is skipped by every later stamp), so re-using one form would race
+// only on the first pass and then go quiet; a fresh form per iteration keeps
+// presenting the first write, which is the racing one.
+func TestMacroExpansionSharedParseTreeIsRaceFree(t *testing.T) {
+	const forms = 200
+
+	envs := []*lisp.LEnv{newStampEnv(t), newStampEnv(t)}
+	shared := make([]*lisp.LVal, forms)
+	for i := range shared {
+		shared[i] = parseOneForm(t, "shared.lisp", sharedFormSrc)
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, env := range envs {
+		wg.Add(1)
+		go func(env *lisp.LEnv) {
+			defer wg.Done()
+			<-start
+			for _, form := range shared {
+				env.Eval(form)
+			}
+		}(env)
+	}
+	close(start)
+	wg.Wait()
+
+	// The tree the two of them walked must still say what the reader said.
+	for i, form := range shared {
+		head := findSymbol(form, "lisp:function")
+		require.NotNil(t, head)
+		require.NotNil(t, head.Source)
+		assert.GreaterOrEqualf(t, head.Source.Pos, 0,
+			"form %d: the #' head lost its real source location", i)
+		assert.Equalf(t, "shared.lisp", head.Source.File,
+			"form %d: the #' head was relocated", i)
+	}
+}

--- a/parser/rdparser/fuzz_test.go
+++ b/parser/rdparser/fuzz_test.go
@@ -67,6 +67,15 @@ func FuzzParseProgram(f *testing.F) {
 			// one.
 			_ = expr.String()
 		}
+		// Property 4: nothing the reader hands back carries a SYNTHETIC
+		// source location.  lisp.stampMacroExpansion rewrites Source on every
+		// expanded node whose location is nil or has Pos < 0, and macro
+		// arguments reach the expansion as the caller's own parse-tree nodes
+		// -- so a synthetic location here is a node the interpreter writes
+		// into, concurrently, across environments that share the tree
+		// (elps#370).  Stated over the whole tree rather than over the two
+		// heads that broke it, so the next desugaring is covered too.
+		assertRealSourceLocations(t, string(src), exprs)
 	})
 }
 
@@ -153,6 +162,11 @@ func FuzzParseFormatting(f *testing.F) {
 				t.Fatalf("expression %d mismatch:\n standard = %s\n formatting = %s", i, want, got)
 			}
 		}
+		// The elps#370 invariant again, this time for the mode the LSP and
+		// `elps fmt` parse in.  It builds the metadata-carrying tree that is
+		// held across requests, so a stampable node here is the longest-lived
+		// one there is.
+		assertRealSourceLocations(t, string(src), exprs)
 	})
 }
 

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -348,12 +348,19 @@ func (p *Parser) ParseUnbound() *lisp.LVal {
 	prefixNewlines := p.src.Token.PrecedingNewlines
 	prefixSpaces := p.src.Token.PrecedingSpaces
 	prefixLoc := p.Location() // save #^ location before parsing inner expression
+	sym := p.locateSynthesized(lisp.Symbol("lisp:expr"))
 	expr := p.ParseExpression()
 	if expr.Type == lisp.LError {
 		return expr
 	}
-	sym := lisp.Symbol("lisp:expr")
-	sym.Source = expr.Source
+	if expr.Source != nil && expr.Source.Pos >= 0 {
+		// Preferred when it is real: the head stands for the whole #^ form,
+		// and pointing it at the operand keeps `#^x` reporting the same
+		// position it always has.  locateSynthesized above is the fallback,
+		// and it is not decorative -- see its comment for why the head must
+		// never be left on a synthetic location.
+		sym.Source = expr.Source
+	}
 	// Ensure that the expression doesn't contain nested cons expressions.
 	for _, c := range expr.Cells {
 		if c.Type == lisp.LSExpr && !c.Quoted {
@@ -370,13 +377,13 @@ func (p *Parser) ParseUnbound() *lisp.LVal {
 }
 
 func (p *Parser) ParseFunRef() *lisp.LVal {
-	op := lisp.Symbol("lisp:function")
 	if !p.Accept(token.FUN_REF) {
 		return p.errorf("parse-error", "invalid quote: %v", p.PeekType())
 	}
 	prefixNewlines := p.src.Token.PrecedingNewlines
 	prefixSpaces := p.src.Token.PrecedingSpaces
 	prefixLoc := p.Location() // save #' location before parsing inner expression
+	op := p.locateSynthesized(lisp.Symbol("lisp:function"))
 	name := p.ParseSymbol()
 	if name.Type == lisp.LError {
 		return name
@@ -406,6 +413,58 @@ func (p *Parser) ParseFunRef() *lisp.LVal {
 	p.hoistOperandComments(result, name)
 	p.applyPrefixNewlines(result, prefixNewlines, prefixSpaces)
 	return result
+}
+
+// locateSynthesized gives a node the parser SYNTHESIZED -- one that stands for
+// a prefix the reader desugared rather than for a token of its own -- the real
+// location of the prefix token it was synthesized from.  It must be called
+// while that token is still the one under the cursor, i.e. immediately after
+// the Accept that consumed it.
+//
+// WHY THIS IS NOT COSMETIC.  lisp.Symbol gives every new symbol
+// lisp.nativeSource(), the shared "<native code>" location whose Pos is -1,
+// and the head symbols behind #' and #^ were left carrying it.  That put a
+// PARSER-PRODUCED node into the population that lisp.stampMacroExpansion
+// treats as its own to rewrite: the stamp walk replaces any Source that is nil
+// or has Pos < 0 with the macro call site (and, with a debugger attached,
+// attaches a MacroExpansionInfo).
+//
+// Macro arguments are not evaluated, so a form containing #' reaches the
+// macro's parameters as the caller's own parse-tree nodes and is spliced into
+// the expansion; the stamp walk then wrote into the caller's parse tree.  The
+// AST is not private to one evaluation.  LEnv.load evaluates the reader's
+// nodes directly (it does not copy), a function body is the parse tree it was
+// defined from and is re-entered on every call, and a *Package -- LFun bodies
+// included -- is shared by pointer across the per-request environments an
+// embedder derives from one registry.  Two environments expanding the same
+// macro call therefore wrote to the same *LVal.Source word with nothing
+// between them: elps#370, reported by -race at macro.go:276/277.
+//
+// Fixing it here rather than in the stamp walk is deliberate.  A synthetic
+// location on a node the reader produced is wrong on its own terms -- a
+// function reference the user wrote reported itself as "<native code>" -- and
+// internal/fuzzval already documents the intended invariant: "every callable
+// that receives an UNEVALUATED fragment receives it straight from the reader,
+// so in production those nodes all carry real, distinct, per-node locations.
+// Synthetic locations are what a COMPUTED value has."  Restoring that
+// invariant empties the set of shared nodes the stamp can reach instead of
+// teaching the stamp to recognise them, and it costs nothing at expansion
+// time.  TestParserEmitsNoSyntheticSourceLocations pins it.
+//
+// The token's own *Location is handed over rather than copied.  It is
+// allocated per token by Scanner.LocStart and, for a prefix token, no LVal is
+// built from it -- tokenLVal is never called on a #' or #^ -- so this node is
+// its only owner.  applyPrefixLocation reads it and writes elsewhere.
+func (p *Parser) locateSynthesized(v *lisp.LVal) *lisp.LVal {
+	loc := p.Location()
+	if loc == nil {
+		return v
+	}
+	if tok := p.src.Token; tok != nil {
+		loc.EndLine, loc.EndCol, loc.EndPos = token.TokenEnd(tok)
+	}
+	v.Source = loc
+	return v
 }
 
 // recordSynthesizedBrackets stamps the paren bracket kind onto an s-expression

--- a/parser/rdparser/synthetic_source_test.go
+++ b/parser/rdparser/synthetic_source_test.go
@@ -1,0 +1,192 @@
+// Copyright © 2026 The ELPS authors
+
+package rdparser_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/internal/fuzzseed"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/rdparser"
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// syntheticSourceNodes walks a parsed expression and returns a description of
+// every node carrying a location the interpreter treats as SYNTHETIC: nil, or
+// Pos < 0 (lisp.nativeSource, rendered "<native code>").
+//
+// The three process-wide singletons are excluded.  lisp.Nil(), lisp.Bool(true)
+// and lisp.Bool(false) are shared immutable values that legitimately carry a
+// synthetic location, and lisp.stampMacroExpansion skips them by identity
+// (elps#274), so they are not part of the population this file is about.
+func syntheticSourceNodes(v *lisp.LVal, path string) []string {
+	if v == nil || v == lisp.Nil() || v == lisp.Bool(true) || v == lisp.Bool(false) {
+		return nil
+	}
+	var found []string
+	here := path + "/" + v.Type.String()
+	switch {
+	case v.Source == nil:
+		found = append(found, fmt.Sprintf("%s %q: Source is nil", here, v.Str))
+	case v.Source.Pos < 0:
+		found = append(found, fmt.Sprintf("%s %q: synthetic Source %v (Pos=%d)",
+			here, v.Str, v.Source, v.Source.Pos))
+	}
+	for _, c := range v.Cells {
+		found = append(found, syntheticSourceNodes(c, here)...)
+	}
+	return found
+}
+
+// AssertRealSourceLocations fails t if any node reachable from exprs carries a
+// synthetic source location.  Exported to the fuzz targets in this package,
+// which apply the same rule to generated input.
+func assertRealSourceLocations(t *testing.T, src string, exprs []*lisp.LVal) {
+	t.Helper()
+	var found []string
+	for i, expr := range exprs {
+		found = append(found, syntheticSourceNodes(expr, fmt.Sprintf("expr[%d]", i))...)
+	}
+	if len(found) > 0 {
+		t.Errorf("parsing %q produced %d node(s) with a synthetic source location:\n  %s",
+			src, len(found), strings.Join(found, "\n  "))
+	}
+}
+
+// TestParserEmitsNoSyntheticSourceLocations pins the invariant that closes
+// elps#370: NOTHING the reader hands back carries a synthetic source location.
+//
+// lisp.stampMacroExpansion rewrites Source (and, with a debugger attached,
+// MacroExpansion) on every expanded node whose location is nil or has Pos < 0.
+// Macro arguments are not evaluated, so they arrive as the CALLER'S OWN
+// parse-tree nodes and are spliced into the expansion -- which makes any
+// parser-produced node with a synthetic location a node the stamp walk will
+// write into.  That parse tree is not private to one evaluation: LEnv.load
+// evaluates the reader's nodes directly, a function body IS the parse tree it
+// was defined from, and a *Package is shared by pointer across the per-request
+// environments an embedder derives from one registry.  Two of them expanding
+// the same macro call raced on LVal.Source with nothing between them.
+//
+// The two violations were the head symbols the reader SYNTHESIZES for the #'
+// and #^ prefixes -- lisp.Symbol seeds every new symbol with
+// lisp.nativeSource() and neither head was given a location of its own.
+//
+// This is stated as a property over the whole tree rather than as two
+// assertions about those two heads on purpose.  The bug was not that those
+// particular symbols were wrong; it was that the reader was allowed to emit a
+// stampable node at all, and the next desugaring added would reopen it.
+//
+// The same rule is applied to generated input by FuzzParseProgram and
+// FuzzParseFormatting.
+func TestParserEmitsNoSyntheticSourceLocations(t *testing.T) {
+	srcs := []string{
+		// The two regressions.  Both parsed to a form whose HEAD carried
+		// "<native code>": (lisp:function foo) and (lisp:expr ...).
+		`#'foo`,
+		`#'mypkg:myfun`,
+		`'#'x`,
+		`(map () #'first '((1 2) (3 4)))`,
+		`#^(+ %1 1)`,
+		`#^()`,
+		`#^0`,
+		`#^"abc"`,
+		`'#^0`,
+		`#^'%`,
+		// Ordinary forms, which were already clean and must stay so.
+		`(defun f (x) (+ x 1))`,
+		"; comment\n(a b [c] 'd 1.5 \"s\" :key)",
+		"(defmacro m (&rest body) (quasiquote (progn (unquote-splicing body))))",
+	}
+	for _, src := range srcs {
+		t.Run(src, func(t *testing.T) {
+			for _, mode := range []struct {
+				name    string
+				newFunc func(*token.Scanner) *rdparser.Parser
+			}{
+				{"standard", rdparser.New},
+				{"formatting", rdparser.NewFormatting},
+			} {
+				t.Run(mode.name, func(t *testing.T) {
+					p := mode.newFunc(token.NewScanner("test.lisp", strings.NewReader(src)))
+					exprs, err := p.ParseProgram()
+					require.NoError(t, err)
+					assertRealSourceLocations(t, src, exprs)
+				})
+			}
+		})
+	}
+}
+
+// TestRepoSourcesHaveNoSyntheticLocations runs the same property over the real
+// library and example code in the seed corpus -- the population an embedder's
+// parse cache would actually hold.
+//
+// This is a GUARD, not a catch: it passes on main.  No file under _examples or
+// lisp/lisplib happens to use #' today (the tree's only #' is in
+// editors/vscode/test/grammar, which the corpus does not walk), so there was
+// nothing here for the defect to show up in.  It is worth having anyway --
+// adding a #' to the standard library is an ordinary thing to do, and without
+// this the class would come back through the corpus without a word.
+func TestRepoSourcesHaveNoSyntheticLocations(t *testing.T) {
+	sources := fuzzseed.LispSources()
+	require.NotEmpty(t, sources, "no .lisp sources found; the corpus path is broken")
+	for i, src := range sources {
+		p := rdparser.New(token.NewScanner("corpus.lisp", bytes.NewReader(src)))
+		exprs, err := p.ParseProgram()
+		if err != nil {
+			continue // not every fixture is a valid program on its own
+		}
+		assertRealSourceLocations(t, fmt.Sprintf("corpus source %d", i), exprs)
+	}
+}
+
+// TestSynthesizedHeadsCarryPrefixLocation states what the heads now point AT,
+// which the property above deliberately does not.
+//
+// A synthesized head has no text of its own, so the prefix token that produced
+// it is the only honest answer -- and it is a better one than the old
+// "<native code>", which reported a function reference the user wrote as
+// though the interpreter had invented it.
+func TestSynthesizedHeadsCarryPrefixLocation(t *testing.T) {
+	t.Run("funref", func(t *testing.T) {
+		// "(f #'g)": the #' prefix is at column 4.
+		exprs, err := rdparser.New(token.NewScanner("test.lisp", strings.NewReader("(f #'g)"))).ParseProgram()
+		require.NoError(t, err)
+		require.Len(t, exprs, 1)
+		funref := exprs[0].Cells[1]
+		require.Equal(t, "lisp:function", funref.Cells[0].Str)
+		head := funref.Cells[0]
+		require.NotNil(t, head.Source)
+		assert.Equal(t, "test.lisp", head.Source.File)
+		assert.Equal(t, 1, head.Source.Line)
+		assert.Equal(t, 4, head.Source.Col, "head should sit on the #' prefix")
+		assert.GreaterOrEqual(t, head.Source.Pos, 0)
+		// The head gets a *token.Location of its own rather than borrowing
+		// the operand's.  It has to: tokenLVal gives the enclosing
+		// s-expression the OPERAND'S Location object, and applyPrefixLocation
+		// then rewrites that object in place to point at the prefix -- so
+		// `funref.Source` and `funref.Cells[1].Source` are already one object
+		// (long-standing behaviour, unchanged here).  Adding a third borrower
+		// would put the head on that same object too.
+		assert.NotSame(t, head.Source, funref.Cells[1].Source)
+	})
+
+	t.Run("unbound expression", func(t *testing.T) {
+		// #^ keeps pointing its head at the operand, which is where it always
+		// pointed.  The change there is only the fallback for an operand with
+		// no real location of its own.
+		exprs, err := rdparser.New(token.NewScanner("test.lisp", strings.NewReader("#^(+ %1 1)"))).ParseProgram()
+		require.NoError(t, err)
+		require.Len(t, exprs, 1)
+		head := exprs[0].Cells[0]
+		require.Equal(t, "lisp:expr", head.Str)
+		require.NotNil(t, head.Source)
+		assert.GreaterOrEqual(t, head.Source.Pos, 0)
+		assert.Equal(t, 3, head.Source.Col)
+	})
+}


### PR DESCRIPTION
Fixes #370.

## The bug — and yes, it survives #396

#396 fixed the argument **array**: `analysis/expander.go` and `builtinMacroExpand` built the macro's argument list as `SExpr(form.Cells[1:])`, a header over the caller's own backing storage. That fix is explicitly **shallow** — "the ELEMENTS must stay the caller's nodes, because the expansion splices them into its result" — so it does nothing about writes to the elements themselves. #370 is a write to an element. It survives #396 untouched.

`lisp.stampMacroExpansion` walks a macro's expansion and replaces every **synthetic** source location — `nil`, or `Pos < 0`, i.e. `lisp.nativeSource`'s `"<native code>"` — with the macro's call site, attaching a `MacroExpansionInfo` as well when a debugger is attached. The walk is meant to reach only nodes the macro **created**.

It reached parser output too. `lisp.Symbol` seeds every new symbol with `nativeSource()`, and the reader synthesizes two head symbols it never gave a location of their own:

- `ParseFunRef`: `op := lisp.Symbol("lisp:function")` — the head of the form `#'f` desugars to.
- `ParseUnbound`: `sym.Source = expr.Source` — `nil` whenever the operand has no real location.

Macro arguments are not evaluated, so a form containing `#'` arrives at the macro's parameters as the **caller's own parse-tree nodes** and is spliced into the expansion. The stamp then wrote into the caller's parse tree:

```
before: (lisp:function target).Source = <native code>
after:  (lisp:function target).Source = shared.lisp:1:1   <- the `ident` call site
```

That tree is not private to one evaluation:

- `LEnv.load` evaluates the reader's expressions **directly**. `lisp.TextLoader` copies; the `Load*` entry points do not.
- A function body **is** the parse tree it was defined from, re-entered on every call.
- A `*Package` — LFun bodies included — is shared by pointer across the per-request environments an embedder derives from one registry. That is the same sharing #397 turned into `fatal error: concurrent map read and map write`.

So two environments expanding the same macro call wrote to one `*LVal.Source` word with nothing between them.

The asymmetry the issue predicted holds, but pointing the other way from #396. `LEnv.evalSExprCells` copying its cells is what protects the array; it does nothing for the elements, so here **running** the macro is as destructive as analysing it. The stamp is on the eval path.

## The fix — in the reader, not in the stamp walk

`rdparser` now gives both synthesized heads the real location of the prefix token they stand for.

The issue proposed fixing this in the stamp walk (`claude/exp-cow-seal`, skipping sealed subtrees), which needs #374's sealing infrastructure and leaves those heads on `"<native code>"`. Fixing the producer is better on three counts:

1. **The synthetic location was wrong on its own terms.** A function reference the user wrote reported itself as `<native code>`. It now reports the `#'`.
2. **`internal/fuzzval` already documents the invariant the parser was breaking:** *"every callable that receives an UNEVALUATED fragment receives it straight from the reader, so in production those nodes all carry real, distinct, per-node locations. Synthetic locations are what a COMPUTED value has."* `internal/fuzzfp`'s Source watch rule is built on it.
3. It **empties the set** of shared nodes the stamp can reach instead of teaching the stamp to recognise them, and it costs nothing at expansion time.

`#^` keeps pointing its head at the operand, which is where it always pointed; the prefix location is the fallback for an operand with no real location of its own.

## Red-then-green

Written first, run against `main` at `ab0686d`, then fixed. Reproduced by reverting **only** `parser/rdparser/parser.go` with the tests in place.

**`lisp` — deterministic:**

```
--- FAIL: TestMacroExpansionDoesNotRestampCallerParseTree
    Error: Not equal:
      expected: "<native code>"
      actual  : "shared.lisp:1:1"
    Messages: evaluation moved the source location of symbol lisp:function
              in the caller's parse tree

--- FAIL: TestMacroExpansionDoesNotStampMacroExpansionInfo
    Error: Expected nil, but got:
      &lisp.MacroExpansionInfo{MacroExpansionContext:0xc00007f140, ID:1}
    Messages: macro expansion attached MacroExpansionInfo to a node the
              reader produced
```

**`lisp` — `-race`, two independent runtimes over one parsed tree:**

```
WARNING: DATA RACE
Read at 0x00c0002d7ba0 by goroutine 20:
  lisp.stampGuarded()          lisp/macro.go:276
  lisp.stampGuarded()          lisp/macro.go:286
  lisp.stampMacroExpansion()   lisp/macro.go:243
  lisp.(*LEnv).macroCall()     lisp/env.go:1161
  lisp.(*LEnv).evalSExpr()     lisp/env.go:1097
  lisp.(*LEnv).eval()          lisp/env.go:1032
  lisp.(*LEnv).Eval()          lisp/env.go:930

Previous write at 0x00c0002d7ba0 by goroutine 19:
  lisp.stampGuarded()          lisp/macro.go:277
  ... identical stack ...

--- FAIL: TestMacroExpansionSharedParseTreeIsRaceFree
    race detected during execution of test
```

Line 276 is the guard's read of `v.Source`, line 277 the write of `v.Source = callSite`. The two goroutines share nothing but the AST. Each iteration uses a **fresh** form: the write settles once a node has a real location, so re-using one form would race on the first pass and then go quiet.

**`parser/rdparser`:** `TestParserEmitsNoSyntheticSourceLocations` fails on 4 of its 13 inputs (`#'foo`, `#'mypkg:myfun`, `'#'x`, `(map () #'first ...)`), each reporting `expr[0]/list/symbol "lisp:function": synthetic Source <native code> (Pos=-1)`, in both standard and formatting mode. `TestSynthesizedHeadsCarryPrefixLocation` fails with `"<native code>"` where `"test.lisp"` is expected.

All green with the fix; `go test -race ./lisp/... ./analysis/...` clean.

## Two of the new tests are guards, not catches

Labelled as such in-file rather than counted as reproductions.

- `TestRepoSourcesHaveNoSyntheticLocations` — no file under `_examples` or `lisp/lisplib` uses `#'` today (the tree's only one is in `editors/vscode/test/grammar`, which the seed corpus does not walk), so there was nothing here for the defect to show up in. Adding a `#'` to the standard library is an ordinary thing to do.
- `analysis`'s `TestExpandMacroDoesNotRestampCallerSourceLocations` — the stamp **does** fire on the analyzer path, but its call site is `env.Loc`, and an expander env that has just finished loading macros is left pointing at `nativeSource`, so the write lands the same value the node already held. Value-neutral, therefore invisible. Worth pinning anyway: position information *is* the analyzer's output, since #359 the LSP holds this tree across requests in `workspaceRefs` and expands over it from `NumCPU` workers, and whether the call site is real depends on nothing more than which form the expander env last evaluated.

## The property is stated over the whole tree

Not over the two heads that broke it — the bug was not that those particular symbols were wrong, it was that the reader was allowed to emit a stampable node at all. The next desugaring would reopen it.

The same rule is applied to generated input inside the **existing** `FuzzParseProgram` and `FuzzParseFormatting` targets, rather than as a new target, so the fuzz sweep's derived budget is untouched (`fuzz-budget-check.sh`: fits, 60/60 min). 168k executions over the full seed corpus found no other node in the reader's output carrying a synthetic location.

## Neighbourhood audit — every metadata write examined

`Meta`, `MacroExpansion`, `Quoted`, `Spliced` and `Source` writes across the repo. **Changed: 2** (the two reader heads). **Examined and left alone:**

| Site | Why it is safe |
|---|---|
| `lisp/macro.go:277,279` — the stamp itself | The site in question. Left as is: its `isSingleton` identity guard (#274) plus a now-empty parser population is what makes it safe. Nodes it still writes are ones the macro created. |
| `lisp/macro.go:419` `expr.Source = v.Source` | `expr` is the `SExpr(cells)` built two lines above in `doUnquoteSExpr`. Owned by the call. |
| `lisp/lisp.go:664,681,690` — `Quote`, `Splice`, `shallowUnquote` | All do `cp := &LVal{}; *cp = *v` **first**, then set the flag on the copy. `Quote`'s `LQuote` branch allocates fresh with `nativeSource` — that node is macro-owned and legitimately stampable. |
| `lisp/lisp.go:269` `t.Quoted = true` in `GetType` | `t` is a fresh `Symbol(...)`. |
| `lisp/env.go:890` `lerr.Source = env.Loc` in `ErrorAssociate` | Writes an **error** value. The reader never hands back an `LError` — `Parse` converts it to a Go error first, and `FuzzParseProgram` asserts no `LError` survives — so no parser node is ever a target here. |
| `lisp/loader.go:51` `lerr.Source = expr.Source` | `lerr` is a freshly built `Error(err)`; `expr.Source` is only read. |
| `lisp/package.go:100` `lerr.Source = k.Source` | `lerr` is a fresh `Errorf(...)`. The read path #397 touched; the write is to the new error, not to `k`. |
| `parser/rdparser` `Meta` writes — `tokenLVal`, `recordSynthesizedBrackets`, `hoistOperandComments`, `applyPrefixNewlines` | Parse time, on nodes the parser is still constructing and exclusively owns. Nothing else can hold them yet. |
| `parser/rdparser/parser.go:640` `p.src.Peek().Source = p.Location()` | Writes a **token**, not an LVal (the `NEGATIVE`+digits merge). |
| `analysis/analyzer.go:1341` `sym.Source = cell.Source` | `sym` is an `*analysis.Symbol`, the analyzer's own struct. The LVal is only read. |
| `internal/fuzzval/fuzzval.go:267` | Harness generator assigning to values it just constructed; `TestGeneratorNeverRelocatesSharedValues` already pins that it touches nothing shared. |
| `repl/repl.go:497` | `obj` is a JSON DTO; `val.Source` is read. |

**One thing found that is NOT fixed here**, deliberately. `tokenLVal` hands a prefix form the **operand's** `*token.Location`, and `applyPrefixLocation` then rewrites that object **in place** — so `(f #'g)` reports the symbol `g` at column 4 (the `#'`) rather than 6, and `'x` likewise reports `x` at the quote. Pre-existing on `main`, and for `#^` all three of head, form and operand end up on one `Location` object. That is a position-**fidelity** question, not a sharing one: it is a parse-time write on nodes the parser exclusively owns, it is not reachable across environments, and changing it would move ranges the LSP and formatter goldens pin. Not silently widened into this PR; `TestSynthesizedHeadsCarryPrefixLocation` records the aliasing in a comment, and the new head deliberately takes a `Location` of its **own** rather than becoming a third borrower of that object.

## Benchmark impact — none

Parse-time only, and **zero-allocation**: the head takes the prefix token's own `*Location`, which nothing else owns (`Scanner.LocStart` allocates one per token, and `tokenLVal` is never called on a `#'` or `#^`). No copy, no new object.

`./parser/...`, `-benchmem -benchtime=100ms -count=6`, base `ab0686d`:

| metric | result |
|---|---|
| `allocs/op` | **identical on all 12 rows** — benchstat reports `~ (p=1.000) ¹ all samples are equal`; geomean +0.00% |
| `B/op` | `~` on 11 of 12; one row at −0.01%; geomean −0.00% |
| `sec/op` | noise (geomean −8.5%, i.e. this run happened to be faster; ± up to 279% within-arm variance) |

Nowhere near the gate's 15% timing / 5% `B/op` / 5% `allocs/op` thresholds. **No waiver needed**, and `scripts/benchstat-waivers.txt` is untouched.

## Gates

`go build ./...`, `go vet ./...`, `go test -count=1 ./...`, `go test -race -count=1 ./lisp/... ./analysis/...`, `golangci-lint run ./...` (**0 issues**), `elps fmt -l ./...` (clean, binary deleted before commit), `elps doc -m` (*All functions and exports are documented*), `scripts/ci-gates-test.sh` (**210 passed, 0 failed**), `scripts/confidentiality-guard.sh` (clean, after `git add`), `scripts/fuzz-budget-check.sh` (fits).

`gofmt -l` reports `analysis/analyzer.go`; pre-existing on `main`, not from this branch.

## Nothing in the issue proved wrong

Both reported sites are real and both reproduce. The one clarification: the `#^` head is only stampable in the `nil`-source edge case the issue names — in ordinary use it inherits the operand's real location — whereas the `#'` head carried `<native code>` **unconditionally**, which is the one every reproduction here goes through. The severity note ("lower than value corruption... metadata, not cells") is fair for the race, but the deterministic arm shows it is also a plain correctness bug on the single-threaded path: position information is what every error message, stack frame and LSP range is computed from, and once moved it stays moved for the life of the process.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_