### PR TITLE
Build the mcpserver workspace index with the macro expander its per-document analysis uses

### DIFF
--- a/analysis/expander.go
+++ b/analysis/expander.go
@@ -87,9 +87,11 @@ type EnvMacroExpander struct {
 	mu       sync.Mutex
 	notMacro map[string]bool // cache: symbols that are not macros in the env
 	// NOTE: notMacro assumes the env's macro set is stable for this
-	// expander's lifetime. If macros are added to the env after creation
-	// (e.g. LoadWorkspaceMacros), create a new EnvMacroExpander or call
-	// Reset() to clear the cache.
+	// expander's lifetime. If macros are added to the env after creation,
+	// create a new EnvMacroExpander or call Reset() to clear the cache.
+	// (*EnvMacroExpander).LoadWorkspaceMacros does both the loading and the
+	// invalidation, and is the safe way to add workspace macros to a live
+	// expander's env.
 
 	// aborted counts ExpandMacro calls that left the function without
 	// reaching the statement after expand() returned. Monotonic, and there
@@ -101,7 +103,9 @@ type EnvMacroExpander struct {
 }
 
 // Reset clears the not-a-macro cache. Call this after loading new macros
-// into the env (e.g. via LoadWorkspaceMacros) if the expander is reused.
+// into the env if the expander is reused. Prefer the expander's own
+// LoadWorkspaceMacros method, which loads and invalidates under one lock and
+// so cannot leave a window where the cache and the env disagree.
 //
 // Reset does NOT clear the abort count or the last recorded panic. Evidence
 // that host code crashed during analysis outlives a cache invalidation, and a
@@ -316,6 +320,34 @@ func (e *EnvMacroExpander) expand(form *lisp.LVal, pkg string) *lisp.LVal {
 	}
 
 	return mark.Cells[0]
+}
+
+// LoadWorkspaceMacros replays preamble forms into this expander's environment
+// while holding the same lock that serializes ExpandMacro, then clears the
+// not-a-macro cache.
+//
+// Prefer it to the package-level LoadWorkspaceMacros whenever the expander is
+// reachable from another goroutine. The package-level function evaluates the
+// preamble against the env directly, and an expansion running concurrently
+// reads and writes that very env — Runtime.Package, the call stack, the
+// package registry. ExpandMacro's mutex cannot help there: the loader never
+// asked for it. mcpserver reaches exactly that pairing, because one env backs
+// every workspace root it indexes, so replaying one root's preamble overlaps
+// with expanding macros for a document belonging to another (issue #403).
+//
+// Clearing the cache is why this is a method rather than a mutex taken at the
+// call site: the preamble defines macros, so any "not a macro" answer recorded
+// before it ran may now be wrong. Reset documents the same requirement; this
+// removes the chance to forget it.
+func (e *EnvMacroExpander) LoadWorkspaceMacros(preamble []*lisp.LVal) []error {
+	if e.Env == nil {
+		return nil
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	errs := LoadWorkspaceMacros(e.Env, preamble)
+	e.notMacro = nil
+	return errs
 }
 
 // LoadWorkspaceMacros replays workspace preamble forms (in-package,

--- a/analysis/expander_test.go
+++ b/analysis/expander_test.go
@@ -490,6 +490,45 @@ func TestLoadWorkspaceMacros_ErrorReturned(t *testing.T) {
 	require.NotEmpty(t, errs, "malformed defmacro should return an error")
 }
 
+// TestEnvMacroExpanderLoadWorkspaceMacros_ClearsNegativeCache pins the reason
+// the method exists rather than a mutex taken at the call site: a symbol
+// recorded as "not a macro" before the preamble ran is a macro after it, and a
+// stale negative would make the analyzer walk it opaquely forever.
+func TestEnvMacroExpanderLoadWorkspaceMacros_ClearsNegativeCache(t *testing.T) {
+	env := newTestEnv(t)
+	expander := &EnvMacroExpander{Env: env}
+
+	form := lisp.SExpr([]*lisp.LVal{
+		lisp.Symbol("my-unless"),
+		lisp.Symbol("flag"),
+	})
+
+	require.Nil(t, expander.ExpandMacro(form, lisp.DefaultUserPackage),
+		"my-unless is not defined yet")
+	require.True(t, expander.notMacro[lisp.DefaultUserPackage+"\x00my-unless"],
+		"the miss should have been cached")
+
+	preamble := parsePreamble(t,
+		`(defmacro my-unless (cond &rest body) (quasiquote (if (unquote cond) () (progn (unquote-splicing body)))))`)
+	require.Empty(t, expander.LoadWorkspaceMacros(preamble))
+	assert.Nil(t, expander.notMacro, "loading a preamble must invalidate the cache")
+
+	expanded := expander.ExpandMacro(form, lisp.DefaultUserPackage)
+	require.NotNil(t, expanded, "my-unless must expand once the preamble is loaded")
+	assert.Equal(t, "if", expanded.Cells[0].Str)
+}
+
+func TestEnvMacroExpanderLoadWorkspaceMacros_NilEnv(t *testing.T) {
+	expander := &EnvMacroExpander{}
+	assert.Nil(t, expander.LoadWorkspaceMacros(parsePreamble(t, `(defmacro m () '1)`)))
+}
+
+func TestEnvMacroExpanderLoadWorkspaceMacros_ReportsErrors(t *testing.T) {
+	expander := &EnvMacroExpander{Env: newTestEnv(t)}
+	assert.NotEmpty(t, expander.LoadWorkspaceMacros(parsePreamble(t, `(defmacro)`)),
+		"the method must surface preamble failures exactly as the package-level function does")
+}
+
 func TestLoadWorkspaceMacros_MultiplePackages(t *testing.T) {
 	// Macros in different packages via in-package switching.
 	env := newTestEnv(t)

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -56,8 +56,28 @@ type service struct {
 	linter          *lint.Linter
 	logger          *slog.Logger
 
+	// expander is the one analysis-time macro expander for env, shared by
+	// every workspace state. One env backs every root the server indexes, so
+	// per-state expanders would be several mutexes over one piece of mutable
+	// state: a document request served from a cached state could expand a
+	// macro while another root's index build replayed its preamble into the
+	// same env. Nil when env is nil.
+	expander *analysis.EnvMacroExpander
+
 	mu         sync.RWMutex
 	workspaces map[string]*workspaceState
+
+	// buildMu serializes buildWorkspaceState. The build is not pure: it
+	// replays workspace macros into s.env and, since issue #403, expands
+	// macros against s.env from ScanWorkspaceRefs' worker pool. A single
+	// EnvMacroExpander serializes its own expansions, but two builds running
+	// at once hold two expanders over one env and nothing serializes them
+	// against each other or against LoadWorkspaceMacros.
+	//
+	// Only cache misses take this lock — s.workspace serves a validated
+	// cached state without calling the build at all — so a concurrent request
+	// for an already-indexed root does not wait behind another root's scan.
+	buildMu sync.Mutex
 
 	buildWorkspaceStateHook     func(string)
 	workspaceFingerprintHook    func(string)
@@ -80,9 +100,14 @@ type document struct {
 }
 
 func newService(cfg serviceConfig) *service {
+	var expander *analysis.EnvMacroExpander
+	if cfg.env != nil {
+		expander = &analysis.EnvMacroExpander{Env: cfg.env}
+	}
 	return &service{
 		registry:                    cfg.registry,
 		env:                         cfg.env,
+		expander:                    expander,
 		sharedDocEnv:                cfg.docEnv,
 		envFactory:                  cfg.envFactory,
 		workspaceRoot:               cfg.workspaceRoot,
@@ -619,10 +644,10 @@ func (s *service) workspace(root string) (*workspaceState, error) {
 	s.mu.RUnlock()
 
 	// NOTE: Between the RUnlock above and the Lock below, another goroutine
-	// may also build a workspace state for the same root. This is benign —
-	// buildWorkspaceState is pure and the last writer wins with an identical
-	// result. A full mutex around the build would serialize all workspace
-	// loads, which is worse than occasional duplicate work.
+	// may also decide to build a workspace state for the same root. The
+	// duplicate work is wasteful but harmless — the two builds produce equal
+	// results and the last writer wins. They do NOT run concurrently:
+	// buildWorkspaceState takes buildMu, because it mutates the shared env.
 	state, err := s.buildWorkspaceState(root, fingerprint, time.Now())
 	if err != nil {
 		return nil, err
@@ -634,6 +659,8 @@ func (s *service) workspace(root string) (*workspaceState, error) {
 }
 
 func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time.Time) (*workspaceState, error) {
+	s.buildMu.Lock()
+	defer s.buildMu.Unlock()
 	if s.buildWorkspaceStateHook != nil {
 		s.buildWorkspaceStateHook(root)
 	}
@@ -678,17 +705,33 @@ func (s *service) buildWorkspaceState(root, fingerprint string, validatedAt time
 	for pkgName, syms := range state.cfg.PackageExports {
 		state.cfg.PackageExports[pkgName] = deduplicateExports(syms)
 	}
-	if root != "" {
-		state.refs = analysis.ScanWorkspaceRefs(root, state.cfg, scanCfg)
-		state.cfg.WorkspaceRefs = state.refs
-	}
-	if s.env != nil {
-		if errs := analysis.LoadWorkspaceMacros(s.env, preamble); len(errs) > 0 {
+	// Install the macro expander BEFORE scanning references (issue #403).
+	// ScanWorkspaceRefs analyses every workspace file with this Config, and
+	// loadDocument analyses the open file with a per-file copy of the same
+	// Config. If the expander is only attached afterwards the two disagree:
+	// the index is built from unexpanded macro calls while per-document
+	// analysis expands them, so the workspace index gains references the
+	// language does not have (a symbol the macro rebinds looks like a call to
+	// the global of that name) and loses the ones it does (call-site forms the
+	// expansion moves from data position into code position).
+	//
+	// The expander is shared by ScanWorkspaceRefs' NumCPU workers, which is
+	// what lsp.buildWorkspaceIndex already does: EnvMacroExpander serializes
+	// every expansion on its own mutex, so only one worker at a time touches
+	// s.env. It is the service-wide expander rather than a fresh one per
+	// build so that expansions requested by an already-cached workspace state
+	// serialize against this build's expansions too — see s.expander.
+	if s.expander != nil {
+		if errs := s.expander.LoadWorkspaceMacros(preamble); len(errs) > 0 {
 			for _, err := range errs {
 				slog.Warn("failed to load workspace macro", "error", err)
 			}
 		}
-		state.cfg.MacroExpander = &analysis.EnvMacroExpander{Env: s.env}
+		state.cfg.MacroExpander = s.expander
+	}
+	if root != "" {
+		state.refs = analysis.ScanWorkspaceRefs(root, state.cfg, scanCfg)
+		state.cfg.WorkspaceRefs = state.refs
 	}
 	return state, nil
 }

--- a/mcpserver/workspace_index_bench_test.go
+++ b/mcpserver/workspace_index_bench_test.go
@@ -1,0 +1,73 @@
+package mcpserver
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// BenchmarkBuildWorkspaceState measures a full workspace index build over a
+// macro-heavy workspace.
+//
+// It exists because issue #403's fix moved macro expansion into the index
+// build: ScanWorkspaceRefs now expands every macro call in every workspace
+// file, where before it walked them opaquely. That is the intended behaviour
+// — the index has to agree with per-document analysis — but it made indexing
+// cost proportional to how many macro call sites a workspace has, which it
+// was not before, so the cost belongs under measurement.
+//
+// The workspace is generated rather than read from testdata so the shape being
+// measured (call sites per file, files, distinct callees) is visible here and
+// stays stable if testdata changes.
+func BenchmarkBuildWorkspaceState(b *testing.B) {
+	root := macroHeavyWorkspace(b)
+	srv := New(WithWorkspaceRoot(root))
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := srv.service.buildWorkspaceState(root, "benchmark", time.Now()); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// macroHeavyWorkspace writes a workspace of 10 files with 20 macro call sites
+// each. Every call site expands to a call of a function defined in lib.lisp,
+// so expansion is what makes those references visible to the index.
+func macroHeavyWorkspace(tb testing.TB) string {
+	tb.Helper()
+	root := tb.TempDir()
+
+	const (
+		files       = 10
+		callsPer    = 20
+		helperCount = 5
+	)
+
+	var lib strings.Builder
+	lib.WriteString("(defmacro run-all (specs)\n  (quasiquote (progn (unquote-splicing specs))))\n")
+	for i := range helperCount {
+		lib.WriteString("(defun helper" + strconv.Itoa(i) + " () " + strconv.Itoa(i) + ")\n")
+	}
+	writeBenchFile(tb, filepath.Join(root, "lib.lisp"), lib.String())
+
+	for f := range files {
+		var src strings.Builder
+		for c := range callsPer {
+			src.WriteString("(defun caller" + strconv.Itoa(f) + "-" + strconv.Itoa(c) +
+				" () (run-all '((helper" + strconv.Itoa(c%helperCount) + "))))\n")
+		}
+		writeBenchFile(tb, filepath.Join(root, "file"+strconv.Itoa(f)+".lisp"), src.String())
+	}
+	return root
+}
+
+func writeBenchFile(tb testing.TB, path, content string) {
+	tb.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		tb.Fatal(err)
+	}
+}

--- a/mcpserver/workspace_macro_test.go
+++ b/mcpserver/workspace_macro_test.go
@@ -1,0 +1,195 @@
+package mcpserver
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWorkspaceIndexExpandsMacros_AddsReference covers the additive half of
+// issue #403: a call site whose only reference to a function is produced by
+// macro expansion.
+//
+// caller.lisp mentions `alpha` and `beta` only inside quoted data, which the
+// analyzer skips as data when it walks a macro call opaquely. Expanding
+// `run-all` splices those caller-side forms into code positions, so they
+// become real references carrying caller.lisp's own source locations.
+//
+// Before the fix, buildWorkspaceState ran ScanWorkspaceRefs with a Config
+// whose MacroExpander was still nil (it was assigned afterwards), so the
+// workspace index never saw them and `references` reported the definition
+// only.
+func TestWorkspaceIndexExpandsMacros_AddsReference(t *testing.T) {
+	tmp := t.TempDir()
+	libPath := filepath.Join(tmp, "lib.lisp")
+	callerPath := filepath.Join(tmp, "caller.lisp")
+	libContent := "(defun alpha () 1)\n" +
+		"(defun beta () 2)\n" +
+		"(defmacro run-all (specs)\n" +
+		"  (quasiquote (progn (unquote-splicing specs))))\n"
+	writeTestFile(t, libPath, libContent)
+	writeTestFile(t, callerPath, "(defun f () (run-all '((alpha) (beta))))\n")
+
+	srv := New(WithWorkspaceRoot(tmp))
+	session, serverSession := connectTestServer(t, srv)
+	defer closeClientSession(t, session)
+	defer closeServerSession(t, serverSession)
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "references",
+		Arguments: map[string]any{
+			"path":                libPath,
+			"line":                0,
+			"character":           strings.Index("(defun alpha () 1)", "alpha"),
+			"include_declaration": true,
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	refs := decodeStructured[ReferencesResponse](t, res)
+	assert.Equal(t, "alpha", refs.SymbolName)
+	paths := make([]string, 0, len(refs.References))
+	for _, ref := range refs.References {
+		paths = append(paths, ref.Path)
+	}
+	assert.Contains(t, paths, callerPath,
+		"workspace index must be built with the macro expander, so the macro-expanded call in caller.lisp is a reference to alpha")
+}
+
+// TestWorkspaceIndexExpandsMacros_DropsShadowedReference covers the
+// subtractive half of issue #403: index entries that exist only because the
+// index was built without macro expansion.
+//
+// `with-binding` expands to a `let` that binds its first argument, so both
+// occurrences of `total` in caller.lisp belong to that local binding, not to
+// the global function of the same name. An index built without the expander
+// walks the macro call opaquely, resolves each of them against the global
+// scope, and records two cross-file references the language does not have.
+//
+// Two things go wrong downstream. `references` on the global `total` reports
+// hits in caller.lisp that point at a local binding, and the `unused-function`
+// lint check treats those phantoms as real external callers and suppresses the
+// "unused function" diagnostic for a function nothing calls.
+func TestWorkspaceIndexExpandsMacros_DropsShadowedReference(t *testing.T) {
+	tmp := t.TempDir()
+	libPath := filepath.Join(tmp, "lib.lisp")
+	callerPath := filepath.Join(tmp, "caller.lisp")
+	libContent := "(defun total () 42)\n" +
+		"(defmacro with-binding (name value &rest body)\n" +
+		"  (quasiquote (let ([(unquote name) (unquote value)]) (unquote-splicing body))))\n"
+	writeTestFile(t, libPath, libContent)
+	writeTestFile(t, callerPath, "(defun f () (with-binding total 1 (+ total 1)))\n")
+
+	srv := New(WithWorkspaceRoot(tmp))
+	session, serverSession := connectTestServer(t, srv)
+	defer closeClientSession(t, session)
+	defer closeServerSession(t, serverSession)
+
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "references",
+		Arguments: map[string]any{
+			"path":                libPath,
+			"line":                0,
+			"character":           strings.Index("(defun total () 42)", "total"),
+			"include_declaration": true,
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	refs := decodeStructured[ReferencesResponse](t, res)
+	for _, ref := range refs.References {
+		assert.NotEqual(t, callerPath, ref.Path,
+			"total in caller.lisp is bound by the macro's let, so it must not be indexed as a reference to the global function")
+	}
+
+	diagRes, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "diagnostics",
+		Arguments: map[string]any{"path": libPath},
+	})
+	require.NoError(t, err)
+	require.False(t, diagRes.IsError)
+
+	diags := decodeStructured[DiagnosticsResponse](t, diagRes)
+	var messages []string
+	for _, file := range diags.Files {
+		for _, diag := range file.Diagnostics {
+			messages = append(messages, diag.Message)
+		}
+	}
+	assert.Contains(t, messages, "unused function: total",
+		"the only apparent caller of total is a phantom index entry from unexpanded macro analysis")
+}
+
+// macroWorkspace writes a workspace whose files all call a macro, so both the
+// index build and per-document analysis do real macro expansion against the
+// server's env.
+func macroWorkspace(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	writeTestFile(t, filepath.Join(tmp, "lib.lisp"),
+		"(defun alpha () 1)\n"+
+			"(defun beta () 2)\n"+
+			"(defmacro run-all (specs)\n"+
+			"  (quasiquote (progn (unquote-splicing specs))))\n")
+	for i := range 6 {
+		name := string(rune('a' + i))
+		writeTestFile(t, filepath.Join(tmp, name+"caller.lisp"),
+			"(defun f"+name+" () (run-all '((alpha) (beta))))\n")
+	}
+	return tmp
+}
+
+// TestWorkspaceIndexBuildsAreRaceFree is a -race regression test for the
+// concurrency the #403 fix widens.
+//
+// Before the fix the expander ran only on the per-document path. Running it
+// from ScanWorkspaceRefs as well puts macro expansion inside the index build,
+// where NumCPU workers share it, and the workspace cache lets one root's build
+// overlap with another root's document requests. Every one of those paths
+// mutates the single lisp env behind the server (Runtime.Package, the call
+// stack, the package registry).
+//
+// Both halves are exercised: duplicate concurrent builds of one root, and a
+// build of a second root racing document analysis served from the first root's
+// cached state. Without the service-wide expander and the build lock this
+// reports data races inside analysis.LoadWorkspaceMacros and
+// EnvMacroExpander.expand.
+func TestWorkspaceIndexBuildsAreRaceFree(t *testing.T) {
+	first := macroWorkspace(t)
+	second := macroWorkspace(t)
+
+	srv := New(WithWorkspaceRoot(first))
+	srv.service.workspaceValidationInterval = time.Hour
+	_, err := srv.service.workspace(first)
+	require.NoError(t, err)
+
+	cached := filepath.Join(first, "acaller.lisp")
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			switch i % 3 {
+			case 0:
+				_, _, docErr := srv.service.loadDocument(cached, nil, &first)
+				assert.NoError(t, docErr)
+			case 1:
+				_, buildErr := srv.service.buildWorkspaceState(first, "fingerprint", time.Now())
+				assert.NoError(t, buildErr)
+			default:
+				_, buildErr := srv.service.buildWorkspaceState(second, "fingerprint", time.Now())
+				assert.NoError(t, buildErr)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
`mcpserver`'s `buildWorkspaceState` called `ScanWorkspaceRefs` **before** assigning `state.cfg.MacroExpander`, so the workspace index was built from unexpanded macro calls while per-document analysis (`loadDocument`, via `ConfigForFile`) expanded them. This is the last caller with the index/per-document disagreement #353 describes; `lsp.buildWorkspaceIndex` and `lint.BuildAnalysisConfig` already install the expander first.

## User-visible symptom

Three, all verified against `main`:

1. **Missing references.** `references` on a function whose only call site is produced by macro expansion returned the definition alone. A call site that reaches a function only through a macro is invisible to the index, because the analyzer walks an unexpanded macro call opaquely and skips its quoted arguments as data.
2. **Phantom references.** `references` on a function whose name a macro rebinds returned hits in the caller that actually point at the macro's `let` binding. An agent renaming from that answer would edit a local.
3. **Suppressed diagnostic.** `diagnostics` did not report `unused function: total` for a function nothing calls, because the phantom index entry above looked to the `unused-function` check like a caller in another file.

The index and the per-file analysis of the *same* file disagreed, so which answer a client got depended on which tool it asked.

## Red then green

`mcpserver/workspace_macro_test.go` was written first and run against `ab0686d` with only the test file added:

```
--- FAIL: TestWorkspaceIndexExpandsMacros_AddsReference (0.17s)
    Error: []string{".../lib.lisp"} does not contain ".../caller.lisp"
    Messages: workspace index must be built with the macro expander, so the
              macro-expanded call in caller.lisp is a reference to alpha
--- FAIL: TestWorkspaceIndexExpandsMacros_DropsShadowedReference (0.18s)
    Error: Should not be: ".../caller.lisp"        (x2 - both occurrences)
    Messages: total in caller.lisp is bound by the macro's let, so it must not
              be indexed as a reference to the global function
    Error: []string(nil) does not contain "unused function: total"
    Messages: the only apparent caller of total is a phantom index entry from
              unexpanded macro analysis
```

Index dump for the shadowing workspace, same build, expander moved:

```
before:  user:with-binding/macro -> caller.lisp:1:14   (recorded twice)
         user:total/function     -> caller.lisp:1:27   <- the let binding's name
         user:total/function     -> caller.lisp:1:38   <- a use of that binding
after:   user:with-binding/macro -> caller.lisp:1:14
```

`TestWorkspaceIndexBuildsAreRaceFree` is the third new test and is also red on `main`: 45 race reports under `-race`.

## Had #406 / #396 already fixed part of this?

No. #406 (`AnalyzeFile` honouring `Config.MacroExpander`, and expansion no longer aliasing the form) is what makes this fix *work* — `ScanWorkspaceRefs` calls `AnalyzeFile`, which before #406 would have dropped the expander again one layer down, and the expander now runs over the whole workspace where a destructive macro would otherwise have written corrupted ranges into the long-lived index. But the ordering defect in `buildWorkspaceState` was untouched and reproduces exactly as filed. #397 is likewise a prerequisite rather than a partial fix: `Package.Get` is now read-only, which is what lets `NumCPU` scan workers reach the env at all.

## Concurrency

The issue predicted this fix "widens [expansion] further still", and it does — `EnvMacroExpander` now runs from `ScanWorkspaceRefs`' worker pool for every workspace file. Two supporting changes come with it, both required, neither cosmetic:

* **`buildWorkspaceState` takes a lock.** Its comment claimed the build was "pure" and duplicate concurrent builds were benign. It never was: it replays workspace macros into the shared env. Concurrent builds already raced inside `analysis.LoadWorkspaceMacros` on `main` (reproduced), and after this change they would also expand macros concurrently. Only cache misses take the lock, so a request for an already-indexed root never waits.
* **One expander per service, not per workspace state.** One env backs every root the server indexes, so per-state expanders were several mutexes over one piece of mutable state — a document request served from a cached state could expand while another root's build replayed its preamble. `(*EnvMacroExpander).LoadWorkspaceMacros` (new) does the load and the not-a-macro cache invalidation under the expansion lock, closing the last unguarded pairing.

`go test -race ./...` is clean; `mcpserver` specifically is exercised by the new race test.

## Indexing cost

Measured, because expanding every macro call in every workspace file is not free. `BenchmarkBuildWorkspaceState` (new, committed) indexes a generated workspace of 10 files x 20 macro call sites, 5 runs of 20 iterations each per arm:

| metric | base (`ab0686d`) | this PR | delta |
|---|---|---|---|
| sec/op | 47.2 ms | 46.1 ms | within noise |
| B/op | 10,973,589 | 11,257,025 | **+2.6%** |
| allocs/op | 73,407 | 77,639 | **+5.8%** |

Timing is a wash on this runner (samples spanned 37-55 ms on both arms; the machine is too noisy to claim a difference either way). Allocations are stable to three digits and are the honest number: **+5.8% allocs/op**, which is above the gate's 5% ceiling. It cannot fire on this PR — the benchmark is new, so the arms do not pair and `bench-arms-check.sh` reports it as unpaired rather than failing — and no waiver has been added. It is stated here so the next PR to touch this path is not surprised by the baseline. A larger sweep over the repository's own 35 `.lisp` files, which are macro-light, showed +0.6% allocs; a synthetic 2,000-call-site workspace showed +4.8%. The cost scales with macro call sites, which is expected, and a correct index is worth it.

## Neighbourhood audit

Every other entry point into `analysis` that builds a config, and why it is unchanged:

| site | expander? | verdict |
|---|---|---|
| `lsp/server.go` `buildWorkspaceIndex` | yes, installed before `ScanWorkspaceRefs` | **Correct already.** Also immune to the concurrency problem fixed here: `ensureWorkspaceIndex` wraps it in a `sync.Once` and the LSP is single-root, so exactly one expander ever exists per server. |
| `lint/lint.go` `BuildAnalysisConfig` | yes, when `Env` or `MacroExpander` is set, before `ScanWorkspaceRefs` | Correct already (#359). |
| `mcpserver/service.go` `lintTool` | **no** | **Verified divergent, deliberately not changed.** It builds `lint.LintConfig{Workspace: root}` with no `Env`, `Registry` or `MacroExpander`, so the `lint` tool analyses without expansion while `diagnostics` — the same analyzers, same file, same workspace — analyses with it. On the shadowing workspace above, `diagnostics` reports `unused function: total` and `lint` reports nothing. It also rebuilds the entire workspace config (full prescan + full `ScanWorkspaceRefs`) on every call instead of using the cached `workspaceState`, which this PR makes materially more expensive. The right fix is to serve it from `s.workspace(root)` rather than to bolt an env onto `LintConfig` — passing `Env` would have `BuildAnalysisConfig` call the package-level `LoadWorkspaceMacros` per request, reintroducing the race closed above. That is a behaviour change to a second tool and belongs in its own issue. |
| `cmd/lint.go` | **no** | Unchanged by design. Passes `Registry` but never an `Env`, so `elps lint` has never expanded macros. Turning it on would change lint output for every CLI user and slow the command; a deliberate CLI policy decision, not this bug. |
| `cmd/minify.go` -> `minifier` | **no** | Unchanged. `lint.BuildAnalysisConfig(&lint.LintConfig{Workspace: ...})` with no env, and `mergeAnalysisConfig` rebuilds a `Config` field-by-field carrying only `ExtraGlobals`, `PackageExports` and `DefForms` — the exact rebuild pattern `ConfigForFile` exists to replace. Renaming decisions made without macro expansion is a real question, but the minifier has its own preservation set and its own risk model; out of scope. |
| `analysis.PrescanWorkspace` | n/a | Correctly expander-free, and cannot be otherwise: it produces the preamble the expander is built from. |
| `analysis.ConfigForFile` / `AnalyzeFile` | pass-through | Correct since #406; whole-struct copy, so `MacroExpander` cannot be dropped again. |

## Corrections to the issue

The issue says the symptom is "references introduced by macro expansion are visible in per-document diagnostics but missing from workspace-wide reference queries". That direction is real (test 1), but it is only half of it, and empirically the *phantom* direction is easier to hit: `ExtractFileRefs` deliberately drops references whose node came from the macro's definition site (`sameSourceFile`), so expansion adds an index entry only when the expansion moves a *caller-side* node from data position into code position. Expansion removing a wrong entry needs nothing so specific — any macro that rebinds a name a caller mentions does it. Both directions are covered by the tests.

## Test plan

- `go build ./...`, `go vet ./...` — clean
- `go test -count=1 ./...` — pass
- `go test -race -count=1 ./...` — pass
- `golangci-lint run ./...` — 0 issues
- `elps fmt -l ./...` — clean; `elps doc -m` — all documented
- `./scripts/ci-gates-test.sh` — 210 passed, 0 failed
- `./scripts/confidentiality-guard.sh` — clean

Fixes #403


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_