### PR TITLE
ci(bench): do not gate a timing row on a move it cannot measure

### DIFF
--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -162,10 +162,33 @@ esac
 # normal case and must not fail the step under `set -o pipefail`.
 waiver_lines="$(grep -E '^  (WAIVED|WAIVER-|waiver-)' gate-report.txt || true)"
 
+# NOISE-FLOOR lines get the same treatment, and for the same reason. A row whose
+# own measured spread is larger than the move it just made cannot be adjudicated
+# by this comparison at all (see the resolution-check note in
+# scripts/benchstat-gate.sh). That is a standing problem with the benchmark, not
+# a clean result, and it is only ever fixed by someone who sees it -- so it goes
+# above the fold rather than inside a collapsed block nobody expands.
+noise_lines="$(grep -E '^  NOISE-FLOOR' gate-report.txt || true)"
+
 {
   echo 'result<<BENCHSTAT_EOF'
   echo '## Benchmark Comparison (main baseline vs PR)'
   echo ''
+  if [ -n "$noise_lines" ]; then
+    echo '### Rows this comparison could not resolve'
+    echo ''
+    echo 'These timing rows moved past the gate by LESS than their own measured'
+    echo 'spread, so this comparison cannot tell the move from noise. They are'
+    echo 'NOT counted as regressions and they are NOT suppressed — they are'
+    echo 'unmeasurable as sampled. A row that keeps appearing here needs a longer'
+    echo '`-benchtime`, or to be kept out of the comparison set; see the'
+    echo 'resolution-check note in `scripts/benchstat-gate.sh`.'
+    echo ''
+    echo '```'
+    echo "$noise_lines"
+    echo '```'
+    echo ''
+  fi
   if [ -n "$waiver_lines" ]; then
     echo '### Reviewed waivers'
     echo ''

--- a/scripts/benchstat-gate.sh
+++ b/scripts/benchstat-gate.sh
@@ -125,6 +125,74 @@
 # That is left as a follow-up so this change stays a gate fix rather than a
 # benchmark-tuning change.
 #
+# A threshold cannot be right for every row: the resolution check
+# --------------------------------------------------------------
+# Both thresholds above are single numbers applied to every row of their metric
+# class, which is exactly as good as the assumption behind it: that the rows in
+# a class have comparable noise.  For the allocation metrics it holds --
+# identical code reproduces them EXACTLY, benchstat prints "± 0%" and routinely
+# annotates the row "all samples are equal".  For timing it does not.
+#
+# Issue #443 is the worked example.  BenchmarkPackageGetFunParallel failed the
+# gate on PR #442 -- a parser-only change with no path to a map lookup in the
+# lisp package -- at +15.96% (p=0.035), and a re-run with no code change turned
+# it green.  Its noise floor was then measured directly: two independent
+# checkouts of the SAME commit, interleaved, at the runner's GOMAXPROCS.
+#
+#     base vs base2 (identical code, n=20)
+#     PackageGetFunParallel-2   38.70n ± 24%   38.94n ± 24%   ~ (p=0.841 n=20)
+#
+# A row with a ±24% spread on identical code cannot resolve a 16% move.  The
+# 15% threshold is BELOW that row's own measurement resolution, so a p<=alpha
+# draw over 15% will happen there by chance at some rate on every PR that runs
+# the comparison -- on code that cannot reach the benchmark.  It is a sub-100ns
+# body measured under RunParallel at -benchtime=100ms: the worst case for these
+# sampling parameters, and the only such row in the comparison set today.
+#
+# Raising the threshold is the wrong answer, for the reason the waivers file
+# already gives: 15% is a per-class noise floor, and moving it to accommodate
+# one row blinds every serial benchmark in the repository to the same magnitude
+# of move, permanently.  A waiver is wrong too -- a waiver records a cost that
+# is REAL and accepted, and this one is not real.
+#
+# So the gate asks the row instead.  benchstat already prints, per arm, the 95%
+# confidence interval of that arm's median as a percentage -- the "± 24%" above.
+# That IS the row's measurement resolution, computed from the very samples being
+# adjudicated, and it is already in the table this script parses.  The rule:
+#
+#   A TIMING row at or above its threshold is called a REGRESSION only when the
+#   move is LARGER than the row's own measured spread.  When it is not, the row
+#   is reported as NOISE-FLOOR and excluded from the verdict.
+#
+# That is the "significant AND large enough to see" rule, with "large enough"
+# denominated in the row's own dispersion rather than in a constant somebody
+# chose once.  Note what it does NOT do:
+#
+#   * It never applies to B/op or allocs/op.  Those are the metrics that have
+#     caught every real regression this gate has caught; they are exact rather
+#     than sampled, and their spread is "± 0%", so a rule keyed on spread would
+#     be a no-op there anyway.  It is skipped explicitly regardless, so that
+#     stays true even if some future benchmark makes an allocation column
+#     jitter.
+#   * It cannot suppress a large move.  On the row above it would take a >24%
+#     regression to fire -- which is what "this row cannot resolve less than
+#     that" means.  A row whose noise is genuinely that large is not being
+#     protected; it is being reported as unmeasurable, every run, by name.
+#   * It does nothing when benchstat could not compute an interval ("± ∞ ¹",
+#     which it prints below 6 samples).  Those rows fall back to the threshold
+#     alone and SAY SO on the regression line, so a check that did not run is
+#     never mistaken for one that ran and passed.  CI runs n=10, so this is the
+#     fixtures' case rather than CI's.
+#
+# The honest cost: on a row whose spread exceeds the threshold, a real
+# regression BETWEEN the threshold and the spread is now reported rather than
+# gated.  It was never detectable there -- it sat inside the row's own null
+# distribution, and the gate's "detection" of it was a coin flip that landed the
+# other way on the re-run.  The fix for such a row is to make it quieter (a
+# longer -benchtime for that benchmark, or keeping a sub-100ns RunParallel body
+# out of the comparison set), and the NOISE-FLOOR line is what tells you which
+# rows need it.
+#
 # Reviewed waivers
 # ---------------
 # Sometimes a regression is real, understood and deliberately accepted.  The
@@ -252,7 +320,8 @@ trap 'rm -f "$report" "$waiver_input"' EXIT
 # The awk program emits one human-readable line per interesting row, then a
 # final machine-readable line:
 #   "VERDICT <regressions> <significant> <compared> <tilde> <badp> <waived>
-#            <waiver_bad> <waiver_stale> <waiver_unused> <waiver_expired>".
+#            <waiver_bad> <waiver_stale> <waiver_unused> <waiver_expired>
+#            <waivers> <waiver_outscope> <unresolved>".
 awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRESHOLD" \
 	-v wfile="$waiver_input" -v wsource="${WAIVERS:-<none>}" -v today="$TODAY" '
 	# Last signed-percentage token (e.g. +7.14% / -1.20%) inside s, "" if none.
@@ -280,6 +349,47 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 			best = pos + off - 1
 			pos = best + 1
 		}
+		return best
+	}
+
+	# The LARGEST per-arm spread benchstat printed on this row, as a percent, or
+	# -1 when it printed none it could compute.
+	#
+	# benchstat writes each arm as "<median> ± <pct>%": the half-width of the
+	# 95% confidence interval of the median of that arm, relative to it. That
+	# is how finely this comparison can see on this row, measured
+	# on the same samples the verdict is drawn from. Below 6 samples it cannot
+	# compute one and prints "± ∞ ¹" instead; that is reported as -1 (unknown)
+	# rather than as 0, because treating "no interval" as "a perfect interval"
+	# would suppress nothing while looking like it had checked.
+	#
+	# The LARGER of the two arms, not the base arm alone: dispersion in both
+	# arms feeds the uncertainty of the delta. Taking the max is the
+	# lenient direction of the two (it suppresses more), but the alternative --
+	# base only -- would let a change that ADDS variance be judged against the
+	# quiet arm it replaced, and this rule must never be easier to trip by
+	# making a benchmark noisier.
+	function max_spread(s,   pos, off, rest, tok, num, best, sawinf) {
+		best = -1
+		sawinf = 0
+		pos = 1
+		while (1) {
+			rest = substr(s, pos)
+			off = index(rest, "±")
+			if (off == 0) break
+			pos = pos + off + length("±") - 1
+			rest = substr(s, pos)
+			# "± 24%" and "±24%" both occur; "± ∞ ¹" is the no-interval case.
+			if (match(rest, /^[ \t]*[0-9]+(\.[0-9]+)?%/)) {
+				tok = substr(rest, RSTART, RLENGTH)
+				sub(/%$/, "", tok)
+				num = tok + 0
+				if (num > best) best = num
+			} else {
+				sawinf = 1
+			}
+		}
+		if (best < 0 && sawinf) return -1
 		return best
 	}
 
@@ -481,6 +591,12 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 			pval_str = "n/a"
 		}
 
+		# Read the per-arm spreads BEFORE the region is truncated past them:
+		# this is the measurement resolution of the row, and it is what the
+		# resolution check below is judged against. -1 means benchstat printed
+		# no interval it could compute.
+		spread = max_spread(region)
+
 		lastpm = last_spread(region)
 		if (lastpm > 0) region = substr(region, lastpm + 1)
 
@@ -541,6 +657,24 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 			next
 		}
 
+		# RESOLUTION. A timing row is only adjudicated when the move is larger
+		# than what that row can measure. See the "resolution check" note in the
+		# header: the threshold is one number for a whole metric class, and on a
+		# sub-100ns RunParallel body it sits BELOW the row own null distribution,
+		# so p<=alpha over the threshold happens there by chance (#443).
+		#
+		# Deliberately not applied to the allocation metrics, and deliberately
+		# skipped when benchstat could not compute an interval -- in that case
+		# the regression line says so, so a check that did not run is never
+		# mistaken for one that ran and passed.
+		if (!is_alloc_metric(metric) && spread >= 0 && regr <= spread) {
+			unresolved++
+			printf "  NOISE-FLOOR %-46s %-9s %-40s delta=%s p=%s (gate %s%%) spread ±%s%% -- the OWN measured spread of this row on these samples is at or above this move, so the comparison cannot resolve it; not a regression, and not suppressed either: make the benchmark quieter (longer -benchtime, or keep it out of the comparison set) if this row needs to be gateable %s\n",
+				pkg, metric, name, delta_tok, pval_str, gate, spread, dir
+			next
+		}
+		nospread = (!is_alloc_metric(metric) && spread < 0) ? " [no interval: benchstat needs >= 6 samples, so the resolution check did not run]" : ""
+
 		# At or above the gate. A waiver can turn this into a PASS, but only
 		# a live one, and only while the move stays inside the ceiling it
 		# recorded. Every outcome below is printed either way: the waiver
@@ -548,15 +682,15 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 		if (wi && wexpired[wi]) {
 			regressions++
 			wexpiredhit[wi] = 1
-			printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) WAIVER EXPIRED %s (%s), no longer suppressing %s\n",
-				pkg, metric, name, delta_tok, pval_str, gate, wexp[wi], wissue[wi], dir
+			printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) WAIVER EXPIRED %s (%s), no longer suppressing %s%s\n",
+				pkg, metric, name, delta_tok, pval_str, gate, wexp[wi], wissue[wi], dir, nospread
 			next
 		}
 		if (wi && regr > wceil[wi]) {
 			regressions++
 			wexceeded[wi] = 1
-			printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) EXCEEDS its waiver ceiling %s%% (%s) %s\n",
-				pkg, metric, name, delta_tok, pval_str, gate, wceilstr[wi], wissue[wi], dir
+			printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) EXCEEDS its waiver ceiling %s%% (%s) %s%s\n",
+				pkg, metric, name, delta_tok, pval_str, gate, wceilstr[wi], wissue[wi], dir, nospread
 			next
 		}
 		if (wi) {
@@ -568,8 +702,8 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 		}
 
 		regressions++
-		printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) %s\n",
-			pkg, metric, name, delta_tok, pval_str, gate, dir
+		printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) %s%s\n",
+			pkg, metric, name, delta_tok, pval_str, gate, dir, nospread
 	}
 
 	END {
@@ -601,10 +735,10 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 					wsource, wline[i], wpkg[i], wbench[i], wmetric[i], wexp[i], wissue[i]
 			}
 		}
-		printf "VERDICT %d %d %d %d %d %d %d %d %d %d %d %d\n",
+		printf "VERDICT %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
 			regressions + 0, significant + 0, compared + 0, tilde + 0, badp + 0,
 			waived + 0, wbad + 0, wstale + 0, wunused + 0, wexp_n + 0, nw + 0,
-			woutscope + 0
+			woutscope + 0, unresolved + 0
 	}
 ' "$waiver_input" "$input" >"$report"
 
@@ -613,7 +747,7 @@ sed '$d' "$report"
 
 read -r _ n_regressions n_significant n_compared n_tilde n_badp \
 	n_waived n_waiver_bad n_waiver_stale n_waiver_unused n_waiver_expired n_waivers \
-	n_waiver_outscope <<<"$verdict_line"
+	n_waiver_outscope n_unresolved <<<"$verdict_line"
 
 if [ "$n_waiver_bad" -gt 0 ]; then
 	cat >&2 <<-EOF
@@ -648,6 +782,16 @@ if [ "$((n_compared + n_tilde))" -eq 0 ]; then
 fi
 
 echo "benchstat-gate: interpreted ${n_compared} delta row(s) + ${n_tilde} no-change row(s); ${n_significant} significant move(s) in the bad direction; ${n_regressions} at or above the gate (timing ${THRESHOLD}%, allocation ${ALLOC_THRESHOLD}%)."
+
+# Printed whenever it is nonzero, and never folded into the regression count. A
+# NOISE-FLOOR row is a benchmark this comparison cannot adjudicate at all, which
+# is a standing problem with the benchmark rather than a clean result -- see the
+# resolution-check note in the header. Silence here would turn "we could not
+# measure it" into "it was fine", which is the shape of defect this whole gate
+# exists to fix.
+if [ "$n_unresolved" -gt 0 ]; then
+	echo "benchstat-gate: ${n_unresolved} timing row(s) moved past the gate but by LESS than their own measured spread, so this comparison cannot resolve them (reported as NOISE-FLOOR above, excluded from the verdict). They are not gateable as sampled; make them quieter or keep them out of the comparison set."
+fi
 
 # Printed on EVERY run, including clean ones. A waiver is a standing decision,
 # and a standing decision that stops being visible stops being reviewed.

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -357,6 +357,121 @@ assert_exit 2 "the shipped waivers do NOT turn an uninterpretable table green" \
 	"$GATE" "${TESTDATA}/benchstat-crash.txt"
 
 echo
+echo "== benchstat-gate: the resolution check (#443) ==========================="
+
+# A threshold is one number for a whole metric class, and it is only as good as
+# the assumption that rows in that class have comparable noise. On elps' timing
+# rows they do not: BenchmarkPackageGetFunParallel is a sub-100ns map lookup
+# under RunParallel, measured at -benchtime=100ms, and it has a ±24% spread on
+# IDENTICAL code -- above the 15% gate. It red PR #442, a parser-only change
+# that cannot reach it, and a re-run with no code change turned it green.
+#
+# So a timing row at or above its gate is called a regression only when the move
+# is bigger than the spread benchstat measured for that row, on those samples.
+# Everything below is the pair that has to hold together: the fix must silence
+# the noise AND still fire on a real move, or it is just the gate switched off.
+NOISE_FIXTURE="${TESTDATA}/benchstat-parallel-noise-443.txt"
+TRUE_FIXTURE="${TESTDATA}/benchstat-parallel-true-regression.txt"
+
+# The noise-only half: #443's row, +15.96% p=0.035 over a 15% gate, with the
+# ±24%/±25% spread the null comparison measured.
+assert_exit 0 "a timing move INSIDE the row's own measured spread is not a regression" \
+	env BENCH_WAIVERS= "$GATE" "$NOISE_FIXTURE"
+# ...and it is NOT silence. A benchmark that cannot be adjudicated is a standing
+# problem with the benchmark, and a gate that quietly drops rows is the exact
+# defect this script exists to prevent.
+assert_contains "NOISE-FLOOR" "the unresolvable row is REPORTED, not dropped" \
+	env BENCH_WAIVERS= "$GATE" "$NOISE_FIXTURE"
+assert_contains "+15.96%" "the unresolvable row still carries its measured delta" \
+	env BENCH_WAIVERS= "$GATE" "$NOISE_FIXTURE"
+assert_contains "spread ±25%" "the report names the spread it was judged against" \
+	env BENCH_WAIVERS= "$GATE" "$NOISE_FIXTURE"
+assert_contains "cannot resolve them" "the summary line counts unresolvable rows" \
+	env BENCH_WAIVERS= "$GATE" "$NOISE_FIXTURE"
+
+# The true-regression half. Same benchmark, same spread, same flat allocation
+# columns; only the size of the move differs. If this ever stops failing, the
+# resolution check has become an off switch.
+assert_exit 1 "a timing move LARGER than the row's spread is still a regression" \
+	env BENCH_WAIVERS= "$GATE" "$TRUE_FIXTURE"
+assert_contains "REGRESSION" "the real move is reported as a regression" \
+	env BENCH_WAIVERS= "$GATE" "$TRUE_FIXTURE"
+assert_contains "+48.00%" "the real move is reported with its delta" \
+	env BENCH_WAIVERS= "$GATE" "$TRUE_FIXTURE"
+
+# The check is about RESOLUTION, not about size: the same +48% row is a
+# regression at any threshold below it, and the +15.96% row is suppressed only
+# because its spread is larger than the move -- not because 16% moves are now
+# allowed anywhere.
+assert_exit 0 "the noise row stays unresolvable even with the gate lowered to 1%" \
+	env BENCH_WAIVERS= BENCH_REGRESSION_THRESHOLD_PCT=1 "$GATE" "$NOISE_FIXTURE"
+assert_contains "NOISE-FLOOR" "...and says so, rather than passing silently" \
+	env BENCH_WAIVERS= BENCH_REGRESSION_THRESHOLD_PCT=1 "$GATE" "$NOISE_FIXTURE"
+
+# CLASS BOUNDARY. Allocation metrics are exempt, explicitly. They are exact
+# rather than sampled and they have caught every real regression this gate has
+# caught; the exemption must not depend on their spread happening to be 0%.
+# One fixture, three rows, same delta and same spread, differing only in class.
+ALLOC_SPREAD_FIXTURE="${TESTDATA}/benchstat-alloc-with-spread.txt"
+assert_exit 1 "an ALLOCATION row is judged on its threshold even with a large spread" \
+	env BENCH_WAIVERS= "$GATE" "$ALLOC_SPREAD_FIXTURE"
+assert_contains "REGRESSION  github.com/luthersystems/elps/lisp             B/op" \
+	"the B/op row with a ±30% spread is still a regression" \
+	env BENCH_WAIVERS= "$GATE" "$ALLOC_SPREAD_FIXTURE"
+assert_contains "REGRESSION  github.com/luthersystems/elps/lisp             allocs/op" \
+	"the allocs/op row with a ±30% spread is still a regression" \
+	env BENCH_WAIVERS= "$GATE" "$ALLOC_SPREAD_FIXTURE"
+assert_contains "NOISE-FLOOR github.com/luthersystems/elps/lisp             sec/op" \
+	"...while the sec/op row with the SAME delta and spread is not" \
+	env BENCH_WAIVERS= "$GATE" "$ALLOC_SPREAD_FIXTURE"
+
+# WHEN THERE IS NO INTERVAL. benchstat prints "± ∞ ¹" below 6 samples, so there
+# is no resolution to check against. Those rows fall back to the threshold alone
+# and must SAY SO -- a check that did not run must never look like one that ran
+# and passed. (CI uses n=10; this is the n=5 fixtures' case.)
+assert_exit 1 "a row with no computable interval is still gated on the threshold" \
+	env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-regression-new.txt"
+assert_contains "resolution check did not run" \
+	"a regression judged without an interval says the check did not run" \
+	env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-regression-new.txt"
+
+# THE MEASUREMENT ITSELF. A real null comparison -- one tree, two interleaved
+# runs, CI's sampling parameters -- kept as evidence for the spreads quoted
+# above. Nothing in it is significant, so it must be clean, which also shows the
+# NOISE-FLOOR verdicts come from the resolution check rather than from these
+# benchmarks being odd in some other way.
+assert_exit 0 "a measured null comparison on identical code is clean" \
+	env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-null-parallel-sandbox.txt"
+
+# AND THE ONE THAT ACTUALLY FIRED. Same procedure, one tree, both arms; on 2 of
+# 15 such comparisons the pre-#443 gate reported a REGRESSION. This is trial 8
+# verbatim: +18.48% p=0.009 over a 15% gate, on code that did not change, with
+# the offending arm measuring itself at ±19%. It is the live counterpart of the
+# CI failure in #443, and the reason this check is not a matter of taste.
+SPURIOUS_FIXTURE="${TESTDATA}/benchstat-null-spurious-firing.txt"
+assert_exit 0 "a NULL comparison that fired the old gate no longer reds the build" \
+	env BENCH_WAIVERS= "$GATE" "$SPURIOUS_FIXTURE"
+# NOISE-FLOOR is only ever printed for a row that reached the threshold, so this
+# is also the proof that the row genuinely WAS over the gate -- i.e. that the
+# assertion above passes because the row was adjudicated and found unresolvable,
+# not because it was quietly under the bar all along.
+assert_contains "NOISE-FLOOR" "...and says so: the row DID cross the gate and could not be resolved" \
+	env BENCH_WAIVERS= "$GATE" "$SPURIOUS_FIXTURE"
+assert_contains "+18.48%" "the false regression keeps its number in the report" \
+	env BENCH_WAIVERS= "$GATE" "$SPURIOUS_FIXTURE"
+# The allocation columns of that same run: exact, "all samples are equal". The
+# contrast is the argument for leaving the 5% allocation gate alone.
+assert_contains "no-change row" "the allocation rows of the same run are unmoved" \
+	env BENCH_WAIVERS= "$GATE" "$SPURIOUS_FIXTURE"
+
+# The shipped waivers must not be what makes any of this pass, and must not
+# rescue the true regression.
+assert_exit 0 "the noise-floor fixture passes with the SHIPPED waivers too" \
+	"$GATE" "$NOISE_FIXTURE"
+assert_exit 1 "the shipped waivers do NOT rescue the true regression" \
+	"$GATE" "$TRUE_FIXTURE"
+
+echo
 echo "== benchstat-gate: the threshold is the only thing holding it back ======="
 
 # Proves the parser genuinely SEES the real comparison's significant deltas and

--- a/scripts/testdata/benchstat-alloc-with-spread.txt
+++ b/scripts/testdata/benchstat-alloc-with-spread.txt
@@ -1,0 +1,36 @@
+# The allocation metrics are NOT subject to the resolution check added for
+# #443, and this pins it.
+#
+# Every real regression this gate has caught, it caught on B/op or allocs/op:
+# they are exact rather than sampled, identical code reproduces them to the
+# byte, and benchstat prints "± 0%" and annotates the row "all samples are
+# equal". A rule keyed on measured spread would therefore be a no-op on them in
+# practice -- which is precisely why it must be switched off for them
+# EXPLICITLY rather than left to happen to be a no-op. A future benchmark whose
+# allocation column jitters (a map that resizes at a data-dependent point, a
+# sync.Pool that hits differently under load) would otherwise start suppressing
+# real allocation regressions silently.
+#
+# So: three rows of one benchmark carrying the SAME delta (+20.00%), the SAME
+# spread (±30%) and the SAME p-value, differing only in metric class. The
+# sec/op row is over its 15% gate but under its spread, so it is NOISE-FLOOR.
+# The B/op and allocs/op rows are over their 5% gate and under the same spread,
+# and must still be REGRESSIONs.
+#
+# One fixture, one controlled variable: the metric class is the only thing that
+# differs, so the different verdicts can only come from the class rule.
+goos: linux
+goarch: arm64
+pkg: github.com/luthersystems/elps/lisp
+cpu: Neoverse-N1
+                        │     base     │                 pr                  │
+                        │    sec/op    │    sec/op     vs base               │
+JitteryThing-2            100.0n ± 30%   120.0n ± 30%  +20.00% (p=0.008 n=10)
+
+                        │     base      │                  pr                  │
+                        │     B/op      │      B/op      vs base               │
+JitteryThing-2            1.000Ki ± 30%   1.200Ki ± 30%  +20.00% (p=0.008 n=10)
+
+                        │     base     │                 pr                  │
+                        │  allocs/op   │  allocs/op    vs base               │
+JitteryThing-2            100.0 ± 30%    120.0 ± 30%   +20.00% (p=0.008 n=10)

--- a/scripts/testdata/benchstat-null-parallel-sandbox.txt
+++ b/scripts/testdata/benchstat-null-parallel-sandbox.txt
@@ -1,0 +1,52 @@
+# A NULL comparison measured while fixing #443: two runs of the SAME tree, on
+# the same machine, interleaved, at the sampling parameters CI uses
+# (GOMAXPROCS=2, -benchtime=100ms, n=10 rounds per arm). Nothing changed between
+# the arms, so every number here is noise by construction.
+#
+# It is preserved because of the SPREAD column, not the deltas. On identical
+# code:
+#
+#     PackageGetFun-2           30.69n ±  52%   34.95n ± 102%
+#     PackageGetFunAliased-2    17.05n ±  15%   21.43n ±  27%
+#     PackageGetFunParallel-2   38.38n ±  31%   30.57n ±  57%
+#
+# ...against a 15% timing threshold. These sub-100ns bodies cannot resolve a 15%
+# move at these sampling parameters -- on THIS sandbox, which is noisier than a
+# CI runner; the CI measurement in #443 put the same parallel row at ±24%. Both
+# are far above the gate.
+#
+# Meanwhile every allocation row in the same run is "± 0%" with "all samples are
+# equal", which is the whole argument for judging the two metric classes
+# differently and for leaving the allocation gate exactly where it is.
+#
+# The gate must pass this file: no row here is significant (every p > 0.05), so
+# it is also the control proving the NOISE-FLOOR verdict comes from the
+# resolution check and not from these rows being unusual in some other way.
+goos: linux
+goarch: amd64
+pkg: github.com/luthersystems/elps/lisp
+cpu: Intel(R) Xeon(R) Processor @ 2.80GHz
+                        │     base     │                  pr                  │
+                        │    sec/op    │    sec/op      vs base               │
+PackageGetFun-2           30.69n ± 52%   34.95n ± 102%       ~ (p=0.529 n=10)
+PackageGetFunAliased-2    17.05n ± 15%   21.43n ±  27%       ~ (p=0.289 n=10)
+PackageGetFunParallel-2   38.38n ± 31%   30.57n ±  57%       ~ (p=0.089 n=10)
+geomean                   27.18n         28.39n         +4.47%
+
+                        │     base     │                 pr                  │
+                        │     B/op     │    B/op     vs base                 │
+PackageGetFun-2           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+PackageGetFunAliased-2    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+PackageGetFunParallel-2   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+geomean                              ²               +0.00%                ²
+¹ all samples are equal
+² summaries must be >0 to compute geomean
+
+                        │     base     │                 pr                  │
+                        │  allocs/op   │ allocs/op   vs base                 │
+PackageGetFun-2           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+PackageGetFunAliased-2    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+PackageGetFunParallel-2   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+geomean                              ²               +0.00%                ²
+¹ all samples are equal
+² summaries must be >0 to compute geomean

--- a/scripts/testdata/benchstat-null-spurious-firing.txt
+++ b/scripts/testdata/benchstat-null-spurious-firing.txt
@@ -1,0 +1,67 @@
+# A SPURIOUS gate firing, caught live on a NULL comparison.
+#
+# This is not a synthetic table and not a transcription. Both arms are the SAME
+# tree at the same commit -- one checkout, two interleaved measurement runs, at
+# the sampling parameters CI uses (GOMAXPROCS=2, -benchtime=100ms, 10 rounds per
+# arm). Nothing whatsoever differs between "base" and "pr". Every number below
+# is noise by construction, so every REGRESSION verdict on it is a false one.
+#
+# Repeated 25 times. The gate as it stood before the resolution check reported a
+# REGRESSION on 3 of the 25 -- a 12% false-positive rate per comparison, on code
+# that did not change:
+#
+#     trial  6: REGRESSION ... sec/op PackageGetVal-2        delta=+94.25% p=0.015 (gate 15%)
+#     trial  8: REGRESSION ... sec/op PackageGetVal-2        delta=+18.48% p=0.009 (gate 15%)
+#     trial 23: REGRESSION ... sec/op PackageGetFunAliased-2 delta=+19.97% p=0.014 (gate 15%)
+#
+# With the resolution check: 0 of 25.
+#
+# This file is trial 8, kept because it is the same shape as the #443 CI failure
+# it was hunted to corroborate: a small sub-100ns row, a delta just over the 15%
+# threshold, and a p-value comfortably under alpha. On identical code. (Trial 6
+# is the same defect wearing a louder number: a +94% "regression" between two
+# runs of one binary.)
+#
+# Read the spread column and the reason is right there. On code that did not
+# change, these rows measure themselves at ±5% to ±66%, against a 15% gate.
+# PackageGetVal-2 says ±19% in the arm that "regressed" -- larger than the
+# +18.48% move the gate was about to fail a PR for. The comparison cannot
+# resolve what it was being asked to adjudicate.
+#
+# What the gate must do with this file: PASS, and say NOISE-FLOOR while doing
+# it. Passing silently would be the other half of the same disease.
+#
+# Note the allocation tables further down: every row "all samples are equal",
+# ± 0%, p=1.000. That is the contrast the two metric classes are judged by, and
+# it is why the 5% allocation gate is left exactly where it is.
+goos: linux
+goarch: amd64
+pkg: github.com/luthersystems/elps/lisp
+cpu: Intel(R) Xeon(R) Processor @ 2.80GHz
+                        │     base     │                  pr                  │
+                        │    sec/op    │    sec/op     vs base                │
+PackageGetFun-2           32.30n ± 66%   29.64n ± 61%        ~ (p=0.684 n=10)
+PackageGetFunAliased-2    15.59n ± 42%   20.14n ± 29%        ~ (p=0.060 n=10)
+PackageGetVal-2           26.78n ±  5%   31.73n ± 19%  +18.48% (p=0.009 n=10)
+PackageGetFunParallel-2   32.38n ± 31%   32.15n ± 26%        ~ (p=0.971 n=10)
+geomean                   25.71n         27.93n         +8.67%
+
+                        │     base     │                 pr                  │
+                        │     B/op     │    B/op     vs base                 │
+PackageGetFun-2           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+PackageGetFunAliased-2    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+PackageGetVal-2           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+PackageGetFunParallel-2   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+geomean                              ²               +0.00%                ²
+¹ all samples are equal
+² summaries must be >0 to compute geomean
+
+                        │     base     │                 pr                  │
+                        │  allocs/op   │ allocs/op   vs base                 │
+PackageGetFun-2           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+PackageGetFunAliased-2    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+PackageGetVal-2           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+PackageGetFunParallel-2   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
+geomean                              ²               +0.00%                ²
+¹ all samples are equal
+² summaries must be >0 to compute geomean

--- a/scripts/testdata/benchstat-parallel-noise-443.txt
+++ b/scripts/testdata/benchstat-parallel-noise-443.txt
@@ -1,0 +1,51 @@
+# The row that red an innocent PR: luthersystems/elps#443.
+#
+# PR #442 changed parser/rdparser and nothing else. Its first CI Benchmark
+# Comparison failed on exactly one row:
+#
+#     REGRESSION  github.com/luthersystems/elps/lisp  sec/op  PackageGetFunParallel-2  delta=+15.96% p=0.035 (gate 15%)
+#
+# Re-running the job with no code change turned it green.
+#
+# BenchmarkPackageGetFunParallel builds its fixture entirely through the Go API
+# (NewPackage, Symbol, FunInPackage, Int) and never invokes the parser; its
+# measured loop is a map lookup under RunParallel. There is no path from
+# parser/rdparser to it. The deterministic columns agreed at the time and are
+# reproduced below: B/op and allocs/op both "all samples are equal".
+#
+# The spreads are the point. Two independent checkouts of the SAME commit
+# (ce9798d), interleaved, GOMAXPROCS=2, -benchtime=100ms, n=20, produced
+#
+#     base vs base2 (identical code)
+#     PackageGetFunParallel-2   38.70n ± 24%   38.94n ± 24%   ~ (p=0.841 n=20)
+#
+# so this benchmark has a ±24% noise floor on code that did not change. A +16%
+# move is inside that. The 15% timing threshold is below the resolution of this
+# row, which is why a p<=0.05 draw over the gate happens here by chance.
+#
+# Independently re-measured while fixing this, on a 4-core sandbox at the same
+# sampling parameters (preserved as benchstat-null-parallel-sandbox.txt): the
+# same benchmark showed ±31% / ±57% on identical code, and its two sibling rows
+# ±52% / ±102% and ±15% / ±27%. The allocation columns were ± 0% on all three.
+#
+# The gate must NOT call this a regression, and must not stay silent about it
+# either -- it is reported as NOISE-FLOOR, because a benchmark that cannot be
+# adjudicated is a standing problem rather than a clean result.
+goos: linux
+goarch: arm64
+pkg: github.com/luthersystems/elps/lisp
+cpu: Neoverse-N1
+                        │     base     │                  pr                  │
+                        │    sec/op    │    sec/op      vs base               │
+PackageGetFunParallel-2   38.70n ± 24%    44.88n ± 25%  +15.96% (p=0.035 n=20)
+geomean                   38.70n          44.88n        +15.96%
+
+                        │     base     │                 pr                  │
+                        │     B/op     │    B/op      vs base                │
+PackageGetFunParallel-2   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=20) ¹
+¹ all samples are equal
+
+                        │     base     │                 pr                  │
+                        │  allocs/op   │  allocs/op   vs base                │
+PackageGetFunParallel-2   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=20) ¹
+¹ all samples are equal

--- a/scripts/testdata/benchstat-parallel-true-regression.txt
+++ b/scripts/testdata/benchstat-parallel-true-regression.txt
@@ -1,0 +1,35 @@
+# The control for benchstat-parallel-noise-443.txt, and the more important half
+# of the pair.
+#
+# SAME benchmark, SAME package, SAME measured spread (±24% / ±25%), SAME
+# unchanged allocation columns. The ONLY difference is the size of the move:
+# +48.00% instead of +15.96%.
+#
+# That is larger than what the row can measure, so it is a regression and the
+# gate must still fail on it. Without this fixture the resolution check added
+# for #443 would be indistinguishable from switching the row off -- and a check
+# that cannot fire is the defect this whole gate was written to fix (473 green
+# runs of a `grep` no benchstat line could ever match).
+#
+# Note that the allocation columns are deliberately FLAT here. A timing
+# regression this large must fail on the timing evidence alone; requiring
+# allocations to move too would have made the timing gate unfireable on any
+# change that is slower without allocating more, which is most of them.
+goos: linux
+goarch: arm64
+pkg: github.com/luthersystems/elps/lisp
+cpu: Neoverse-N1
+                        │     base     │                  pr                  │
+                        │    sec/op    │    sec/op      vs base               │
+PackageGetFunParallel-2   38.70n ± 24%    57.28n ± 25%  +48.00% (p=0.000 n=20)
+geomean                   38.70n          57.28n        +48.00%
+
+                        │     base     │                 pr                  │
+                        │     B/op     │    B/op      vs base                │
+PackageGetFunParallel-2   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=20) ¹
+¹ all samples are equal
+
+                        │     base     │                 pr                  │
+                        │  allocs/op   │  allocs/op   vs base                │
+PackageGetFunParallel-2   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=20) ¹
+¹ all samples are equal


### PR DESCRIPTION
Fixes #443

The benchmark gate applies one timing threshold (15%) to every timing row, which is exactly as good as the assumption behind it: that timing rows have comparable noise. On elps they do not. `BenchmarkPackageGetFunParallel` measures itself at ±24% on identical code, and red PR #442 — a parser-only change that cannot reach it — at +15.96% (p=0.035).

`BENCH_REGRESSION_THRESHOLD_PCT` is **unchanged at 15**. Both allocation thresholds are **unchanged at 5**.

## Red: measured, not argued

25 **null** comparisons — one tree, both arms, at CI's own sampling parameters (`GOMAXPROCS=2`, `-benchtime=100ms`, 10 interleaved rounds per arm). Nothing differs between the arms, so every regression verdict is false by construction. The gate as it stands today:

```
trial  6: REGRESSION ... sec/op PackageGetVal-2        delta=+94.25% p=0.015 (gate 15%)
trial  8: REGRESSION ... sec/op PackageGetVal-2        delta=+18.48% p=0.009 (gate 15%)
trial 23: REGRESSION ... sec/op PackageGetFunAliased-2 delta=+19.97% p=0.014 (gate 15%)

SPURIOUS FIRINGS OF THE MAIN GATE: 3 / 25 null comparisons on IDENTICAL code
```

**12% of comparisons red an innocent PR.** One of them claims a +94% regression between two runs of the same binary.

Trial 8 is preserved verbatim as `scripts/testdata/benchstat-null-spurious-firing.txt`. Its spread column is the whole story — on code that did not change, these rows measure themselves at ±5% to ±66% against a 15% gate, and the arm that "regressed" says ±19%, larger than the +18.48% move.

## Green

With this change: **0 / 25**.

## The fix: ask the row, not a constant

benchstat already prints, per arm, the 95% confidence interval of that arm's median as a percentage — the `± 24%`. That *is* the resolution of the comparison, computed from the very samples being adjudicated, and it is already in the table this gate parses.

> A **timing** row at or above its threshold is called a REGRESSION only when the move is **larger than the row's own measured spread**. Otherwise it is reported as `NOISE-FLOOR` and excluded from the verdict.

This is the "significant **and** large enough to see" rule, with "large enough" denominated in the row's own dispersion rather than in a constant chosen once. It cannot suppress a large move: on a ±24% row it takes a >24% regression to fire, which is precisely what "this row cannot resolve less than that" means.

**Not silence.** A `NOISE-FLOOR` row is a benchmark this comparison cannot adjudicate *at all* — a standing problem, not a clean result. So it is printed per row with its delta and its spread, counted in a summary line, and lifted out of the collapsed block into the body of the PR comment, the same treatment a reviewed waiver gets and for the same reason. Silence here would turn "we could not measure it" into "it was fine", which is the shape of defect this gate exists to fix.

## Both halves of the pair are asserted

The fix must silence the noise **and** still fire on a real move, or it is just the gate switched off.

| Fixture | Verdict |
|---|---|
| `benchstat-parallel-noise-443.txt` — #443's row, +15.96% inside a ±25% spread | passes, `NOISE-FLOOR` |
| `benchstat-parallel-true-regression.txt` — **same** benchmark, **same** spread, **same** flat allocation columns, +48.00% | **fails** |
| `benchstat-null-spurious-firing.txt` — the live 3/25 firing | passes, `NOISE-FLOOR` |
| `benchstat-null-parallel-sandbox.txt` — a measured null comparison, nothing significant | passes, silent |

`NOISE-FLOOR` is only ever printed for a row that reached the threshold, so its presence is also the proof that those rows genuinely *were* over the gate — they pass because they were adjudicated and found unresolvable, not because they were quietly under the bar.

## The allocation gate is preserved, explicitly

Allocation metrics are exempt from the resolution check by an explicit `is_alloc_metric` test, **not** by happening to have a `± 0%` spread. They are exact rather than sampled, and they have caught every real regression this gate has caught (the +7.8% on PR #442, the +8.44% on PR #310). A future benchmark whose allocation column jittered must not start suppressing them silently.

`benchstat-alloc-with-spread.txt` pins that with one benchmark whose `sec/op`, `B/op` and `allocs/op` rows carry the **same** delta (+20.00%), the **same** ±30% spread and the **same** p-value. The sec/op row is `NOISE-FLOOR`; the two allocation rows are `REGRESSION`. One controlled variable: the metric class.

## No computable interval

benchstat prints `± ∞ ¹` below 6 samples. Those rows fall back to the threshold alone and **say so** on the regression line — a check that did not run must never look like one that ran and passed. CI runs `n=10`; this is the n=5 fixtures' case.

## What I rejected

- **Raising the threshold** — ruled out by the issue and by the waivers file: 15% is a per-class noise floor, and moving it for one row blinds every serial benchmark in the repository to the same magnitude of move, permanently.
- **A waiver for the row** — a waiver records a cost that is *real* and accepted. This one is not real, and it would permanently suppress a row that might one day move for an actual reason.
- **A longer `-benchtime` for this benchmark** (the issue's option 1) — it treats the symptom on one row. The 3/25 hunt fired on `PackageGetVal` and `PackageGetFunAliased`, not on `PackageGetFunParallel`, so the problem is not one benchmark. It remains the right *follow-up*, and the `NOISE-FLOOR` lines are now what tell you which rows need it.
- **Gating timing only when allocations also move** — would make the timing gate unfireable on any change that is slower without allocating more, which is most of them. The true-regression fixture has deliberately flat allocation columns to pin that it does not work this way.
- **Timing advisory, allocations hard** — that *is* raising the timing threshold to infinity, for every row including the quiet ones. The resolution check gives the same protection only where it is warranted.

## Compatibility

Every one of the 19 pre-existing fixtures reaches an **identical exit code**, verified by running both gate versions over all of them. The only output change is the added `[no interval …]` annotation on n=5 regression rows. The six self-test assertions pinning the shipped waiver file are untouched and pass. `scripts/ci-gates-test.sh` goes from **182 to 205** assertions.

## Neighbourhood audit: other CI thresholds that could sit below their own resolution

| Threshold | Verdict |
|---|---|
| `BENCH_ALLOC_THRESHOLD_PCT=5` (`B/op`, `allocs/op`) | **Safe, left alone.** Measured resolution on identical code is `± 0%` with "all samples are equal" — including in the live spurious-firing run whose timing rows were at ±66%. 5% is ~26x the worst noise ever measured (0.19%). |
| `BENCH_ALPHA=0.05` | Not a magnitude threshold, so "below its resolution" does not apply. It is exactly the knob that lets a 16% draw look significant inside a ±24% null, which is why the effect-size half is what needed adding. |
| `BENCH_COUNT=10` | Above benchstat's floor of 6; raising it is a job-time trade, tracked as the follow-up above rather than changed here. |
| Waiver ceilings (9%, 14% on libjson `Encode`) | Allocation columns at `± 0%`, so far above their own resolution. |
| `scripts/fuzz-budget-check.sh` | Arithmetic over declared workflow timeouts, not a measurement. Reported 0 min headroom against a 60 min budget — tight, but exact rather than sampled. Untouched. |
| `SCRIPT_FLOOR` in `ci-gates-test.sh` | A count of files, exact. |

## Dead waiver entry: left in place, deliberately

The shipped `scripts/benchstat-waivers.txt` carries two entries (`libjson` / `Encode` / `allocs/op` and `/ B/op`), tracked by #413. They now report `waiver-unused … can be deleted` on any comparison whose base already contains PR #411's change — i.e. every current CI run. So the observation is right.

I left them, for three reasons:

1. **My change is orthogonal.** The resolution check never touches allocation metrics, so nothing here makes the cleanup natural.
2. **#413 says not to.** "Do not just delete the waiver … Removing the waiver without addressing the cost simply reds every PR." It lists three ways to close it, all of which are #412/#413 work.
3. **Deleting them would weaken the self-test.** Six assertions pin the *shipped* file against PR #411's real comparison — that is what stops the file being deleted, emptied or edited hollow. Repointing them at a `testdata/` waiver fixture would keep the count and lose the property.

Worth noting for whoever picks it up: the issue number in the brief was #413 (the tracking issue); the entries themselves cite `elps#412 elps#410` in their issue field.

## Gates

`go build ./...`, `go vet ./...`, `go test -count=1 ./...`, `go test -race -count=1 ./...`, `golangci-lint run ./...` (0 issues), `elps fmt -l ./...`, `elps doc -m`, `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `./scripts/ci-gates-test.sh` (205 passed, 0 failed), `./scripts/confidentiality-guard.sh` (clean), `./scripts/fuzz-budget-check.sh` — all green.

One note on the way: the first `go test -race ./...` on this branch failed `TestEvalTerminatingSeedsComplete/tail-recursion-bounded` at 35,308 steps — on a branch that changes **no Go code at all**. That is #435, reproducing itself unprompted on the PR that exists to stop checks firing on innocent code. It is fixed by #447; the re-run here is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_