### PR TITLE
Give each parsed node its own *token.Location (#426)

### DIFF
--- a/lisp/macro_test.go
+++ b/lisp/macro_test.go
@@ -37,9 +37,23 @@ func TestMacros(t *testing.T) {
 			{"(quasiquote (list (unquote-splicing test-symbol)))", "test:1:37: lisp:quasiquote: unbound symbol: test-symbol", ""},
 			{"(quasiquote (list (unquote-splicing 1 2)))", "test:1:19: lisp:quasiquote: unquote-splicing: one argument expected (got 2)", ""},
 			{"(quasiquote (list (unquote 1 2)))", "test:1:19: lisp:quasiquote: unquote: one argument expected (got 2)", ""},
+			// The three spellings blame the same node: the innermost form
+			// that directly contains unquote-splicing.  Its column is the
+			// column that form starts at -- col 13 for the bare list and for
+			// the singly-quoted one, and col 14 for the DOUBLY-quoted one,
+			// whose inner "'" is at 14.
+			//
+			// The last of the three read 13 before elps#426.  It was wrong,
+			// and wrong for a reason visible in the parse tree: the outer
+			// quote's node and the inner quoted list's node were one
+			// *token.Location, so applyPrefixLocation moving the outer form
+			// to the outer "'" moved the inner form there too.  On ce9798d
+			// both nodes reported "test:1:13..1:15" -- a 30-column form
+			// claiming to span two columns.  They now report 1:13..1:42 and
+			// 1:14..1:42.
 			{"(quasiquote (unquote-splicing '(+ 2 3)))", "test:1:13: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
 			{"(quasiquote '(unquote-splicing '(+ 2 3)))", "test:1:13: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
-			{"(quasiquote ''(unquote-splicing '(+ 2 3)))", "test:1:13: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
+			{"(quasiquote ''(unquote-splicing '(+ 2 3)))", "test:1:14: lisp:quasiquote: unquote-splicing used in an invalid context", ""},
 			{"(quasiquote ((unquote-splicing '(+ 2 3))))", "'(+ 2 3)", ""},
 		}},
 		{"defmacro", elpstest.TestSequence{

--- a/parser/rdparser/fuzz_test.go
+++ b/parser/rdparser/fuzz_test.go
@@ -223,3 +223,85 @@ func TestParserSurvivesPathologicalInput(t *testing.T) {
 		}
 	}
 }
+
+// FuzzParsedLocationInvariants states, over arbitrary input, the three
+// position properties elps#426 broke.  For every node the reader produces:
+//
+//  1. It owns its *token.Location.  No two distinct nodes in one parse tree
+//     may hold the same object.  Sharing is what let applyPrefixLocation move
+//     a prefix form and drag its operand along, and it is a live hazard
+//     independently of that: lsp/, lint/ and lisp.stampMacroExpansion all walk
+//     the tree writing positions, and a shared Location turns any one of those
+//     writes into an edit of an unrelated node's reported position.
+//
+//  2. Its span lies inside the source.  0 <= Pos <= EndPos <= len(src), so
+//     slicing the source by a reported span cannot panic -- which the LSP,
+//     the diagnostic renderer and `elps fmt` all effectively do.
+//
+//  3. Its span lies inside its parent's.  A child that escapes its parent
+//     produces an inverted or negative LSP range.  This is the property that
+//     detected the second-order damage: once applyPrefixLocation had moved a
+//     token's Location, token.TokenEnd computed the NEXT node's end position
+//     by walking the token text forward from the MOVED column, so "'#'car"
+//     reported its outer form as ending four columns before its own operand
+//     did.
+//
+// Locations are checked only for nodes that carry a real one (Pos >= 0);
+// synthetic locations are a separate invariant, pinned by
+// assertRealSourceLocations and TestParserEmitsNoSyntheticSourceLocations.
+func FuzzParsedLocationInvariants(f *testing.F) {
+	addSeeds(f)
+	for _, s := range []string{
+		"'a", "''a", "'''''test", "#'car", "#^a", "'#'car", "'#^a", "''#^a",
+		"#^#'a", "#^(+ %1 1)", "(quote x)", "(map 'list #'car '((1 2)))",
+		"(quasiquote ''(unquote-splicing '(+ 2 3)))",
+	} {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, src []byte) {
+		for _, formatting := range []bool{false, true} {
+			sc := token.NewScanner("fuzz", bytes.NewReader(src))
+			p := rdparser.New(sc)
+			if formatting {
+				p = rdparser.NewFormatting(sc)
+			}
+			exprs, err := p.ParseProgram()
+			if err != nil {
+				continue
+			}
+			owner := make(map[*token.Location]*lisp.LVal)
+			var check func(v, parent *lisp.LVal)
+			check = func(v, parent *lisp.LVal) {
+				loc := v.Source
+				if loc == nil {
+					return
+				}
+				if prev, dup := owner[loc]; dup {
+					t.Fatalf("formatting=%v: nodes %v %q and %v %q share one *token.Location %v; every node must own its position (#426)",
+						formatting, prev.Type, prev.Str, v.Type, v.Str, loc)
+				}
+				owner[loc] = v
+				if loc.Pos >= 0 && loc.EndPos > 0 {
+					if loc.EndPos < loc.Pos || loc.EndPos > len(src) {
+						t.Fatalf("formatting=%v: node %v %q reports span [%d,%d) outside a %d-byte source (#426)",
+							formatting, v.Type, v.Str, loc.Pos, loc.EndPos, len(src))
+					}
+					if parent != nil && parent.Source != nil &&
+						parent.Source.Pos >= 0 && parent.Source.EndPos > 0 {
+						if loc.Pos < parent.Source.Pos || loc.EndPos > parent.Source.EndPos {
+							t.Fatalf("formatting=%v: child %v %q spans [%d,%d), escaping parent %v %q span [%d,%d) (#426)",
+								formatting, v.Type, v.Str, loc.Pos, loc.EndPos,
+								parent.Type, parent.Str, parent.Source.Pos, parent.Source.EndPos)
+						}
+					}
+				}
+				for _, c := range v.Cells {
+					check(c, v)
+				}
+			}
+			for _, e := range exprs {
+				check(e, nil)
+			}
+		}
+	})
+}

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -53,6 +53,7 @@ const DefaultMaxParseDepth = 10000
 type Parser struct {
 	src             *TokenSource
 	nameReadback    map[string]bool
+	locGivenAway    *token.Location
 	pendingComments []*token.Token
 	depth           int
 	maxDepth        int
@@ -353,14 +354,21 @@ func (p *Parser) ParseUnbound() *lisp.LVal {
 	if expr.Type == lisp.LError {
 		return expr
 	}
-	if expr.Source != nil && expr.Source.Pos >= 0 {
-		// Preferred when it is real: the head stands for the whole #^ form,
-		// and pointing it at the operand keeps `#^x` reporting the same
-		// position it always has.  locateSynthesized above is the fallback,
-		// and it is not decorative -- see its comment for why the head must
-		// never be left on a synthetic location.
-		sym.Source = expr.Source
-	}
+	// The head keeps the location locateSynthesized gave it -- the #^ token's
+	// own -- and does NOT borrow the operand's.
+	//
+	// It used to borrow it, on the reasoning that "the head stands for the
+	// whole #^ form, and pointing it at the operand keeps `#^x` reporting the
+	// same position it always has" (#419).  That reasoning depended on the
+	// aliasing this file no longer has: the operand's Location was the same
+	// object as the enclosing form's, and applyPrefixLocation rewrote it to
+	// the prefix, so borrowing the operand's Location was in fact how the head
+	// ended up reporting the PREFIX.  Now that each node owns its Location,
+	// borrowing the operand's would move the head to the operand and lose the
+	// position it always had.  Keeping the #^ token's location preserves it,
+	// and makes #^ agree with #', whose lisp:function head has spanned its
+	// own "#'" since #419.
+
 	// Ensure that the expression doesn't contain nested cons expressions.
 	for _, c := range expr.Cells {
 		if c.Type == lisp.LSExpr && !c.Quoted {
@@ -451,10 +459,13 @@ func (p *Parser) ParseFunRef() *lisp.LVal {
 // teaching the stamp to recognise them, and it costs nothing at expansion
 // time.  TestParserEmitsNoSyntheticSourceLocations pins it.
 //
-// The token's own *Location is handed over rather than copied.  It is
-// allocated per token by Scanner.LocStart and, for a prefix token, no LVal is
-// built from it -- tokenLVal is never called on a #' or #^ -- so this node is
-// its only owner.  applyPrefixLocation reads it and writes elsewhere.
+// The Location handed over is this node's own -- Parser.Location gives each
+// caller a Location no other caller holds (elps#426) -- so the end positions
+// written into it below reach only this node.  In practice this is the second
+// ask about the prefix token, the first being prefixLoc in the caller, so what
+// this node gets is a copy and the scanner's token keeps its own; nothing
+// reads a token's end fields either way, since TokenEnd recomputes them from
+// the token text.
 func (p *Parser) locateSynthesized(v *lisp.LVal) *lisp.LVal {
 	loc := p.Location()
 	if loc == nil {
@@ -708,7 +719,9 @@ func (p *Parser) ParseConsExpression() *lisp.LVal {
 		p.ignoreComments()
 		p.attachTrailingComment(expr)
 		if p.src.IsEOF() {
-			return p.errorAtf(open.Source, "unmatched-syntax", "unclosed %s opened at %s", open.Text, open.Source)
+			// open.Source.Copy(): the error outlives the parse, and the
+			// token's Location belongs to the scanner (elps#426).
+			return p.errorAtf(open.Source.Copy(), "unmatched-syntax", "unclosed %s opened at %s", open.Text, open.Source)
 		}
 		if p.PeekType() == token.BRACE_R {
 			p.ReadToken()
@@ -747,7 +760,9 @@ func (p *Parser) ParseList() *lisp.LVal {
 		p.ignoreComments()
 		p.attachTrailingComment(expr)
 		if p.src.IsEOF() {
-			return p.errorAtf(open.Source, "unmatched-syntax", "unclosed %s opened at %s", open.Text, open.Source)
+			// open.Source.Copy(): the error outlives the parse, and the
+			// token's Location belongs to the scanner (elps#426).
+			return p.errorAtf(open.Source.Copy(), "unmatched-syntax", "unclosed %s opened at %s", open.Text, open.Source)
 		}
 		if p.PeekType() == token.PAREN_R {
 			p.ReadToken()
@@ -840,16 +855,78 @@ func (p *Parser) TokenType() token.Type {
 	return p.src.Token.Type
 }
 
+// Location returns the position of the token under the cursor, as a Location
+// the caller OWNS.  No two callers are ever given the same one.
+//
+// THE DEFECT (elps#426).  This used to return p.src.Token.Source -- the
+// scanner's own object -- so every caller asking about one token took joint
+// ownership of it with every other, and the parser has callers that WRITE
+// through what Location returns.  tokenLVal stores it on the LVal it is
+// building and then writes EndLine/EndCol/EndPos into it; a prefix form builds
+// TWO LVals from one token, because the operand is parsed first and nothing is
+// consumed after it, so the operand's token is still under the cursor when the
+// enclosing s-expression is built.  Both nodes held that one object, and
+// applyPrefixLocation then rewrote it to the prefix's column -- moving the
+// operand's reported position along with the form's.  "#'car" reported the
+// symbol "car" as spanning "#'car"; "#^a" gave all three of its nodes one
+// position.  Longhand "(quote x)" consumes a ")" after its operand, so its
+// form is built from a different token, and it reported "x" at "x" all along:
+// #426 is the two spellings disagreeing about where the operand is.
+//
+// THE MODEL.  A Location is MOVED, not shared.  Scanner.LocStart allocates one
+// per token; the parser hands that object to the FIRST caller to ask about the
+// token, which is the node the token produces, and gives every later caller an
+// independent copy.  The scanner's per-token allocation therefore becomes the
+// AST node's, rather than being duplicated by it.
+//
+// Ownership is tracked by comparing against the last object given away, which
+// is sufficient because the parser never returns to an earlier token: a
+// pointer equal to locGivenAway is necessarily the current token's, asked for
+// a second time.  A token whose Location has been given away is not thereby
+// corrupted -- the new owner writes only the End fields (tokenLVal) or is a
+// private copy (every prefix form's enclosing node, which is by construction
+// a second ask), and the start fields the parser reads back off a token, in
+// the "unclosed %s opened at %s" errors, are never written.
+//
+// Copying HERE rather than only in tokenLVal is the choice among the three
+// #426 lists.  It is the only one that also covers the next caller: errorf and
+// scanError put the result on an error value that outlives the parse, and
+// locateSynthesized writes end positions into it.
+//
+// The alternative -- copying unconditionally -- was implemented and measured
+// first.  It costs one extra Location per parsed node: +7.4% to +8.5%
+// allocs/op and +8.7% to +16.1% B/op across the six BenchmarkParser corpora,
+// deterministic (all rows p=0.000, +-0%).  That is a real cost on the parse
+// path for no additional safety, since a Location given away exactly once
+// cannot be shared.
 func (p *Parser) Location() *token.Location {
-	return p.src.Token.Source
+	loc := p.src.Token.Source
+	if loc == nil {
+		return nil
+	}
+	if loc == p.locGivenAway {
+		return loc.Copy()
+	}
+	p.locGivenAway = loc
+	return loc
 }
 
 func (p *Parser) PeekType() token.Type {
 	return p.src.Peek().Type
 }
 
+// PeekLocation returns the position of the NEXT token, as a Location the
+// caller owns.
+//
+// It copies unconditionally rather than taking ownership the way Location
+// does (elps#426).  Taking it would give away the Location of a token the
+// parser has not reached yet, so the node eventually built from that token
+// would be the one paying for a copy -- charging the parse path for a call it
+// did not make.  PeekLocation has no caller in this repository and is
+// exported, which is the whole reason it is closed here: an embedder's peek
+// must not be able to move a position the parser later reports.
 func (p *Parser) PeekLocation() *token.Location {
-	return p.src.Peek().Source
+	return p.src.Peek().Source.Copy()
 }
 
 func (p *Parser) String(s string) *lisp.LVal {

--- a/parser/rdparser/prefix_location_test.go
+++ b/parser/rdparser/prefix_location_test.go
@@ -1,0 +1,241 @@
+// Copyright © 2026 The ELPS authors
+
+package rdparser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// prefixSources are the reader shorthands that build more than one LVal from a
+// single token, plus longhand and non-prefix controls.
+//
+// A prefix form parses its operand FIRST and consumes nothing afterwards, so
+// p.src.Token is still the operand's token when the enclosing form is built.
+// Before #426 that meant tokenLVal handed the enclosing form the operand's own
+// *token.Location -- the object, not a copy -- and applyPrefixLocation then
+// rewrote it in place to the prefix's column, dragging the operand's reported
+// position along with it.
+var prefixSources = []string{
+	"'a",
+	"''a",
+	"'(a b)",
+	"#'car",
+	"#'+",
+	"#^a",
+	"'#'car",
+	"'#^a",
+	"(quote x)",
+	"(map 'list #'car '((1 2) (3 4)))",
+	"(defun f (x) (#'g x))",
+}
+
+// locatedNodes walks v and returns every node with a non-nil Source.
+func locatedNodes(v *lisp.LVal) []*lisp.LVal {
+	var out []*lisp.LVal
+	walkLVal(v, func(n *lisp.LVal) {
+		if n.Source != nil {
+			out = append(out, n)
+		}
+	})
+	return out
+}
+
+// TestPrefixFormNodesDoNotShareLocationObject is the pointer-identity
+// statement of #426: two distinct nodes in one parse tree must never hold the
+// same *token.Location.
+//
+// This is a CATCH, not a guard.  On ce9798d it fails on every prefix
+// shorthand: "#'car" gives the enclosing form and the operand "car" one
+// object, and "#^a" gives all three nodes one object.
+//
+// Sharing is a defect independently of which column each node ends up
+// reporting.  A *Location that two nodes hold is a *Location either of them
+// can write through -- the LSP, the linter and stampMacroExpansion all walk
+// the tree and write positions -- so a node's position can be changed by an
+// edit aimed at an unrelated node.  applyPrefixLocation is simply the first
+// caller in the tree to do it.
+func TestPrefixFormNodesDoNotShareLocationObject(t *testing.T) {
+	t.Parallel()
+
+	for _, src := range prefixSources {
+		t.Run(src, func(t *testing.T) {
+			t.Parallel()
+			for _, expr := range parseAll(t, src) {
+				owner := make(map[*token.Location]*lisp.LVal)
+				for _, n := range locatedNodes(expr) {
+					if prev, dup := owner[n.Source]; dup {
+						t.Errorf("parsing %q: nodes %v %q and %v %q share one *token.Location (%v); each node must own its position (#426)",
+							src, prev.Type, prev.Str, n.Type, n.Str, n.Source)
+						continue
+					}
+					owner[n.Source] = n
+				}
+			}
+		})
+	}
+}
+
+// synthesizedHeadText maps the head symbol the reader synthesizes for a prefix
+// shorthand to the prefix token it stands for.  Those heads have no token of
+// their own; locateSynthesized (#419) gives them the prefix token's location,
+// so their span is the prefix, not the operand.
+var synthesizedHeadText = map[string]string{
+	"lisp:function": "#'",
+	"lisp:expr":     "#^",
+}
+
+// TestSymbolLocationSpansItsOwnText states the invariant #426 breaks in the
+// form a reader of the source can check by hand: the span a symbol reports,
+// [Pos, EndPos), must be that symbol's own text.
+//
+// The one licensed exception is a leading run of "'".  `'a` is ONE LVal --
+// lisp.Quote copies the symbol and sets Quoted rather than wrapping it -- so
+// that node is both the quoted form and the symbol, and its span covering the
+// quote is right.  A "#'" or "#^" in front of the text is NOT licensed: those
+// desugar to a two-cell s-expression in which the operand is a node of its
+// own, and its span must be the operand alone.
+//
+// This is a CATCH.  On ce9798d, parsing "#'car" reports the symbol "car" as
+// spanning "#'car", and parsing "#^a" reports the symbol "a" as spanning
+// "#^a" -- both because the operand is holding the enclosing form's rewritten
+// Location object.
+//
+// The longhand "(quote x)" is the control and passes on ce9798d: it reports
+// "x" spanning "x".  Two spellings of one form disagreeing about where the
+// operand is, is the argument that the shorthand is the one that is wrong.
+func TestSymbolLocationSpansItsOwnText(t *testing.T) {
+	t.Parallel()
+
+	for _, src := range prefixSources {
+		t.Run(src, func(t *testing.T) {
+			t.Parallel()
+			for _, expr := range parseAll(t, src) {
+				for _, n := range locatedNodes(expr) {
+					if n.Type != lisp.LSymbol {
+						continue
+					}
+					want := n.Str
+					if prefix, ok := synthesizedHeadText[n.Str]; ok {
+						want = prefix
+					}
+					loc := n.Source
+					if loc.Pos < 0 || loc.EndPos > len(src) || loc.EndPos < loc.Pos {
+						t.Errorf("parsing %q: symbol %q reports span [%d,%d), outside the source (#426)",
+							src, n.Str, loc.Pos, loc.EndPos)
+						continue
+					}
+					got := src[loc.Pos:loc.EndPos]
+					if !strings.HasSuffix(got, want) ||
+						strings.Trim(strings.TrimSuffix(got, want), "'") != "" {
+						t.Errorf("parsing %q: symbol %q reports span [%d,%d) = %q at %v, want %q (optionally behind quotes) (#426)",
+							src, n.Str, loc.Pos, loc.EndPos, got, loc, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestNestedPrefixFormEndPositionIsNotCorrupted pins the second-order damage:
+// once applyPrefixLocation has rewritten the operand token's own Location, the
+// NEXT tokenLVal computes its end position from that rewritten start, because
+// token.TokenEnd walks the token text forward from tok.Source.Col -- and
+// tok.Source is the object that was just moved.
+//
+// This is a CATCH.  On ce9798d "'#'car" (6 columns, ending at column 7)
+// reports its outer form as ending at column 5, and "'#^a" as ending at
+// column 3.  An end position that lands INSIDE the form is not a cosmetic
+// error: lsp/position.go, lsp/selection_range.go and lint/lint.go all build
+// ranges from EndLine/EndCol.
+func TestNestedPrefixFormEndPositionIsNotCorrupted(t *testing.T) {
+	t.Parallel()
+
+	for _, src := range []string{"'#'car", "'#^a", "''a", "#'car", "#^a", "'(a b)"} {
+		t.Run(src, func(t *testing.T) {
+			t.Parallel()
+			exprs := parseAll(t, src)
+			require.Len(t, exprs, 1)
+			loc := exprs[0].Source
+			require.NotNil(t, loc)
+			assert.Equal(t, 0, loc.Pos, "outer form must start at the first column of %q", src)
+			assert.Equal(t, len(src), loc.EndPos,
+				"outer form of %q must end past its last character (#426)", src)
+			assert.Equal(t, 1, loc.Col, "outer form of %q starts at column 1", src)
+			assert.Equal(t, len(src)+1, loc.EndCol,
+				"outer form of %q must end at the exclusive column past its text (#426)", src)
+		})
+	}
+}
+
+// TestParsedNodeSpansContainTheirChildren is a structural restatement: a
+// child's reported span must lie inside its parent's.
+//
+// GUARD, not a catch: it passes unmodified on ce9798d, because sharing one
+// Location object between a parent and a child makes their spans IDENTICAL,
+// and an identical span is a contained one.  It is here because it is the
+// property FuzzPrefixLocationInvariants checks over generated input, and
+// because it is the property that stops being free once each node owns its
+// own Location -- from here on, containment is a real constraint on the two
+// independent numbers rather than an artefact of them being one number.
+func TestParsedNodeSpansContainTheirChildren(t *testing.T) {
+	t.Parallel()
+
+	for _, src := range prefixSources {
+		t.Run(src, func(t *testing.T) {
+			t.Parallel()
+			for _, expr := range parseAll(t, src) {
+				var check func(v *lisp.LVal)
+				check = func(v *lisp.LVal) {
+					for _, c := range v.Cells {
+						if v.Source != nil && c.Source != nil && c.Source.EndPos > 0 {
+							if c.Source.Pos < v.Source.Pos || c.Source.EndPos > v.Source.EndPos {
+								t.Errorf("parsing %q: child %v %q spans [%d,%d) which escapes parent %v %q span [%d,%d) (#426)",
+									src, c.Type, c.Str, c.Source.Pos, c.Source.EndPos,
+									v.Type, v.Str, v.Source.Pos, v.Source.EndPos)
+							}
+						}
+						check(c)
+					}
+				}
+				check(expr)
+			}
+		})
+	}
+}
+
+// TestParserGivesOneTokensLocationAwayOnce is the narrowest statement of the
+// cause, at the accessor rather than at the tree.  Parser.Location() returned
+// p.src.Token.Source to every caller, so the two nodes a prefix form builds
+// from one token took joint ownership of the scanner's object.  It now gives
+// that object to the first caller and an independent copy to every later one,
+// so asking twice about one token cannot produce two nodes on one Location.
+//
+// CATCH on ce9798d.  It is stated over the parse tree rather than by calling
+// Location() twice, because Parser's cursor is not reachable from an external
+// test -- and because "the operand holds a Location whose Pos was moved to the
+// prefix" is the same fact, in the form a user sees it.
+func TestParserGivesOneTokensLocationAwayOnce(t *testing.T) {
+	t.Parallel()
+
+	funref := parseAll(t, "#'car")[0]
+	require.Len(t, funref.Cells, 2)
+	operand := funref.Cells[1]
+	require.Equal(t, "car", operand.Str)
+
+	require.NotSame(t, funref.Source, operand.Source,
+		"the #' form and its operand must not share one *token.Location (#426)")
+
+	// The write applyPrefixLocation makes, made by hand: moving the form must
+	// not move the operand.
+	funref.Source.Col = 99
+	funref.Source.Pos = 99
+	assert.Equal(t, 3, operand.Source.Col, "moving the #' form moved its operand (#426)")
+	assert.Equal(t, 2, operand.Source.Pos, "moving the #' form moved its operand (#426)")
+}

--- a/parser/rdparser/synthetic_source_test.go
+++ b/parser/rdparser/synthetic_source_test.go
@@ -166,20 +166,34 @@ func TestSynthesizedHeadsCarryPrefixLocation(t *testing.T) {
 		assert.Equal(t, 1, head.Source.Line)
 		assert.Equal(t, 4, head.Source.Col, "head should sit on the #' prefix")
 		assert.GreaterOrEqual(t, head.Source.Pos, 0)
-		// The head gets a *token.Location of its own rather than borrowing
-		// the operand's.  It has to: tokenLVal gives the enclosing
-		// s-expression the OPERAND'S Location object, and applyPrefixLocation
-		// then rewrites that object in place to point at the prefix -- so
-		// `funref.Source` and `funref.Cells[1].Source` are already one object
-		// (long-standing behaviour, unchanged here).  Adding a third borrower
-		// would put the head on that same object too.
+		// The head gets a *token.Location of its own.  When this was written
+		// it had to have one specially: tokenLVal gave the enclosing
+		// s-expression the OPERAND'S Location OBJECT and applyPrefixLocation
+		// rewrote that object in place, so `funref.Source` and
+		// `funref.Cells[1].Source` were one object and a third borrower would
+		// have joined them on it.  elps#426 removed the sharing at the source
+		// -- Parser.Location copies -- so all three are distinct now and this
+		// assertion is one instance of the general rule
+		// TestPrefixFormNodesDoNotShareLocationObject states.
 		assert.NotSame(t, head.Source, funref.Cells[1].Source)
+		assert.NotSame(t, funref.Source, funref.Cells[1].Source)
 	})
 
 	t.Run("unbound expression", func(t *testing.T) {
-		// #^ keeps pointing its head at the operand, which is where it always
-		// pointed.  The change there is only the fallback for an operand with
-		// no real location of its own.
+		// The #^ head sits on the "#^" prefix, at column 1 -- the same rule as
+		// #' above, and the location locateSynthesized gives it.
+		//
+		// CHANGED BY #426, from column 3.  ParseUnbound used to overwrite the
+		// head's location with the operand's whenever the operand had a real
+		// one, on the reasoning that this "keeps `#^x` reporting the same
+		// position it always has".  That held only because of the aliasing:
+		// for "#^x" the operand's Location object WAS the enclosing form's,
+		// and applyPrefixLocation had moved it to the prefix -- so borrowing
+		// it reported column 1.  For "#^(+ %1 1)" the operand is a list, whose
+		// closing ")" is consumed before the form is built, so no aliasing
+		// occurred and the borrow reported column 3 instead.  The head's
+		// column therefore depended on whether the operand was a symbol or a
+		// list.  It no longer does.
 		exprs, err := rdparser.New(token.NewScanner("test.lisp", strings.NewReader("#^(+ %1 1)"))).ParseProgram()
 		require.NoError(t, err)
 		require.Len(t, exprs, 1)
@@ -187,6 +201,17 @@ func TestSynthesizedHeadsCarryPrefixLocation(t *testing.T) {
 		require.Equal(t, "lisp:expr", head.Str)
 		require.NotNil(t, head.Source)
 		assert.GreaterOrEqual(t, head.Source.Pos, 0)
-		assert.Equal(t, 3, head.Source.Col)
+		assert.Equal(t, 1, head.Source.Col, "head should sit on the #^ prefix")
+		assert.Equal(t, 3, head.Source.EndCol, "head spans exactly the two columns of #^")
+
+		// The same, with a SYMBOL operand: the head's column must not depend
+		// on the operand's shape.
+		exprs, err = rdparser.New(token.NewScanner("test.lisp", strings.NewReader("#^x"))).ParseProgram()
+		require.NoError(t, err)
+		require.Len(t, exprs, 1)
+		head = exprs[0].Cells[0]
+		require.Equal(t, "lisp:expr", head.Str)
+		assert.Equal(t, 1, head.Source.Col, "head should sit on the #^ prefix")
+		assert.Equal(t, 3, head.Source.EndCol, "head spans exactly the two columns of #^")
 	})
 }


### PR DESCRIPTION
Fixes #426

`Parser.Location()` returned `p.src.Token.Source` — the scanner's own object — so every caller of one token took joint ownership of it. `tokenLVal` stores it on the LVal it is building and then writes `EndLine/EndCol/EndPos` through it, and a prefix form builds **two** LVals from one token: the operand is parsed first and nothing is consumed after it, so the operand's token is still under the cursor when the enclosing s-expression is built. Both nodes held one `Location`, and `applyPrefixLocation` then rewrote it to the prefix's column — moving the operand's reported position along with the form's.

`Location()` now hands out a Location the caller **owns**, and no two callers are ever given the same one. That is option 3 from the issue — the fix lives at the accessor, so it also covers `errorf`, `scanError` and `locateSynthesized`, and it closes the accessor against the next borrower rather than against this one caller.

It is implemented as a **move, not a copy**, for a measured reason (see Benchmarks). `Scanner.LocStart` already allocates a `Location` per token; `Location()` gives that object to the first caller to ask about the token — the node the token produces — and an independent copy to every later caller. So the scanner's per-token allocation *becomes* the AST node's instead of being duplicated by it. Copying unconditionally was implemented and benchmarked first; it costs one extra `Location` per parsed node, +7.4–8.5% allocs/op on the parser, for no additional safety, since a Location given away exactly once cannot be shared.

`PeekLocation()` copies unconditionally: taking ownership there would give away the Location of a token the parser has not reached, charging the parse path for a call it did not make.

**This PR moves reported positions.** That is the point of it, and the inventory below is what a reviewer is approving.

---

## Position-change inventory

Every `.lisp` file in the repo and a 40-snippet grammar sweep were parsed on `ce9798d` and on this branch, in both standard and format-preserving mode, and every node's `Line:Col..EndLine:EndCol[Pos,EndPos)` diffed. **118 of 24,596 nodes move (0.48%).** All 118 are in one of the five classes below, and every one is a correction.

Nothing else moves. `'a`, `'(a b)`, `(quote x)`, `(lisp:function car)`, every non-prefix form, and every node in `lisp/lisplib` are byte-identical.

### 1. The `#'` operand now spans the operand, not the whole form

| source | node | before | after |
|---|---|---|---|
| `#'car` | `car` | `1:1..1:6` — spans `#'car` | `1:3..1:6` — spans `car` |
| `#'+` | `+` | `1:1..1:4` | `1:3..1:4` |
| `(f #'g)` | `g` | `1:4..1:7` | `1:6..1:7` |
| `(map 'list #'car ...)` | `car` | `1:12..1:17` | `1:14..1:17` |
| `editors/vscode/test/grammar/basics.lisp:48` | `func-ref` | `48:1..48:11` | `48:3..48:11` |

**Why the new one is right.** `#'car` desugars to `(lisp:function car)`, in which the operand is a node of its own. The longhand has always reported `car` at `car`; the shorthand reported it at the `#'`. Two spellings of one form cannot both be right about where the operand is, and the longhand is not the one to change.

### 2. The `#^` head now spans `#^`, consistently

| source | node | before | after |
|---|---|---|---|
| `#^a` | `lisp:expr` | `1:1..1:4` — spans `#^a` | `1:1..1:3` — spans `#^` |
| `#^(+ %1 1)` | `lisp:expr` | `1:3..1:11` — spans the operand | `1:1..1:3` — spans `#^` |
| `_examples/sicp/sicp.lisp:65` | `lisp:expr` | `65:22..65:29` | `65:20..65:22` |

**Why the new one is right, and why this one needs the most reading.** Before this PR the `#^` head's column *depended on the shape of its operand*: `#^x` reported column 1 and `#^(...)` reported column 3, for the same syntax. That is because `ParseUnbound` overwrote the head with the operand's `Location` **object**, and for a symbol operand that object was also the enclosing form's, which `applyPrefixLocation` had already moved to the prefix. So the borrow reported the prefix by accident for symbols and the operand deliberately for lists.

`ParseUnbound`'s borrow is therefore removed, and the head keeps the location `locateSynthesized` (#419) already gives it: the `#^` token's own. Column 1 is what `#^x` reported before, so the common case is preserved; `#^(...)` is corrected from 3 to 1; and `#^` now agrees with `#'`, whose `lisp:function` head has spanned its own `#'` since #419.

`TestSynthesizedHeadsCarryPrefixLocation/unbound_expression` is the one existing assertion updated, from 3 to 1, with the reasoning above recorded in the test. It is the only golden in the tree that had pinned the old value.

### 3. The `#^` operand now spans the operand

| source | node | before | after |
|---|---|---|---|
| `#^a` | `a` | `1:1..1:4` | `1:3..1:4` |
| `basics.lisp:51` | `expr-shorthand` | `51:1..51:17` | `51:3..51:17` |

Same argument as class 1. On `ce9798d` all three nodes of `#^a` reported one identical position.

### 4. Nested quotes: every node in the chain was collapsed onto the first two columns

| source | node | before | after |
|---|---|---|---|
| `''a` | outer quote | `1:1..1:3` | `1:1..1:4` |
| `''a` | inner `a` | `1:1..1:3` | `1:2..1:4` |
| `'''''test` | all five nodes | `1:1..1:6` each | `1:1..1:10`, `1:2..1:10`, `1:3..1:10`, `1:4..1:10`, `1:5..1:10` |
| `'#'car` | outer form | `1:1..1:5` | `1:1..1:7` |
| `'#^a` | outer form | `1:1..1:3` | `1:1..1:5` |

**Why the new one is right.** These are not one-column adjustments — the old **end** positions landed *inside* the form. `'#'car` is six columns long and reported itself as ending at column 5; `'''''test` reported all five of its nodes as spanning exactly the five quote characters and none of `test`.

The mechanism is second-order and is the part worth reading twice: `token.TokenEnd` computes a token's end by walking its text forward **from `tok.Source.Col`** — and `tok.Source` is the object `applyPrefixLocation` had just moved. So an outer prefix form computed its end from the inner form's *already-rewritten* start. `lsp/position.go`, `lsp/selection_range.go`, `lsp/folding.go` and `lint/lint.go` all build ranges from these fields.

### 5. The one runtime golden: `TestMacros` / quasiquote, `1:13` → `1:14`

```
(quasiquote ''(unquote-splicing '(+ 2 3)))
             ^^
            13 14
```

This is the change both previous attempts stopped at. It is class 4, surfacing as an error message.

All three spellings of this case blame the same node: the innermost form that directly contains `unquote-splicing`. Its column is the column that form starts at.

| spelling | offending node | before | after |
|---|---|---|---|
| `(quasiquote (unquote-splicing …))` | the bare list, col 13 | 13 | 13 (unchanged) |
| `(quasiquote '(unquote-splicing …))` | the quoted list, col 13 | 13 | 13 (unchanged) |
| `(quasiquote ''(unquote-splicing …))` | the **inner** quoted list, col **14** | 13 | **14** |

The two unchanged rows are the control: the same error, blaming the same kind of node, already reports the node's own start. The third differed only because the outer quote's node and the inner quoted list's node were one `*token.Location`.

Parse trees, printed on each tree:

```
ce9798d:                                    this branch:
quote  test:1:13..1:15  0xc00013b040        quote  test:1:13..1:42  0xc0001659a0
  list test:1:13..1:15  0xc00013b040          list test:1:14..1:42  0xc000165950
        ^ same object, and a 30-column              ^ distinct objects, and both
          form claiming to span two columns           spans are the real ones
```

The column that moves by one comes with an end column that moves from 15 to 42.

### Checked and did not move

`go test -count=1 ./...` is green with exactly the one golden edit above. That covers `lsp/` (ranges, selection ranges, folding, semantic tokens, inlay hints, call hierarchy, signature help), `lint/`, `analysis/`, `analysis/perf/`, `lisp/x/profiler/`, `mcpserver/`, `minifier/`, `formatter/` and `elpstest/`. `make tree-sitter-test`, `make test-examples` and `make test-elpscheck` are green unmodified. No LSP range golden, formatter golden or `elpstest` expectation other than the one above needed touching.

---

## Red, then green

### The pointer-identity evidence

`parser/rdparser/prefix_location_test.go` (new). On `ce9798d`, unmodified except for adding the file:

```
--- FAIL: TestPrefixFormNodesDoNotShareLocationObject
    parsing "#'car":  nodes list "" and symbol "car" share one *token.Location (test:1:1)
    parsing "#^a":    nodes list "" and symbol "lisp:expr" share one *token.Location (test:1:1)
    parsing "#^a":    nodes list "" and symbol "a" share one *token.Location (test:1:1)
    parsing "''a":    nodes quote "" and symbol "a" share one *token.Location (test:1:1)
    parsing "'#'car": nodes list "" and symbol "car" share one *token.Location (test:1:1)
    parsing "'#^a":   nodes list "" and symbol "lisp:expr" share one *token.Location (test:1:1)
    parsing "'#^a":   nodes list "" and symbol "a" share one *token.Location (test:1:1)
    parsing "#'+":    nodes list "" and symbol "+" share one *token.Location (test:1:1)
    parsing "(map 'list #'car '((1 2) (3 4)))": nodes list "" and symbol "car" share one *token.Location (test:1:12)
    parsing "(defun f (x) (#'g x))":            nodes list "" and symbol "g"   share one *token.Location (test:1:15)

--- FAIL: TestSymbolLocationSpansItsOwnText
    parsing "#'car":  symbol "car" reports span [0,5) = "#'car" at test:1:1, want "car"
    parsing "#'+":    symbol "+"   reports span [0,3) = "#'+"   at test:1:1, want "+"
    parsing "#^a":    symbol "lisp:expr" reports span [0,3) = "#^a" at test:1:1, want "#^"
    parsing "#^a":    symbol "a"   reports span [0,3) = "#^a"   at test:1:1, want "a"
    parsing "''a":    symbol "a"   reports span [0,2) = "''"    at test:1:1, want "a"
    parsing "'#'car": symbol "car" reports span [0,4) = "'#'c"  at test:1:1, want "car"
    parsing "'#^a":   symbol "lisp:expr" reports span [0,2) = "'#" at test:1:1, want "#^"
    parsing "'#^a":   symbol "a"   reports span [0,2) = "'#"    at test:1:1, want "a"
    parsing "(map 'list #'car '((1 2) (3 4)))": symbol "car" reports span [11,16) = "#'car" at test:1:12, want "car"
    parsing "(defun f (x) (#'g x))":            symbol "g"   reports span [14,17) = "#'g"   at test:1:15, want "g"

--- FAIL: TestNestedPrefixFormEndPositionIsNotCorrupted
    "'#'car": outer form must end past its last character: expected 6, actual 4
    "'#'car": outer form must end at the exclusive column past its text: expected 7, actual 5
    "'#^a":   expected 4, actual 2 / expected 5, actual 3
    "''a":    expected 3, actual 2 / expected 4, actual 3

--- FAIL: TestParserGivesOneTokensLocationAwayOnce
    Expected and actual point to the same object: 0xc000314a00
    &token.Location{File:"test", Pos:0, Line:1, Col:1, EndPos:5, EndLine:1, EndCol:6}
    the #' form and its operand must not share one *token.Location (#426)
```

`(quote x)` is in the same table and passes on `ce9798d` throughout — it is the control, not a case that happens to be excluded.

All four are green on this branch.

`TestSymbolLocationSpansItsOwnText` licenses exactly one prefix on a symbol's span: a leading run of `'`. `lisp.Quote` copies a symbol and sets `Quoted` rather than wrapping it, so `'a` is **one** LVal that is both the quoted form and the symbol, and its span covering the quote is correct — `'a` does not move. `#'`/`#^` are not licensed, because those desugar to a two-cell s-expression in which the operand is its own node. Worth stating plainly, because #426's headline example reads as though `'a` moves: it does not, and the observation behind it was of the *discarded* pre-copy LVal rather than a node in the tree. The real disagreements are `#'`, `#^` and nested quotes.

### Labelled guards

`TestParsedNodeSpansContainTheirChildren` passes unmodified on `ce9798d` and says so in-file. Sharing one object makes a parent's and a child's spans *identical*, and identical is contained. It is here because it is the property the fuzz target checks and because containment stops being free once the two spans are independent numbers.

---

## Fuzzing

`FuzzParsedLocationInvariants` (new, `parser/rdparser/fuzz_test.go`) states the three properties over arbitrary input, in both parser modes: every node owns its `*token.Location`; every span lies inside the source; every child's span lies inside its parent's.

- **289,088 execs, 5m, 0 failures, 113 new interesting inputs** on this branch (plus a second 150s run of 401,874 execs after the implementation changed).
- **Red on `ce9798d` from the seed corpus alone** — it does not need a mutation to find this:

```
--- FAIL: FuzzParsedLocationInvariants/seed#9
    nodes quote "" and quote "" share one *token.Location fuzz:1:1
--- FAIL: FuzzParsedLocationInvariants/seed#95
    nodes symbol "lisp:expr" and list "" share one *token.Location fuzz:1:3
--- FAIL: FuzzParsedLocationInvariants/seed#99
    nodes symbol "lisp:expr" and list "" share one *token.Location fuzz:96:13
    (… and every other repo source containing #^ or #')
```

`scripts/fuzz-budget-check.sh` passes with the added target.

The span-containment arm is the one that would have caught class 4 unaided: it is the property that fails the moment `TokenEnd` computes an end from a moved start.

---

## Neighbourhood audit

Every producer of a `*token.Location` that hands out a pointer a caller can write through. #421's audit already cleared most of the tree; this covers what it left and what is new.

The tree-wide check behind "no writers": every in-place write through a `*token.Location` in non-test code lives in `parser/rdparser/parser.go` — `tokenLVal`, `locateSynthesized`, `inheritEndPos`, `applyPrefixLocation`, and the two closing-bracket end-position blocks. `lisp/env.go`'s three error constructors take `.Copy()` (#421). Nothing in `lsp/`, `lint/`, `analysis/`, `mcpserver/`, `minifier/`, `formatter/` or `profiler/` writes through one at all.

### Changed here

| Site | Why |
|---|---|
| `Parser.Location()` | The defect. Now gives the token's Location away exactly once and copies for every later ask. |
| `Parser.PeekLocation()` | Same accessor, same hazard, and **exported** — its callers are not all in this repo. Has no in-tree caller today, which is exactly why it would have been the next one. Now `.Copy()`, unconditionally. |
| `ParseConsExpression` / `ParseList` → `errorAtf(open.Source, …)` | Hands the open-bracket token's own `Location` to an error value that outlives the parse — the shape #366 fixed in `lisp/env.go`. `errorf` and `scanError` go through `Location()` and were covered by it; these two bypassed it and were the inconsistent pair. Now `.Copy()`. |
| `ParseUnbound` `sym.Source = expr.Source` | The head and the operand shared one object. Removed; see inventory class 2. |

### Examined, left, reported

**`rdparser.TokenChannel`** (`source.go`) keeps `pos = tok[len(tok)-1].Source` and, on channel close, returns an EOF token carrying **that same object** — so the synthetic EOF token and the last real token share a `Location`. No LVal is built from an EOF token, and `Location()` will not hand that object to a second node, so nothing can write through it; but it is the same shape, in a constructor an embedder can reach. Left rather than widened into this PR.

**`lisp.stampGuarded`** sets `v.Source = callSite` on *every* node of a macro expansion, so an entire expansion shares one `*token.Location` — and it is the caller's own AST node's `Location`. Nothing writes through it in-tree today (per the tree-wide check above), so this is latent, not live. It is also load-bearing behaviour: reporting the call site is the whole purpose of the stamp. Filed as #431 rather than changed.

**`Scanner.LocStart()` / `Scanner.Loc()`** allocate a fresh `Location` per call. Correct, unchanged — as #421 found.

**`lint.bindingSource`, `analysis/perf.callSource`, `profiler.getSourceLoc`, `lisp.FunctionInfo.Source`, `LEnv.Lambda`, `LEnv.TaggedValue`, `CallFrame.Source`, `env.Loc = v.Source`, `nativeSource()`** — all cleared by #421 with measurements attached. Not re-litigated here.

---

## Benchmarks

Two full interleaved two-tree comparisons with the workflow's own `scripts/bench-run-arms.sh`, `BENCH_COUNT=10`, base = `ce9798d`. Both arms measured in the same job, alternating every round.

### The unconditional copy — measured, then rejected

The straightforward fix (`Location()` returns `.Copy()` always) costs one extra `Location` per parsed node. It is not noise; every row is `p=0.000` with `±0%` spread, because allocation counts are deterministic:

```
pkg: github.com/luthersystems/elps/parser/rdparser
                              │   base    │              pr               │
                              │   B/op    │    B/op       vs base         │
Parser/approx.lisp-4            239.6Ki     260.4Ki       +8.68% (p=0.000)
Parser/complex.lisp-4           464.5Ki     526.4Ki      +13.34% (p=0.000)
Parser/diff.lisp-4              269.4Ki     297.4Ki      +10.41% (p=0.000)
Parser/scheme-math.lisp-4       907.6Ki    1052.1Ki      +15.93% (p=0.000)
Parser/sicp.lisp-4              681.0Ki     790.8Ki      +16.12% (p=0.000)
Parser/stream.lisp-4            593.3Ki     681.6Ki      +14.88% (p=0.000)
geomean                         471.5Ki     533.7Ki      +13.19%

                              │ allocs/op │  allocs/op    vs base         │
Parser/approx.lisp-4             3.565k      3.831k       +7.46% (p=0.000)
Parser/complex.lisp-4            10.79k      11.59k       +7.35% (p=0.000)
Parser/diff.lisp-4               4.233k      4.592k       +8.48% (p=0.000)
Parser/scheme-math.lisp-4        24.86k      26.71k       +7.44% (p=0.000)
Parser/sicp.lisp-4               16.70k      18.10k       +8.41% (p=0.000)
Parser/stream.lisp-4             14.63k      15.76k       +7.72% (p=0.000)
geomean                          9.982k      10.76k       +7.81%
```

(`BenchmarkParserFaultTolerant` reproduces the same six numbers to two decimal places.) That is **above the gate's 5% allocation threshold on all twelve rows**.

This is where the waiver mechanism in `scripts/benchstat-waivers.txt` would have come in. It is not used, because the cost turned out to be avoidable rather than inherent.

### What shipped

`Location()` moves the token's Location to the first caller and copies for later ones. Same positions — the location dump over every repo `.lisp` file and the grammar sweep is **byte-identical** between the two implementations — at roughly a twenty-sixth of the allocation cost:

```
pkg: github.com/luthersystems/elps/parser/rdparser
                              │   base    │              pr               │
                              │   B/op    │    B/op       vs base         │
Parser/approx.lisp-4            239.5Ki     240.5Ki       +0.40% (p=0.000)
Parser/complex.lisp-4           464.5Ki     467.6Ki       +0.67% (p=0.000)
Parser/diff.lisp-4              269.4Ki     270.3Ki       +0.35% (p=0.000)
Parser/scheme-math.lisp-4       907.6Ki     913.7Ki       +0.67% (p=0.000)
Parser/sicp.lisp-4              681.0Ki     683.5Ki       +0.38% (p=0.000)
Parser/stream.lisp-4            593.3Ki     596.6Ki       +0.54% (p=0.000)
geomean                         471.5Ki     473.9Ki       +0.50%

                              │ allocs/op │  allocs/op    vs base         │
Parser/approx.lisp-4             3.565k      3.577k       +0.34% (p=0.000)
Parser/complex.lisp-4            10.79k      10.83k       +0.36% (p=0.000)
Parser/diff.lisp-4               4.233k      4.245k       +0.28% (p=0.000)
Parser/scheme-math.lisp-4        24.86k      24.94k       +0.31% (p=0.000)
Parser/sicp.lisp-4               16.70k      16.73k       +0.19% (p=0.000)
Parser/stream.lisp-4             14.63k      14.68k       +0.28% (p=0.000)
geomean                          9.982k      10.01k       +0.29%
```

The residue is real and expected: `locateSynthesized`, the two `errorAtf` sites, and the second ask a prefix form makes are genuine extra copies. They are per *prefix form*, not per node.

Timing: every `parser/rdparser` row is `~`, geomean **-2.52%**. The box is contended (per-row spread runs to ±288%), so no timing claim is made in either direction beyond "no signal".

Other packages, geomean:

```
lisp                  sec/op -0.51%   B/op +0.00%   allocs/op -0.00%
lisp/lisplib/libjson  sec/op +1.37%   B/op +0.08%   allocs/op +0.00%
```

### Gate verdict

```
benchstat-gate: interpreted 36 delta row(s) + 301 no-change row(s);
                26 significant move(s) in the bad direction;
                0 at or above the gate (timing 15%, allocation 5%).
benchstat-gate: 2 reviewed waiver(s) loaded; 0 row(s) WAIVED, 0 stale,
                2 currently unused, 0 expired.
```

**No waiver added, and neither threshold touched.**

---

## Gates

All run on the final tree.

| Gate | Result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test -count=1 ./...` | pass |
| `go test -race ./...` | pass, no races |
| `golangci-lint run ./...` | **0 issues** |
| `make static-checks` (incl. the `elpscheck`-tagged pass) | 0 issues |
| `make go-test` | pass |
| `make race` | pass |
| `make test-elpscheck` | pass |
| `make test-examples` | pass |
| `make tree-sitter-test` | pass |
| `elps fmt -l ./...` | clean (binary deleted before committing) |
| `elps doc -m` | "All functions and exports are documented." |
| `./scripts/ci-gates-test.sh` | **210 passed, 0 failed** |
| `./scripts/fuzz-budget-check.sh` | fits (27 targets, largest shard 5, unchanged from base's 26) |
| `./scripts/confidentiality-guard.sh` (after `git add`) | clean |

`golangci-lint` caught one thing worth naming: adding a field to `Parser` tripped `fieldalignment` ("48 pointer bytes could be 32"). Ordering `locGivenAway` before `pendingComments` puts it inside the pointer prefix rather than after the slice's length and capacity words. Fixed in place, not suppressed.

---

## Found along the way, filed rather than folded in

Neither is fixed here.

- **#430 — the `p.src.Token != nil` guards in `rdparser` cannot fail.** Found by *reading*, in the function this PR edits. `tokenLVal` checks `p.src.Token != nil` one line after `p.Location()` has unconditionally dereferenced it. The check is not merely dead: it documents an invariant that is not the real one, and a reader who believes it will write code the rest of the file does not honour. The half worth reproducing before acting is whether an embedder can reach `Location()` before the first scan, in which case the fix belongs at the accessor rather than in the guard.
- **#431 — `stampMacroExpansion` gives every node of an expansion the caller's own `*token.Location`, shared.** Found by *reading*, during the audit above. The third instance of the #362/#426 shape. Latent rather than live: the tree-wide check for writers found none that can reach it, and the sharing is deliberate (reporting the call site is the point of the stamp). Recorded against the `LVal.Source` immutability work #362 sequenced, with a two-step reproduce-or-close.

One non-finding worth recording so nobody re-derives it: `scripts/fuzz-budget-check.sh` reports **0 minutes of headroom** — but it does so on `ce9798d` too. 26 targets and 27 both give `ceil(n/6) = 5` for the largest shard. This PR's new target does not consume the last of the budget; there was none to begin with.

---

## Decisions the issue asked for

1. **Should `'x` report `x` at the quote or at `x`?** Neither, as it turns out: `'x` is a single LVal that is both the quoted form and the symbol, and it does not move. The shorthands that *do* have a separate operand node — `#'` and `#^` — now report it at the operand, agreeing with their longhands. Nested quotes (`''x`) do have two nodes, and the inner one now reports the inner quote.
2. **Same question for `#'f` and `#^e`.** Operands report at the operand (class 1, class 3). The synthesized head reports at the prefix token it stands for, for both, which for `#^` also removes a dependence on the operand's shape (class 2).
3. **Copy at `Parser.Location()` or only in `tokenLVal`?** At `Location()` — the only choice that also covers `errorf`, `scanError` and `locateSynthesized`, and the only one that leaves the accessor closed rather than leaving the next borrower a pointer to write through. The issue notes copying at the source is "slightly wasteful"; it was measured, found to be more than slightly (+7.4–8.5% allocs/op on the parse path), and replaced by a move that costs nothing and gives the same guarantee.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_