### PR TITLE
Refuse unknown check names in mcpserver's lint tool (#438)

### DIFF
--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -332,8 +332,8 @@ func (s *Server) registerCoreTools() {
 	s.registerTool("format", "Format ELPS source code. Pass content for unsaved buffers or path for files on disk. Returns formatted source and whether it changed. Supports indent_size override.")
 	mcp.AddTool(s.server, &mcp.Tool{Name: "format", Description: "Format ELPS source code. Pass content for unsaved buffers or path for files on disk. Returns formatted source and whether it changed. Supports indent_size override."}, s.service.formatTool)
 
-	s.registerTool("lint", "Run specific lint analyzers on a file or inline content. Use checks to select analyzers (e.g., [\"undefined-symbol\", \"user-arity\"]). Supports severity filter, limit, and offset for pagination.")
-	mcp.AddTool(s.server, &mcp.Tool{Name: "lint", Description: "Run specific lint analyzers on a file or inline content. Use checks to select analyzers (e.g., [\"undefined-symbol\", \"user-arity\"]). Supports severity filter, limit, and offset for pagination."}, s.service.lintTool)
+	s.registerTool("lint", "Run specific lint analyzers on a file or inline content. Use checks to select analyzers (e.g., [\"undefined-symbol\", \"user-arity\"]); an unknown check name is rejected with invalid_input rather than ignored. Supports severity filter, limit, and offset for pagination.")
+	mcp.AddTool(s.server, &mcp.Tool{Name: "lint", Description: "Run specific lint analyzers on a file or inline content. Use checks to select analyzers (e.g., [\"undefined-symbol\", \"user-arity\"]); an unknown check name is rejected with invalid_input rather than ignored. Supports severity filter, limit, and offset for pagination."}, s.service.lintTool)
 
 	s.registerTool("doc", "Look up documentation for an ELPS function, macro, operator, or package by name. Use package=true to list all symbols in a package. Supports qualified names like math:sin.")
 	mcp.AddTool(s.server, &mcp.Tool{Name: "doc", Description: "Look up documentation for an ELPS function, macro, operator, or package by name. Use package=true to list all symbols in a package. Supports qualified names like math:sin."}, s.service.docTool)

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -982,12 +982,26 @@ func TestEvalTool_EnvironmentIsolation(t *testing.T) {
 func TestLintTool_MixedValidInvalidChecks(t *testing.T) {
 	srv := New()
 	content := "(set 'x 1)\n(set 'x 2)\n(if true 1)"
-	_, resp, err := srv.service.lintTool(context.Background(), nil, LintInput{
+	// Until #438 this required no error and asserted only that the surviving
+	// diagnostics came from the valid names — the typo in the middle was
+	// invisible to the client. It is now refused, as `elps lint --checks` has
+	// always refused it.
+	_, _, err := srv.service.lintTool(context.Background(), nil, LintInput{
 		Content: &content,
 		Checks:  []string{"set-usage", "nonexistent-analyzer", "if-arity"},
 	})
+	require.Error(t, err, "one unknown name among valid ones should still be reported")
+	var te *toolErr
+	require.ErrorAs(t, err, &te)
+	assert.Equal(t, "invalid_input", te.Code)
+	assert.Contains(t, te.Message, "nonexistent-analyzer")
+
+	// The valid names on their own still filter as before.
+	_, resp, err := srv.service.lintTool(context.Background(), nil, LintInput{
+		Content: &content,
+		Checks:  []string{"set-usage", "if-arity"},
+	})
 	require.NoError(t, err)
-	// Only valid checks should produce results; invalid ones silently skipped.
 	for _, d := range resp.Diagnostics {
 		assert.Contains(t, []string{"set-usage", "if-arity"}, d.Code,
 			"diagnostic code %q should be from a valid requested analyzer", d.Code)
@@ -1718,12 +1732,18 @@ func TestHotspots_TopZeroErrors(t *testing.T) {
 func TestLintTool_InvalidCheckName(t *testing.T) {
 	srv := New()
 	content := "(defun foo () 1)"
-	_, resp, err := srv.service.lintTool(context.Background(), nil, LintInput{
+	// Until #438 this asserted the opposite ("invalid check names should not
+	// error, just produce no results"), which is exactly the wrong answer: an
+	// empty diagnostics list is how the tool reports a clean file.
+	_, _, err := srv.service.lintTool(context.Background(), nil, LintInput{
 		Content: &content,
 		Checks:  []string{"nonexistent-analyzer"},
 	})
-	require.NoError(t, err, "invalid check names should not error, just produce no results")
-	assert.Empty(t, resp.Diagnostics)
+	require.Error(t, err, "an unknown check name should be refused, not silently dropped")
+	var te *toolErr
+	require.ErrorAs(t, err, &te)
+	assert.Equal(t, "invalid_input", te.Code)
+	assert.Contains(t, te.Message, "nonexistent-analyzer")
 }
 
 func TestDiagnostics_SeverityFilterAllItems(t *testing.T) {
@@ -1970,4 +1990,83 @@ func workspaceSymbols(t *testing.T, session *mcp.ClientSession, root string, que
 	require.NoError(t, err)
 	require.False(t, res.IsError)
 	return decodeStructured[WorkspaceSymbolsResponse](t, res)
+}
+
+// TestLintTool_UnknownCheckName is the regression test for issue #438. The lint
+// tool dropped unknown names in `checks` on the floor: a client that misspelled
+// a check got `{"diagnostics": []}`, which is indistinguishable from a clean
+// file. `elps lint --checks` has always refused an unknown name and exited 2.
+func TestLintTool_UnknownCheckName(t *testing.T) {
+	srv := New()
+	content := "(set 'x 1)\n(set 'x 2)\n(if true 1)"
+
+	// Sanity: with no filter the content really does produce findings, so a
+	// zero-diagnostic answer below would be a wrong answer, not an empty file.
+	_, allResp, err := srv.service.lintTool(context.Background(), nil, LintInput{
+		Content: &content,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, allResp.Diagnostics)
+
+	t.Run("all unknown", func(t *testing.T) {
+		_, _, err := srv.service.lintTool(context.Background(), nil, LintInput{
+			Content: &content,
+			Checks:  []string{"typoed-name"},
+		})
+		require.Error(t, err, "an unknown check name must not read as a clean file")
+		var te *toolErr
+		require.ErrorAs(t, err, &te)
+		assert.Equal(t, "invalid_input", te.Code)
+		assert.Contains(t, te.Message, "typoed-name")
+	})
+
+	t.Run("mixed with a valid check", func(t *testing.T) {
+		_, _, err := srv.service.lintTool(context.Background(), nil, LintInput{
+			Content: &content,
+			Checks:  []string{"set-usage", "typoed-name"},
+		})
+		require.Error(t, err, "a typo alongside a valid check must not be invisible")
+		var te *toolErr
+		require.ErrorAs(t, err, &te)
+		assert.Equal(t, "invalid_input", te.Code)
+		assert.Contains(t, te.Message, "typoed-name")
+		named, _, _ := strings.Cut(te.Message, " (valid checks:")
+		assert.NotContains(t, named, "set-usage",
+			"only the unknown names should be reported as unknown")
+	})
+
+	t.Run("several unknown names are all reported", func(t *testing.T) {
+		_, _, err := srv.service.lintTool(context.Background(), nil, LintInput{
+			Content: &content,
+			Checks:  []string{"zzz-check", "aaa-check"},
+		})
+		require.Error(t, err)
+		var te *toolErr
+		require.ErrorAs(t, err, &te)
+		assert.Contains(t, te.Message, "aaa-check")
+		assert.Contains(t, te.Message, "zzz-check")
+		assert.Less(t, strings.Index(te.Message, "aaa-check"), strings.Index(te.Message, "zzz-check"),
+			"unknown names should be listed in a deterministic order")
+	})
+
+	// GUARD (passes on main): a checks list of only valid names keeps working,
+	// and an explicit empty list still means syntax-only.
+	t.Run("guard: valid checks still filter", func(t *testing.T) {
+		_, resp, err := srv.service.lintTool(context.Background(), nil, LintInput{
+			Content: &content,
+			Checks:  []string{"set-usage"},
+		})
+		require.NoError(t, err)
+		for _, d := range resp.Diagnostics {
+			assert.Equal(t, "set-usage", d.Code)
+		}
+	})
+	t.Run("guard: empty checks list is unfiltered", func(t *testing.T) {
+		_, resp, err := srv.service.lintTool(context.Background(), nil, LintInput{
+			Content: &content,
+			Checks:  []string{},
+		})
+		require.NoError(t, err)
+		assert.Len(t, resp.Diagnostics, len(allResp.Diagnostics))
+	})
 }

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -2103,7 +2103,8 @@ explicit ` + "`(use-package 'testing)`" + ` in any package context.
 ## Diagnostics vs Lint
 - **diagnostics**: returns parse errors AND lint warnings for files. Use for "is this file healthy?"
   Supports ` + "`include_workspace`" + ` for cross-file analysis.
-- **lint**: runs specific analyzers only. Use ` + "`checks`" + ` to select which analyzers to run.
+- **lint**: runs specific analyzers only. Use ` + "`checks`" + ` to select which analyzers to run;
+  an unknown name there is an ` + "`invalid_input`" + ` error, not an empty result.
   Supports ` + "`severity`" + ` filter and pagination. Better for targeted analysis.
 
 ## Format check_only
@@ -2247,7 +2248,24 @@ func (s *service) lintTool(_ context.Context, _ *mcp.CallToolRequest, in LintInp
 
 	linter := s.linter
 	if len(in.Checks) > 0 {
-		linter = filterLinter(s.linter, in.Checks)
+		// Refuse an unknown check name rather than silently narrowing the
+		// check set, which answered "no diagnostics" for a file that had
+		// them (#438). An MCP client cannot see stderr and has no exit code
+		// to inspect, so the CLI's "unknown check" + exit 2 becomes the tool
+		// error the client already handles for a bad path. Naming the valid
+		// checks inline saves a round trip to the help tool.
+		filtered, unknown := filterLinter(s.linter, in.Checks)
+		if len(unknown) > 0 {
+			quoted := make([]string, len(unknown))
+			for i, name := range unknown {
+				quoted[i] = strconv.Quote(name)
+			}
+			return nil, LintResponse{}, newToolErr("invalid_input", fmt.Sprintf(
+				"unknown check: %s (valid checks: %s)",
+				strings.Join(quoted, ", "), strings.Join(lint.AnalyzerNames(), ", ")),
+				in.Path)
+		}
+		linter = filtered
 	}
 
 	// Parse first to collect parse errors.
@@ -2316,7 +2334,16 @@ func (s *service) lintTool(_ context.Context, _ *mcp.CallToolRequest, in LintInp
 	return nil, resp, nil
 }
 
-func filterLinter(original *lint.Linter, checks []string) *lint.Linter {
+// filterLinter narrows a linter to the named checks. It also returns the
+// requested names that match no analyzer, sorted, so the caller can refuse the
+// request rather than quietly run a smaller check set.
+//
+// Issue #438: this used to drop unknown names on the floor, so `checks:
+// ["typoed-name"]` answered with an empty diagnostics list — indistinguishable
+// from a clean file — while `elps lint --checks=typoed-name` printed "unknown
+// check" and exited 2. cmd/lint.go has carried the leftover-name loop all
+// along; this is that same loop.
+func filterLinter(original *lint.Linter, checks []string) (*lint.Linter, []string) {
 	selected := make(map[string]bool, len(checks))
 	for _, name := range checks {
 		selected[strings.TrimSpace(name)] = true
@@ -2325,9 +2352,15 @@ func filterLinter(original *lint.Linter, checks []string) *lint.Linter {
 	for _, a := range original.Analyzers {
 		if selected[a.Name] {
 			filtered = append(filtered, a)
+			delete(selected, a.Name)
 		}
 	}
-	return &lint.Linter{Analyzers: filtered}
+	unknown := make([]string, 0, len(selected))
+	for name := range selected {
+		unknown = append(unknown, name)
+	}
+	sort.Strings(unknown)
+	return &lint.Linter{Analyzers: filtered}, unknown
 }
 
 func newToolErr(code, message, path string) error {


### PR DESCRIPTION
`filterLinter` kept the analyzers a client named and dropped every name that matched none of them, so a misspelled check produced a `Linter` with no analyzers and the tool answered `{"diagnostics": []}` — byte for byte what a clean file returns.

## Reproduction

Confirmed on `main` at `bfb6ee8`, with the tests this PR adds. Content with two real findings:

```
--- FAIL: TestLintTool_UnknownCheckName/all_unknown
    Error: An error is expected but got nil.
    Messages: an unknown check name must not read as a clean file
--- FAIL: TestLintTool_UnknownCheckName/mixed_with_a_valid_check
    Error: An error is expected but got nil.
    Messages: a typo alongside a valid check must not be invisible
--- FAIL: TestLintTool_UnknownCheckName/several_unknown_names_are_all_reported
    Error: An error is expected but got nil.
```

Two of the five sub-tests are **guards**, labelled in-file: valid names still filter, and an explicit empty `checks` array is still unfiltered. Both pass on `main` and are not counted as catches.

## Fix

`cmd/lint.go` has had the correct loop all along — the same filter plus a `delete`, then it acts on what is left:

```go
for name := range selected {
	fmt.Fprintf(os.Stderr, "elps lint: unknown check: %s\n", name)
	os.Exit(2)
}
```

`filterLinter` now runs that `delete` and returns the leftovers sorted; `lintTool` turns a non-empty leftover set into the `invalid_input` tool error it already returns for a bad path, naming the unknown checks and the valid set:

```
invalid_input: unknown check: "typoed-name" (valid checks: builtin-arity, cond-missing-else, ...)
```

### The design choice, and what I rejected

**Chosen: an `invalid_input` tool error.** An MCP client's failure mode is not a CLI user's. A CLI user sees stderr next to the output and gets a non-zero exit code; an MCP client sees only the structured response, and the lint tool has no field naming which checks ran, so there is no second channel through which a dropped name could ever become visible. The tool already returns `invalid_input` for a bad path and for a bad workspace root, so clients have the handling path. `mergePerfConfig` in this same file already refuses an unsupported `rules` entry exactly this way — the lint tool's `checks` was the odd one out, not the precedent.

Rejected alternatives:

* **Report it as a diagnostic.** A diagnostic carries a range in the file, and a bad check name has no location; more decisively, it would then pass through `filterDiagnosticsBySeverity` and the pagination `limit`/`offset` — the two mechanisms most likely to drop it again, which is how it became invisible in the first place. A warning that the response's own filters can delete is not a fix.
* **Add a `checks_run` field and keep answering.** Honest, and a client *could* diff it against its request, but it makes noticing the typo opt-in for every client, forever, to save a round trip in a case that is always a caller bug.
* **Silently expand to all analyzers when everything is unknown.** Turns a typo into a different wrong answer — a diagnostic set the caller did not ask for.
* **Warn on stderr like the CLI.** The server's stderr is not the client's; this is precisely the gap.

Deliberately unchanged, per the issue's "separate call": an explicit empty `checks` array still means "no filter". The guard test pins that. A whitespace-only entry now trims to `""` and is reported as an unknown check, which seems clearly better than running nothing.

### Two existing tests asserted the bug

`TestLintTool_InvalidCheckName` required *no* error — "invalid check names should not error, just produce no results" — and `TestLintTool_MixedValidInvalidChecks` asserted only that surviving diagnostics came from the valid names, so the typo in the middle was invisible to the test as well as to the client. Both now assert the refusal and keep their coverage of the valid-name path. Worth flagging in review: the old behaviour was pinned, not accidental, so this PR is a deliberate contract change to the tool.

The tool description and the `help` tool's "Diagnostics vs Lint" section now say unknown names are rejected.

## Interaction with #439

None. This PR does not touch the analysis path #439 rewired: no `Env` is added to `LintConfig`, no package-level `analysis.LoadWorkspaceMacros` call is introduced, and `s.workspace(root)` + `analysis.ConfigForFile` still serve semantics. The only change is upstream of parsing, on the analyzer set. #439's `-race` guard passes.

## Neighbourhood audit

Every other place a user-supplied name or option is dropped rather than reported.

**Found and filed, not fixed here** (would widen the PR): **#445** — `severity` has the identical failure mode. `filterDiagnosticsBySeverity` compares a free-form string against each diagnostic's severity with no validation, so an unrecognised value filters everything out and the tool answers "clean". Confirmed by running:

```
severity=""         -> 2 diagnostics
severity="warning"  -> 1 diagnostic
severity="warn"     -> 0 diagnostics   <-- reads as "file is clean"
severity="Errors"   -> 0 diagnostics
severity="nonsense" -> 0 diagnostics
```

It affects the `diagnostics` tool as well as `lint`, and the CLI again validates where the MCP server does not (`elps lint --fail-on` goes through `lint.ParseSeverity`, which returns `unknown severity: %q (valid: error, warning, info)`). Separate field, separate call sites, separate revert — hence a separate issue rather than a second commit here.

Sites checked and **not** changed:

* **`mergePerfConfig` / `validPerfRule`** already rejects an unsupported `rules` entry with `unsupported rule: %s`. This is the house pattern; nothing to do.
* **`hotspots` `top`** rejects `top=0` with an error rather than silently returning everything or nothing.
* **`format` `indent_size`** ignores values `<= 0`, which reads as "unset" for an int field with no sentinel. Zero is the JSON default for an omitted field, so it cannot be distinguished from "not supplied" — not a droppable *name*, and rejecting it would break clients that send `0` meaning "default".
* **`doc` `query` and `workspace_symbols` `query`** return `found: false` / an empty result set for an unknown name. That is a search returning no match, and the response says so explicitly — not a silent drop.
* **`resolveWorkspaceRoot` / `resolvePath`** already return `invalid_input` for anything they cannot resolve.
* **`cmd/lint.go` `--fail-on`, `--checks`** both validate. `--exclude` / `--include` are patterns, not names from a fixed set, so a non-matching one is legitimately a no-op.

## Gates

`go build`, `go vet`, `go test -count=1 ./...`, `go test -race ./...`, `golangci-lint run ./...` (0 issues), `elps fmt -l ./...` (clean, binary deleted before commit), `elps doc -m`, `make go-test`, `make test-elpscheck`, `make test-examples`, `./scripts/ci-gates-test.sh` (210 passed, 0 failed), `./scripts/confidentiality-guard.sh` (clean), `./scripts/fuzz-budget-check.sh` (the sweep fits) — all clean.

`make go-test` and `make race` each failed once on `TestEvalTerminatingSeedsComplete/tail-recursion-bounded` in `lisp/`, a package this PR does not touch. That is the known #435 wall-clock flake: no `DATA RACE` was reported, the seed passes `-count=3` in isolation with and without `-race`, and a re-run of the full `make go-test` on an unloaded machine was green. I added the evidence to #435 — notably that it flakes under plain coverage instrumentation too, so it is CPU contention rather than the race detector.

`scripts/benchstat-gate.sh` was left to CI. The changed code runs once per lint request on a path that only executes when `checks` is non-empty, and adds one map `delete` plus a short sorted slice; no benchmarked path allocates differently.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_