### PR TITLE
elpstest: give every benchmark iteration a fresh AST (#365)

### DIFF
--- a/elpstest/lisptest.go
+++ b/elpstest/lisptest.go
@@ -383,6 +383,22 @@ func RunTestSuite(t *testing.T, tests TestSuite) {
 
 // RunBenchmark runs a standard benchmark that executes expressions parsed from
 // source.
+//
+// Each iteration gets a fresh environment and a fresh copy of the parsed
+// expressions.  The copy matters: an ELPS expression's quoted literals are AST
+// nodes, and evaluation can write to them -- `stable-sort` sorts a literal in
+// place, which lisp.TestSliceViewSharesElements pins as current behaviour.
+// Without the copy, one parsed tree was shared by every iteration, so a
+// benchmark over such a source measured its declared workload once and its own
+// output thereafter, and the reported number moved with b.N.  This is the same
+// hazard lisp.TextLoader copies to avoid.  See issue #365.
+//
+// Both the environment and the copy are built with the timer stopped, so
+// neither is charged to ns/op, B/op or allocs/op.  Note that the untimed
+// per-iteration setup still costs wall clock, and the framework sizes b.N from
+// the timed duration alone: a source whose timed region is microseconds will
+// run for many multiples of -benchtime in real time.  Sources here are
+// expected to do enough work per iteration for that ratio to stay sane.
 func RunBenchmark(b *testing.B, source string) {
 	b.StopTimer()
 	p := parser.NewReader()
@@ -401,8 +417,12 @@ func RunBenchmark(b *testing.B, source string) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		b.StartTimer()
+		iterExprs := make([]*lisp.LVal, len(exprs))
 		for i, expr := range exprs {
+			iterExprs[i] = expr.Copy()
+		}
+		b.StartTimer()
+		for i, expr := range iterExprs {
 			lerr := env.Eval(expr)
 			if lerr.Type == lisp.LError {
 				b.Fatalf("expr %d: %v", i, lerr)

--- a/elpstest/runbenchmark_test.go
+++ b/elpstest/runbenchmark_test.go
@@ -1,0 +1,158 @@
+// Copyright © 2026 The ELPS authors
+
+package elpstest
+
+import (
+	"flag"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+)
+
+// This file covers issue #365: RunBenchmark parsed its source once, outside
+// the loop, and then evaluated that one tree in every b.N iteration. Each
+// iteration got a fresh Runtime but the same AST nodes, so iteration k saw
+// whatever iterations 1..k-1 left behind in them.
+//
+// That is not hypothetical in ELPS. A quoted literal in a source expression is
+// an AST node, and `stable-sort` is documented to sort in place and is pinned
+// as doing so through a literal by lisp.TestSliceViewSharesElements. So a
+// benchmark whose source sorts a literal sorts unsorted input on iteration 1
+// and already-sorted input on every iteration after it -- the harness quietly
+// substitutes a different workload for the one the benchmark declares, and the
+// reported number depends on b.N.
+//
+// The same reasoning is why lisp.TextLoader copies: it calls expr.Copy() on
+// every load precisely so two loads of one file cannot share nodes.
+const staleASTSource = `
+  ;; A quoted literal inside a function body is part of the parsed tree.
+  (defun literal () '(3 1 2))
+
+  ;; Detector: the literal must be pristine when an iteration begins. On a
+  ;; shared tree it is not, because the sort below already reordered it.
+  (if (equal? (literal) '(3 1 2))
+      ()
+      (error 'stale-ast "iteration began with an AST a previous iteration mutated"))
+
+  ;; Ordinary ELPS that mutates the tree: stable-sort sorts in place.
+  (stable-sort < (literal))
+`
+
+// staleASTIterations bounds the benchmark this test drives. Two iterations
+// would be enough to observe the sharing, but a benchmark measured by time
+// would run for -benchtime of *timed* work while paying the untimed
+// per-iteration environment build on top, which for a source this small is
+// several seconds of wall clock for a property that shows up on iteration 2.
+const staleASTIterations = "20x"
+
+// TestRunBenchmarkGivesEachIterationAFreshAST is the catch for #365. On main
+// the second iteration evaluates the literal the first one sorted, the
+// detector in staleASTSource raises stale-ast, RunBenchmark calls b.Fatalf,
+// and testing.Benchmark reports a zero result.
+func TestRunBenchmarkGivesEachIterationAFreshAST(t *testing.T) {
+	if f := flag.Lookup("test.benchtime"); f != nil {
+		prev := f.Value.String()
+		if err := f.Value.Set(staleASTIterations); err != nil {
+			t.Fatalf("set benchtime: %v", err)
+		}
+		defer func() {
+			if err := f.Value.Set(prev); err != nil {
+				t.Errorf("restore benchtime: %v", err)
+			}
+		}()
+	}
+	res := testing.Benchmark(func(b *testing.B) {
+		RunBenchmark(b, staleASTSource)
+	})
+	if res.N == 0 {
+		// testing.Benchmark discards the failed benchmark's output, so
+		// reproduce the failure here to say what actually went wrong.
+		t.Fatalf("RunBenchmark failed: an iteration evaluated an AST that an earlier iteration had already mutated.\n"+
+			"testing.Benchmark reports N=0 when the benchmark function calls Fatal and discards its output, so the\n"+
+			"same source evaluated twice against one parsed tree was re-run here, and the second pass reported:\n\n  %s",
+			sharedTreeSecondPass(t, staleASTSource))
+	}
+	if res.N < 2 {
+		t.Fatalf("benchmark ran %d iteration(s); this test cannot observe cross-iteration sharing with fewer than 2", res.N)
+	}
+}
+
+// sharedTreeSecondPass parses source once and evaluates that one tree in two
+// successive environments, exactly as the unfixed RunBenchmark did, and
+// returns what the second pass reported. It exists only to make the failure
+// message above say something.
+func sharedTreeSecondPass(tb testing.TB, source string) string {
+	tb.Helper()
+	p := parser.NewReader()
+	exprs, err := p.Read("benchmark", strings.NewReader(source))
+	if err != nil {
+		return "parse error: " + err.Error()
+	}
+	var last string
+	for pass := range 2 {
+		env := lisp.NewEnv(nil)
+		if err := lisp.GoError(lisp.InitializeUserEnv(env,
+			lisp.WithReader(p),
+			lisp.WithStderr(io.Discard),
+		)); err != nil {
+			return "environment: " + err.Error()
+		}
+		last = "no error"
+		for _, expr := range exprs {
+			if lerr := env.Eval(expr); lerr.Type == lisp.LError {
+				last = lerr.String()
+				break
+			}
+		}
+		if pass == 1 {
+			return last
+		}
+	}
+	return last
+}
+
+// TestQuotedLiteralIsMutatedByEval is a GUARD, not a catch: it passes on main.
+// It pins the premise the test above depends on -- that evaluating a tree can
+// leave state in the tree -- without going through RunBenchmark. If ELPS ever
+// copies quoted literals on evaluation, this guard fails first and says so,
+// rather than leaving the detector above passing for a reason it did not
+// intend.
+func TestQuotedLiteralIsMutatedByEval(t *testing.T) {
+	// concat copies, so `before` records the literal's state on entry rather
+	// than aliasing the node the sort is about to reorder.
+	const src = `(defun literal () '(3 1 2))
+	             (set 'before (concat 'list (literal)))
+	             (stable-sort < (literal))
+	             before`
+	p := parser.NewReader()
+	exprs, err := p.Read("guard", strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	eval := func() string {
+		env := lisp.NewEnv(nil)
+		if err := lisp.GoError(lisp.InitializeUserEnv(env,
+			lisp.WithReader(p),
+			lisp.WithStderr(io.Discard),
+		)); err != nil {
+			t.Fatal(err)
+		}
+		var last *lisp.LVal
+		for i, expr := range exprs {
+			last = env.Eval(expr)
+			if last.Type == lisp.LError {
+				t.Fatalf("expr %d: %v", i, last)
+			}
+		}
+		return last.String()
+	}
+	first := eval()
+	second := eval()
+	if first == second {
+		t.Skipf("evaluating a quoted literal no longer mutates it (both runs returned %s); TestRunBenchmarkGivesEachIterationAFreshAST needs a new detector", first)
+	}
+	t.Logf("premise holds: same tree, two runtimes, run 1 returned %s and run 2 returned %s", first, second)
+}


### PR DESCRIPTION
Fixes #365

## What the defect actually costs

The issue reports that `RunBenchmark` parses once and then evaluates that one tree in every `b.N` iteration under a fresh `Runtime`. That is accurate. The question worth answering before fixing it is whether the harness is *lying* about its numbers or merely sharing something it should not, so this was measured rather than argued.

**The reported numbers are honest today, and no historical number in this repository is wrong.** Two measurements say so:

1. **Environment construction is not being measured.** `b.StopTimer()` covers the per-iteration `NewEnv` + `InitializeUserEnv`, and `StopTimer` stops allocation accounting as well as the clock. Measured on this machine, building one benchmark environment costs ~900µs, while `RunBenchmark` on `(dotimes (n 100) (+ 1 2 3))` reports 128µs/op. If setup leaked into the measurement the reported figure could not be below it.

2. **No in-tree benchmark mutates its AST.** `RunBenchmark` was instrumented to snapshot every AST node (type, `Str`, `Int`, `Float`, `Quoted`, `Spliced`, `FunType`, `Native` type, `Source`/`Meta`/`MacroExpansion` pointers, cell count and capacity, and each node's own address) before the loop and after every iteration, and the whole benchmark set was run under it — `go test -run '^$' -bench . -benchtime=4x ./...`, all packages. Zero mutations. Every benchmark in the tree evaluates a tree that comes back byte-identical.

**But the mechanism is live, not theoretical, and it is reachable from ordinary ELPS.** A quoted literal is an AST node and `stable-sort` sorts in place — pinned as current, deliberate behaviour by `lisp.TestSliceViewSharesElements` ("stable-sort mutates a quoted literal in place"). Under the instrumented harness, `(stable-sort < '(5 3 1 4 2))` mutates the parsed tree on iteration 1:

```
--- FAIL: BenchmarkProbeSortLiteralDirect
    PROBE: AST MUTATED after iteration 1
      line 4:
       before:   p=0xc0000c9110 t=int i=5 ...
       after:    p=0xc0000c91f0 t=int i=1 ...
```

So a benchmark whose source sorts a literal sorts unsorted input on iteration 1 and already-sorted input on iterations 2..N — the harness silently substitutes a different workload for the one the benchmark declares.

### Quantified: what such a benchmark would report

Two arms of the same measured region, differing only in whether the evaluated tree was shared with earlier iterations, over `(stable-sort < '(...))` on a 1500-element shuffled literal, `-count=6`:

| arm | sec/op (median of 6) | B/op | allocs/op |
|---|---|---|---|
| shared tree (main) | 5.07 ms | 1.18 MB | 15,140 |
| fresh tree (this PR) | 50.67 ms | 12.29 MB | 157,531 |
| **understatement** | **~10.0x** | **~10.4x** | **~10.4x** |

The shared arm's six samples were 2.79, 2.82, 4.81, 5.34, 8.47 and 11.95 ms — a 4.3x spread, and it tracks `b.N` rather than tracking noise: the 11.95 ms sample ran 222 iterations and the 2.82 ms sample ran 508, because the single honest iteration is amortised over more and more dishonest ones as `b.N` grows. A number that moves with `b.N` is the signature of the defect. It is not a noisy measurement of one thing; it is a weighted average of two different workloads, and the weighting is chosen by the benchmark framework.

The fresh arm, by contrast, is stable at 45–55 ms across five of its six samples — it measures the same workload every time.

Nothing in the harness signals any of this. The benchmark passes, benchstat compares it happily, and the gate cannot fire because both arms of a comparison share the flaw. That is the argument for fixing it: not that the current numbers are wrong, but that the harness cannot be trusted to keep the next ones right, and there is no failure mode that would tell anyone.

## The fix

The issue's fix, unchanged: copy the expressions per iteration, outside the timed region.

```go
iterExprs := make([]*lisp.LVal, len(exprs))
for i, expr := range exprs {
	iterExprs[i] = expr.Copy()
}
b.StartTimer()
```

This is what `lisp.TextLoader` already does for the same reason — `env.Eval(expr.Copy())` on every load, so two loads of one file cannot share nodes.

The copy is charged to nobody: it happens with the timer stopped, so it lands in neither `ns/op` nor `B/op`/`allocs/op`. Measured, it costs ~3.9µs for a small tree against the ~900µs environment build that already sat in the same untimed region — a 0.4% addition to per-iteration setup.

## Red evidence, on `ce9798d` with only the test file added

```
=== RUN   TestRunBenchmarkGivesEachIterationAFreshAST
    runbenchmark_test.go:73: RunBenchmark failed: an iteration evaluated an AST that an earlier iteration had already mutated.
        testing.Benchmark reports N=0 when the benchmark function calls Fatal and discards its output, so the
        same source evaluated twice against one parsed tree was re-run here, and the second pass reported:

          benchmark:9:7: stale-ast: iteration began with an AST a previous iteration mutated
--- FAIL: TestRunBenchmarkGivesEachIterationAFreshAST (0.04s)
=== RUN   TestQuotedLiteralIsMutatedByEval
    runbenchmark_test.go:157: premise holds: same tree, two runtimes, run 1 returned '(3 1 2) and run 2 returned '(1 2 3)
--- PASS: TestQuotedLiteralIsMutatedByEval (0.00s)
```

The catch drives `RunBenchmark` through `testing.Benchmark` on a source that checks its own literal is pristine at the top of each iteration and then sorts it. On `main` iteration 2 raises `stale-ast`, `RunBenchmark` calls `b.Fatalf`, and `testing.Benchmark` reports `N=0`. Because `testing.Benchmark` discards the failed benchmark's output, the failure message re-runs the same source against one shared tree so the log says what actually happened rather than just "N=0".

`TestQuotedLiteralIsMutatedByEval` is a **guard**, not a catch, and is labelled as such in-file: it passes on `main`. It pins the premise the catch depends on — that evaluation can leave state in the tree — without going through `RunBenchmark`. If ELPS ever copies quoted literals on evaluation, that guard skips with an explicit "this detector needs replacing" message instead of leaving the catch passing for a reason it did not intend.

The test pins `-test.benchtime` to `20x` for its own `testing.Benchmark` call and restores it afterwards. Left on the default 1s, a benchmark this small drives `b.N` into the tens of thousands chasing a time budget it can only accrue while the timer is running, and pays the untimed environment build on each one: 8.5s of wall clock to observe a property that appears on iteration 2. With the bound it takes 0.18s.

## Benchmark impact

This change alters the harness that 43 of the repository's benchmarks run through, so the reasonable expectation is that every one of their numbers moves. **None of them do**, and that is the point of putting the copy outside the timed region rather than inside it.

`scripts/bench-run-arms.sh` with `BENCH_COUNT=6`, base `ce9798d`, arms interleaved. `bench-arms-check.sh`: same goos/goarch/cpu, **105 paired benchmarks** (base 105, pr 105 — nothing unpaired), 6 samples each. Gate verdict:

```
benchstat-gate: interpreted 16 delta row(s) + 321 no-change row(s); 1 significant move(s)
in the bad direction; 0 at or above the gate (timing 15%, allocation 5%).
```

**0 rows at or above the gate.** The allocation metrics are the load-bearing evidence, because they are the ones the gate's own documentation calls effectively deterministic:

| package | `B/op` geomean | `allocs/op` geomean |
|---|---|---|
| `lisp` | +0.00% | -0.00% |
| `lisp/lisplib/libjson` | +0.04% | +0.12% |
| `parser/rdparser` | -0.00% | +0.00% |

The single significant bad-direction move in the whole comparison is `lisp` `MacroDefun-4` `B/op` **+0.02%** (p=0.041), which is 33.32Ki against 33.32Ki — a rounding artefact two orders of magnitude below the 5% gate. This flatness is itself a measurement: `StopTimer` stops allocation accounting as well as the clock, so a per-iteration deep copy of the AST — which is thousands of bytes of real allocation — shows up as nothing at all in `B/op`. If the copy had been placed after `StartTimer` these rows would all have moved.

**The timing rows are not interpretable in this sandbox and no conclusion is drawn from them.** The machine was running unrelated concurrent fuzz jobs at load ~35 on 4 cores throughout, which shows up directly in the per-row spreads: `AliasSliceVector-4` reports ±1674% on the base arm, `Package/dump-array-4` ±388%. The `sec/op` geomeans (`lisp` -8.23%, `libjson` -15.34%, `rdparser` +5.00%) carry no p-value, are informational by the gate's design, and point in both directions across packages, which is what noise looks like rather than what a harness change looks like. The three individually significant timing rows are all *improvements* of 23–44% with base-arm spreads of 86–388% — noise again, and in the direction that cannot be a regression. Interleaving the arms is what keeps that noise from pooling into one side.

**No new benchmark was added**, so the structural gap where a new benchmark has no paired baseline and the gate therefore cannot fire on it does not arise here: all 105 rows are paired, and the two new tests are `Test` functions, not `Benchmark` functions.

The one number that genuinely moves is untimed wall clock. Each iteration now does one extra deep copy of the parsed source: ~3.9µs for a small tree, against the ~900µs environment build already in the same untimed region.

The **Benchmark Comparison** check on this PR is the cleaner measurement of the same question — a quiet dedicated runner at n=10 rather than a contended sandbox at n=6 — and it adjudicates the change on its own.

## Neighbourhood audit

The brief was every other place `elpstest` builds a Runtime inside a measured loop. Sites examined and **not** changed:

- **`Runner.RunBenchmark`** (`elpstest/lisptest.go`) builds exactly one environment per benchmark, outside any loop, and passes `b.N` into the lisp-level benchmark function so the iteration happens inside ELPS. There is no Go loop to construct a runtime in. Its source is re-read and re-loaded per call through `env.Load`, which goes through `TextLoader` and therefore already copies.
- **`RunBenchmarkFile`'s `$load` sub-benchmark** does build a full runtime — `NewEnv` plus `lisplib.LoadLibrary` plus `env.Load` — inside a timed `for range b.N` with no `StopTimer`. That is correct and deliberate: `$load` measures loading, and constructing the environment is part of what loading costs. It parses from a fresh `bytes.Reader` each iteration, so it shares no AST either.
- **`BenchmarkParse`** constructs a new `lisp.Reader` per iteration inside the timed loop, which is intended — the reader's construction is part of the parse cost being measured — and it builds no runtime at all.
- **The lisp-level benchmark body inside `Runner.RunBenchmark`** reuses one tree across the ELPS-level iterations of a single call. That is in-runtime reuse under one environment, which is what a Go benchmark does with its own fixtures too, and is a different question from handing one tree to a succession of *different* runtimes. Not changed.

**Found and deliberately not fixed here**, filed as #434: `Runner.RunBenchmark` charges `env.Load` — parsing and evaluating the entire benchmark file — to the timed region if and only if a `SetupFn` is configured, because the `SetupFn` branch ends in `b.StartTimer()` and the path without it does not. No in-tree Runner sets `SetupFn`, so no number produced in this repository is affected, but `elpstest` is an exported package and `SetupFn` is an exported field, so a downstream Runner that sets one gets the inflated measurement. Found by reading, not by running; the issue says so and asks for the red test first.

## Gates

| gate | result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test -count=1 ./...` | clean |
| `go test -race ./...` | clean on retry — see the flake note below |
| `golangci-lint run ./...` | 0 issues |
| `elps fmt -l ./...` | clean (binary deleted before commit) |
| `elps doc -m` | "All functions and exports are documented." |
| `make go-test` | clean |
| `make race` | clean |
| `make test-elpscheck` | clean |
| `make test-examples` | clean |
| `./scripts/ci-gates-test.sh` | 210 passed, 0 failed |
| `./scripts/confidentiality-guard.sh` | clean (after `git add`) |
| `./scripts/bench-arms-check.sh` | arms comparable, 105 paired, n=6 per arm |
| `./scripts/benchstat-gate.sh` | 0 rows at or above gate |
| `./scripts/fuzz-budget-check.sh` | the sweep fits |

**Flake note, so the table is not read as cleaner than the runs were.** `lisp`'s `TestEvalTerminatingSeedsComplete/tail-recursion-bounded` failed once during the `-race` sweep with `context deadline exceeded`, and passed when `./lisp/` was re-run under `-race` immediately afterwards. It is unrelated to this change — the change is confined to `elpstest` — and it reproduces on an unmodified `ce9798d` worktree, 2 failures in 6 concurrent runs, stopping at a different step count every time (49,792 / 61,723 / 73,618 / 89,062 / 108,562 for the same fixed seed). Filed as #435.

## On fuzzing

No fuzz target was added. `RunBenchmark` is a test harness rather than a surface an ELPS program reaches — the fuzz targets exist to drive arbitrary program text through the evaluator, and the property fixed here ("two iterations must not share nodes") is an identity question about the harness, not a question about any input. The property is pinned by the catch above, and by the guard that fails loudly if the premise it relies on disappears.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_