### PR TITLE
Stop errors aliasing env.Loc, and guard the shared native Location (#362, #366)

### DIFF
--- a/lisp/env.go
+++ b/lisp/env.go
@@ -828,8 +828,11 @@ func (env *LEnv) ErrorCondition(condition string, v ...interface{}) *LVal {
 		}
 	}
 	lerr := &LVal{
-		Type:   LError,
-		Source: env.Loc,
+		Type: LError,
+		// Copied, not aliased: the error outlives the evaluator's
+		// current location and must not move when env.Loc's pointee
+		// does.  Same reasoning as ErrorAssociate below (issue #366).
+		Source: env.Loc.Copy(),
 		Str:    condition,
 		Native: env.Runtime.Stack.Copy(),
 		Cells:  cells,
@@ -857,7 +860,8 @@ func (env *LEnv) Errorf(format string, v ...interface{}) *LVal {
 // with a copy env.Runtime.Stack.
 func (env *LEnv) ErrorConditionf(condition string, format string, v ...interface{}) *LVal {
 	lerr := &LVal{
-		Source: env.Loc,
+		// Copied, not aliased -- see ErrorAssociate (issue #366).
+		Source: env.Loc.Copy(),
 		Type:   LError,
 		Str:    condition,
 		Native: env.Runtime.Stack.Copy(),
@@ -886,8 +890,20 @@ func (env *LEnv) ErrorAssociate(lerr *LVal) *LVal {
 	// file and has an invalid position (-1).  When associating an error
 	// the env's current location is probably more accurate than native
 	// source (or it may also be native source).
+	//
+	// The location is COPIED rather than aliased (issue #366).  env.Loc
+	// is a pointer the evaluator keeps rebinding, and it points either
+	// at an AST node's Source or -- when the node was built by Go
+	// rather than parsed -- at the process-wide nativeSource singleton
+	// (issue #362).  Storing the pointer leaves the raised error and
+	// the still-running evaluator sharing one Location, so a later
+	// in-place write through either retroactively moves the position an
+	// already-reported error blames, and the damage surfaces nowhere
+	// near the write.  Copy preserves nil, so a nil env.Loc still
+	// yields a nil Source and the `Source == nil` convention on the
+	// line above is unchanged.
 	if lerr.Source == nil || lerr.Source.Pos < 0 {
-		lerr.Source = env.Loc
+		lerr.Source = env.Loc.Copy()
 	}
 	return nil
 }

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -1568,13 +1568,58 @@ func makeByteSeq(v *LVal) *LVal {
 	}
 }
 
-var defaultSourceLocation = &token.Location{
-	File: "<native code>",
-	Pos:  -1,
-}
+// defaultSourceLocation is the single, process-wide Location stamped onto
+// every natively-constructed LVal.  It is a shared mutable singleton in the
+// same family as singletonNil/singletonTrue/singletonFalse, and like them it
+// is covered by SingletonSnapshot: TakeSingletonSnapshot records its bit
+// pattern and Verify names it as "nativeSource()" when it drifts.  Before
+// issue #362 nothing watched it at all, so a stray `v.Source.Pos = 7` on a
+// value from lisp.Int corrupted every value in the process and surfaced as a
+// mysterious failure in an unrelated test.
+//
+// It is initialised from token.NativeLocation, which is the one definition of
+// what "<native code>" means.
+var defaultSourceLocation = func() *token.Location {
+	loc := token.NativeLocation()
+	return &loc
+}()
 
+// nativeSource returns the shared Location for values constructed by Go code
+// rather than read from a source stream.
+//
+// THE RETURNED POINTER IS SHARED BY EVERY NATIVELY-CONSTRUCTED LVal IN THE
+// PROCESS AND MUST BE TREATED AS READ-ONLY.  A write through it -- including
+// a write to a single field of an LVal's Source -- corrupts the reported
+// position of every such value at once (issue #362).  Code that needs a
+// Location it may write to must take its own copy:
+//
+//	loc := token.NativeLocation()
+//	v.Source = &loc
+//
+// The sharing is deliberate, and measured.  Handing out a fresh Location per
+// call adds a heap allocation to every LVal Go builds: interleaved n=12
+// against this tree it costs +18.6% sec/op and +20.2% allocs/op geomean on
+// the lisp benchmarks, and +56% sec/op on EnvFunCallBuiltin.  (Issue #362
+// records an independent measurement, +22.9%/+48.3%.)  A fifth of
+// interpreter throughput is too much to pay for a latent trap, so the hazard
+// is bounded from both ends instead:
+//
+//   - the PARSER never leaves this pointer in an AST it produces, which is
+//     the channel by which it reached user-reachable trees -- see
+//     TestParserDoesNotAliasSharedNativeLocation in parser/rdparser; and
+//   - SingletonSnapshot records this Location's bit pattern, so a write
+//     through it is named ("nativeSource()") at the next singleton check
+//     rather than surfacing later in an unrelated test.
+//
+// Neither bound reaches an EMBEDDER that builds an LVal tree through the Go
+// API: its nodes carry this pointer by construction, and a walker of its own
+// that stamps positions corrupts the singleton for the whole process.  Only
+// making Source immutable closes that, which is:
+//
 // TODO(elps2): make the LVal.Source "immutable" (possibly an interface or a
 // string) so it won't matter that nativeSource returns a shared reference.
+// That is an API break for every embedder reading v.Source and is tracked on
+// issue #362; the guard and the parser fix above stand in for it until then.
 func nativeSource() *token.Location {
 	return defaultSourceLocation
 }

--- a/lisp/lisplib/fuzz_test.go
+++ b/lisp/lisplib/fuzz_test.go
@@ -524,6 +524,14 @@ func newStdlibEnv(tb fuzzT, configs ...lisp.Config) *lisp.LEnv {
 	return env
 }
 
+// sharedNativeLocation is the single process-wide Location that
+// lisp.nativeSource stamps on every Go-constructed LVal (it is package lisp's
+// unexported defaultSourceLocation, and a constructed value is the only handle
+// on it from out here). Writing through it corrupts the reported position of
+// every such value in the process -- issue #362 -- so the corruption cases
+// below identify it in order to leave it alone.
+var sharedNativeLocation = lisp.Symbol("shared-native-location-probe").Source
+
 // TestArgumentGuardIsWiredIn is the negative control for assertion 4a, in the
 // same spirit as TestInternalPanicMarkerIsNotForgeable in lisp/eval_fuzz_test.go:
 // it installs a builtin that commits each defect the guard claims to catch and
@@ -574,14 +582,27 @@ func TestArgumentGuardIsWiredIn(t *testing.T) {
 		// Source by POINTER, so this is invisible to the singleton check that
 		// was previously the only thing guarding an argument at all.
 		//
-		// This leaves internal/fuzzval's location pool perturbed for the rest
-		// of the test binary, which is harmless and unavoidable: undoing it is
-		// what would make the case vacuous, and nothing in this package reads
-		// a generated value's line number.
+		// It edits one of internal/fuzzval's pooled Locations, which several
+		// values in a generated tree share -- that is the sharing this case is
+		// about, and leaving it perturbed is harmless: nothing in this package
+		// reads a generated value's line number.
+		//
+		// It must NOT edit the process-wide "<native code>" Location that
+		// lisp.nativeSource stamps on every Go-constructed value, lisp.Nil()
+		// among them. That one is not "shared by many values in a tree", it is
+		// shared by every value in the process, and corrupting it poisons the
+		// rest of the test binary -- the exact trap issue #362 is filed about,
+		// and the exact way internal/fuzzfp's "shared synthetic edited in
+		// place" case broke an unrelated test before #356 gave it a location
+		// of its own. Since #362 the singleton snapshot covers it, so under
+		// `make test-elpscheck` the corruption panics here instead of
+		// surfacing somewhere unrelated. Skipping it costs the case nothing:
+		// fuzzval stamps every generated value with a pooled Location, so the
+		// seeds that exercise this guard still do.
 		name: "corrupt-shared-location",
 		fn: func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 			for _, a := range args.Cells {
-				if a.Source != nil {
+				if a.Source != nil && a.Source != sharedNativeLocation {
 					a.Source.Line++
 					return lisp.Nil()
 				}

--- a/lisp/location_alias_test.go
+++ b/lisp/location_alias_test.go
@@ -1,0 +1,171 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// A *token.Location is a mutable object, and until issues #362 and #366 the
+// interpreter handed the same one to several owners at once.  The tests here
+// pin the two ends of that: an error must not share a Location with the
+// evaluator that raised it (#366), and the process-wide "<native code>"
+// Location must be watched by the singleton guard (#362).
+
+// TestErrorAssociateCopiesLocation is the regression test for issue #366.
+//
+// ErrorAssociate used to store env.Loc by reference.  env.Loc is a pointer
+// the evaluator rebinds on every eval step, and it points at an AST node's
+// Source -- or, for a natively constructed node, at the process-wide
+// nativeSource singleton.  Storing the pointer left an already-raised error
+// and the still-running evaluator sharing one Location, so an in-place write
+// through either silently moved the position the error had already reported.
+func TestErrorAssociateCopiesLocation(t *testing.T) {
+	t.Parallel()
+	env := initSafetyTestEnv(t)
+
+	loc := &token.Location{File: "err.lisp", Path: "/tmp/err.lisp", Pos: 10, Line: 3, Col: 4}
+	env.Loc = loc
+
+	lerr := &LVal{Type: LError, Str: "test-error", Cells: []*LVal{String("boom")}}
+	if res := env.ErrorAssociate(lerr); res != nil {
+		t.Fatalf("ErrorAssociate failed: %v", res)
+	}
+
+	// 1. The error's location is pointer-independent of env.Loc.
+	if lerr.Source == nil {
+		t.Fatal("ErrorAssociate did not stamp a source location")
+	}
+	if lerr.Source == loc {
+		t.Error("the error's Source aliases env.Loc; ErrorAssociate must store a copy (#366)")
+	}
+	if *lerr.Source != *loc {
+		t.Errorf("the copied location differs from env.Loc: got %+v, want %+v", *lerr.Source, *loc)
+	}
+
+	// 2. Mutating env.Loc in place afterwards does not move the position the
+	//    error already recorded.  This is the failure the aliasing produced:
+	//    a position that changes after the fact, at a point unrelated to the
+	//    write.
+	before := lerr.Source.String()
+	loc.Line = 99
+	loc.Col = 42
+	loc.Pos = 1234
+	if got := lerr.Source.String(); got != before {
+		t.Errorf("an in-place write through env.Loc moved the error's reported position: %s -> %s (#366)", before, got)
+	}
+
+	// 3. A nil env.Loc still yields a nil Source: the copy preserves nil, so
+	//    the `Source == nil` convention ErrorAssociate itself tests for is
+	//    unchanged.
+	env.Loc = nil
+	nilErr := &LVal{Type: LError, Str: "test-error", Cells: []*LVal{String("boom")}}
+	if res := env.ErrorAssociate(nilErr); res != nil {
+		t.Fatalf("ErrorAssociate failed: %v", res)
+	}
+	if nilErr.Source != nil {
+		t.Errorf("a nil env.Loc must leave Source nil, got %+v", nilErr.Source)
+	}
+}
+
+// TestErrorConstructorsCopyLocation covers the two sibling sites found by the
+// audit for #366: ErrorCondition and ErrorConditionf built their LError with
+// `Source: env.Loc`, the same aliasing statement ErrorAssociate had.  Fixing
+// only ErrorAssociate would have left every error raised by Errorf aliased.
+func TestErrorConstructorsCopyLocation(t *testing.T) {
+	t.Parallel()
+	env := initSafetyTestEnv(t)
+
+	loc := &token.Location{File: "err.lisp", Pos: 10, Line: 3, Col: 4}
+	env.Loc = loc
+
+	for _, test := range []struct {
+		name string
+		fn   func() *LVal
+	}{
+		{"Errorf", func() *LVal { return env.Errorf("boom") }},
+		{"ErrorConditionf", func() *LVal { return env.ErrorConditionf("test-error", "boom") }},
+		{"ErrorCondition", func() *LVal { return env.ErrorCondition("test-error", "boom") }},
+	} {
+		lerr := test.fn()
+		if lerr.Type != LError {
+			t.Fatalf("%s: expected an error value, got %v", test.name, lerr.Type)
+		}
+		if lerr.Source == nil {
+			t.Fatalf("%s: expected a source location", test.name)
+		}
+		if lerr.Source == loc {
+			t.Errorf("%s: the error's Source aliases env.Loc (#366)", test.name)
+		}
+		if *lerr.Source != *loc {
+			t.Errorf("%s: copied location differs: got %+v, want %+v", test.name, *lerr.Source, *loc)
+		}
+	}
+
+	// A nil env.Loc is preserved rather than materialised into a zero
+	// Location, which would print as ":0:0" instead of being omitted.
+	env.Loc = nil
+	if lerr := env.Errorf("boom"); lerr.Source != nil {
+		t.Errorf("a nil env.Loc must leave Source nil, got %+v", lerr.Source)
+	}
+}
+
+// TestSingletonSnapshotDetectsNativeLocationDrift is the guard added for
+// issue #362.  defaultSourceLocation is a fourth shared mutable singleton
+// alongside the three singleton LVals, and TakeSingletonSnapshot did not
+// cover it: a stray `v.Source.Pos = 7` on a value from lisp.Int corrupted
+// every value in the process and Verify reported nothing, so the failure
+// landed later, elsewhere, in whatever test happened to read a position.
+//
+// This does not stop the write.  It converts it from action at a distance
+// into a named offender at the next singleton check.
+func TestSingletonSnapshotDetectsNativeLocationDrift(t *testing.T) {
+	// This test writes to a shared singleton on purpose.  Pause the write
+	// watchdog so the deliberate mutation is ordered against its reads and
+	// does not surface as a data race under `make race`.
+	defer pauseSingletonWatchdog()()
+
+	orig := *defaultSourceLocation
+	defer func() { *defaultSourceLocation = orig }()
+
+	snap := TakeSingletonSnapshot()
+	if drift := snap.Verify(); drift != "" {
+		t.Fatalf("fresh snapshot should match current state, got drift %q", drift)
+	}
+
+	// Exactly the write from the issue: reach a shared Location through a
+	// value a constructor handed out, and edit it in place.
+	v := Int(1)
+	v.Source.Pos = 7
+
+	if drift := snap.Verify(); drift != "nativeSource()" {
+		t.Errorf("Verify() = %q, want %q: a write through a constructed value's Source must be named (#362)", drift, "nativeSource()")
+	}
+
+	*defaultSourceLocation = orig
+	if drift := snap.Verify(); drift != "" {
+		t.Errorf("after restore Verify() = %q, want empty", drift)
+	}
+}
+
+// TestNativeLocationIsValueTyped pins the shape that makes the fix hold:
+// token.NativeLocation returns a VALUE, so a caller that needs a Location it
+// may write to cannot accidentally get the shared one.
+func TestNativeLocationIsValueTyped(t *testing.T) {
+	t.Parallel()
+
+	a := token.NativeLocation()
+	b := token.NativeLocation()
+	if a != b {
+		t.Errorf("NativeLocation is not stable: %+v vs %+v", a, b)
+	}
+	if a != *defaultSourceLocation {
+		t.Errorf("the shared native location has drifted from token.NativeLocation: %+v vs %+v", *defaultSourceLocation, a)
+	}
+	a.Pos = 7
+	if b.Pos == 7 || defaultSourceLocation.Pos == 7 {
+		t.Error("writing to a NativeLocation value must not reach any other copy")
+	}
+}

--- a/lisp/singleton.go
+++ b/lisp/singleton.go
@@ -4,6 +4,8 @@ package lisp
 
 import (
 	"fmt"
+
+	"github.com/luthersystems/elps/parser/token"
 )
 
 // Singleton LVals for Nil, true, and false.
@@ -55,22 +57,34 @@ func assertNotSingleton(v *LVal) {
 }
 
 // SingletonSnapshot captures the current bit pattern of the three
-// singleton LVals. It is used by test infrastructure to detect
-// inadvertent mutations to shared singletons — see TestMain in lisp_
-// and the per-test guard in elpstest.Runner.
+// singleton LVals and of the shared native source Location. It is used
+// by test infrastructure to detect inadvertent mutations to shared
+// singletons — see TestMain in lisp_ and the per-test guard in
+// elpstest.Runner.
 type SingletonSnapshot struct {
 	nilV   LVal
 	trueV  LVal
 	falseV LVal
+
+	// nativeLoc is the pointee of defaultSourceLocation — the Location
+	// nativeSource hands to every natively-constructed LVal. It is a
+	// fourth shared mutable singleton, and it is the one this snapshot
+	// used not to cover (issue #362). The three LVal fields above
+	// record the Source POINTER, so they catch a singleton being
+	// re-pointed but never a write THROUGH the pointer all three (and
+	// every value from lisp.Int, lisp.Symbol, ...) share.
+	nativeLoc token.Location
 }
 
 // TakeSingletonSnapshot captures the current state of the three
-// singleton LVals so callers can later verify they were not mutated.
+// singleton LVals, and of the shared native source Location, so callers
+// can later verify they were not mutated.
 func TakeSingletonSnapshot() SingletonSnapshot {
 	return SingletonSnapshot{
-		nilV:   *singletonNil,
-		trueV:  *singletonTrue,
-		falseV: *singletonFalse,
+		nilV:      *singletonNil,
+		trueV:     *singletonTrue,
+		falseV:    *singletonFalse,
+		nativeLoc: *defaultSourceLocation,
 	}
 }
 
@@ -93,6 +107,9 @@ func (s SingletonSnapshot) Verify() string {
 	}
 	if !singletonLValEqual(&s.falseV, singletonFalse) {
 		return "Bool(false)"
+	}
+	if s.nativeLoc != *defaultSourceLocation {
+		return "nativeSource()"
 	}
 	return ""
 }

--- a/parser/rdparser/location_alias_test.go
+++ b/parser/rdparser/location_alias_test.go
@@ -1,0 +1,150 @@
+// Copyright © 2026 The ELPS authors
+
+package rdparser_test
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/rdparser"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// sharedNativeLocation returns the exact *token.Location that lisp's
+// nativeSource hands to every natively-constructed LVal.  It is package
+// lisp's unexported defaultSourceLocation; a constructed value is the only
+// handle on it from outside the package, and it is the object issue #362 is
+// about.
+func sharedNativeLocation() *token.Location {
+	return lisp.Symbol("probe").Source
+}
+
+// walkLVal visits v and every node beneath it.
+func walkLVal(v *lisp.LVal, fn func(*lisp.LVal)) {
+	if v == nil {
+		return
+	}
+	fn(v)
+	for _, c := range v.Cells {
+		walkLVal(c, fn)
+	}
+}
+
+func parseAll(t *testing.T, src string) []*lisp.LVal {
+	t.Helper()
+	exprs, err := rdparser.New(token.NewScanner("test", bytes.NewReader([]byte(src)))).ParseProgram()
+	require.NoError(t, err, "parsing %q", src)
+	return exprs
+}
+
+// funRefSources are the sources exercised by the tests below.  #' is the one
+// that mattered -- ParseFunRef synthesized its head symbol with lisp.Symbol
+// and never re-stamped it -- but the invariant is stated over the whole
+// grammar so a future synthesized node cannot reintroduce the leak quietly.
+var funRefSources = []string{
+	"#'car",
+	"#'+",
+	"(map 'list #'car '((1 2) (3 4)))",
+	"'a",
+	"'()",
+	"'(a b c)",
+	"(quote x)",
+	"#^a",
+	"(defun f (x) (#'g x))",
+	"1",
+	"\"s\"",
+	"()",
+}
+
+// TestParserDoesNotAliasSharedNativeLocation is the regression test for issue
+// #362's concrete instance.
+//
+// Parsing "#'car" produced an AST whose head symbol (lisp:function) held a
+// pointer to the process-wide "<native code>" Location.  Nothing writes
+// through it in-tree today, which is why the issue calls it a latent trap
+// rather than a live defect -- but the pointer is reachable from any AST
+// walk, and a walker that stamps positions while descending corrupts the
+// reported position of every natively-constructed value in the process, with
+// the damage surfacing nowhere near the write.
+func TestParserDoesNotAliasSharedNativeLocation(t *testing.T) {
+	t.Parallel()
+	shared := sharedNativeLocation()
+	require.NotNil(t, shared, "expected constructed values to carry a native source location")
+
+	for _, src := range funRefSources {
+		for _, expr := range parseAll(t, src) {
+			walkLVal(expr, func(v *lisp.LVal) {
+				if v.Source == shared {
+					t.Errorf("parsing %q produced node %v %q holding the shared process-wide native Location; a parsed AST must not alias it (#362)",
+						src, v.Type, v.Str)
+				}
+			})
+		}
+	}
+}
+
+// TestFunRefHeadLocationIsPrivate demonstrates the consequence directly, and
+// without the race detector: editing one parse's location must not be visible
+// to an unrelated parse or to an unrelated constructed value.
+func TestFunRefHeadLocationIsPrivate(t *testing.T) {
+	t.Parallel()
+
+	first := parseAll(t, "#'car")[0]
+	second := parseAll(t, "#'cdr")[0]
+
+	firstHead := first.Cells[0]
+	secondHead := second.Cells[0]
+	require.Equal(t, "lisp:function", firstHead.Str)
+	require.Equal(t, "lisp:function", secondHead.Str)
+
+	witness := lisp.Int(1)
+	witnessPos := witness.Source.Pos
+	secondPos := secondHead.Source.Pos
+
+	// The kind of write a position-stamping AST walker makes.
+	firstHead.Source.Pos = 7
+
+	require.Equal(t, secondPos, secondHead.Source.Pos,
+		"editing one parsed #' form's location moved another parse's location (#362)")
+	require.Equal(t, witnessPos, witness.Source.Pos,
+		"editing a parsed #' form's location moved the location of an unrelated constructed value (#362)")
+}
+
+// TestFunRefHeadLocationRace is the -race half.  Two goroutines parse their
+// own program and stamp their own AST -- no shared state by construction --
+// so under `go test -race` this is silent unless the two ASTs are handed the
+// same Location, which is what sharing the process-wide singleton did.
+func TestFunRefHeadLocationRace(t *testing.T) {
+	t.Parallel()
+
+	// Parse on the test goroutine -- parsing is not what is under test here,
+	// and require.* may only be called from the goroutine running the test.
+	const n = 8
+	exprs := make([]*lisp.LVal, n)
+	for i := range exprs {
+		exprs[i] = parseAll(t, "#'car")[0]
+	}
+
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+	for i := range n {
+		done.Add(1)
+		go func(i int) {
+			defer done.Done()
+			start.Wait()
+			walkLVal(exprs[i], func(v *lisp.LVal) {
+				if v.Source != nil {
+					v.Source.Pos = i
+					v.Source.Line = i
+				}
+			})
+		}(i)
+	}
+	start.Done()
+	done.Wait()
+}

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -371,6 +371,18 @@ func (p *Parser) ParseUnbound() *lisp.LVal {
 
 func (p *Parser) ParseFunRef() *lisp.LVal {
 	op := lisp.Symbol("lisp:function")
+	// The synthesized head symbol has no token of its own, so it keeps the
+	// "<native code>" location every Go-constructed LVal is stamped with.
+	// lisp.Symbol stamps the process-wide SHARED instance of that location
+	// though, and unlike ParseUnbound's "lisp:expr" head (which is re-stamped
+	// from expr.Source below) nothing here replaces it -- so every parsed #'
+	// form used to leave a node holding a pointer to process-global mutable
+	// state inside a user-reachable AST.  Any walker that stamps positions
+	// while descending then corrupts the location of every natively
+	// constructed value in the process (issue #362).  Give the node a
+	// location it owns; the reported position is unchanged.
+	opLoc := token.NativeLocation()
+	op.Source = &opLoc
 	if !p.Accept(token.FUN_REF) {
 		return p.errorf("parse-error", "invalid quote: %v", p.PeekType())
 	}

--- a/parser/token/location_test.go
+++ b/parser/token/location_test.go
@@ -1,0 +1,70 @@
+// Copyright © 2026 The ELPS authors
+
+package token
+
+import "testing"
+
+// TestNativeLocationReturnsAValue pins the property that makes it safe to
+// call from anywhere: NativeLocation returns a Location, not a *Location, so
+// no two callers can end up writing through one object (issues #362, #366).
+func TestNativeLocationReturnsAValue(t *testing.T) {
+	a := NativeLocation()
+	b := NativeLocation()
+	if a != b {
+		t.Fatalf("NativeLocation is not stable: %+v vs %+v", a, b)
+	}
+	if a.File != NativeFile {
+		t.Errorf("File = %q, want %q", a.File, NativeFile)
+	}
+	if a.Pos != -1 {
+		t.Errorf("Pos = %d, want -1: a negative Pos is how the tree spells \"no real position\"", a.Pos)
+	}
+	if got, want := a.String(), NativeFile; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+
+	a.Pos = 7
+	if b.Pos == 7 {
+		t.Error("writing to one NativeLocation value reached another")
+	}
+	if NativeLocation().Pos == 7 {
+		t.Error("writing to a NativeLocation value reached the next call's result")
+	}
+}
+
+func TestLocationCopy(t *testing.T) {
+	orig := &Location{
+		File: "f.lisp", Path: "/tmp/f.lisp",
+		Pos: 1, Line: 2, Col: 3, EndPos: 4, EndLine: 5, EndCol: 6,
+	}
+
+	cp := orig.Copy()
+	if cp == orig {
+		t.Fatal("Copy returned the same pointer")
+	}
+	if *cp != *orig {
+		t.Errorf("Copy changed the value: got %+v, want %+v", *cp, *orig)
+	}
+
+	// Independent in both directions.
+	cp.Line = 99
+	if orig.Line == 99 {
+		t.Error("a write to the copy reached the original")
+	}
+	orig.Col = 42
+	if cp.Col == 42 {
+		t.Error("a write to the original reached the copy")
+	}
+}
+
+// TestLocationCopyPreservesNil pins the nil convention.  A nil Source means
+// "no position recorded" throughout the tree and is checked for explicitly
+// (lisp.LEnv.ErrorAssociate, every lsp/ and analysis/ walker); materialising
+// nil into a zero Location would turn those checks into false positives and
+// print positions as ":0:0".
+func TestLocationCopyPreservesNil(t *testing.T) {
+	var loc *Location
+	if got := loc.Copy(); got != nil {
+		t.Errorf("(*Location)(nil).Copy() = %+v, want nil", got)
+	}
+}

--- a/parser/token/token.go
+++ b/parser/token/token.go
@@ -119,6 +119,50 @@ func (loc *Location) String() string {
 	}
 }
 
+// NativeFile is the File reported by a Location that does not come from a
+// source stream -- a value constructed by Go code rather than read from a
+// file.  Paired with Pos == -1, which is what Location.String and the
+// "is this a real position?" checks throughout the tree test for.
+const NativeFile = "<native code>"
+
+// NativeLocation returns the Location describing code that has no source
+// stream: values constructed by Go rather than read by the parser.
+//
+// It returns a VALUE, deliberately, and it is the only definition of that
+// location in the tree.  A function handing out a *Location here would hand
+// every caller a pointer into shared state that any one of them could write
+// through, which is issue #362 -- and lisp.nativeSource is exactly that
+// function.  Callers that need a *Location for a node they own take the
+// address of their own copy:
+//
+//	loc := token.NativeLocation()
+//	v.Source = &loc
+func NativeLocation() Location {
+	return Location{
+		File: NativeFile,
+		Pos:  -1,
+	}
+}
+
+// Copy returns a pointer to an independent copy of loc, or nil if loc is nil.
+//
+// Location holds no reference-typed fields, so the shallow copy is fully
+// independent: a later write through either pointer is invisible to the
+// other.  Nil is preserved rather than materialised into a zero Location
+// because a nil Source is meaningful throughout the tree ("no position
+// recorded") and distinct from a zero one ("position 0").
+//
+// Use it at every point where a Location owned by one object is stored into
+// another that outlives, or is mutated independently of, the first --
+// see issues #362 and #366.
+func (loc *Location) Copy() *Location {
+	if loc == nil {
+		return nil
+	}
+	cp := *loc
+	return &cp
+}
+
 // TokenEnd computes the end position of a token from its start position
 // and text. The end column is exclusive (one past the last character).
 // For multi-line tokens (e.g., raw strings), the line and column are


### PR DESCRIPTION
Fixes #362
Fixes #366

Two reported instances of one shape: a `*token.Location` owned by one object is stored into another that outlives it, so an in-place write through either retroactively moves a position the other already reported — and the damage surfaces nowhere near the write.

> **Read this first — scope changed after #419 landed.** This branch was opened against `ab0686d`. While it was open, PR #419 (issue #370) landed and independently fixed the parser half of #362, from a different direction and better than this branch had. **That fix is `main`'s, not this PR's**, and the conflicting hunk here was dropped in its favour — `parser/rdparser/parser.go` is now byte-identical to `main`. The three parser tests are kept and relabelled as guards. Details in "What #419 already covered" below.
>
> What is still this PR's: the `env.Loc` copies for #366, `token.NativeLocation()`, `(*Location).Copy()`, the `SingletonSnapshot` coverage of `defaultSourceLocation` for #362, and the `lisp/lisplib` fuzz-control fix that coverage caught.

## What #419 already covered

#419 was chasing `lisp.stampMacroExpansion` writing into a caller's parse tree. The stamp rewrites any `Source` that is nil or has `Pos < 0`; the synthesized heads behind `#'` and `#^` carried `nativeSource()`, so the walk reached parser output — and because macro arguments arrive unevaluated as the caller's own nodes, it wrote into a tree shared across evaluations and across the per-request environments an embedder derives from one registry.

This branch reached the same line of the reader from the other side: that head is a node in a user-reachable AST holding a pointer to process-global mutable state (#362). Two issues, two routes, one defect.

#419's fix is strictly better and is the one that shipped. `rdparser.locateSynthesized` hands the head **the prefix token's own real `*Location`**. Both fixes remove the pointer to the singleton; #419's also stops `#'g` reporting itself as `<native code>`, and reuses a `Location` the scanner had already allocated instead of allocating a private copy of the native one. So the hunk here was dropped, not merged.

**Verified rather than assumed.** Against `751e61e` with only this branch's test file added and no source change, all three parser tests pass:

```
--- PASS: TestParserDoesNotAliasSharedNativeLocation (0.00s)
--- PASS: TestFunRefHeadLocationIsPrivate (0.00s)
--- PASS: TestFunRefHeadLocationRace (0.00s)     [under -race]
```

They are therefore **guards, not catches**, and their doc comments now say so. They stay because the two issues bound different properties and #419's fix is not obliged to keep satisfying both: #370 pins *the reader emits no SYNTHETIC location*, this pins *the reader emits no pointer to the SHARED one*. A future synthesized node given a private `nativeSource` copy would satisfy the first and fail the second.

For the record, here is what they reported before #419 (i.e. the state this branch was opened against, `ab0686d`) — the finding was real, it is simply no longer this PR that fixes it:

```
--- FAIL: TestParserDoesNotAliasSharedNativeLocation
    parsing "#'car" produced node symbol "lisp:function" holding the shared process-wide native Location
    (also "#'+", "(map 'list #'car ...)", "(defun f (x) (#'g x))")
--- FAIL: TestFunRefHeadLocationIsPrivate
    expected: -1  actual: 7 — editing one parsed #' form's location moved another parse's location

WARNING: DATA RACE
Write at 0x000000c414e0 by goroutine 11 ... Previous write at 0x000000c414e0 by goroutine 17
```

`0x000000c414e0` is a data-segment address: `defaultSourceLocation`, reached from two ASTs that share nothing else.

## Red, then green — what this PR still fixes

**#366 — `ErrorAssociate` stores `env.Loc` by reference.** `lisp/location_alias_test.go`, against unmodified `main`:

```
--- FAIL: TestErrorAssociateCopiesLocation
    location_alias_test.go:42: the error's Source aliases env.Loc; ErrorAssociate must store a copy (#366)
    location_alias_test.go:57: an in-place write through env.Loc moved the error's reported position: err.lisp:3:4 -> err.lisp:99:42 (#366)
--- FAIL: TestErrorConstructorsCopyLocation
    location_alias_test.go:100: Errorf: the error's Source aliases env.Loc (#366)
    location_alias_test.go:100: ErrorConditionf: the error's Source aliases env.Loc (#366)
    location_alias_test.go:100: ErrorCondition: the error's Source aliases env.Loc (#366)
```

The second failure is the audit's find: `ErrorCondition` and `ErrorConditionf` carry the identical `Source: env.Loc` statement. Fixing only `ErrorAssociate` would have left every error raised through `Errorf` aliased, which is most of them. Still red on `751e61e`; #419 does not touch this.

**#362 — the guard.** `TestSingletonSnapshotDetectsNativeLocationDrift` performs the exact write from the issue (`Int(1).Source.Pos = 7`) and asks the guard who did it:

```
--- FAIL: TestSingletonSnapshotDetectsNativeLocationDrift
    Verify() = "", want "nativeSource()": a write through a constructed value's Source must be named (#362)
```

Also a **guard, not a catch**: it makes a future write nameable, it does not prevent it. Counted as such. This is option (1) from #362's own body, which the issue recommends "now regardless" of which larger fix is eventually chosen.

### The guard immediately caught a live instance

This is the whole argument for adding it. With the snapshot extended, `make test-elpscheck` failed:

```
--- FAIL: TestArgumentGuardIsWiredIn/corrupt-shared-location
panic: singleton corruption detected: nativeSource() mutated
    lisp/lisplib/fuzz_test.go:617
```

That control takes the first argument with a non-nil `Source` and does `a.Source.Line++`. Usually that is one of `internal/fuzzval`'s pooled Locations — the sharing the case is about. Sometimes it is `lisp.Nil()`, whose `Source` is the process-wide singleton, and then the case corrupts the reported position of every Go-constructed value for the remainder of the test binary. Its own comment called that "harmless and unavoidable". It is neither: it is the trap #362 is filed about, and it is exactly how `internal/fuzzfp`'s "shared synthetic edited in place" case broke an unrelated test before #356 gave that case a location of its own.

Same remedy: skip the shared native Location, corrupt a pooled one. The control is not weakened — it still reports on **41 of 140 seeds**, unchanged.

## The fix

- `token.NativeLocation()` — the single definition of the native-code location (File reads "native code" in angle brackets, Pos -1), returning a **value** so no caller can accidentally take the shared one. `token.NativeFile` names the string.
- `(*Location).Copy()` — nil-preserving. Nil is meaningful throughout the tree ("no position recorded") and is distinct from a zero `Location`; materialising it would turn `Source == nil` checks into false positives and print `:0:0`.
- `ErrorAssociate`, `ErrorCondition`, `ErrorConditionf` store `env.Loc.Copy()`.
- `SingletonSnapshot` gains the pointee of `defaultSourceLocation`; `Verify` returns `"nativeSource()"`. The three `LVal` fields recorded the Source *pointer*, so they caught a singleton being re-pointed but never a write *through* the pointer all three share. Because `checkSingleton` and the `-race` write watchdog both go through `TakeSingletonSnapshot`, they inherit the coverage for free — which is how the lisplib case surfaced.
- `lisp/lisplib/fuzz_test.go` — the control above stops corrupting the process-wide Location.

## Neighbourhood audit

Every producer of a `*token.Location` and every field that stores one, and what was done about it.

### Changed

| Site | Why |
|---|---|
| `lisp/env.go` `ErrorAssociate`, `ErrorCondition`, `ErrorConditionf` | Errors escape to the caller and hold the location past the eval step that set it. Copy cost is noise beside the `Stack.Copy()` these already do. |
| `lisp/lisplib/fuzz_test.go` `corrupt-shared-location` | Test-only. Corrupted the process-wide singleton for the rest of the binary; now corrupts a pooled Location instead. |

### Fixed on main by #419, not here

`parser/rdparser` `ParseFunRef` / `ParseUnbound`. Was the only in-tree producer leaving the process-wide singleton inside a parsed AST; `locateSynthesized` closed it. Tests kept as guards.

### Not changed, deliberately

**`nativeSource()` still returns the shared pointer.** Confirmed rather than assumed: a fourth arm allocating a fresh `Location` per call, interleaved n=12, costs **+18.6% sec/op and +20.2% allocs/op geomean** on the `lisp` benchmarks — `EnvFunCallBuiltin` +56.4% sec/op / +62.4% allocs/op, `MacroDefun` +32.5%, `Equal/nested` +65.2%. That corroborates the +22.9%/+48.3% recorded on the issue. The real fix is the API break (unexport `Source`, add accessors) that #362's own comment settled on and deliberately sequenced after the v1.50.0 set; this PR bounds the hazard instead and leaves that TODO in place, now with the measurement attached.

**Embedders building an LVal tree through the Go API are not covered, and this PR does not pretend otherwise.** Probed: evaluate a natively-constructed `(defun probe-fn (x) x)` and four nodes of the resulting function still hold the shared pointer — via `LEnv.Lambda`'s `Source: env.Loc` and `stampGuarded`'s `v.Source = callSite`, both fed by `env.Loc = v.Source` where `v` was built by `lisp.SExpr`/`lisp.Symbol`. The pointer comes from *construction*, so nothing short of making `Source` immutable removes it. A one-line change giving the root env its own `Location` was written, measured against this probe, found to change nothing (the evaluator re-points `env.Loc` at the node's own `Source` immediately), and reverted rather than shipped as a fix that isn't one.

**`LEnv.Lambda` and `LEnv.TaggedValue` (`Source: env.Loc`).** Same aliasing shape, but these are not errors and, unlike the error constructors, they allocate nothing else — a copy here is a new allocation on a path that has none, per lambda and per tagged value. Subsumed by the immutability work. Left, reported.

**`CallFrame.Source` / `CallStack.Copy()`.** `PushFID(env.Loc, ...)` stores the pointer, and `Copy()` copies frames by value, so a copied stack still aliases every frame's `Location`. `PushFID` runs on every function call and `Copy()` on every error construction, so copying here is O(depth) allocations on two hot paths. Frame locations point at AST nodes that are not mutated after parse. Left, reported.

**`env.Loc = v.Source` (`env.go`, `op.go`, `macro.go`).** A read-only borrow for the duration of one eval step, on the hottest path in the interpreter — exactly the shape the +18.6% measurement rules out. The design this PR lands is: **borrow on the hot path, copy at the retention boundaries.** Everything that keeps `env.Loc` beyond the step now copies.

**`lint.bindingSource`, `analysis/perf.callSource`, `profiler.getSourceLoc`, `lisp.FunctionInfo.Source`.** All hand an AST node's `Location` to consumers that only format it. No writers. Copying would allocate on analysis paths for nothing.

**`token.Scanner.LocStart()` / `Loc()`.** Allocate a fresh `Location` per call. Already correct.

### Found twice, independently, and now getting its own ticket

`Parser.Location()` returns `p.src.Token.Source` uncopied, and `tokenLVal` both stores it on the LVal and writes `EndLine/EndCol/EndPos` through it, so two AST nodes built from the same token share one `Location` and `applyPrefixLocation` writes through the shared object:

```
"'a"     -> root 0xc0000f6410, symbol "a" 0xc0000f6410   (same object; "a" reports test:1:1, not 1:2)
"#^a"    -> all three nodes share 0xc0000f6960
"#'car"  -> root and "car" share 0xc0000f6640            ("car" reports 1:1, not 1:3)
"(quote x)" -> distinct locations; "x" correctly at 1:8
```

Copying in `tokenLVal` was implemented and run here: the suite passes except `TestMacros`, where a reported error position moves from `test:1:13` to `test:1:14` — a user-visible position change needing its own review and golden pass. #419's author found the same defect independently and reverted their fix for the same reason (it moves ranges the LSP pins). Two independent findings; it is getting its own issue rather than riding along in either PR.

## Benchmarks

Full two-tree interleaved comparison, `BENCH_COUNT=10`, the workflow's own `scripts/bench-run-arms.sh`. Allocation metrics flat everywhere:

```
lisp             B/op geomean -0.00%   allocs/op geomean -0.00%
libjson          B/op geomean -0.00%   allocs/op geomean -0.00%
parser/rdparser  B/op geomean +0.00%   allocs/op geomean +0.00%
```

Locally `scripts/benchstat-gate.sh` first reported two timing rows over gate — `AliasAppendVectorOnce` +22.28% (p=0.043) and `AliasStableSortSliceView` +33.12% (p=0.029) — on a contended 4-core box where sec/op variance ran to ±180%. Both have **byte-identical** `B/op` and `allocs/op`, and neither benchmark constructs an error, so there is no mechanism for a real move. Re-measured with a three-arm control (base / PR / a second checkout of base), n=20, quiet machine:

```
base vs base2 (identical code — the noise floor)
AliasAppendVectorOnce-4      3.929m ± 10%   3.842m ± 12%   ~ (p=0.862 n=20)
AliasStableSortSliceView-4   12.64m ±  8%   12.20m ±  7%   ~ (p=0.414 n=20)

base vs PR
AliasAppendVectorOnce-4      3.929m ± 10%   3.702m ±  5%   ~ (p=0.461 n=20)
AliasStableSortSliceView-4   12.64m ±  8%   12.76m ±  8%   ~ (p=0.445 n=20)
```

Both `~` against the PR, and the control behaves the same way. CI's Benchmark Comparison passed. No regression, and **no waiver added** — the gate was not weakened or worked around.

## Gates

All re-run on the merged tree: `go build ./...`, `go vet ./...`, `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `golangci-lint run ./...` (0 issues), `elps fmt -l ./...` (clean; binary deleted before committing), `elps doc -m`, `./scripts/ci-gates-test.sh` (210 passed, 0 failed), `./scripts/confidentiality-guard.sh` after `git add` (clean).

`make test-elpscheck` is the one that caught the lisplib case, and it is worth adding to the standard gate list — it is in the Makefile and in CI's `Lint & Test` job, but not in the checklist this work started from.
