### PR TITLE
libtesting: synchronise TestSuite so a shared suite cannot kill the process (#420)

### DIFF
--- a/lisp/lisplib/libtesting/libtesting.go
+++ b/lisp/lisplib/libtesting/libtesting.go
@@ -4,6 +4,7 @@ package libtesting
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/lisplib/internal/libutil"
@@ -41,13 +42,39 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 }
 
 // TestSuite is an ordered set of named tests.
+//
+// A TestSuite's own bookkeeping is safe for concurrent use, so one suite may
+// be registered into, and read from, any number of environments at once.
+// LoadPackage gives every environment its own suite, so the ordinary path never
+// shares one, but NewTestSuite and EnvTestSuite are exported with no stated
+// scope: an embedder that installs one suite into several runtimes is doing
+// something the API permits. Evaluating a `test` or `benchmark` form writes the
+// suite's maps, and two goroutines writing one Go map is `fatal error:
+// concurrent map writes`, which is thrown by the runtime and cannot be
+// recovered. The mutex below is what keeps that from being reachable. See
+// issue #420.
+//
+// What this does NOT promise is anything about running a registered test. A
+// Test's Fun is a lambda closed over the environment that defined it, so
+// evaluating it from a different runtime is environment sharing, which is a
+// separate question from whether the suite is a safe container.
 type TestSuite struct {
 	tests      map[string]*Test
 	benchmarks map[string]*Test
 	torder     []string
 	border     []string
+
+	// mu guards every field above it. Add and AddBenchmark run once per
+	// definition form, at load time, never inside an assertion or inside a
+	// running test body, so the lock is not on any hot path. It sits last
+	// rather than first because fieldalignment is enforced across lisp/...
+	// and a pointer-free mutex ahead of the maps would push the struct's
+	// pointer bytes from 48 to 72.
+	mu sync.RWMutex
 }
 
+// NewTestSuite returns an empty suite. The result may be installed into any
+// number of environments and used from all of them concurrently.
 func NewTestSuite() *TestSuite {
 	return &TestSuite{
 		tests:      make(map[string]*Test),
@@ -56,6 +83,8 @@ func NewTestSuite() *TestSuite {
 }
 
 func (s *TestSuite) Add(t *Test) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.tests[t.Name] != nil {
 		return fmt.Errorf("test with the same name already defined: %v", t.Name)
 	}
@@ -65,26 +94,36 @@ func (s *TestSuite) Add(t *Test) error {
 }
 
 func (s *TestSuite) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return len(s.torder)
 }
 
 func (s *TestSuite) Tests() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	names := make([]string, len(s.torder))
 	copy(names, s.torder)
 	return names
 }
 
 func (s *TestSuite) Benchmarks() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	names := make([]string, len(s.border))
 	copy(names, s.border)
 	return names
 }
 
 func (s *TestSuite) Test(i int) *Test {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.tests[s.torder[i]]
 }
 
 func (s *TestSuite) AddBenchmark(b *Test) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.benchmarks[b.Name] != nil {
 		return fmt.Errorf("benchmark with the same name already defined: %v", b.Name)
 	}
@@ -94,6 +133,8 @@ func (s *TestSuite) AddBenchmark(b *Test) error {
 }
 
 func (s *TestSuite) Benchmark(i int) *Test {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.benchmarks[s.border[i]]
 }
 
@@ -401,6 +442,9 @@ type Test struct {
 	Name string
 }
 
+// EnvTestSuite returns the suite installed in env, or nil if there is none.
+// The suite is returned by pointer and is safe to use while other environments
+// holding the same suite are evaluating.
 func EnvTestSuite(env *lisp.LEnv) *TestSuite {
 	lsuite := env.Runtime.Registry.Packages[DefaultPackageName].Get(lisp.Symbol(DefaultSuiteSymbol))
 	if lsuite.Type != lisp.LNative {

--- a/lisp/lisplib/libtesting/multi_runtime_test.go
+++ b/lisp/lisplib/libtesting/multi_runtime_test.go
@@ -1,0 +1,345 @@
+// Copyright © 2026 The ELPS authors
+
+package libtesting_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libtesting"
+	"github.com/luthersystems/elps/parser"
+)
+
+// This file covers issue #420: *TestSuite is handed out by an exported
+// constructor (NewTestSuite) and an exported accessor (EnvTestSuite), with no
+// stated scope, and its four fields -- tests, benchmarks, torder, border --
+// were unsynchronised. Evaluating a `test` or `benchmark` form calls Add /
+// AddBenchmark, so ordinary ELPS source is a write to those fields.
+//
+// LoadPackage is not affected: it calls NewTestSuite() itself, so every
+// environment loaded the normal way owns its suite. The hazard needs an
+// embedder that builds one suite and installs it into several runtimes, which
+// is reachable through exported API alone -- that is what sharedSuiteEnv below
+// does, using nothing LoadPackage does not use.
+//
+// # Why every test here runs in a child process
+//
+// The failure mode is not a data race the runtime tolerates. Two goroutines
+// writing one Go map is
+//
+//	fatal error: concurrent map writes
+//
+// which is thrown by the runtime, is not a panic, and CANNOT be recovered. A
+// test that triggers it in-process takes the whole test binary down with it,
+// so every other test in the package stops reporting and the failure looks
+// like an infrastructure problem rather than a defect.
+//
+// So the concurrency lives in a child process: the parent re-executes this
+// same test binary with ELPS_ISSUE_420_CHILD set to a scenario name, the child
+// runs the scenario, and the parent asserts the child exited cleanly. On main
+// the child dies and the parent reports its output; after the fix the child
+// exits 0. The parent survives either way, which is what makes this test
+// re-runnable rather than a one-shot demonstration.
+//
+// Running under -race adds a second, independent signal for free: the child
+// inherits the parent's instrumentation, so the torder/border slice appends
+// are reported as DATA RACE even in the runs where the map write happens to
+// interleave harmlessly.
+
+const (
+	childEnvVar   = "ELPS_ISSUE_420_CHILD"
+	childTestName = "TestSharedSuiteConcurrentDefinition"
+)
+
+// sharedSuiteEnv installs an externally-owned suite into a fresh runtime the
+// same way LoadPackage installs a private one. Every call it makes is exported:
+// DefinePackage, InPackage, PutGlobal, AddSpecialOps, AddMacros, and the suite
+// itself came from NewTestSuite. This is the embedder shape issue #420
+// describes, not a reach into package internals.
+func sharedSuiteEnv(tb testing.TB, suite *libtesting.TestSuite) *lisp.LEnv {
+	tb.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); !rc.IsNil() {
+		tb.Fatalf("initialize-user-env: %v", rc)
+	}
+	name := lisp.Symbol(libtesting.DefaultPackageName)
+	if rc := env.DefinePackage(name); !rc.IsNil() {
+		tb.Fatalf("define-package: %v", rc)
+	}
+	if rc := env.InPackage(name); !rc.IsNil() {
+		tb.Fatalf("in-package: %v", rc)
+	}
+	if rc := env.PutGlobal(lisp.Symbol(libtesting.DefaultSuiteSymbol), lisp.Native(suite)); rc.Type == lisp.LError {
+		tb.Fatalf("put-global: %v", rc)
+	}
+	for _, fn := range suite.Ops() {
+		env.AddSpecialOps(true, fn)
+	}
+	for _, fn := range suite.Macros() {
+		env.AddMacros(true, fn)
+	}
+	return env
+}
+
+// TestEnvTestSuiteHandsOutTheSharedSuite pins the premise the rest of the file
+// rests on: the suite an embedder installed is the suite the package hands back
+// out, so "two runtimes, one suite" is a real configuration and not a fiction
+// the test constructed. This is a GUARD -- it passes on main.
+func TestEnvTestSuiteHandsOutTheSharedSuite(t *testing.T) {
+	suite := libtesting.NewTestSuite()
+	a := sharedSuiteEnv(t, suite)
+	b := sharedSuiteEnv(t, suite)
+	if got := libtesting.EnvTestSuite(a); got != suite {
+		t.Errorf("runtime A: EnvTestSuite returned %p, want the shared suite %p", got, suite)
+	}
+	if got := libtesting.EnvTestSuite(b); got != suite {
+		t.Errorf("runtime B: EnvTestSuite returned %p, want the shared suite %p", got, suite)
+	}
+
+	// A definition made through one runtime is visible through the other's
+	// view of the suite, which is what makes concurrent definition a shared
+	// write rather than two independent ones.
+	if rc := a.LoadStringContext(context.Background(), "premise", `(test "from-a" ())`); rc.Type == lisp.LError {
+		t.Fatalf("define via A: %v", rc)
+	}
+	if names := libtesting.EnvTestSuite(b).Tests(); len(names) != 1 || names[0] != "from-a" {
+		t.Errorf("suite seen through B is %v, want [from-a]", names)
+	}
+}
+
+// TestLoadPackageSuitesAreNotShared is a GUARD, not a catch: it passes on main
+// and records the scope limit the issue claims. Environments built the ordinary
+// way must NOT share a suite, or this defect would reach every embedder rather
+// than only the ones that deliberately share.
+func TestLoadPackageSuitesAreNotShared(t *testing.T) {
+	newEnv := func() *lisp.LEnv {
+		env := lisp.NewEnv(nil)
+		env.Runtime.Reader = parser.NewReader()
+		if rc := lisp.InitializeUserEnv(env); !rc.IsNil() {
+			t.Fatalf("initialize-user-env: %v", rc)
+		}
+		if rc := libtesting.LoadPackage(env); !rc.IsNil() {
+			t.Fatalf("load-package: %v", rc)
+		}
+		return env
+	}
+	a, b := libtesting.EnvTestSuite(newEnv()), libtesting.EnvTestSuite(newEnv())
+	if a == nil || b == nil {
+		t.Fatalf("LoadPackage did not install a suite: a=%p b=%p", a, b)
+	}
+	if a == b {
+		t.Errorf("LoadPackage shared one suite between two runtimes (%p)", a)
+	}
+}
+
+// TestSharedSuiteConcurrentDefinition is the catch.
+//
+// Each subtest re-executes this binary with ELPS_ISSUE_420_CHILD set and
+// asserts the child exits 0. On main all three fail, every run, under -race,
+// because the child dies in the runtime rather than returning. Verbatim from
+// the run against 751e61e:
+//
+//	fatal error: concurrent map read and map write
+//
+//	goroutine 25 [running]:
+//	internal/runtime/maps.fatal(...)
+//	    /usr/local/go/src/runtime/panic.go:1046
+//	.../libtesting.(*TestSuite).AddBenchmark(0xc000110940, 0xc0000ac0d8)
+//	    lisp/lisplib/libtesting/libtesting.go:88
+//	.../libtesting.(*TestSuite).OpBenchmark(...)
+//	    lisp/lisplib/libtesting/libtesting.go:392
+//	.../lisp.(*LEnv).LoadStringContext(...)
+//	    lisp/env.go:1276
+//
+// and, for the read scenario, the same fault raised from a plain accessor:
+//
+//	fatal error: concurrent map read and map write
+//	.../libtesting.(*TestSuite).Test(...)
+//	    lisp/lisplib/libtesting/libtesting.go:84
+//
+// Under -race the child additionally reports the unsynchronised access as a
+// DATA RACE, which is what makes the failure deterministic rather than
+// timing-dependent:
+//
+//	WARNING: DATA RACE
+//	Read at 0x00c00010a6f0 by goroutine 9:
+//	  runtime.mapaccess1_faststr()
+//	  .../libtesting.(*TestSuite).Add()   libtesting.go:59
+//	Previous write at 0x00c00010a6f0 by goroutine 16:
+//	  runtime.mapassign_faststr()
+//	  .../libtesting.(*TestSuite).Add()   libtesting.go:63
+//
+// Without -race the fault is probabilistic per round, which is why each
+// scenario runs nRounds of the workload before reporting success.
+func TestSharedSuiteConcurrentDefinition(t *testing.T) {
+	if scenario := os.Getenv(childEnvVar); scenario != "" {
+		runChildScenario(t, scenario)
+		return
+	}
+	for _, scenario := range childScenarioNames {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+			runParent(t, scenario)
+		})
+	}
+}
+
+func runParent(t *testing.T, scenario string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// #nosec G204 -- os.Args[0] is this test binary; the only variable part
+	// is a scenario name from childScenarioNames, passed via the environment.
+	cmd := exec.CommandContext(ctx, os.Args[0],
+		"-test.run=^"+childTestName+"$",
+		"-test.count=1",
+		"-test.timeout=90s",
+		"-test.v",
+	)
+	cmd.Env = append(os.Environ(), childEnvVar+"="+scenario)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return
+	}
+	text := string(out)
+	switch {
+	case strings.Contains(text, "concurrent map writes"),
+		strings.Contains(text, "concurrent map read and map write"),
+		strings.Contains(text, "concurrent map iteration and map write"):
+		t.Errorf("shared TestSuite killed the process with an unrecoverable map fault (%v)\n%s",
+			err, indent(text))
+	case strings.Contains(text, "DATA RACE"):
+		t.Errorf("shared TestSuite raced (%v)\n%s", err, indent(text))
+	default:
+		t.Errorf("child scenario %q failed: %v\n%s", scenario, err, indent(text))
+	}
+}
+
+func indent(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > 60 {
+		lines = append(lines[:60], fmt.Sprintf("... (%d more lines)", len(lines)-60))
+	}
+	return "\t" + strings.Join(lines, "\n\t")
+}
+
+var childScenarioNames = []string{"test-forms", "benchmark-forms", "define-while-reading"}
+
+// runChildScenario is the half that runs in the child process. It does the
+// concurrent work directly, with no recover() anywhere, because the fault it
+// provokes is not recoverable.
+func runChildScenario(t *testing.T, scenario string) {
+	for range nRounds {
+		if t.Failed() {
+			return
+		}
+		switch scenario {
+		case "test-forms":
+			concurrentDefine(t, `(test "%s" ())`)
+		case "benchmark-forms":
+			concurrentDefine(t, `(benchmark "%s" (n) ())`)
+		case "define-while-reading":
+			defineWhileReading(t)
+		default:
+			t.Fatalf("unknown child scenario %q", scenario)
+		}
+	}
+}
+
+const (
+	nRuntimes = 8
+	nDefines  = 40
+	// nRounds repeats the workload on a fresh suite. One round is enough
+	// under -race; without it the interleaving that makes the map fault
+	// fatal is probabilistic, and repeating drives the miss rate down.
+	nRounds = 8
+)
+
+// concurrentDefine is the shape issue #420 reports: one suite, several
+// runtimes, each evaluating definition forms at the same time. Names are
+// unique per goroutine so nothing fails for the boring reason of a duplicate.
+func concurrentDefine(t *testing.T, form string) {
+	suite := libtesting.NewTestSuite()
+	envs := make([]*lisp.LEnv, nRuntimes)
+	for i := range envs {
+		envs[i] = sharedSuiteEnv(t, suite)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(nRuntimes)
+	for i := range nRuntimes {
+		go func() {
+			defer wg.Done()
+			for j := range nDefines {
+				src := fmt.Sprintf(form, fmt.Sprintf("t-%d-%d", i, j))
+				if rc := envs[i].LoadStringContext(context.Background(), "issue420", src); rc.Type == lisp.LError {
+					t.Errorf("runtime %d: %v", i, rc)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got, want := suite.Len()+len(suite.Benchmarks()), nRuntimes*nDefines; got != want {
+		t.Errorf("suite holds %d definitions, want %d: a write was lost", got, want)
+	}
+}
+
+// defineWhileReading covers the READ side. A map read concurrent with a map
+// write is `fatal error: concurrent map read and map write` -- exactly as fatal
+// as two writes -- so Len, Tests, Benchmarks, Test(i) and Benchmark(i) have to
+// be synchronised too, not just Add and AddBenchmark. An embedder polling the
+// suite it installed (a progress report, an MCP tool listing the registered
+// tests) reaches this without evaluating anything.
+func defineWhileReading(t *testing.T) {
+	suite := libtesting.NewTestSuite()
+	writer := sharedSuiteEnv(t, suite)
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(done)
+		for j := range nRuntimes * nDefines {
+			src := fmt.Sprintf(`(test "t-%d" ()) (benchmark "b-%d" (n) ())`, j, j)
+			if rc := writer.LoadStringContext(context.Background(), "issue420", src); rc.Type == lisp.LError {
+				t.Errorf("writer: %v", rc)
+				return
+			}
+		}
+	}()
+
+	for range nRuntimes {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				if n := suite.Len(); n > 0 {
+					_ = suite.Test(n - 1)
+				}
+				_ = suite.Tests()
+				if b := suite.Benchmarks(); len(b) > 0 {
+					_ = suite.Benchmark(len(b) - 1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #420

## Verdict: it reproduces

#420 was filed from reading, and asked for the red test first with closing as the right outcome if it did not reproduce. It reproduces, deterministically, and on the read paths as well as the write paths.

`TestSuite`'s four fields — `tests`, `benchmarks`, `torder`, `border` — were unsynchronised. `Add`/`AddBenchmark` write them from `OpTest`/`OpBenchmark`, so an ordinary `(test "name" ...)` form is a map write. One suite reachable from two evaluating environments is a concurrent map access, which is not a race the runtime tolerates: it is `fatal error: concurrent map writes`, thrown by the runtime, not a panic, and unrecoverable.

The issue's scope claim also holds, and is now pinned rather than asserted: `LoadPackage` calls `NewTestSuite()` per environment, so the ordinary path never shares a suite and `elps test` never reaches this.

## Red evidence, on `751e61e` with only `libtesting.go` reverted

The first failure landed on a plain accessor, not on `Add`:

```
fatal error: concurrent map read and map write

goroutine 33 [running]:
internal/runtime/maps.fatal({0x5f7025?, 0x7818a0?})
	/usr/local/go/src/runtime/panic.go:1046 +0x18
github.com/luthersystems/elps/lisp/lisplib/libtesting.(*TestSuite).Test(...)
	lisp/lisplib/libtesting/libtesting.go:84
```

and from the definition side, through ordinary ELPS source:

```
fatal error: concurrent map read and map write

goroutine 25 [running]:
internal/runtime/maps.fatal({0x5f7025?, 0xc000118928?})
	/usr/local/go/src/runtime/panic.go:1046 +0x18
.../libtesting.(*TestSuite).AddBenchmark(0xc000110940, 0xc0000ac0d8)
	lisp/lisplib/libtesting/libtesting.go:88
.../libtesting.(*TestSuite).OpBenchmark(0xc000110940, 0xc000110ec0, ...)
	lisp/lisplib/libtesting/libtesting.go:392
.../libutil.(*Builtin).Eval(...)
	lisp/lisplib/internal/libutil/builtin.go:31
.../lisp.(*LEnv).LoadStringContext(...)
	lisp/env.go:1276
```

Under `-race` the same access is reported as a data race, which is what makes the failure deterministic rather than timing-dependent:

```
WARNING: DATA RACE
Read at 0x00c00010a6f0 by goroutine 9:
  runtime.mapaccess1_faststr()
  .../libtesting.(*TestSuite).Add()        libtesting.go:59
  .../libtesting.(*TestSuite).OpTest()     libtesting.go:362
Previous write at 0x00c00010a6f0 by goroutine 16:
  runtime.mapassign_faststr()
  .../libtesting.(*TestSuite).Add()        libtesting.go:63
  .../libtesting.(*TestSuite).OpTest()     libtesting.go:362
```

Failure rates against reverted `libtesting.go`: all 3 subtests fail on 5 of 5 runs without `-race`, and 3 of 3 with it. All pass with the fix.

## Demonstrating a fatal that cannot be caught in-process

A concurrent map fault is thrown by the runtime. `recover()` does not see it, `t.Fatal` never runs, and the test binary dies — every other test in the package stops reporting, and the failure reads as an infrastructure problem rather than a defect.

So the concurrency runs in a **child process**. `TestSharedSuiteConcurrentDefinition` re-executes this same test binary with `ELPS_ISSUE_420_CHILD` set to a scenario name, and the parent asserts the child exited 0, printing the child's output (classified as map fault / data race / other) when it did not. The parent survives either way, which is what makes this re-runnable rather than a one-shot demonstration. The child inherits the parent's `-race` instrumentation for free.

Three scenarios, each repeating its workload `nRounds` times so the un-instrumented run is not probabilistic either:

| scenario | what it drives |
|---|---|
| `test-forms` | 8 runtimes, one shared suite, concurrent `(test ...)` forms |
| `benchmark-forms` | same through `(benchmark ...)` |
| `define-while-reading` | one writer plus 8 readers on `Len`/`Tests`/`Test(i)`/`Benchmarks`/`Benchmark(i)` |

The sharing is set up with exported API only — `NewTestSuite`, `DefinePackage`, `InPackage`, `PutGlobal`, `AddSpecialOps`, `AddMacros` — using nothing `LoadPackage` does not use itself.

Two of the new tests are **guards**, not catches, and are labelled as such in-file because they pass on `main`:

- `TestEnvTestSuiteHandsOutTheSharedSuite` — pins the premise that the suite an embedder installs is the suite `EnvTestSuite` returns, so "two runtimes, one suite" is a real configuration and not one the test invented.
- `TestLoadPackageSuitesAreNotShared` — pins the scope limit, that environments built the ordinary way do **not** share a suite.

## The fix

Option (1) from the issue: a `sync.RWMutex` over the four fields. Writes (`Add`, `AddBenchmark`) take `Lock`; reads (`Len`, `Tests`, `Benchmarks`, `Test(i)`, `Benchmark(i)`) take `RLock` — the read paths are covered because the reproduction hit them first.

Option (2), documenting a single-environment contract, is **rejected** for the reason #418 rejected it: `NewTestSuite` is exported, returns a value with no stated scope, and `EnvTestSuite` hands the same value back out. Turning a reasonable reading of an exported constructor into a documented misuse is worse than a mutex on a path that runs once per definition form.

The issue asserted the cost is irrelevant; this confirms it rather than repeating it. `Add`/`AddBenchmark` run at definition time, never inside an assertion or a running test body. The benchstat gate over the full benchmark set (n=6 interleaved arms, `base` = `751e61e`) reports **0 rows at or above the gate** — timing 15%, `B/op` and `allocs/op` 5% — with `B/op` and `allocs/op` geomeans flat to 0.02%. The one significant move, `lisp` `Equal/wide` `sec/op` `+2.40%`, is unrelated noise well under the gate.

`mu` sits last in the struct rather than first: `fieldalignment` is enforced across `lisp/...`, and a pointer-free mutex ahead of the maps pushes the struct's pointer bytes from 48 to 72. A comment records why.

## Neighbourhood audit

Everything else in `lisp/lisplib/libtesting/` was examined. Sites **not** changed, and why:

- **`Test{Fun, Name}`** — written before `Add` is called, never afterwards. Registration now publishes it through the mutex, so a reader that obtained the `*Test` from `Test(i)` sees it fully initialised. The value needs no lock of its own.
- **Running a registered test** — explicitly not covered, and the doc comment says so rather than over-promising. `Test.Fun` is a lambda closed over the environment that defined it, so evaluating it from another runtime is *environment* sharing, which is a different question from whether the suite is a safe container.
- **`Ops()` / `Macros()`** — allocate a fresh slice of freshly-constructed `libutil.Builtin` values on every call. No slice or builtin is handed out twice, so there is nothing shared to guard.
- **The nine `Macro*` methods** — pure functions of `(env, args)`. They alias the caller's argument cells into the expansion they return, which is how every macro in this tree works and is the territory #370/#419 just covered on the reader side; it is not new state in this package.
- **`LoadPackage`** — writes only into the environment it was handed, and mints the suite itself.
- **Package-level state** — none. Two consts, no vars.

One thing found and deliberately left: **`EnvTestSuite` nil-derefs** on a runtime that never loaded the testing package. It indexes `Runtime.Registry.Packages[DefaultPackageName]` and calls `Get` on the result unchecked; a missing key yields a nil `*Package` and `Package.get` dereferences `pkg.Symbols`. That is a robustness nit rather than a synchronisation one, no in-tree caller reaches it, and folding it into a concurrency fix would blur what this change answers for.

## Gates

| gate | result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test -count=1 ./...` | clean |
| `go test -race ./...` | clean |
| `golangci-lint run ./...` | 0 issues |
| `elps fmt -l ./...` | clean (binary deleted before commit) |
| `elps doc -m` | clean |
| `./scripts/ci-gates-test.sh` | 210 passed, 0 failed |
| `./scripts/confidentiality-guard.sh` | clean |
| `./scripts/benchstat-gate.sh` | 0 rows at or above gate |


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_