### PR TITLE
libtesting: stop EnvTestSuite panicking on a runtime with no testing package (#425)

### DIFF
--- a/lisp/lisplib/libtesting/env_suite_test.go
+++ b/lisp/lisplib/libtesting/env_suite_test.go
@@ -1,0 +1,175 @@
+// Copyright © 2026 The ELPS authors
+
+package libtesting_test
+
+import (
+	"bytes"
+	"runtime/debug"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libmath"
+	"github.com/luthersystems/elps/lisp/lisplib/libtesting"
+	"github.com/luthersystems/elps/parser"
+)
+
+// This file covers issue #425: EnvTestSuite indexed
+// env.Runtime.Registry.Packages[DefaultPackageName] without a comma-ok and
+// called Get on the result. A runtime that never loaded the testing package
+// has no such key, the zero value of the map is a nil *Package, and
+// Package.get dereferences pkg.Symbols on it -- a nil pointer dereference
+// inside a function whose documented contract is to return nil when there is
+// no suite.
+//
+// The reachable shape is an embedder, not lisp source: EnvTestSuite is
+// exported, documented as returning nil "if there is none", and takes an
+// arbitrary *lisp.LEnv. Asking an arbitrary runtime whether it has a suite is
+// the question the nil return advertises, and on main asking it panicked the
+// host. That is issue #367's rule ("an elps program must never panic the
+// host") reached through the embedder API.
+//
+// callEnvTestSuite recovers so the red run stays readable. A nil dereference
+// is an ordinary panic, unlike the runtime throw issue #420 needed a child
+// process for, so recovering is enough to keep the rest of the package
+// reporting -- but an unrecovered panic here would still take the whole test
+// binary down, which is exactly what an embedder gets.
+func callEnvTestSuite(tb testing.TB, env *lisp.LEnv) (suite *libtesting.TestSuite) {
+	tb.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			tb.Fatalf("EnvTestSuite panicked: %v\n\n%s", r, debug.Stack())
+		}
+	}()
+	return libtesting.EnvTestSuite(env)
+}
+
+// TestEnvTestSuiteWithoutTestingPackage is the catch for #425: on main every
+// subtest panics with a nil pointer dereference where the documented answer is
+// a nil *TestSuite.
+func TestEnvTestSuiteWithoutTestingPackage(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(testing.TB) *lisp.LEnv
+	}{{
+		// The minimum an embedder can hold: a runtime with an empty
+		// registry. StandardRuntime starts with no packages at all.
+		name: "bare-runtime",
+		build: func(tb testing.TB) *lisp.LEnv {
+			return lisp.NewEnv(nil)
+		},
+	}, {
+		// The ordinary embedder shape: a usable user environment that
+		// simply did not opt into the testing package.
+		name: "user-env-without-testing",
+		build: func(tb testing.TB) *lisp.LEnv {
+			tb.Helper()
+			env := lisp.NewEnv(nil)
+			env.Runtime.Reader = parser.NewReader()
+			if rc := lisp.InitializeUserEnv(env); !rc.IsNil() {
+				tb.Fatalf("initialize-user-env: %v", rc)
+			}
+			return env
+		},
+	}, {
+		// A populated registry that still lacks this one key, so the
+		// failure is the missing key and not an empty map.
+		name: "other-lisplib-packages-loaded",
+		build: func(tb testing.TB) *lisp.LEnv {
+			tb.Helper()
+			env := lisp.NewEnv(nil)
+			env.Runtime.Reader = parser.NewReader()
+			if rc := lisp.InitializeUserEnv(env); !rc.IsNil() {
+				tb.Fatalf("initialize-user-env: %v", rc)
+			}
+			if rc := libmath.LoadPackage(env); !rc.IsNil() {
+				tb.Fatalf("load math: %v", rc)
+			}
+			return env
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env := test.build(t)
+			if _, ok := env.Runtime.Registry.Packages[libtesting.DefaultPackageName]; ok {
+				t.Fatalf("premise broken: %q is already in the registry, so this subtest does not exercise the missing-package path", libtesting.DefaultPackageName)
+			}
+			if suite := callEnvTestSuite(t, env); suite != nil {
+				t.Errorf("EnvTestSuite = %p, want nil on a runtime with no testing package", suite)
+			}
+		})
+	}
+}
+
+// TestEnvTestSuitePackagePresentWithoutSuite is a GUARD, not a catch: it
+// passes on main. It pins the neighbouring case the function always handled --
+// the package exists but the suite symbol is unbound or is not a *TestSuite --
+// so a future rewrite of the lookup cannot regress it while fixing the missing
+// -package case.
+func TestEnvTestSuitePackagePresentWithoutSuite(t *testing.T) {
+	newEnv := func(tb testing.TB) *lisp.LEnv {
+		tb.Helper()
+		env := lisp.NewEnv(nil)
+		env.Runtime.Reader = parser.NewReader()
+		if rc := lisp.InitializeUserEnv(env); !rc.IsNil() {
+			tb.Fatalf("initialize-user-env: %v", rc)
+		}
+		name := lisp.Symbol(libtesting.DefaultPackageName)
+		if rc := env.DefinePackage(name); !rc.IsNil() {
+			tb.Fatalf("define-package: %v", rc)
+		}
+		if rc := env.InPackage(name); !rc.IsNil() {
+			tb.Fatalf("in-package: %v", rc)
+		}
+		return env
+	}
+
+	t.Run("symbol-unbound", func(t *testing.T) {
+		env := newEnv(t)
+		if suite := callEnvTestSuite(t, env); suite != nil {
+			t.Errorf("EnvTestSuite = %p, want nil when the suite symbol is unbound", suite)
+		}
+	})
+
+	t.Run("symbol-bound-to-non-native", func(t *testing.T) {
+		env := newEnv(t)
+		if rc := env.PutGlobal(lisp.Symbol(libtesting.DefaultSuiteSymbol), lisp.String("not a suite")); rc.Type == lisp.LError {
+			t.Fatalf("put-global: %v", rc)
+		}
+		if suite := callEnvTestSuite(t, env); suite != nil {
+			t.Errorf("EnvTestSuite = %p, want nil when the suite symbol is not a native value", suite)
+		}
+	})
+
+	t.Run("symbol-bound-to-other-native", func(t *testing.T) {
+		env := newEnv(t)
+		// A real native value of some other type, so this exercises the
+		// type assertion rather than stopping at the LNative check.
+		other := lisp.Native(new(bytes.Buffer))
+		if other.Type != lisp.LNative {
+			t.Fatalf("premise broken: lisp.Native produced %v, not LNative", other.Type)
+		}
+		if rc := env.PutGlobal(lisp.Symbol(libtesting.DefaultSuiteSymbol), other); rc.Type == lisp.LError {
+			t.Fatalf("put-global: %v", rc)
+		}
+		if suite := callEnvTestSuite(t, env); suite != nil {
+			t.Errorf("EnvTestSuite = %p, want nil when the native value is not a *TestSuite", suite)
+		}
+	})
+}
+
+// TestEnvTestSuiteAfterLoadPackage is a GUARD: it passes on main and pins the
+// positive case, so a fix that returns nil too eagerly is caught here.
+func TestEnvTestSuiteAfterLoadPackage(t *testing.T) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); !rc.IsNil() {
+		t.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := libtesting.LoadPackage(env); !rc.IsNil() {
+		t.Fatalf("load-package: %v", rc)
+	}
+	if suite := callEnvTestSuite(t, env); suite == nil {
+		t.Error("EnvTestSuite = nil after LoadPackage, want the installed suite")
+	}
+}

--- a/lisp/lisplib/libtesting/libtesting.go
+++ b/lisp/lisplib/libtesting/libtesting.go
@@ -445,8 +445,18 @@ type Test struct {
 // EnvTestSuite returns the suite installed in env, or nil if there is none.
 // The suite is returned by pointer and is safe to use while other environments
 // holding the same suite are evaluating.
+//
+// "None" includes a runtime that never loaded this package at all.  The map
+// index is comma-ok because the zero value of Registry.Packages is a nil
+// *Package and Package.Get dereferences pkg.Symbols, so indexing it unchecked
+// turned "does this runtime have a suite?" -- the question the nil return
+// advertises -- into a nil pointer dereference in the host.  See issue #425.
 func EnvTestSuite(env *lisp.LEnv) *TestSuite {
-	lsuite := env.Runtime.Registry.Packages[DefaultPackageName].Get(lisp.Symbol(DefaultSuiteSymbol))
+	pkg, ok := env.Runtime.Registry.Packages[DefaultPackageName]
+	if !ok || pkg == nil {
+		return nil
+	}
+	lsuite := pkg.Get(lisp.Symbol(DefaultSuiteSymbol))
 	if lsuite.Type != lisp.LNative {
 		return nil
 	}


### PR DESCRIPTION
Fixes #425

## Verdict: it reproduces

#425 was filed from reading `main`, and asked for the red test first with closing as the right outcome if the panic did not appear. It appears, deterministically, on every runtime shape an embedder can hold.

`EnvTestSuite` indexed `env.Runtime.Registry.Packages[DefaultPackageName]` without a comma-ok and called `Get` on the result. `StandardRuntime` starts with an empty registry, so a runtime that never loaded this package has no such key, the zero value of the map is a nil `*Package`, and `Package.get` dereferences `pkg.Symbols` on it. The premise the issue flagged as the thing to check — "unless `Registry.Packages` is pre-populated somewhere I did not find" — is checked explicitly in the test rather than assumed: every subtest asserts the key is absent before calling, and fails with a "premise broken" message if it is not.

## Red evidence, on `ce9798d` with only the test file added

```
=== RUN   TestEnvTestSuiteWithoutTestingPackage/bare-runtime
    env_suite_test.go:40: EnvTestSuite panicked: runtime error: invalid memory address or nil pointer dereference

        goroutine 8 [running]:
        runtime/debug.Stack()
        panic({0x5c3700?, 0x77ed70?})
        	/usr/local/go/src/runtime/panic.go:783 +0x132
        github.com/luthersystems/elps/lisp.(*Package).get(0x684523?, 0xc00012efc0)
        	lisp/package.go:95 +0x11c
        github.com/luthersystems/elps/lisp.(*Package).Get(...)
        	lisp/package.go:81
        github.com/luthersystems/elps/lisp/lisplib/libtesting.EnvTestSuite(0xc000074980)
        	lisp/lisplib/libtesting/libtesting.go:449 +0xa5
```

```
--- FAIL: TestEnvTestSuiteWithoutTestingPackage (0.00s)
    --- FAIL: TestEnvTestSuiteWithoutTestingPackage/bare-runtime (0.00s)
    --- FAIL: TestEnvTestSuiteWithoutTestingPackage/user-env-without-testing (0.00s)
    --- FAIL: TestEnvTestSuiteWithoutTestingPackage/other-lisplib-packages-loaded (0.00s)
```

Three catches, all failing on `main`, all passing with the fix:

| subtest | runtime shape |
|---|---|
| `bare-runtime` | `lisp.NewEnv(nil)` — the minimum an embedder can hold; `StandardRuntime`'s registry is empty |
| `user-env-without-testing` | a usable user environment that did not opt into the testing package |
| `other-lisplib-packages-loaded` | a populated registry that lacks this one key, so the fault is the missing key and not an empty map |

Three more subtests are **guards**, not catches, and are labelled as such in-file because they pass on `main`. They pin the neighbouring cases the function always handled, so a rewrite of the lookup cannot regress them while fixing the missing-package one: the symbol unbound, the symbol bound to a non-native, the symbol bound to some other native. `TestEnvTestSuiteAfterLoadPackage` is a guard in the other direction — a fix that returns `nil` too eagerly fails there.

The helper recovers, so the red run stays readable and the rest of the package keeps reporting. That is a convenience for the test, not the embedder's experience: a nil dereference is an ordinary panic, so unlike #420's runtime throw it can be recovered — but an embedder that does not wrap the call loses the process.

## The fix

Comma-ok on the map index, returning `nil` when the package is absent, which is what the function already did when the symbol was absent. `pkg == nil` is checked alongside `!ok` because a nil value stored under a present key would dereference identically, and the check costs nothing.

## Neighbourhood audit

The brief was every other unchecked map index and unchecked type assertion on the embedder-facing surface of `lisp/lisplib/`. Sites examined and **not** changed:

- **Every type assertion in `lisp/lisplib/`** — all 30 of them are comma-ok already (`libtime` ×20, `libgolang` ×3, `libregexp` ×2, `libjson` ×3, `libhelp` ×1, and `libtesting`'s own `lsuite.Native.(*TestSuite)`). The one that reads as an exception, `libjson/encode.go`'s `if m, own := v.(*ownMessage); !own || !m.loadable`, short-circuits on `!own` and never dereferences `m`. Nothing to fix.
- **`libhelp`'s ten `Registry.Packages[...]` indexes** — the largest concentration in the tree, and all safe. `QueryPackages`, `RenderPackageList` and both loops in `QueryMissingDocs` index with a key they just ranged out of the same map, so the key exists by construction; `QueryPackage`, `QuerySymbol`, `opPackageSymbols`, `RenderPkgExported` and `LookupSymbolDoc` all take the value and check it against nil before use. `LookupSymbolDoc` additionally checks `Registry == nil` and `Runtime.Package == nil`, which is the same defensive posture #425 asked for here.
- **`TestSuite.tests` / `TestSuite.benchmarks`** — `Add`/`AddBenchmark` compare the map value against nil before writing; `Test(i)`/`Benchmark(i)` index the map with a name taken from `torder`/`border`, which only `Add`/`AddBenchmark` append to, so the key always exists. They will panic on an out-of-range `i`, but that is the ordinary Go slice contract and `Len()` is the exported way to stay inside it — turning it into a nil return would hide a caller bug rather than an environment shape.
- **`lisp/` outside lisplib** was swept too, since the defect is really about the shape of `Registry.Packages` rather than about this package. All nine indexes there are either preceded by `DefinePackage` (`InitializeUserEnv`, `builtinInPackage`) or nil-checked before use (`InPackage`, `UsePackage`, `pkgFunName`, the qualified-symbol paths in `env.go`, and the package swap in `funCall`). `EnvTestSuite` was the only unguarded one in the repository.

**Found and deliberately not fixed here**, filed as #433: `lisp.InitializeTypedef` panics on a bare runtime, and its own doc comment invites embedders to call it directly ("Generally that will be enabled by calling InitializeTypedef or InitializeUserEnv"). Confirmed by running, not by reading — `lisp.InitializeTypedef(lisp.NewEnv(nil))` dereferences a nil `Runtime.Package` in `(*LEnv).builtin` at `lisp/env.go:691`, and its `Registry.Packages[Registry.Lang].Put(...)` two lines later is unguarded in the same way `EnvTestSuite` was. It is in `lisp/`, not `lisp/lisplib/`, and folding a second package's fix into a one-line robustness change would blur what this PR answers for.

## On fuzzing

No fuzz target was added. `EnvTestSuite`'s input space is finite and enumerated by the table above — the package is present or absent, and if present the symbol is unbound, non-native, some other native, or the suite. `FuzzApplyStdlib` covers what is reachable from lisp source; this function is not, which is exactly why the issue is filed against the embedder API.

## Gates

| gate | result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test -count=1 ./...` | clean |
| `go test -race ./...` | clean |
| `golangci-lint run ./...` | 0 issues |
| `elps fmt -l ./...` | clean (binary deleted before commit) |
| `elps doc -m` | "All functions and exports are documented." |
| `make go-test` | clean on retry — see the flake note below |
| `make race` | clean |
| `make test-elpscheck` | clean |
| `make test-examples` | clean |
| `./scripts/ci-gates-test.sh` | 210 passed, 0 failed |
| `./scripts/confidentiality-guard.sh` | clean (after `git add`) |

**Flake note, so the table is not read as cleaner than the runs were.** `lisp`'s `TestEvalTerminatingSeedsComplete/tail-recursion-bounded` failed intermittently during these runs with `context deadline exceeded`. It is not caused by this change — the change is confined to `lisp/lisplib/libtesting` — and it reproduces on an unmodified `ce9798d` worktree, 2 failures in 6 concurrent runs, stopping at a different step count every time. Filed as #435. Every gate above passed on a run where that test did not flake.

No benchmark comparison: this change adds one map lookup on a path that runs once per `elps test` invocation, and touches no evaluator code.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_