### PR TITLE
Serve mcpserver's lint tool from the cached workspace state, so it and diagnostics stop contradicting each other

### DIFF
--- a/mcpserver/lint_tool_bench_test.go
+++ b/mcpserver/lint_tool_bench_test.go
@@ -1,0 +1,42 @@
+package mcpserver
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// BenchmarkLintTool measures a warm lint request — the workspace state is
+// already built and validated, so the benchmark isolates what the tool does
+// per request.
+//
+// It exists because issue #424's fix changes exactly that: the tool used to
+// call lint.BuildAnalysisConfig on every request, which runs a full
+// PrescanWorkspace, a full ScanWorkspaceRefs and (through
+// defaultStdlibExports) boots a fresh env with the whole standard library
+// loaded. It now analyses against the cached workspace state. #422 made both
+// of those scans more expensive by putting macro expansion inside them, so the
+// per-request cost of the old shape was still growing.
+//
+// This benchmark is NEW, so the regression gate has no paired baseline for it
+// and cannot fire on it. Its before/after numbers are reported in the pull
+// request by running it against both revisions by hand.
+func BenchmarkLintTool(b *testing.B) {
+	root := macroHeavyWorkspace(b)
+	srv := New(WithWorkspaceRoot(root))
+	srv.service.workspaceValidationInterval = time.Hour
+	if _, err := srv.service.workspace(root); err != nil {
+		b.Fatal(err)
+	}
+	path := filepath.Join(root, "file"+strconv.Itoa(0)+".lisp")
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, _, err := srv.service.lintTool(ctx, nil, LintInput{Path: path}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/mcpserver/lint_tool_expander_test.go
+++ b/mcpserver/lint_tool_expander_test.go
@@ -1,0 +1,229 @@
+package mcpserver
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// callLintMessages runs the lint tool over one path and returns the diagnostic
+// messages.
+func callLintMessages(t *testing.T, session *mcp.ClientSession, path string) []string {
+	t.Helper()
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "lint",
+		Arguments: map[string]any{"path": path},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	resp := decodeStructured[LintResponse](t, res)
+	messages := make([]string, 0, len(resp.Diagnostics))
+	for _, diag := range resp.Diagnostics {
+		messages = append(messages, diag.Message)
+	}
+	return messages
+}
+
+// callDiagnosticsMessages runs the diagnostics tool over one path and returns
+// the diagnostic messages.
+func callDiagnosticsMessages(t *testing.T, session *mcp.ClientSession, path string) []string {
+	t.Helper()
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "diagnostics",
+		Arguments: map[string]any{"path": path},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	resp := decodeStructured[DiagnosticsResponse](t, res)
+	messages := make([]string, 0)
+	for _, file := range resp.Files {
+		for _, diag := range file.Diagnostics {
+			messages = append(messages, diag.Message)
+		}
+	}
+	return messages
+}
+
+// TestLintAndDiagnosticsAgree_MacroShadowedCaller is the issue #424 regression
+// test. It is a CATCH: it fails on main.
+//
+// `with-binding` expands to a `let` binding its first argument, so both
+// occurrences of `total` in caller.lisp belong to that local binding, not to
+// the global function. Analysis WITH the expander sees no cross-file reference
+// to the global `total` and reports "unused function: total"; analysis WITHOUT
+// it records two phantom references and suppresses the diagnostic.
+//
+// diagnostics serves from s.workspace(root), whose config carries the
+// service-wide expander since #422. lint built a throwaway
+// lint.BuildAnalysisConfig with no Env, no Registry and no MacroExpander, so
+// the two tools returned contradictory answers for the same file.
+func TestLintAndDiagnosticsAgree_MacroShadowedCaller(t *testing.T) {
+	tmp := t.TempDir()
+	libPath := filepath.Join(tmp, "lib.lisp")
+	writeTestFile(t, libPath, "(defun total () 42)\n"+
+		"(defmacro with-binding (name value &rest body)\n"+
+		"  (quasiquote (let ([(unquote name) (unquote value)]) (unquote-splicing body))))\n")
+	writeTestFile(t, filepath.Join(tmp, "caller.lisp"),
+		"(defun f () (with-binding total 1 (+ total 1)))\n")
+
+	srv := New(WithWorkspaceRoot(tmp))
+	session, serverSession := connectTestServer(t, srv)
+	defer closeClientSession(t, session)
+	defer closeServerSession(t, serverSession)
+
+	diagMessages := callDiagnosticsMessages(t, session, libPath)
+	lintMessages := callLintMessages(t, session, libPath)
+
+	require.Contains(t, diagMessages, "unused function: total",
+		"precondition: diagnostics expands macros, so the caller-side `total` is a local binding")
+	assert.Contains(t, lintMessages, "unused function: total",
+		"lint must analyse with the same macro expander as diagnostics; without it the macro's local binding looks like an external caller")
+	assert.Equal(t, diagMessages, lintMessages,
+		"lint and diagnostics run the same analyzers over the same file in the same workspace and must not contradict each other")
+}
+
+// TestLintAndDiagnosticsAgree_MacroExpandedCall is the additive half of the
+// same divergence, and is also a CATCH: it fails on main.
+//
+// caller.lisp mentions `alpha` only inside quoted data. Expanding `run-all`
+// splices that form into code position, making it a real reference. Analysis
+// with the expander therefore does NOT report `alpha` unused; analysis without
+// it does.
+func TestLintAndDiagnosticsAgree_MacroExpandedCall(t *testing.T) {
+	tmp := t.TempDir()
+	libPath := filepath.Join(tmp, "lib.lisp")
+	writeTestFile(t, libPath, "(defun alpha () 1)\n"+
+		"(defmacro run-all (specs)\n"+
+		"  (quasiquote (progn (unquote-splicing specs))))\n")
+	writeTestFile(t, filepath.Join(tmp, "caller.lisp"),
+		"(defun f () (run-all '((alpha))))\n")
+
+	srv := New(WithWorkspaceRoot(tmp))
+	session, serverSession := connectTestServer(t, srv)
+	defer closeClientSession(t, session)
+	defer closeServerSession(t, serverSession)
+
+	diagMessages := callDiagnosticsMessages(t, session, libPath)
+	lintMessages := callLintMessages(t, session, libPath)
+
+	require.NotContains(t, diagMessages, "unused function: alpha",
+		"precondition: diagnostics expands run-all, so caller.lisp really does call alpha")
+	assert.NotContains(t, lintMessages, "unused function: alpha",
+		"lint must see the macro-expanded call site too")
+	assert.Equal(t, diagMessages, lintMessages,
+		"lint and diagnostics must not contradict each other")
+}
+
+// TestLintRunsSemanticAnalyzersWithoutWorkspaceRoot is also a CATCH: it fails
+// on main.
+//
+// With no workspace root configured and none in the request, lint skipped
+// analysis entirely (`if root != "" && ...`), so every semantic analyzer was a
+// no-op and the tool answered "no diagnostics" for a file diagnostics flags
+// twice over. loadDocument has no such guard — it calls s.workspace("") and
+// gets a config with stdlib exports and the expander — which is why the two
+// tools diverged hardest in exactly the configuration where a caller has the
+// least other context to check against.
+func TestLintRunsSemanticAnalyzersWithoutWorkspaceRoot(t *testing.T) {
+	srv := New()
+	session, serverSession := connectTestServer(t, srv)
+	defer closeClientSession(t, session)
+	defer closeServerSession(t, serverSession)
+
+	content := "(defun orphan () 1)\n(undefined-thing)\n"
+	callWithContent := func(name string) []string {
+		res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+			Name:      name,
+			Arguments: map[string]any{"content": content},
+		})
+		require.NoError(t, err)
+		require.False(t, res.IsError)
+		return sortedMessages(t, name, res)
+	}
+
+	diagMessages := callWithContent("diagnostics")
+	lintMessages := callWithContent("lint")
+
+	require.Contains(t, diagMessages, "undefined symbol: undefined-thing",
+		"precondition: diagnostics analyses even without a workspace root")
+	assert.Equal(t, diagMessages, lintMessages,
+		"lint must run the same semantic analyzers as diagnostics when there is no workspace root")
+}
+
+// sortedMessages extracts diagnostic messages from either tool's response.
+func sortedMessages(t *testing.T, tool string, res *mcp.CallToolResult) []string {
+	t.Helper()
+	messages := make([]string, 0)
+	if tool == "lint" {
+		for _, diag := range decodeStructured[LintResponse](t, res).Diagnostics {
+			messages = append(messages, diag.Message)
+		}
+		return messages
+	}
+	for _, file := range decodeStructured[DiagnosticsResponse](t, res).Files {
+		for _, diag := range file.Diagnostics {
+			messages = append(messages, diag.Message)
+		}
+	}
+	return messages
+}
+
+// TestLintToolIsRaceFreeWithWorkspaceBuilds is a GUARD, not a catch: it passes
+// on main, where the lint tool analysed with no expander at all and so could
+// not touch the shared env.
+//
+// It exists to fail the tempting version of the #424 fix — adding
+// `Env: s.env` to the LintConfig. That routes every lint request through the
+// package-level analysis.LoadWorkspaceMacros and a fresh EnvMacroExpander,
+// both against the one env the server indexes every root with, which is
+// precisely the race #422 closed (issue #403). Serving lint from
+// s.workspace(root) instead shares the cached state, the single service-wide
+// expander and buildMu, so this stays clean under -race.
+//
+// That is not a hypothetical: adding `Env: s.env` to the old LintConfig and
+// running this test under -race reports analysis.evalPreambleForm called from
+// lintTool's analysis.LoadWorkspaceMacros racing the same function called from
+// buildWorkspaceState's (*EnvMacroExpander).LoadWorkspaceMacros.
+func TestLintToolIsRaceFreeWithWorkspaceBuilds(t *testing.T) {
+	first := macroWorkspace(t)
+	second := macroWorkspace(t)
+
+	srv := New(WithWorkspaceRoot(first))
+	srv.service.workspaceValidationInterval = time.Hour
+	_, err := srv.service.workspace(first)
+	require.NoError(t, err)
+
+	cached := filepath.Join(first, "acaller.lisp")
+	other := filepath.Join(second, "acaller.lisp")
+
+	var wg sync.WaitGroup
+	for i := range 12 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx := context.Background()
+			switch i % 4 {
+			case 0:
+				_, _, lintErr := srv.service.lintTool(ctx, nil, LintInput{Path: cached})
+				assert.NoError(t, lintErr)
+			case 1:
+				root := second
+				_, _, lintErr := srv.service.lintTool(ctx, nil, LintInput{Path: other, WorkspaceRoot: &root})
+				assert.NoError(t, lintErr)
+			case 2:
+				_, _, docErr := srv.service.loadDocument(cached, nil, &first)
+				assert.NoError(t, docErr)
+			default:
+				_, buildErr := srv.service.buildWorkspaceState(second, "fingerprint", time.Now())
+				assert.NoError(t, buildErr)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -2259,11 +2259,38 @@ func (s *service) lintTool(_ context.Context, _ *mcp.CallToolRequest, in LintInp
 		diags = append(diags, parseDiagnostic(parseErr, path))
 	}
 
+	// Analyse from the cached workspace state, exactly as loadDocument (and so
+	// the diagnostics tool) does. Issue #424: this used to build a throwaway
+	// config with lint.BuildAnalysisConfig, which sets no Env, no Registry and
+	// no MacroExpander, so the two tools ran the same analyzers over the same
+	// file in the same workspace and contradicted each other — lint saw macro
+	// calls unexpanded and diagnostics saw them expanded.
+	//
+	// Going through s.workspace is what keeps that fix from reintroducing
+	// issue #403's race. Bolting Env onto LintConfig would make every lint
+	// request call the package-level analysis.LoadWorkspaceMacros against the
+	// shared env, unsynchronised against the expansions and preamble loads
+	// that index builds and document requests are already doing there.
+	// s.workspace serves the cached state, whose Config carries the one
+	// service-wide expander, and only a cache miss reaches buildWorkspaceState
+	// and its lock.
+	//
+	// Serving from cache also drops a full PrescanWorkspace plus
+	// ScanWorkspaceRefs (and, via defaultStdlibExports, a freshly booted env
+	// with the whole standard library loaded) from every lint request.
 	var semantics *analysis.Result
-	if root != "" && parsed.Exprs != nil {
-		lintCfg := &lint.LintConfig{Workspace: root}
-		if analysisCfg, buildErr := lint.BuildAnalysisConfig(lintCfg); buildErr == nil {
-			semantics = analysis.Analyze(parsed.Exprs, analysisCfg)
+	if parsed.Exprs != nil {
+		state, stateErr := s.workspace(root)
+		if stateErr != nil {
+			// Degrade to syntax-only rather than failing the request, which is
+			// what the previous BuildAnalysisConfig error path did. Logged so
+			// the loss of semantic checks is not silent.
+			if s.logger != nil {
+				s.logger.Warn("lint: workspace state unavailable, skipping semantic analysis",
+					"path", path, "workspace_root", root, "error", stateErr)
+			}
+		} else {
+			semantics = analysis.Analyze(parsed.Exprs, analysis.ConfigForFile(state.cfg, path))
 		}
 	}
 	lintDiags, _ := linter.LintFileWithContext(source, path, semantics)

--- a/mcpserver/tool_agreement_fuzz_test.go
+++ b/mcpserver/tool_agreement_fuzz_test.go
@@ -1,0 +1,266 @@
+// Copyright © 2026 The ELPS authors
+
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/internal/fuzzseed"
+	"github.com/luthersystems/elps/internal/fuzzwatch"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser/rdparser"
+)
+
+// FuzzToolAgreement is a DIFFERENTIAL target: it asserts that mcpserver's
+// `lint` and `diagnostics` tools answer the same question about the same file
+// with the same list of diagnostics.
+//
+// # Why this property, and why a fuzzer
+//
+// The two tools run the same analyzer set (s.linter) over the same bytes and
+// build their diagnostic lists from the same two sources (parse errors plus
+// lint diagnostics), so any difference between them comes from the
+// analysis.Config each one hands the semantic analyzers. Issue #424 is exactly
+// that: `lint` built a throwaway config with lint.BuildAnalysisConfig — no Env,
+// no Registry, no MacroExpander — while `diagnostics` served from the cached
+// workspace state, whose config carries the service-wide expander. A client had
+// no way to tell which of the two contradictory answers to believe.
+//
+// The unit tests for #424 pin three specific macro shapes. What makes the
+// divergence worth a fuzz target instead is that the config is a struct of
+// eleven fields feeding analyzers that consult them in combination: the ways
+// two configs can disagree are not enumerable by hand, and the next one to be
+// introduced will not look like a macro at all. A differential assertion needs
+// no oracle — it compares two implementations that are required to agree — so
+// it stays true as analyzers are added.
+//
+// # What is and is not asserted
+//
+// Asserted: the two tools return equal diagnostics (code, message, range) in
+// equal order, and neither panics. Both sort by range before returning, so
+// order is part of the contract rather than an accident.
+//
+// NOT asserted: that any particular diagnostic is produced. Finding nothing in
+// garbage is a correct answer, as is finding a hundred things — the target is
+// blind to which, by design.
+//
+// # Cost
+//
+// This target is SLOW: measured at ~1.7 exec/sec against FuzzLintSource's ~65
+// and FuzzAnalyzeSource's ~280. Each input boots an env, loads the whole
+// standard library into it and builds a workspace index, because that is what
+// makes the two tools share a cached state at all. The env is deliberately not
+// reused across inputs — loading one input's macros into it would leak into the
+// next and make a failure unreproducible from its corpus entry alone. A
+// campaign here buys hundreds of execs, not millions; it is a differential
+// property check, not a throughput target.
+//
+// The env is budgeted (semantic analysis EVALUATES macro bodies drawn from the
+// fuzzer's workspace file) and its Runtime.Library is left nil so `load-file`
+// cannot reach the disk. Filenames are fixed constants, never fuzzer-derived:
+// both tools call os.ReadFile on the path they are given, and a fuzzer-chosen
+// path there would be a file-read primitive aimed at the machine running the
+// tests.
+func FuzzToolAgreement(f *testing.F) {
+	add := func(src, ws string) { f.Add([]byte(src), []byte(ws)) }
+
+	// The #424 shapes: a macro that rebinds a caller-side name (expansion
+	// REMOVES an index entry) and one that splices quoted caller forms into
+	// code position (expansion ADDS one).
+	add("(defun total () 42)\n"+
+		"(defmacro with-binding (name value &rest body)\n"+
+		"  (quasiquote (let ([(unquote name) (unquote value)]) (unquote-splicing body))))",
+		"(defun f () (with-binding total 1 (+ total 1)))")
+	add("(defun alpha () 1)\n(defmacro run-all (specs) (quasiquote (progn (unquote-splicing specs))))",
+		"(defun f () (run-all '((alpha))))")
+
+	// Ordinary shapes that reach the semantic analyzers without a macro:
+	// arity, duplicate definitions, unresolved symbols, package boundaries.
+	for _, s := range []string{
+		"", "(in-package 'user)\n(defun add (a b) (+ a b))\n(add 1)\n(add 1 2 3)",
+		"(in-package 'user)\n(defun dup () 1)\n(defun dup () 2)",
+		"(in-package 'demo)\n(export 'shared)\n(defun shared () 1)",
+		"(undefined-thing)", "(car)", "(let ([a]) a)", "(defun f () (f))",
+		"(", ")", "(defun f (a a) a)",
+	} {
+		add(s, "(in-package 'user)\n(defun helper () 1)")
+	}
+
+	// A macro that errors during expansion, and one that expands forever:
+	// both leave the expander's state where the two tools could diverge on it.
+	add("(in-package 'demo)\n(boom 1)",
+		"(in-package 'demo)\n(defmacro boom (x) (error 'macro-boom \"x\"))")
+	add("(in-package 'demo)\n(loop 1)",
+		"(in-package 'demo)\n(defmacro loop (x) (quasiquote (loop (unquote x))))")
+
+	for _, seed := range fuzzseed.Adversarial() {
+		add(string(seed), "(in-package 'user)\n(defun helper () 1)")
+	}
+
+	f.Fuzz(func(t *testing.T, src, wsSrc []byte) {
+		runAgreementBudgeted(t, t.TempDir(), src, wsSrc)
+	})
+}
+
+const (
+	// Budgets for the injected LEnv. Analysis with a MacroExpander evaluates
+	// macro bodies loaded from the fuzzer's workspace file.
+	agreeEnvMaxSteps          = 200_000
+	agreeEnvMaxTailIterations = 10_000
+	agreeEnvMaxPhysHeight     = 2_000
+	agreeEnvMaxAlloc          = 1_000_000
+	agreeEnvMacroDepth        = 100
+	agreeEnvMaxEvalNesting    = 20_000
+
+	// Fixed names. Never fuzzer-derived — see the target's doc comment.
+	agreeFileA = "fuzz-a.lisp"
+	agreeFileB = "fuzz-b.lisp"
+
+	agreeMaxFileBytes = 64 << 10
+
+	// Denominated in SCHEDULED time (internal/fuzzwatch): wall clock during
+	// which this process was not run by the OS is not charged to the tools.
+	agreeWatchdogTimeout = 60 * time.Second
+)
+
+func runAgreementBudgeted(t *testing.T, root string, src, wsSrc []byte) {
+	t.Helper()
+	if len(src) > agreeMaxFileBytes || len(wsSrc) > agreeMaxFileBytes {
+		t.Skip("input larger than the workspace byte cap")
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runAgreement(root, src, wsSrc) }()
+
+	budget := fuzzwatch.New(agreeWatchdogTimeout)
+	wait := budget.Total()
+	for {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("%v\n--- src (%d bytes) ---\n%q\n--- workspace (%d bytes) ---\n%q",
+					err, len(src), src, len(wsSrc), wsSrc)
+			}
+			return
+		case <-time.After(wait):
+			verdict, more, report := budget.Check()
+			switch verdict {
+			case fuzzwatch.Continue:
+				wait = more
+			case fuzzwatch.Inconclusive:
+				t.Skipf("no verdict: the process was starved throughout (%s)", report)
+				return
+			default:
+				t.Fatalf("the lint/diagnostics comparison did not terminate within %s"+
+					" of SCHEDULED time (%s)"+
+					"\n--- src (%d bytes) ---\n%q\n--- workspace (%d bytes) ---\n%q",
+					budget.Total(), report, len(src), src, len(wsSrc), wsSrc)
+				return
+			}
+		}
+	}
+}
+
+// runAgreement writes the two files, serves both tools from one server, and
+// compares their answers for fuzz-a.lisp.
+func runAgreement(root string, src, wsSrc []byte) error {
+	pathA := filepath.Join(root, agreeFileA)
+	if err := os.WriteFile(pathA, src, 0o600); err != nil {
+		return fmt.Errorf("harness: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, agreeFileB), wsSrc, 0o600); err != nil {
+		return fmt.Errorf("harness: %w", err)
+	}
+
+	env, err := newAgreementEnv()
+	if err != nil {
+		return fmt.Errorf("harness: %w", err)
+	}
+	srv := New(WithWorkspaceRoot(root), WithEnv(env))
+	// One server, so both tools see the same cached workspace state — which is
+	// the point. A divergence here is a divergence in how the tools USE that
+	// state, not in what two independent servers happened to index.
+	svc := srv.service
+	ctx := context.Background()
+
+	fd, diagErr := svc.collectFileDiagnostics(pathA, nil, &root)
+	_, lintResp, lintErr := svc.lintTool(ctx, nil, LintInput{Path: pathA})
+
+	// Whether the file can be served at all is itself part of the agreement.
+	// A workspace neither tool can serve is a legitimate outcome; one tool
+	// refusing what the other answers is not. Only error-ness is compared —
+	// lint wraps its failures in toolErr, so the messages differ by design.
+	switch {
+	case diagErr != nil && lintErr != nil:
+		return nil
+	case diagErr != nil:
+		return fmt.Errorf("lint served %s but diagnostics returned: %w", agreeFileA, diagErr)
+	case lintErr != nil:
+		return fmt.Errorf("diagnostics served %s but lint returned: %w", agreeFileA, lintErr)
+	}
+
+	if len(fd.Diagnostics) != len(lintResp.Diagnostics) {
+		return fmt.Errorf("lint and diagnostics disagree on %s: diagnostics returned %d, lint returned %d"+
+			"\n  diagnostics: %s\n  lint:        %s",
+			agreeFileA, len(fd.Diagnostics), len(lintResp.Diagnostics),
+			describeDiagnostics(fd.Diagnostics), describeDiagnostics(lintResp.Diagnostics))
+	}
+	for i := range fd.Diagnostics {
+		a, b := fd.Diagnostics[i], lintResp.Diagnostics[i]
+		if a.Code != b.Code || a.Message != b.Message || a.Range != b.Range || a.Severity != b.Severity {
+			return fmt.Errorf("lint and diagnostics disagree on %s at index %d"+
+				"\n  diagnostics: %s\n  lint:        %s",
+				agreeFileA, i, describeDiagnostic(a), describeDiagnostic(b))
+		}
+	}
+	return nil
+}
+
+func describeDiagnostic(d Diagnostic) string {
+	return fmt.Sprintf("%s %q [%d:%d-%d:%d] %s", d.Code, d.Message,
+		d.Range.Start.Line, d.Range.Start.Character,
+		d.Range.End.Line, d.Range.End.Character, d.Severity)
+}
+
+func describeDiagnostics(ds []Diagnostic) string {
+	out := make([]string, 0, len(ds))
+	for _, d := range ds {
+		out = append(out, describeDiagnostic(d))
+	}
+	return fmt.Sprint(out)
+}
+
+// newAgreementEnv builds the environment analysis expands macros in.
+// Runtime.Library stays nil so load-file cannot reach the disk.
+func newAgreementEnv() (*lisp.LEnv, error) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = rdparser.NewReader()
+	if rc := lisp.InitializeUserEnv(env,
+		lisp.WithStderr(discardAgreementWriter{}),
+		lisp.WithMaxSteps(agreeEnvMaxSteps),
+		lisp.WithMaxTailIterations(agreeEnvMaxTailIterations),
+		lisp.WithMaximumPhysicalStackHeight(agreeEnvMaxPhysHeight),
+		lisp.WithMaxAlloc(agreeEnvMaxAlloc),
+		lisp.WithMaxMacroExpansionDepth(agreeEnvMacroDepth),
+		lisp.WithMaxEvalNesting(agreeEnvMaxEvalNesting),
+	); rc.Type == lisp.LError {
+		return nil, fmt.Errorf("InitializeUserEnv: %v", rc)
+	}
+	if rc := lisplib.LoadLibrary(env); rc.Type == lisp.LError {
+		return nil, fmt.Errorf("LoadLibrary: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		return nil, fmt.Errorf("InPackage: %v", rc)
+	}
+	return env, nil
+}
+
+type discardAgreementWriter struct{}
+
+func (discardAgreementWriter) Write(p []byte) (int, error) { return len(p), nil }


### PR DESCRIPTION
`mcpserver`'s `lint` tool built its analysis config with `lint.BuildAnalysisConfig(&lint.LintConfig{Workspace: root})` — no `Env`, no `Registry`, no `MacroExpander` — while `diagnostics` served from the cached workspace state, whose `Config` carries the service-wide macro expander since #422. Same analyzers, same file, same workspace, contradictory answers, and nothing in either response telling the caller which one to believe.

## User-visible symptom

Three, all reproduced against `ce9798d` (`main`) before writing a line of the fix.

1. **`lint` misses a finding `diagnostics` reports.** A macro rebinds a name the caller mentions, so with expansion the caller-side occurrences belong to the macro's `let` and the global function has no callers. `diagnostics` says `unused function: total`; `lint` says nothing. An agent asked to clean up dead code sees a clean file.
2. **`lint` invents a finding `diagnostics` does not have.** A macro splices quoted caller-side forms into code position, so with expansion the call site is real. `diagnostics` is silent; `lint` says `unused function: alpha`. An agent acting on that deletes a function that is called.
3. **With no workspace root, `lint` ran no semantic analyzer at all.** The old code was guarded `if root != "" && parsed.Exprs != nil`, and `loadDocument` has no such guard. On `(defun orphan () 1)` + `(undefined-thing)` with no root configured, `diagnostics` returns `unused function: orphan` and `undefined symbol: undefined-thing`; `lint` returns `{"diagnostics": []}`. The tools diverged hardest in exactly the configuration where a caller has the least other context to check against.

In all three the wrong answer has the shape of a right one: a clean lint result is indistinguishable from a clean file.

## Red then green

`mcpserver/lint_tool_expander_test.go` was written first and run against `ce9798d` with only the test file added. Real output:

```
--- FAIL: TestLintAndDiagnosticsAgree_MacroShadowedCaller (0.05s)
    Error:    []string{} does not contain "unused function: total"
    Messages: lint must analyse with the same macro expander as diagnostics;
              without it the macro's local binding looks like an external caller
    Error:    Not equal:
              expected: []string{"unused function: total"}
              actual  : []string{}
--- FAIL: TestLintAndDiagnosticsAgree_MacroExpandedCall (0.03s)
    Error:    []string{"unused function: alpha"} should not contain "unused function: alpha"
    Messages: lint must see the macro-expanded call site too
--- FAIL: TestLintRunsSemanticAnalyzersWithoutWorkspaceRoot (0.02s)
    Error:    Not equal:
    Messages: lint must run the same semantic analyzers as diagnostics when
              there is no workspace root
FAIL	github.com/luthersystems/elps/mcpserver	0.155s
```

Each of the three asserts the `diagnostics` half as a `require` precondition first, so a failure cannot be read as "both tools changed together".

`FuzzToolAgreement`'s **seed corpus is also red on `main`**, which is what makes it a catch rather than decoration:

```
--- FAIL: FuzzToolAgreement/seed#0: lint and diagnostics disagree on fuzz-a.lisp:
          diagnostics returned 1, lint returned 0
--- FAIL: FuzzToolAgreement/seed#1: lint and diagnostics disagree on fuzz-a.lisp:
          diagnostics returned 0, lint returned 1
```

All green after the fix.

`TestLintToolIsRaceFreeWithWorkspaceBuilds` is labelled in-file as a **GUARD, not a catch**: it passes on `main`, where `lint` analysed with no expander and so could not touch the shared env. It is there to fail the tempting fix — see below.

## Not reintroducing #403's race

The obvious patch is `&lint.LintConfig{Workspace: root, Env: s.env}`. `BuildAnalysisConfig` then calls the **package-level** `analysis.LoadWorkspaceMacros` against the server's one env, once per lint request, and mints a fresh `EnvMacroExpander` — precisely the pairing #422 closed by moving to one expander per service under a lock.

That is measured, not asserted. Applying exactly that patch and running the new guard under `-race`:

```
WARNING: DATA RACE
  analysis.evalPreambleForm()
  analysis.LoadWorkspaceMacros()
  mcpserver.(*service).lintTool()
    vs
  analysis.evalPreambleForm()
  analysis.LoadWorkspaceMacros()
  analysis.(*EnvMacroExpander).LoadWorkspaceMacros()
  mcpserver.(*service).buildWorkspaceState()
```

This PR instead routes the tool through `s.workspace(root)` and `analysis.ConfigForFile`, exactly as `loadDocument` does. It therefore shares the cached state, the single service-wide expander and `buildMu`, and adds no new path to the env: a warm request touches no expander machinery at all, and a cold one goes through `buildWorkspaceState` under the lock #422 added. The guard is clean under `-race`.

## Cost

Serving from cache removes a full `PrescanWorkspace`, a full `ScanWorkspaceRefs` and — via `defaultStdlibExports` — a freshly booted env with the whole standard library loaded, from **every** lint request. #422 made both scans more expensive, so the old shape was still getting worse.

`BenchmarkLintTool` (new, committed) over a warm workspace of 10 files x 20 macro call sites, `-benchtime 30x -count 10` per arm, medians:

| metric | base (`ce9798d`) | this PR | delta |
|---|---|---|---|
| sec/op | 70.2 ms | 2.48 ms | **-96.5%** |
| B/op | 11,153,682 | 683,386 | **-93.9%** |
| allocs/op | 74,520 | 7,004 | **-90.6%** |

Timing on this runner is noisy (base samples spanned 45-167 ms), so treat the 28x as an order-of-magnitude claim; the allocation numbers are stable to four digits and are the honest ones. **The regression gate cannot fire on any of this** — `BenchmarkLintTool` is new, so the arms do not pair and `bench-arms-check.sh` reports it as unpaired. The numbers above are hand-run against both revisions rather than gate output.

`scripts/fuzz-budget-check.sh` still passes with `FuzzToolAgreement` added: 27 targets over 6 shards is a largest shard of 5, the same as the 26 targets on `main`, so the nightly sweep's wall clock is unchanged. Headroom was already reported as 0 min before this PR.

## Neighbourhood audit

Every site in `mcpserver/` that builds an analysis config rather than using the cached workspace state, and what happened to it:

| site | verdict |
|---|---|
| `service.go` `lintTool` | **Changed.** The bug. |
| `service.go` `loadDocument` | Unchanged, already correct — `s.workspace(root)` then `analysis.ConfigForFile`. It is the shape `lintTool` now copies, and the source of the `diagnostics` half of every new test. |
| `service.go` `workspaceSymbolsTool` | Unchanged, already correct — reads `state.symbols` from `s.workspace(root)`, no config of its own. |
| `service.go` `buildWorkspaceState` | Unchanged. It *is* the cache builder; it must construct the config. Correct since #422. |
| `service.go` `runPerf` -> `analysis/perf` | **Unchanged deliberately.** Builds a `perf.Config`, never an `analysis.Config`: `analysis/perf` has its own AST walker and no `MacroExpander` concept, so there is no config to share and no divergence to fix. Whether the perf tools *should* see expanded macros is a real question and a separate one — they would need an analysis pipeline they do not currently have. Not filed; that is a feature request, not a defect. |
| `service.go` `formatTool` | Unchanged. `formatter.Config` (indent size), unrelated to analysis. |
| `service.go` `docTool` / `evalTool` / `testTool` | Unchanged. No analysis config; they run against an env from the factory. |
| `server.go` `newService` | Unchanged. Constructs the `lint.Linter` (analyzer list), not an analysis config. |
| `lsp/server.go` `buildWorkspaceIndex` | Out of package, unchanged, already correct — installs the expander before `ScanWorkspaceRefs`, and is immune to the concurrency problem (`sync.Once`, single root, one expander per server). |
| `lint/lint.go` `BuildAnalysisConfig` | Out of package, unchanged. Correct on its own terms since #359; the fix here is to stop calling it from a server that has a cache, not to change it. It keeps its CLI and embedder callers. It does have a separate defect — see #437. |
| `cmd/lint.go` | **Out of scope, deliberately.** Passes a `Registry` but never an `Env`, so `elps lint` has never expanded macros. Turning that on changes output for every CLI user and slows the command: a policy decision, not this bug. Left as-is and not filed, since #424 already records the reasoning. |
| `cmd/minify.go` -> `minifier` | Unchanged. `lint.BuildAnalysisConfig` with no env, then a field-by-field `Config` rebuild. Renaming decisions made without expansion is a real question, but the minifier has its own preservation set and risk model. Out of scope, unchanged from the #422 audit's conclusion. |

## The new fuzz target

`FuzzToolAgreement` asserts the invariant **differentially**: `lint` and `diagnostics`, served from one server, must return the same diagnostics for the same file — same codes, messages, ranges, severities, order — and must agree on whether the file can be served at all. There is no oracle to keep up to date, so it stays true as analyzers are added, and it covers the shape the three unit tests cannot: the next config divergence will not look like a macro.

It is **slow** — measured at ~1.7 exec/sec, against `FuzzLintSource`'s ~65 and `FuzzAnalyzeSource`'s ~280 — because each input boots an env, loads the stdlib and builds a workspace index. The env is deliberately not reused across inputs; loading one input's macros into it would leak into the next and make a failure unreproducible from its corpus entry alone. A 3-minute campaign bought 301 execs and 20 new interesting inputs, and found no divergence beyond the two seeds. That is a small campaign and is reported as such.

`mcpserver` had no fuzz target at all before this.

## Test plan

- `go build ./...`, `go vet ./...` — clean
- `golangci-lint run ./...` — 0 issues
- `go test -count=1 ./...` / `make go-test` — 34 packages pass; see the caveat below
- `go test -race -count=1 ./...` / `make race` — `mcpserver`, `analysis`, `analysis/perf` and `lint` all clean, including the new race guard
- `make test-elpscheck` — 29 packages pass, same caveat
- `make test-examples` — pass
- `elps fmt -l ./...` — clean; `elps doc -m` — all documented (binary removed before committing)
- `./scripts/ci-gates-test.sh` — pass; `./scripts/fuzz-budget-check.sh` — the sweep fits
- `./scripts/confidentiality-guard.sh` — clean
- `FUZZTIME=180s scripts/fuzz.sh ./mcpserver/` — target survived its budget

**Caveat, and it is not this PR's:** `./lisp/` fails on this runner under `go test -race`, and intermittently without it, on `TestEvalTerminatingSeedsComplete/tail-recursion-bounded`. It reproduces on pristine `ce9798d` with no changes applied, and `lisp` does not import `mcpserver` in any build. Filed as #436.

## Filed while in here

Three findings from `mcpserver/`, `lint/` and `lisp/`, none fixed here:

- **#436** — `TestEvalTerminatingSeedsComplete` asserts the terminating seed corpus against a 2s **wall-clock** context deadline, while the watchdog next to it is careful to use scheduled time. Found by running.
- **#437** — `lint.BuildAnalysisConfig` mutates the caller's `LintConfig.StdlibExports` map in place, appending registry and workspace exports into it and accumulating duplicates across calls. The field's own doc comment invites callers to share exactly that map. Found by reading, confirmed by running.
- **#438** — `mcpserver`'s `lint` tool silently ignores unknown names in `checks` and returns zero diagnostics, where `cmd/lint.go` exits 2 on the same input. Same silently-wrong-answer class as this bug. Found by reading, confirmed by running.

## Anything in the issue that proved wrong

Nothing. Both halves of the divergence reproduced as described, `BuildAnalysisConfig` was indeed doing a full prescan and `ScanWorkspaceRefs` per request, and the predicted trap is real — the `Env`-on-`LintConfig` patch does report data races. The issue understated one thing: it describes the divergence for a configured workspace, and the no-workspace-root case (symptom 3) is worse, because there `lint` runs no semantic analyzer at all.

Fixes #424


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_