### PR TITLE
Copy LintConfig.StdlibExports before merging into it (#437)

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -311,6 +311,9 @@ type LintConfig struct {
 	// Embedders that already have a configured env can pass
 	// analysis.ExtractPackageExports(env.Runtime.Registry) here to avoid
 	// the overhead of creating a temporary environment.
+	//
+	// The map and its slices are copied before use, so a map shared across
+	// several runs is neither mutated nor read after the call returns.
 	StdlibExports map[string][]analysis.ExternalSymbol
 
 	// MacroExpander optionally expands user-macro calls at analysis time.
@@ -384,10 +387,25 @@ func BuildAnalysisConfig(cfg *LintConfig) (*analysis.Config, error) {
 		return nil, fmt.Errorf("scanning workspace %s: %w", cfg.Workspace, err)
 	}
 
-	// Start with stdlib exports (either provided or extracted fresh)
-	pkgExports := cfg.StdlibExports
-	if pkgExports == nil {
+	// Start with stdlib exports (either provided or extracted fresh).
+	//
+	// A caller-supplied map is copied, keys and slices both, before anything is
+	// merged into it. Issue #437: this used to alias cfg.StdlibExports, so the
+	// registry and workspace merges below wrote registry and workspace symbols
+	// into the embedder's map — which the field's doc comment invites embedders
+	// to build once and reuse — and two calls with the same map appended each
+	// symbol twice. The inner copy matters as much as the outer one: appending
+	// to a borrowed slice with spare capacity writes into the caller's backing
+	// array (cf. #364). defaultStdlibExports() returns a map this function
+	// owns, so that path needs no copy.
+	var pkgExports map[string][]analysis.ExternalSymbol
+	if cfg.StdlibExports == nil {
 		pkgExports = defaultStdlibExports()
+	} else {
+		pkgExports = make(map[string][]analysis.ExternalSymbol, len(cfg.StdlibExports))
+		for pkg, syms := range cfg.StdlibExports {
+			pkgExports[pkg] = append([]analysis.ExternalSymbol(nil), syms...)
+		}
 	}
 
 	// Merge embedder registry exports

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -3250,3 +3250,71 @@ func TestBuildAnalysisConfig_Excludes(t *testing.T) {
 	assert.Greater(t, countAll, countExcluded, "excluding a file should reduce symbols")
 	assert.Equal(t, 1, countExcluded, "only one helper should remain after excluding generated.lisp")
 }
+
+// TestBuildAnalysisConfig_DoesNotMutateStdlibExports is the regression test for
+// issue #437. BuildAnalysisConfig aliased the caller's LintConfig.StdlibExports
+// map and appended registry and workspace exports straight into it, so a map an
+// embedder kept around — which the field's doc comment explicitly invites —
+// silently acquired symbols from whatever workspace was last linted, and
+// accumulated a fresh duplicate of each on every call.
+func TestBuildAnalysisConfig_DoesNotMutateStdlibExports(t *testing.T) {
+	dir := t.TempDir()
+	writeTempLisp(t, dir, "ws.lisp", `
+(in-package 'mypkg)
+(export 'my-workspace-fn)
+(defun my-workspace-fn () 1)
+`)
+
+	shared := map[string][]analysis.ExternalSymbol{
+		"custom-pkg": {{Name: "custom-fn", Kind: analysis.SymFunction}},
+	}
+
+	cfg1, err := BuildAnalysisConfig(&LintConfig{Workspace: dir, StdlibExports: shared})
+	require.NoError(t, err)
+	// The workspace symbol must reach the analysis config...
+	require.Contains(t, cfg1.PackageExports, "mypkg",
+		"workspace exports should be merged into the returned config")
+
+	// ...without reaching the caller's map.
+	assert.NotContains(t, shared, "mypkg",
+		"workspace exports leaked into the caller's StdlibExports map")
+	assert.Len(t, shared, 1, "caller's StdlibExports map gained packages")
+	assert.Len(t, shared["custom-pkg"], 1, "caller's slice gained symbols")
+
+	cfg2, err := BuildAnalysisConfig(&LintConfig{Workspace: dir, StdlibExports: shared})
+	require.NoError(t, err)
+	assert.Len(t, cfg2.PackageExports["mypkg"], len(cfg1.PackageExports["mypkg"]),
+		"repeated calls accumulated duplicate workspace symbols")
+	assert.Len(t, shared["custom-pkg"], 1,
+		"repeated calls accumulated symbols in the caller's map")
+}
+
+// TestBuildAnalysisConfig_DoesNotMutateStdlibExportsBackingArray covers the
+// inner half of issue #437: even with the map copied, appending to a borrowed
+// slice that has spare capacity writes through into the caller's backing array
+// — the same shape as #364.
+func TestBuildAnalysisConfig_DoesNotMutateStdlibExportsBackingArray(t *testing.T) {
+	dir := t.TempDir()
+	writeTempLisp(t, dir, "ws.lisp", `
+(in-package 'mypkg)
+(export 'my-workspace-fn)
+(defun my-workspace-fn () 1)
+`)
+
+	// Length 1, capacity 4: an append targets the caller's spare slots.
+	syms := make([]analysis.ExternalSymbol, 1, 4)
+	syms[0] = analysis.ExternalSymbol{Name: "caller-fn", Kind: analysis.SymFunction}
+	shared := map[string][]analysis.ExternalSymbol{"mypkg": syms}
+
+	_, err := BuildAnalysisConfig(&LintConfig{Workspace: dir, StdlibExports: shared})
+	require.NoError(t, err)
+
+	for i, sym := range syms[0:cap(syms)] {
+		if i == 0 {
+			continue // the caller's own symbol, asserted below
+		}
+		assert.Empty(t, sym.Name,
+			"BuildAnalysisConfig wrote into the caller's spare slice capacity at index %d", i)
+	}
+	assert.Equal(t, "caller-fn", syms[0].Name, "caller's own symbol was overwritten")
+}


### PR DESCRIPTION
`lint.BuildAnalysisConfig` aliased the caller's `LintConfig.StdlibExports` map and then appended registry exports and workspace exports straight into it:

```go
pkgExports := cfg.StdlibExports          // not copied
if pkgExports == nil {
	pkgExports = defaultStdlibExports()
}
...
pkgExports[pkg] = append(pkgExports[pkg], regSyms...)   // writes into the caller
pkgExports[pkg] = append(pkgExports[pkg], wsSyms...)    // ditto
```

The field's own doc comment invites exactly the sharing this breaks — "Embedders that already have a configured env can pass `analysis.ExtractPackageExports(env.Runtime.Registry)` here to avoid the overhead of creating a temporary environment." An embedder that takes that advice and keeps the map gets a "stdlib exports" map that silently acquires symbols from whatever workspace was last linted, plus one more duplicate of every symbol on each call, without bound.

## Reproduction

Confirmed on `main` at `bfb6ee8` before the fix, with the tests this PR adds:

```
--- FAIL: TestBuildAnalysisConfig_DoesNotMutateStdlibExports
    Error: map[...] should not contain "mypkg"
    Messages: workspace exports leaked into the caller's StdlibExports map
    Error: "map[custom-pkg:[...] mypkg:[...]]" should have 1 item(s), but has 2
    Messages: caller's StdlibExports map gained packages
--- FAIL: TestBuildAnalysisConfig_DoesNotMutateStdlibExportsBackingArray
    Error: Should be empty, but was my-workspace-fn
    Messages: BuildAnalysisConfig wrote into the caller's spare slice capacity at index 1
```

Both are catches, not guards: they fail on `main` and pass here. The second one covers the inner half — a caller slice with spare capacity (`len 1, cap 4`) gets written through even once the map itself is copied, the same shape as #364.

One thing worth noting about the aliasing: it hides itself from a naive duplicate-count assertion. `cfg.PackageExports` from call 1 *is* the caller's map, so after call 2 both configs report the same inflated count and comparing them shows nothing. The test asserts against the caller's map directly.

## Fix

Copy at the retention boundary, map and slices both:

```go
var pkgExports map[string][]analysis.ExternalSymbol
if cfg.StdlibExports == nil {
	pkgExports = defaultStdlibExports()
} else {
	pkgExports = make(map[string][]analysis.ExternalSymbol, len(cfg.StdlibExports))
	for pkg, syms := range cfg.StdlibExports {
		pkgExports[pkg] = append([]analysis.ExternalSymbol(nil), syms...)
	}
}
```

The nil path is unchanged and still pays no copy: `defaultStdlibExports()` returns a map this function owns. The copy is only paid on the path a caller opted into, which is also the path that exists to skip a full env boot — so it stays much the cheaper option.

The field's doc comment now states the contract, since a caller cannot tell from the signature.

## Cross-repo: substrate

I could read `luthersystems/substrate` (it is attached to this session) and checked it at `origin/main` = `8d10622`. There are three `lint.LintConfig` literals in the tree:

| Site | Sets |
|---|---|
| `cmd/shirotester/cmd/lint.go:122` | `Workspace`, `Excludes`, and under `--semantic` also `Registry` and `Env` |
| `internal/substrate/shirocore/lint_test.go:55` | `Workspace`, `Registry`, `Excludes` |
| `internal/substrate/shirocore/lint_test.go:106` | `Workspace`, `Registry` |

**None sets `StdlibExports`,** so no substrate caller is hit today, and no substrate change is needed. Note they all pass `Registry` instead — which is precisely the temporary-env overhead the doc comment offers `StdlibExports` as the way to avoid, so substrate is one performance refactor away from the bug. Better to land the copy before that refactor than after.

## Neighbourhood audit

Every other place `lint`/`analysis` stores or mutates a caller-supplied map or slice. Sites checked and **not** changed:

* **`analysis.Analyze`** retains `cfg.ExtraGlobals` and `cfg.WorkspaceRefs` on the `Result`. Read-only borrow on a hot path, never appended to — house style, left alone.
* **`analysis.PrescanWorkspace` / `remapPackageMap`** mutates `prescan.PkgExports` and `prescan.PkgAllSymbols` in place. Those maps are built by the prescan itself; nothing caller-supplied reaches them.
* **`mcpserver.buildWorkspaceState`** has the mirror-image merge (`state.cfg.PackageExports[pkg] = mergeExternalSymbols(...)`, then a dedup pass). Safe: the map comes from `prescan`, and `analysis.ExtractPackageExports(reg)` returns a freshly built map. Same for `lsp.buildWorkspaceIndex`, which additionally sorts each slice in place — again on prescan-owned data.
* **`analysis.SortDefinitions` / `PreferredDefinition`** sort their argument in place, which is documented ("sorts the input slice in-place as a side effect"). The only callers pass prescan-owned or freshly deduplicated slices.
* **`ScanConfig{Excludes: cfg.Excludes, IncludeDirs: cfg.IncludeDirs}`** borrows the caller's slices; `effectiveExcludes`/`effectiveIncludeDirs` only read them and nothing appends. Same for `WithExcludePatterns` on the mcpserver and lsp servers, which retain the option slice for the process lifetime. Read-only retention, no in-tree mutation — noted rather than changed, since changing it would widen this PR into two other packages for no observed defect.
* **`mergePerfConfig`** already copies every caller-supplied slice and map (`append([]string(nil), ...)`, a fresh `FunctionCosts` map). This is the house pattern the fix above matches.

**Found and filed, not fixed here** (would widen the PR): **#444** — `lint.LintFileWithAnalysis` writes `cfg.Filename` into the caller's `*analysis.Config`. Same family, different mechanism: a struct field rather than a container. Found by reading during this audit, then confirmed by running a throwaway `-race` probe, which reports a genuine data race between two goroutines linting different files through one config. Latent in-tree (both callers are sequential). `analysis.ConfigForFile` is the existing in-repo fix for exactly this and is what #439 routed the mcpserver lint tool through.

## Gates

`go build`, `go vet`, `go test -count=1 ./...`, `go test -race ./...`, `golangci-lint run ./...` (0 issues), `elps fmt -l ./...` (clean, binary deleted before commit), `elps doc -m`, `make go-test`, `make test-elpscheck`, `make test-examples`, `./scripts/ci-gates-test.sh` (210 passed, 0 failed), `./scripts/confidentiality-guard.sh` (clean), `./scripts/fuzz-budget-check.sh` (the sweep fits) — all clean.

`make race` failed once on `TestEvalTerminatingSeedsComplete/tail-recursion-bounded`, which is the known #435 wall-clock flake, in `lisp/` — a package this PR does not touch. No `DATA RACE` was reported anywhere in that run, and the seed passes `-count=3` under `-race` in isolation. I added the evidence to #435, including a new data point: it also flakes under plain `make go-test` when the machine is loaded, so it is CPU contention rather than the race detector specifically.

`scripts/benchstat-gate.sh` was left to CI: the nil-`StdlibExports` path — the only one any in-tree caller or benchmark takes — is unchanged, so there is no new allocation on a measured path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_