### PR TITLE
lisp: stop rendering a Go struct dump into the aref dimension error

### DIFF
--- a/lisp/array_index_message_test.go
+++ b/lisp/array_index_message_test.go
@@ -1,0 +1,75 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An error message is program output.
+//
+// (*LVal).ArrayIndex used to report a dimension-count mismatch with %#v on the
+// dimensions LVal, which prints the Go struct literal -- including the Source
+// and Cells POINTERS.  The message therefore embedded heap addresses and
+// differed on every evaluation of the same source (elps#427), reachable from
+// lisp with a 14-byte expression.
+//
+// Downstream a phylum runs as Fabric chaincode, where every endorsing peer
+// must produce identical output for a transaction.  A phylum that returns,
+// logs or hashes a caught condition's message would produce divergent proposal
+// responses, and the endorsement policy would fail for a reason nothing in the
+// phylum explains.  So the assertion is determinism, not wording.
+func TestArrayIndexMessageIsDeterministic(t *testing.T) {
+	t.Parallel()
+	const src = `(aref (vector))`
+	const runs = 3
+
+	msgs := make([]string, 0, runs)
+	for range runs {
+		v := loadStringFresh(t, src)
+		require.Equal(t, lisp.LError, v.Type, "%s must be an error", src)
+		msgs = append(msgs, v.String())
+	}
+	for i := 1; i < len(msgs); i++ {
+		assert.Equal(t, msgs[0], msgs[i],
+			"evaluating %s twice produced different error text; an error message must not depend on"+
+				" where a value happens to be allocated", src)
+	}
+
+	// The specific regression: no Go struct dump, and no pointer.
+	assert.NotContains(t, msgs[0], "lisp.LVal{",
+		"the message renders the Go struct literal for an LVal")
+	assert.NotContains(t, msgs[0], "0xc0",
+		"the message contains a heap address")
+	assert.Contains(t, msgs[0], "dimensions",
+		"the message should name the dimensions")
+}
+
+// The multi-dimensional spelling reaches the same branch.
+func TestArrayIndexMessageIsDeterministicMultiDim(t *testing.T) {
+	t.Parallel()
+	const src = `(aref (vector 1 2) 0 0)`
+	a := loadStringFresh(t, src)
+	b := loadStringFresh(t, src)
+	require.Equal(t, lisp.LError, a.Type)
+	assert.Equal(t, a.String(), b.String())
+	assert.NotContains(t, a.String(), "lisp.LVal{")
+}
+
+func loadStringFresh(t *testing.T, src string) *lisp.LVal {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	require.True(t, lisp.InitializeUserEnv(env).IsNil())
+	require.True(t, lisplib.LoadLibrary(env).IsNil())
+	require.True(t, env.InPackage(lisp.String(lisp.DefaultUserPackage)).IsNil())
+	v := env.LoadString("test", src)
+	require.NotNil(t, v)
+	return v
+}

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -929,7 +929,15 @@ func (v *LVal) ArrayIndex(index ...*LVal) *LVal {
 	}
 	dims := v.Cells[0]
 	if len(index) != dims.Len() {
-		return Errorf("invalid index into array with dimenions %#v", v.Cells[0])
+		// %v, not %#v.  %#v prints the Go struct literal for the *LVal,
+		// which embeds the Source and Cells POINTERS -- so this message
+		// carried heap addresses and differed on every evaluation of the
+		// same program (elps#427).  Downstream a phylum runs as chaincode,
+		// where every endorsing peer must produce identical output for a
+		// transaction, and this condition is reachable from lisp with
+		// `(aref (vector))`.  An error message is program output.
+		return Errorf("invalid index into array with dimensions %v: got %d index(es), want %d",
+			dims, len(index), dims.Len())
 	}
 	if len(index) == 0 {
 		return v.Cells[1]


### PR DESCRIPTION
Fixes #427.

`(aref (vector))` — 14 bytes of ordinary lisp — produced a **different error string on every evaluation**, in the same process, from a fresh `LEnv` each time:

```
run 0: t:1:1: lisp:aref: <native code>: invalid index into array with dimenions &lisp.LVal{Native:interface {}(nil), Source:(*token.Location)(0xc00013e280), ..., Cells:[]*lisp.LVal{(*lisp.LVal)(0xc0001eb650)}, Type:0x6, ...}
run 1: ...                                                                                                                                                 (*lisp.LVal)(0xc000263650)
run 2: ...                                                                                                                                                 (*lisp.LVal)(0xc0002c9650)
```

## Root cause

`(*LVal).ArrayIndex` reported a dimension-count mismatch with `%#v` on the dimensions `LVal`. `%#v` prints the Go struct literal, which embeds the `Source` and `Cells` pointers, and `Errorf` put that straight into a user-facing condition message.

## Why it matters

An error message is program output.

Downstream a phylum runs as Fabric chaincode, where every endorsing peer must produce identical output for a transaction. A phylum that returns, logs or hashes a caught condition&#39;s message produced divergent proposal responses across peers, and the endorsement policy failed for a reason nothing in the phylum explains. The condition is reachable from lisp with a 14-byte expression, so this is not a corner only host code can hit.

It also handed heap addresses and the internal `LVal` layout to anyone who could trigger it.

## The change

`%v` renders the dimensions as the ordinary value they are — `(vector 0)` — and the message now names which counts disagreed. `dimenions` is fixed on the way past.

```
lisp:aref: invalid index into array with dimensions (vector 0): got 0 index(es), want 1
```

## Test

`TestArrayIndexMessageIsDeterministic` asserts the property rather than the wording: three evaluations of `(aref (vector))` in one process must return the same string, with no `lisp.LVal{` and no `0xc0` in it. `TestArrayIndexMessageIsDeterministicMultiDim` covers `(aref (vector 1 2) 0 0)`, which reaches the same branch.

## How it was found

By **running**, not reading. A new fuzz target (`FuzzSharedTreeEval`, in the stacked PR that follows this one) evaluates the same source twice and compares the rendered results; it minimised a 47-byte input to `(aref(vector))`.

Neither `FuzzEval` nor `FuzzApplyStdlib` can find this. Both evaluate each input exactly once, and one evaluation of a non-deterministic function is indistinguishable from one evaluation of a deterministic one. That is why the target is worth having and why this fix ships ahead of it — the target is red on `main` until this lands.

## Adjacent, NOT fixed here

There is a second `%#v` on an `*LVal` at `lisp/lisp.go:1452`, in `str()`&#39;s `default:` branch (`"#<%s %#v>"`). I did **not** reach it from lisp source and have not shown it is reachable. Noted in #427 as a read-only observation for whoever looks next — reproduce or dismiss it, do not take my word for it.

## Gates

`go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run ./...` (0 issues), `elps fmt -l ./...` (clean, binary deleted before commit), `elps doc -m`, `scripts/confidentiality-guard.sh` (clean). `make race` / `make test-elpscheck` / `make test-examples` / `scripts/ci-gates-test.sh` were run locally on a machine also running a fuzz sweep; CI is the authority on those.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_