### PR TITLE
lsp: emit no semantic token for the reader's #^ and #' heads (#428)

### DIFF
--- a/lsp/lsp_fuzz_test.go
+++ b/lsp/lsp_fuzz_test.go
@@ -207,6 +207,12 @@ type session struct {
 	// failure is recorded and asserted by the caller.
 	marshalErr error
 	marshalCtx string
+
+	// tokenErr holds the first semantic token whose range did not lie inside
+	// the document it was computed for (elps#428). Like marshalErr it is
+	// recorded rather than raised, because the op that produced it has no way
+	// to fail the input on its own.
+	tokenErr error
 }
 
 // opArgs is the fuzzer's four bytes for one operation, already interpreted.
@@ -763,6 +769,72 @@ func (s *session) opFoldingRange(a opArgs) {
 func (s *session) opSemanticTokens(a opArgs) {
 	res, err := s.srv.textDocumentSemanticTokensFull(s.ctx, &protocol.SemanticTokensParams{TextDocument: a.ident()})
 	s.record("semanticTokens", res, err)
+	if err == nil && res != nil {
+		s.checkTokenBounds(a.uri, res.Data)
+	}
+}
+
+// checkTokenBounds is the one CONTENT assertion this target makes, and the
+// exception to "NOT asserted: that any request returns a particular result".
+//
+// It is admissible here because it does not say what the answer should be. It
+// says the answer has to be about THIS DOCUMENT: LSP 3.16 defines a semantic
+// token as (deltaLine, deltaStartChar, length) over the document text, so a
+// token whose range runs past the end of its line names no text at all, and no
+// document and no cursor position can make that the right response. It is
+// checkable from the response alone -- decode the deltas back to absolute
+// triples and compare against the content the harness sent -- which is why it
+// belongs on the fuzzer's arbitrary documents rather than only on the handful
+// of shapes a table test can name.
+//
+// The bound is a BYTE count, matching how every other line index in this
+// package is computed (position.go splits content on "\n" and slices by byte).
+// A client counting UTF-16 code units would be stricter still; this checks the
+// weaker property the server itself claims to satisfy.
+//
+// elps#428: the reader's synthesized #^ and #' heads were reported with the
+// length of their DESUGARED NAME ("lisp:expr", "lisp:function") over a
+// two-column span, so "#'foo" told the editor to decorate 13 characters of a
+// 5-character line. This assertion was left out of the target when that defect
+// was filed, because with it in place the target was red on its own seeds.
+func (s *session) checkTokenBounds(uri string, data []protocol.UInteger) {
+	if s.tokenErr != nil {
+		return
+	}
+	// The SERVER's copy, not the harness's mirror of it: the tokens were
+	// computed from that, so anything else would be checking the wrong text.
+	doc := s.srv.docs.Get(uri)
+	if doc == nil {
+		return
+	}
+	doc.mu.Lock()
+	content := doc.Content
+	doc.mu.Unlock()
+
+	lines := strings.Split(content, "\n")
+	prevLine, prevChar := 0, 0
+	for i := 0; i+4 < len(data); i += 5 {
+		line := prevLine + int(data[i])
+		char := int(data[i+1])
+		if data[i] == 0 {
+			char += prevChar
+		}
+		length := int(data[i+2])
+		prevLine, prevChar = line, char
+
+		if line >= len(lines) {
+			s.tokenErr = fmt.Errorf("semantic token [%d:%d,+%d) is on line %d of a %d-line document (%s)",
+				line, char, length, line, len(lines), uri)
+			return
+		}
+		// A CRLF document keeps its "\r" in the line; the editor does too, so
+		// it is part of the line for this purpose.
+		if char+length > len(lines[line]) {
+			s.tokenErr = fmt.Errorf("semantic token [%d:%d,+%d) overruns line %d, which is %d bytes: %q (%s)",
+				line, char, length, line, len(lines[line]), lines[line], uri)
+			return
+		}
+	}
 }
 
 func (s *session) opSelectionRange(a opArgs) {
@@ -917,6 +989,9 @@ func runSession(srcA, srcB, script []byte) error {
 		op.run(s, args)
 		if s.marshalErr != nil {
 			return fmt.Errorf("%s did not marshal: %w", s.marshalCtx, s.marshalErr)
+		}
+		if s.tokenErr != nil {
+			return s.tokenErr
 		}
 	}
 	// Any timer still armed would fire after the session is over, on a
@@ -1103,6 +1178,25 @@ func FuzzLSPSession(f *testing.F) {
 	add(";; only a comment", "", allOpsScript())
 	add(defs, uses, allOpsScript())
 
+	// The reader's PREFIX SHORTHANDS, which checkTokenBounds exists for
+	// (elps#428): #^e and #'f desugar to (lisp:expr e) and (lisp:function f),
+	// and the head symbol the reader synthesizes carries a 9- or 13-byte name
+	// over 2 bytes of source.
+	//
+	// Seeded here rather than relied on from fuzzseed, which does not reach the
+	// property despite containing the syntax. Of its five prefix seeds three
+	// fail to parse ("#^", "#' ", and fifty nested "#^"), and the other two --
+	// "#^(a (b))" and "#^(+ % 1)" -- are each exactly len("lisp:expr") = 9
+	// characters, so the over-long token ends exactly at the end of the line
+	// and the bound holds by arithmetic accident. An assertion no seed reaches
+	// is not an assertion.
+	add("#'foo", "", allOpsScript())
+	add("(defun g () #'g)", "", allOpsScript())
+	add("(f #^a)", "", allOpsScript())
+	add("'#^0", "", allOpsScript())
+	add("(list #'car\n      #'cdr)", "", allOpsScript())
+	add("(lisp:function foo)", "", allOpsScript()) // longhand: not synthesized
+
 	// Document B as the WORKSPACE FILE that defines a macro and document A as
 	// the file that calls it. This is the only shape that reaches
 	// env.MacroCall -- evaluation of a macro body during mere analysis -- so
@@ -1254,6 +1348,9 @@ func TestLSPFuzzScriptReachesEveryOp(t *testing.T) {
 	}
 	if s.marshalErr != nil {
 		t.Fatalf("%s did not marshal: %v", s.marshalCtx, s.marshalErr)
+	}
+	if s.tokenErr != nil {
+		t.Fatalf("%v", s.tokenErr)
 	}
 }
 

--- a/lsp/semantic_tokens.go
+++ b/lsp/semantic_tokens.go
@@ -145,6 +145,11 @@ func collectSemanticTokens(
 		})
 
 	case lisp.LSymbol:
+		if isSynthesizedPrefixHead(v) {
+			// No token: this symbol is not text the user wrote.  See
+			// isSynthesizedPrefixHead.
+			return
+		}
 		name := v.Str
 		length := len(name)
 		tokType, mods := classifySymbol(name, line, col, defs, refs)
@@ -170,6 +175,57 @@ func collectSemanticTokens(
 		// contents currently go unhighlighted.  Cosmetic, and left as-is
 		// rather than changed under a lint fix.
 	}
+}
+
+// readerPrefixHeads maps the head symbol the READER synthesizes for a prefix
+// form to the prefix it was synthesized from.  The reader desugars #^e to
+// (lisp:expr e) and #'f to (lisp:function f); rdparser.locateSynthesized
+// (elps#419) then gives the manufactured head the prefix TOKEN's own location,
+// so the head stands for those two characters of source and nothing else.
+var readerPrefixHeads = map[string]string{
+	"lisp:expr":     "#^",
+	"lisp:function": "#'",
+}
+
+// isSynthesizedPrefixHead reports whether v is a head symbol the reader
+// manufactured for a #^ or #' prefix, rather than a symbol the user typed.
+//
+// Written out in longhand -- "(lisp:function f)", which is legal and is what
+// the printer emits when it cannot re-sugar -- the head is ordinary source text
+// and spans its whole name.  Synthesized from a prefix it spans exactly the
+// prefix, two columns, while carrying a 9- or 13-byte name that appears nowhere
+// in the document.  That is the difference, and it is the whole test.
+//
+// WHY NO TOKEN, RATHER THAN A TWO-CHARACTER ONE (elps#428).  A semantic token
+// is a claim about the meaning of the text it covers, and the only claim
+// available here is the one classifySymbol derives from the DESUGARED NAME --
+// a name that is not in the document.  What that yields is an accident of the
+// standard library: "lisp:function" resolves to the special operator `function`
+// and comes back a KEYWORD, while "lisp:expr" resolves to nothing and comes
+// back a VARIABLE.  So a length-only fix ships "#^" painted in the same colour
+// as the identifier beside it and "#'" painted in another, with the difference
+// determined by which desugared name happens to be bound.  Neither colour says
+// anything true about the two characters on screen.
+//
+// Suppressing instead leaves those characters to the client's syntax grammar,
+// which is the right owner for fixed punctuation the server knows nothing extra
+// about -- and it makes the three reader prefixes agree, since ' already
+// produces no token of its own (ParseQuote sets Quoted rather than synthesizing
+// a head, so there is no node at the quote to tokenize).  It is also what other
+// language servers do with nodes that stand for desugaring rather than for
+// text: rust-analyzer highlights the syntax tree of real tokens and never the
+// desugared HIR, and clangd drops highlightings whose range is not a plain
+// source range.  The operand keeps its token either way; only the prefix
+// changes hands.
+func isSynthesizedPrefixHead(v *lisp.LVal) bool {
+	prefix, ok := readerPrefixHeads[v.Str]
+	if !ok {
+		return false
+	}
+	if v.Source.EndLine != v.Source.Line {
+		return false
+	}
+	return v.Source.EndCol-v.Source.Col == len(prefix)
 }
 
 // symbolKey uniquely identifies a symbol occurrence by position.

--- a/lsp/semantic_tokens_bounds_test.go
+++ b/lsp/semantic_tokens_bounds_test.go
@@ -1,0 +1,189 @@
+// Copyright © 2026 The ELPS authors
+
+package lsp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/internal/fuzzseed"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// semanticTokenOverruns decodes a semanticTokens/full response back to absolute
+// (line, startChar, length) triples and returns a description of every token
+// whose range does not lie inside the document.
+//
+// LSP 3.16 §textDocument/semanticTokens defines a token as (deltaLine,
+// deltaStartChar, length) over the document text, so a token that runs past the
+// end of its line names no text at all.  Clients disagree about what to do with
+// one -- decorate into the next line, drop the token, or drop the whole
+// response -- so the practical symptom is "highlighting in this file is wrong
+// or missing".
+func semanticTokenOverruns(content string, data []protocol.UInteger) []string {
+	lines := strings.Split(content, "\n")
+	var bad []string
+	for _, tok := range decodeTokens(data) {
+		if tok.line < 0 || tok.line >= len(lines) {
+			bad = append(bad, fmt.Sprintf("token [%d:%d,+%d) is on line %d, but the document has %d lines",
+				tok.line, tok.startChar, tok.length, tok.line, len(lines)))
+			continue
+		}
+		// Lines are indexed by byte everywhere else in this package (see
+		// position.go), so the bound is a byte count, not a rune count.
+		text := strings.TrimSuffix(lines[tok.line], "\r")
+		if tok.startChar+tok.length > len(text) {
+			bad = append(bad, fmt.Sprintf("token [%d:%d,+%d) overruns line %d (%d chars: %q)",
+				tok.line, tok.startChar, tok.length, tok.line, len(text), text))
+		}
+	}
+	return bad
+}
+
+// tokensFor opens content as a document and returns the decoded token stream.
+func tokensFor(t *testing.T, s *Server, uri, content string) []protocol.UInteger {
+	t.Helper()
+	doc := openDoc(s, uri, content)
+	s.ensureAnalysis(doc)
+	res, err := s.textDocumentSemanticTokensFull(mockContext(), &protocol.SemanticTokensParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: doc.URI},
+	})
+	if err != nil {
+		t.Fatalf("semanticTokens/full(%q): %v", content, err)
+	}
+	if res == nil {
+		return nil
+	}
+	return res.Data
+}
+
+// TestSemanticTokensStayInsideTheDocument is the RED test for elps#428: the
+// reader desugars #^e to (lisp:expr e) and #'f to (lisp:function f), and the
+// synthesized head symbol it builds carries the DESUGARED NAME (9 and 13 bytes)
+// while occupying 2 bytes of source.  collectSemanticTokens took the LSymbol
+// case's length from len(v.Str), so #'foo -- five characters -- was reported to
+// the editor as a 13-character token starting at char 0.
+//
+// Every case below FAILED on bfb6ee8 (the commit this fix is based on); none of
+// them is a guard.
+func TestSemanticTokensStayInsideTheDocument(t *testing.T) {
+	s := testServer()
+	for i, content := range []string{
+		"#^a",
+		"#'foo",
+		"(f #^a)",
+		"(defun g () #'g)",
+		"#^(+ % 1)", // fuzzseed.All() seed 95, committed to this repository
+		"'#^0",
+		"(list #'car #'cdr)",
+		"#^(+ #^(+ % 1) 1)",
+		"(defun g ()\n  #'g)", // head not on the first line
+	} {
+		t.Run(fmt.Sprintf("%d/%s", i, content), func(t *testing.T) {
+			data := tokensFor(t, s, fmt.Sprintf("file:///test/bounds%d.lisp", i), content)
+			for _, msg := range semanticTokenOverruns(content, data) {
+				t.Errorf("%s", msg)
+			}
+		})
+	}
+}
+
+// TestSemanticTokensStayInsideTheSeedCorpus runs the same property over every
+// .lisp source in this repository plus the hand-written adversarial seeds.
+//
+// This is the shape the property was found in (elps#428 was reported from a run
+// over fuzzseed.All()), and it is the cheap deterministic half of the assertion
+// FuzzLSPSession now makes on every generated document.
+func TestSemanticTokensStayInsideTheSeedCorpus(t *testing.T) {
+	s := testServer()
+	for i, seed := range fuzzseed.All() {
+		content := string(seed)
+		if !utf8Valid(content) {
+			// Byte-indexed line lengths are still the right bound, but a seed
+			// that is not text is not what this property is about.
+			continue
+		}
+		data := tokensFor(t, s, fmt.Sprintf("file:///test/seed%d.lisp", i), content)
+		for _, msg := range semanticTokenOverruns(content, data) {
+			t.Errorf("seed %d: %s", i, msg)
+		}
+	}
+}
+
+// TestSemanticTokensSuppressSynthesizedPrefixHeads pins the DECISION taken for
+// elps#428 -- suppress the synthesized head rather than shorten it -- and the
+// two things that decision must not break: the operand still gets its token,
+// and a longhand (lisp:function f) the user actually typed is untouched.
+//
+// Without the fix the first four cases each carry an extra 9- or 13-byte token
+// at the prefix; with it they do not.
+func TestSemanticTokensSuppressSynthesizedPrefixHeads(t *testing.T) {
+	s := testServer()
+	for i, tc := range []struct {
+		content string
+		want    []rawToken
+	}{
+		// #^ and #' contribute no token; the operand keeps its own.
+		{"#^a", []rawToken{{line: 0, startChar: 2, length: 1, tokenType: semTokenVariable}}},
+		{"#'foo", []rawToken{{line: 0, startChar: 2, length: 3, tokenType: semTokenVariable}}},
+		{"(f #^a)", []rawToken{
+			{line: 0, startChar: 1, length: 1, tokenType: semTokenVariable},
+			{line: 0, startChar: 5, length: 1, tokenType: semTokenVariable},
+		}},
+		{"(list #'car)", []rawToken{
+			{line: 0, startChar: 1, length: 4, tokenType: semTokenFunction},
+			{line: 0, startChar: 8, length: 3, tokenType: semTokenFunction},
+		}},
+		// Longhand is ordinary source text and keeps its full-width token.
+		// This is the case a name-only test would have broken.
+		{"(lisp:function foo)", []rawToken{
+			{line: 0, startChar: 1, length: 13, tokenType: semTokenKeyword},
+			{line: 0, startChar: 15, length: 3, tokenType: semTokenVariable},
+		}},
+		{"(lisp:expr foo)", []rawToken{
+			{line: 0, startChar: 1, length: 9, tokenType: semTokenVariable},
+			{line: 0, startChar: 11, length: 3, tokenType: semTokenVariable},
+		}},
+	} {
+		t.Run(fmt.Sprintf("%d/%s", i, tc.content), func(t *testing.T) {
+			data := tokensFor(t, s, fmt.Sprintf("file:///test/synth%d.lisp", i), tc.content)
+			got := decodeTokens(data)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d tokens %v, want %d %v", len(got), got, len(tc.want), tc.want)
+			}
+			for j := range got {
+				if got[j].line != tc.want[j].line || got[j].startChar != tc.want[j].startChar ||
+					got[j].length != tc.want[j].length || got[j].tokenType != tc.want[j].tokenType {
+					t.Errorf("token %d: got %+v, want %+v", j, got[j], tc.want[j])
+				}
+			}
+		})
+	}
+}
+
+// TestSemanticTokensQuotePrefixEmitsNoToken is a GUARD, not a catch: it passed
+// on bfb6ee8 as well.  It records the behaviour elps#428's fix was made
+// consistent with -- ' produces no token of its own, because ParseQuote sets
+// Quoted on the node instead of synthesizing a head for the reader to place.
+//
+// If a later change starts emitting a token for ' this will fail, and whoever
+// sees it should revisit whether #^ and #' should stay suppressed.
+func TestSemanticTokensQuotePrefixEmitsNoToken(t *testing.T) {
+	s := testServer()
+	data := tokensFor(t, s, "file:///test/quoteprefix.lisp", "'foo")
+	for _, tok := range decodeTokens(data) {
+		if tok.startChar == 0 && tok.length == 1 {
+			t.Errorf("' produced a token of its own: %+v", tok)
+		}
+	}
+}
+
+func utf8Valid(s string) bool {
+	for _, r := range s {
+		if r == 0xFFFD {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Fixes #428

## The decision: suppress, not shorten

#428 leaves open whether the synthesized head should get a **2-character token** (the length of the prefix it spans) or **no token at all**. This PR emits **no token**, and the argument is about what the editor paints, not about the arithmetic.

Both options put the response back inside the document. They differ in what the two characters `#'` and `#^` end up coloured.

A semantic token's *type* is a claim about the meaning of the text it covers. The only claim available for these heads is the one `classifySymbol` derives from the **desugared name** — a name that is nowhere in the document — and what that yields is an accident of the standard library. Measured on `main` with the length fixed to the span and nothing else changed:

| document | token | type |
|---|---|---|
| `#'foo` | `[0:0,+2)` | **keyword** (6) |
| `#^a` | `[0:0,+2)` | **variable** (3) |

The asymmetry is not about the source. `lisp:function` resolves through the package-qualified lookup to the special operator `function` (`analysis/builtins.go` registers `lisp.DefaultSpecialOps()`), so it comes back `SymSpecialOp` → keyword. `lisp:expr` resolves to nothing, falls off the end of `classifySymbol`, and comes back variable. So a length-only fix ships `#^` painted the same colour as the identifier next to it, `#'` painted another, and the difference decided by which desugared name happens to be bound. Right-length, wrong-colour is still a highlighting bug the user sees, and it is a *new* one.

Suppressing does not mean uncoloured. Semantic tokens are a layer over the client's syntax grammar, so `#'` and `#^` keep whatever the grammar gives them — which is the right owner for fixed punctuation the server knows nothing extra about. It also makes the three reader prefixes agree: `'` already produces no token of its own, because `ParseQuote` sets `Quoted` on the node instead of synthesizing a head for the reader to place. And it is what other language servers do with nodes that stand for desugaring rather than for text — rust-analyzer highlights the syntax tree of real tokens and never the desugared HIR; clangd drops highlightings whose range is not a plain source range.

**What suppression costs.** The prefix loses a token it should arguably never have had; the operand keeps its own (`foo` in `#'foo` is still classified and highlighted). Nothing else changes.

**Why the alternative is still reasonable.** `#'` *is* source text the user typed, and #419 gave the head that text's location on purpose. If the server ever gains a defensible fixed type for a reader prefix — `operator`, say, assigned by the prefix rather than looked up by name — emitting a 2-character token becomes the better answer, and `isSynthesizedPrefixHead` is exactly the predicate that would select those nodes. That is a different change with a different justification, and it is not what "the length must not come from the desugared name" asks for.

**Longhand is untouched.** `(lisp:function f)` is legal, a user may write it, and the printer emits it whenever it cannot re-sugar. It spans its whole name; a synthesized head spans exactly the two-character prefix. That difference is the whole test — a name-only check would have silently killed the longhand token, so it is pinned by a test.

## Was it already fixed by #442?

No. #442 changed what the head's *position* is, not its length. It did move the one repository-corpus case out of the failing set, by coincidence: `internal/fuzzseed` seed 95 is `#^(+ % 1)`, and #428 recorded it emitting `[0:2,+9)` on a 9-character line. After #442 the head sits at column 0 instead of 2, so the same over-long token now ends exactly at the end of the line and the bound holds. `lisp:expr` is 9 characters and both prefix seeds in the corpus are 9 characters long. Confirmed red on `bfb6ee8` before any change:

```
--- FAIL: TestSemanticTokensStayInsideTheDocument
    0/#^a               token [0:0,+9)  overruns line 0 (3 chars: "#^a")
    1/#'foo             token [0:0,+13) overruns line 0 (5 chars: "#'foo")
    2/(f_#^a)           token [0:3,+9)  overruns line 0 (7 chars: "(f #^a)")
    3/(defun_g_()_#'g)  token [0:12,+13) overruns line 0 (16 chars: "(defun g () #'g)")
    5/'#^0              token [0:1,+9)  overruns line 0 (4 chars: "'#^0")
    6/(list_#'car_#'cdr) token [0:6,+13) and [0:12,+13) overrun line 0 (18 chars)
    8/(defun_g_()\n__#'g) token [1:2,+13) overruns line 1 (6 chars: "  #'g)")
--- FAIL: TestSemanticTokensStayInsideTheSeedCorpus
    seed 105: token [19:45,+9) overruns line 19 (50 chars: "                      (set! (unquote funsym) #^())")
```

All green with the fix. Two of the nine table cases (`#^(+ % 1)`, `#^(+ #^(+ % 1) 1)`) passed on `main` for the coincidence above and are kept as regression cover, not counted as catches.

## The fuzz assertion

#428 notes the bounds property belongs in `FuzzLSPSession` and was left out because the target would be red. It is added here, in `checkTokenBounds`: decode every token back to an absolute `(line, startChar, length)` triple against the content the **server** holds, and require `startChar + length <= len(line)`. It is the one content assertion the target makes, and admissible because it does not say what the answer should be — only that the answer has to be about this document. No document and no cursor position makes an out-of-range token right.

It also needed **seeds**, because on `main` it was green: of `fuzzseed`'s five prefix seeds, three fail to parse (`#^`, `#' `, fifty nested `#^`) and the other two are the 9-character coincidences above. Six seeds are added to `FuzzLSPSession` (`#'foo`, `(defun g () #'g)`, `(f #^a)`, `'#^0`, a two-line `#'car`/`#'cdr`, and longhand `(lisp:function foo)`). With the assertion and the seeds in place but the production fix reverted to `main`'s, the target fails on seeds 19–23:

```
--- FAIL: FuzzLSPSession/seed#19
    semantic token [0:0,+13) overruns line 0, which is 5 bytes: "#'foo"
--- FAIL: FuzzLSPSession/seed#20
    semantic token [0:12,+13) overruns line 0, which is 16 bytes: "(defun g () #'g)"
--- FAIL: FuzzLSPSession/seed#21
    semantic token [0:3,+9) overruns line 0, which is 7 bytes: "(f #^a)"
```

`FuzzLSPSession` seed replay after the fix: **127 seed executions, 0 failures**. No new fuzz target, so `scripts/fuzz-budget-check.sh` is unchanged from `main` — 28 targets, 6 shards, largest shard 5, required 60 min against a 60 min timeout, **0 min headroom** (identical on `bfb6ee8`).

## Neighbourhood audit

Every place `lsp/` computes a length or range that could come from a name rather than a span, and what was done about it.

**Changed — 1 site.**

- `semantic_tokens.go`, `LSymbol` case. The only place in the package that took a document range's length from a name with **no span fallback**. This is the defect.

**Not changed — span-first, correct as they stand (24 sites).**

- `elpsToLSPRange(loc, nameLen)` (`position.go:54`) prefers `loc.EndCol`/`EndLine` and uses `nameLen` only when the location carries no end. Every caller is therefore correct whenever the span exists — `call_hierarchy.go` (4), `code_actions.go`, `definition.go` (2), `highlight.go` (2), `hover.go` (2), `linked_editing.go` (2), `references.go` (3), `rename.go` (4), `symbols.go`, `workspace_symbols.go` (2). Verified by running: with the cursor on `#'` in `#'foo`, `documentHighlight`, `references` and `hover` all return `{0,0}–{0,2}`, not the 8 characters `len("function")` would give.
- `selection_range.go:91` — same shape, span first, `len(node.Str)` only as a fallback.
- `position.go:112` (`locContainsCol`) — same, `loc.EndCol` wins when present.
- `hover.go:68–70` — picks `len(ref.Node.Str)` over `len(sym.Name)` before handing both to the span-first helper.

**Not changed — not document ranges (2 sites).**

- `signature.go:183` indexes source text by a symbol extracted from that same text.
- `signature.go:428` offsets into a label string the server itself built for `ParameterInformation`, which is defined in label coordinates, not document coordinates.

**Not changed — real defects, but out of scope; filed as #449.**

- `semantic_tokens.go:134`, `LString`: `len(v.Str) + 2` measures the **decoded** string, so any escape under-reports the span. Measured: `"x\ty"` occupies 6 source characters and gets a 5-character token.
- `semantic_tokens.go`, `LSymbol` again, for **quoted** symbols: `applyPrefixLocation` moves the symbol's `Col` onto the `'`, but the length still comes from the name, so the token is shifted left by one. Measured: `'a` yields a token covering just `'` and leaves `a` unhighlighted; `'type-error` covers `'type-erro`.

Both are strictly **in bounds**, so neither is what #428 is about and neither is caught by the new assertion. Both are also genuine design questions rather than one-liners — in particular, whether `'` should be inside the symbol's token at all, or a token of its own — so they belong in their own change.

## Gates

`go build`, `go vet`, `go test -count=1 ./...`, `golangci-lint run ./...` (0 issues), `elps fmt -l ./...` (clean; binary deleted before commit), `elps doc -m` ("All functions and exports are documented"), `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `scripts/ci-gates-test.sh` (210 passed, 0 failed), `scripts/confidentiality-guard.sh` (clean), `scripts/fuzz-budget-check.sh` (fits).

`go test -race ./...` is clean per-package and under `make race`. Running the **whole** suite with `-race` in one invocation, `lisp.TestEvalTerminatingSeedsComplete/tail-recursion-bounded` fails on a 2s wall-clock deadline under the load — and it fails identically on unmodified `bfb6ee8` in a control run, so it is not from this change. That is #435.

No benchmarks exist in `lsp/`, so `scripts/benchstat-gate.sh` cannot be moved by a change confined to this package; no timing control run was needed.