### PR TITLE
Stop macro expansion aliasing the caller's Location, and the guard that could not fail (#431, #430)

### DIFF
--- a/lisp/env.go
+++ b/lisp/env.go
@@ -1132,7 +1132,36 @@ func (env *LEnv) macroCall(ctx context.Context, fun, args *LVal) *LVal {
 
 	// Capture the call-site location before entering the macro body so we
 	// can stamp it onto expanded nodes that lack real source info.
-	callSite := env.Loc
+	//
+	// A COPY, not the pointer (elps#431).  env.Loc is set by eval to the
+	// Source of the node being evaluated, so it is a *token.Location owned by
+	// a node in the CALLER'S parse tree.  Handing that pointer to
+	// stampMacroExpansion gave every synthesized node of the expansion the
+	// caller's own object: one macro call put N+1 nodes -- the N stamped
+	// nodes plus the call site itself -- on one mutable Location, spanning two
+	// trees with independent lifetimes.  It is the same shape as elps#362 (the
+	// process-wide native singleton) and elps#426 (a prefix form and its
+	// operand sharing the scanner's object), and it was reproducible: writing
+	// `expansion.Source.Line = 99` moved the caller's node to line 99.
+	//
+	// One copy per macro call, not one per stamped node.  The distinction the
+	// copy has to buy is between two OWNERS -- the caller's tree and the
+	// expansion -- and one object per expansion buys exactly that.  The N
+	// stamped nodes still share, but they share a Location the expansion owns
+	// and that no other tree can see, and they genuinely all sit at the call
+	// site; collapsing that last bit of sharing is what making LVal.Source
+	// immutable is for, and it would cost an allocation per node on the
+	// expansion path (elps#421 measured a fresh Location per call on a hot
+	// path at +18.6% sec/op, +20.2% allocs/op geomean).  This costs one, next
+	// to the whole expansion tree the macro has just allocated.
+	//
+	// Copy() preserves nil, so a macro called with no location still stamps
+	// nothing -- stampMacroExpansion returns early on a nil callSite.
+	//
+	// The copy is taken here rather than inside stampMacroExpansion so that
+	// MacroExpansionContext.CallSite below, which outlives the expansion on
+	// every node's MacroExpansionInfo, is covered by the same allocation.
+	callSite := env.Loc.Copy()
 
 	// Push a frame onto the stack to represent the function's execution.
 	err := env.Runtime.Stack.PushFID(env.Loc, fun.FID(), fun.Package(), env.GetFunName(fun))

--- a/lisp/eval_fuzz_test.go
+++ b/lisp/eval_fuzz_test.go
@@ -5,6 +5,8 @@ package lisp_test
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/lisplib"
 	"github.com/luthersystems/elps/parser"
+	"github.com/luthersystems/elps/parser/token"
 )
 
 // Fuzzing the EVALUATOR, not the parser.
@@ -165,6 +168,116 @@ type evalOutcome struct {
 	Elapsed time.Duration
 }
 
+// locationWatch records, for every node the loader's reader produces, the
+// *token.Location that node held and the position that Location described --
+// so evaluation can be asked afterwards whether it moved either.
+//
+// WHAT THIS COVERS, and why it lives in FuzzEval rather than in a target of its
+// own (the fuzz sweep's budget has no spare shard-minutes: see
+// scripts/fuzz-budget-check.sh).
+//
+// A parse tree is not private to one evaluation.  LEnv.load evaluates the
+// reader's expressions directly without copying; a function body IS the parse
+// tree it was defined from, re-entered on every call; and a *Package -- LFun
+// bodies included -- is shared by pointer across the per-request environments
+// an embedder derives from one registry.  So a write into a parsed node's
+// position is not a local mistake, it is retroactive corruption of every error
+// message, stack frame and LSP range computed from that node, in every
+// evaluation that ever uses it.
+//
+// The evaluator has exactly one writer of LVal.Source: stampMacroExpansion.
+// It is supposed to claim only nodes the MACRO created.  It reached parser
+// output twice before -- elps#370, where the reader emitted synthetic locations
+// the stamp then rewrote, and elps#431, where the stamp wrote the caller's own
+// *token.Location onto every node of the expansion, leaving two trees on one
+// mutable object.  Both are fixed; this states the property they broke, over
+// arbitrary programs, rather than over the two shapes their regression tests
+// pin.
+//
+// GUARD, NOT A CATCH: this passes on the parent commit.  elps#431 is an
+// ownership defect, and its corruption is latent -- no in-tree writer can
+// currently reach a Location it does not own.  What this adds is that a future
+// one cannot arrive unnoticed.
+type locationWatch struct {
+	lisp.Reader
+	nodes     []*lisp.LVal
+	locs      []*token.Location
+	positions []token.Location
+	truncated bool
+}
+
+// locationWatchLimit bounds what one input may make the watch retain.  A
+// program is free to call `load-string` in a loop, and an unbounded watch would
+// turn that into memory pressure on the fuzz process.  Past the limit the watch
+// stops recording and says so, rather than recording a prefix and reporting as
+// if it had seen everything.
+const locationWatchLimit = 200_000
+
+// Read implements lisp.Reader, recording the tree on the way past.  Every
+// exported Load* entry point funnels through Runtime.Reader, so this sees the
+// program itself and anything it loads at runtime.
+func (w *locationWatch) Read(name string, r io.Reader) ([]*lisp.LVal, error) {
+	exprs, err := w.Reader.Read(name, r)
+	for _, e := range exprs {
+		w.record(e, make(map[*lisp.LVal]bool))
+	}
+	return exprs, err
+}
+
+func (w *locationWatch) record(v *lisp.LVal, seen map[*lisp.LVal]bool) {
+	// Bounded like every other walk over a value the fuzzer chose: a macro may
+	// build a structure that contains itself (elps#390), and the reader is not
+	// the only producer feeding this.
+	if v == nil || seen[v] {
+		return
+	}
+	if len(w.nodes) >= locationWatchLimit {
+		w.truncated = true
+		return
+	}
+	seen[v] = true
+	if v.Source != nil {
+		w.nodes = append(w.nodes, v)
+		w.locs = append(w.locs, v.Source)
+		w.positions = append(w.positions, *v.Source)
+	}
+	for _, c := range v.Cells {
+		w.record(c, seen)
+	}
+}
+
+// verify reports the first node whose position evaluation moved.
+func (w *locationWatch) verify(t fatalf, src []byte) {
+	t.Helper()
+	// A truncated watch still reports honestly on what it did record; it says
+	// so, so a failure is never read as "and nothing else moved".
+	scope := fmt.Sprintf("%d nodes watched", len(w.nodes))
+	if w.truncated {
+		scope = fmt.Sprintf("first %d nodes only; the watch was truncated at its limit", len(w.nodes))
+	}
+	for i, node := range w.nodes {
+		switch {
+		case node.Source == nil:
+			t.Fatalf("evaluation cleared the source location of a parsed %v %q (was %v) [%s]"+
+				"\n--- source (%d bytes) ---\n%q",
+				node.Type, node.Str, w.positions[i], scope, len(src), src)
+			return
+		case node.Source != w.locs[i]:
+			t.Fatalf("evaluation re-pointed the Source of a parsed %v %q from %v to %v;"+
+				" the stamp must claim only nodes the macro created (#370, #431) [%s]"+
+				"\n--- source (%d bytes) ---\n%q",
+				node.Type, node.Str, w.positions[i], node.Source, scope, len(src), src)
+			return
+		case *node.Source != w.positions[i]:
+			t.Fatalf("evaluation moved the recorded position of a parsed %v %q from %+v to %+v;"+
+				" a write through a *token.Location the evaluator does not own (#431) [%s]"+
+				"\n--- source (%d bytes) ---\n%q",
+				node.Type, node.Str, w.positions[i], *node.Source, scope, len(src), src)
+			return
+		}
+	}
+}
+
 // fatalf is the subset of *testing.T and *testing.F the harness needs, so the
 // same code serves the fuzz target and the ordinary corpus tests.
 type fatalf interface {
@@ -210,6 +323,14 @@ func evalBudgeted(t fatalf, src []byte) (evalOutcome, bool) {
 		return evalOutcome{}, false
 	}
 
+	// Watch the positions of every node the loader is about to evaluate.
+	// Installed AFTER newFuzzEnv so the stdlib's own parse trees -- tens of
+	// thousands of nodes, evaluated once during setup and never again -- are
+	// not recorded per input.  The wrapper adds one walk of the program's tree
+	// and no extra evaluation.
+	watch := &locationWatch{Reader: env.Runtime.Reader}
+	env.Runtime.Reader = watch
+
 	ctx, cancel := context.WithTimeout(context.Background(), fuzzDeadline)
 	defer cancel()
 
@@ -239,6 +360,10 @@ func evalBudgeted(t fatalf, src []byte) (evalOutcome, bool) {
 				t.Fatalf("evaluation returned a nil LVal")
 				return evalOutcome{}, false
 			}
+			// Only once the evaluation goroutine has finished: verify walks
+			// the same nodes it was writing to, and reading them while it runs
+			// is the race the property is about.
+			watch.verify(t, src)
 			return evalOutcome{
 				Result:  d.result,
 				Stderr:  stderr.String(),

--- a/lisp/macro.go
+++ b/lisp/macro.go
@@ -238,6 +238,12 @@ func macroDeftype(env *LEnv, args *LVal) *LVal {
 // handed to stampMacroExpansion can contain itself, and an unguarded walk over
 // one overflows the goroutine stack and kills the process.  The walk is
 // bounded the same way rendering is; see lisp/cycle.go and issue #390.
+//
+// callSite is stored by POINTER on every node the walk claims, so the caller
+// must pass a Location the expansion may own -- not one a live parse tree also
+// holds.  macroCall takes env.Loc.Copy() for exactly this reason; passing
+// env.Loc itself put the caller's node and the whole expansion on one mutable
+// object (issue #431).
 func stampMacroExpansion(v *LVal, callSite *token.Location, ctx *MacroExpansionContext, rt *Runtime) {
 	var st cycleState
 	stampGuarded(v, callSite, ctx, rt, cycleGuard{state: &st})

--- a/lisp/macro_callsite_alias_test.go
+++ b/lisp/macro_callsite_alias_test.go
@@ -1,0 +1,205 @@
+// Copyright © 2026 The ELPS authors
+
+// Call-site aliasing regression tests for elps#431.
+//
+// stampMacroExpansion writes callSite onto every node of a macro expansion
+// that has no real position of its own, by POINTER.  macroCall used to pass
+// env.Loc -- which eval sets to the Source of the node it is evaluating, i.e.
+// a *token.Location owned by a node in the CALLER'S parse tree.  One expansion
+// of a macro with N synthesized nodes therefore left N+1 nodes, in two trees
+// with unrelated lifetimes, holding one mutable object; writing through any of
+// them moved the position the others report.
+//
+// Third instance of one shape: elps#362 (a process-wide native Location handed
+// to every constructed value) and elps#426 (a prefix form and its operand
+// sharing the scanner's per-token object) are the other two.
+//
+// STATUS -- read this before treating these as a caught bug.  Both tests below
+// are red on the parent commit and green after, so they are regression tests
+// for the ALIASING.  The CORRUPTION the aliasing enables is LATENT: nothing in
+// the tree writes through a *token.Location it does not own, except the five
+// sites in parser/rdparser/parser.go -- which operate on nodes the reader has
+// just built, and since elps#426 on Locations those nodes own -- and
+// lisp/env.go's error constructors, which take env.Loc.Copy() since elps#421.
+// lsp/, lint/, analysis/, analysis/perf/, mcpserver/, minifier/, formatter/,
+// lisp/x/debugger/ and lisp/x/profiler/ read a Location and format it into
+// their own Position/Range/Span value types; none writes through one.
+//
+// So the write in step 3 of the first test is one the TEST performs: it
+// demonstrates the mechanism, it does not record an observed failure.  What
+// these pin is the ownership property, which does not depend on today's
+// population of writers -- the point, since that population is not fixed:
+// elps#370 was a walk writing positions into a tree it did not own, and
+// elps#426 was a parser helper writing through a pointer two nodes held.
+//
+// NOT COVERED HERE, deliberately: LEnv.Lambda's `Source: env.Loc` puts the same
+// caller-owned Location on the LFun a `defun` expansion builds.  elps#421's
+// neighbourhood audit found that, weighed it ("a copy here is a new allocation
+// on a path that has none, per lambda"), and left it reported and subsumed by
+// the LVal.Source immutability work.  It is still there; these tests use macros
+// whose expansions contain no lambda so they measure the stamp and not that.
+
+package lisp_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// callSiteEnv builds an environment with a real reader, so the caller's nodes
+// carry the parser's own Locations rather than constructed ones.
+func callSiteEnv(t testing.TB) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	require.NotEqual(t, lisp.LError, lisp.InitializeUserEnv(env).Type)
+	return env
+}
+
+// expandOnce drives a macro exactly as eval does -- env.Loc set to the calling
+// node's own Source -- and returns the expansion with MacroCall's
+// LMarkMacExpand wrapper removed.
+func expandOnce(t testing.TB, env *lisp.LEnv, name string, callNode *lisp.LVal, args ...*lisp.LVal) *lisp.LVal {
+	t.Helper()
+	fun := env.GetGlobal(lisp.Symbol(name))
+	require.Equal(t, lisp.LFun, fun.Type, "%s is not a macro: %v", name, fun)
+
+	if callNode != nil {
+		env.Loc = callNode.Source
+	} else {
+		env.Loc = nil
+	}
+	res := env.MacroCall(fun, lisp.SExpr(args))
+	require.NotEqual(t, lisp.LError, res.Type, "%v", res)
+	if res.Type == lisp.LMarkMacExpand {
+		require.Len(t, res.Cells, 1)
+		res = res.Cells[0]
+	}
+	return res
+}
+
+// collectSources returns every distinct non-nil Source pointer in v's tree.
+func collectSources(v *lisp.LVal) map[*token.Location]bool {
+	out := map[*token.Location]bool{}
+	seen := map[*lisp.LVal]bool{}
+	var walk func(*lisp.LVal)
+	walk = func(v *lisp.LVal) {
+		if v == nil || seen[v] {
+			return
+		}
+		seen[v] = true
+		if v.Source != nil {
+			out[v.Source] = true
+		}
+		for _, c := range v.Cells {
+			walk(c)
+		}
+	}
+	walk(v)
+	return out
+}
+
+// parseOne reads a single form and returns it.
+func parseOne(t testing.TB, env *lisp.LEnv, name, src string) *lisp.LVal {
+	t.Helper()
+	exprs, err := env.Runtime.Reader.Read(name, strings.NewReader(src))
+	require.NoError(t, err)
+	require.Len(t, exprs, 1)
+	require.NotNil(t, exprs[0].Source)
+	return exprs[0]
+}
+
+// TestMacroExpansionDoesNotAliasCallerLocation is the regression arm.
+//
+// `defconst` is a builtin macro that builds its whole expansion from
+// lisp.Symbol/lisp.SExpr/lisp.Quote, so every node arrives carrying the
+// synthetic "<native code>" position the stamp exists to replace: the maximal
+// case, and one with no lambda in it.
+//
+// Pre-fix every one of those nodes held the *same pointer* as the caller's
+// `(defconst ...)` node, and a write through the expansion moved the caller's
+// node with it.
+func TestMacroExpansionDoesNotAliasCallerLocation(t *testing.T) {
+	t.Parallel()
+	env := callSiteEnv(t)
+
+	callNode := parseOne(t, env, "caller.lisp", "(defconst answer 42)\n")
+	expansion := expandOnce(t, env, "lisp:defconst", callNode,
+		lisp.Symbol("answer"), lisp.Int(42))
+
+	// 1. No node of the expansion holds the caller's object.
+	for loc := range collectSources(expansion) {
+		assert.NotSame(t, callNode.Source, loc,
+			"a macro expansion node shares the caller's *token.Location (#431)")
+	}
+
+	// 2. It still reports the call site, by value.
+	require.NotNil(t, expansion.Source)
+	assert.Equal(t, *callNode.Source, *expansion.Source,
+		"the expansion must still report the call site's position")
+
+	// 3. The failure the aliasing enables: an in-place write through the
+	//    expansion moving a position the caller's parse tree records.  That
+	//    tree outlives the expansion -- a function body IS the parse tree it
+	//    was defined from, re-entered on every call -- and every error
+	//    message, stack frame and LSP range is computed from those positions.
+	before := callNode.Source.String()
+	expansion.Source.Line = 99
+	expansion.Source.Col = 42
+	assert.Equal(t, before, callNode.Source.String(),
+		"a write through the expansion moved the caller's recorded position (#431)")
+}
+
+// TestMacroExpansionCallSiteIsPrivate states the ownership property on its own
+// terms, with no write at all: whatever Location the expansion is stamped with
+// must be an object no node of the caller's parse tree holds.  It covers the
+// ordinary user-macro shape -- quasiquote splicing an argument into a
+// synthesized frame -- rather than the all-synthetic builtin above.  Also red
+// on the parent commit.
+func TestMacroExpansionCallSiteIsPrivate(t *testing.T) {
+	t.Parallel()
+	env := callSiteEnv(t)
+
+	require.NotEqual(t, lisp.LError,
+		env.LoadString("prelude.lisp",
+			"(defmacro wrap (x) (quasiquote (progn (unquote x))))").Type)
+
+	callNode := parseOne(t, env, "caller.lisp", "(wrap 1)\n")
+	callerLocs := collectSources(callNode)
+	require.NotEmpty(t, callerLocs)
+
+	// The argument is a value the test constructed, so no node of the caller's
+	// tree is spliced into the expansion; an unquoted caller node legitimately
+	// carries its own Location along with it, and that is not this property.
+	expansion := expandOnce(t, env, "wrap", callNode, lisp.Int(1))
+
+	for loc := range collectSources(expansion) {
+		assert.False(t, callerLocs[loc],
+			"the expansion is stamped with a Location the caller's parse tree also holds (#431)")
+	}
+}
+
+// TestMacroCallSiteCopyPreservesNil pins the nil-preserving half of the copy.
+// A macro expanded with no recorded position must stamp nothing --
+// stampMacroExpansion returns early on a nil callSite -- so materialising nil
+// into a zero Location would relabel every synthesized node from
+// "<native code>" to ":0:0".
+func TestMacroCallSiteCopyPreservesNil(t *testing.T) {
+	t.Parallel()
+	env := callSiteEnv(t)
+
+	expansion := expandOnce(t, env, "lisp:defconst", nil,
+		lisp.Symbol("answer"), lisp.Int(42))
+
+	require.NotNil(t, expansion.Source)
+	assert.Equal(t, token.NativeFile, expansion.Source.File,
+		"a nil call site must leave synthesized nodes on <native code>, not ':0:0'")
+	assert.Negative(t, expansion.Source.Pos,
+		"a nil call site must leave the synthetic Pos < 0 marker in place")
+}

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -471,9 +471,11 @@ func (p *Parser) locateSynthesized(v *lisp.LVal) *lisp.LVal {
 	if loc == nil {
 		return v
 	}
-	if tok := p.src.Token; tok != nil {
-		loc.EndLine, loc.EndCol, loc.EndPos = token.TokenEnd(tok)
-	}
+	// No `p.src.Token != nil` here: Location returned a Location, so there is
+	// a token under the cursor.  The second instance of that unreachable
+	// conjunct, the one in tokenLVal, is what elps#430 is about; see the
+	// token-under-the-cursor note above Parser.TokenText.
+	loc.EndLine, loc.EndCol, loc.EndPos = token.TokenEnd(p.src.Token)
 	v.Source = loc
 	return v
 }
@@ -847,11 +849,50 @@ func (p *Parser) ReadToken() *token.Token {
 	return p.src.Token
 }
 
+// THE TOKEN-UNDER-THE-CURSOR INVARIANT (elps#430).
+//
+// TokenSource.Token starts nil and is only ever assigned by scan(), so "no
+// token under the cursor" is a real state; token.Source documents it -- "Token
+// returns nil if Scan has not been called."  Inside this file that state is
+// unreachable: every caller of TokenText, TokenType and Location runs after an
+// Accept or a ReadToken has consumed a token, and the parser never rewinds to
+// before the first one.
+//
+// It is reachable through the EXPORTED API, and it panicked.  All three
+// accessors are exported, NewFromSource is exported, and
+//
+//	p := rdparser.NewFromSource(rdparser.NewTokenStreamSource(stream))
+//	p.Location()
+//
+// dereferenced a nil *Token -- "invalid memory address or nil pointer
+// dereference" -- from an accessor whose entire job is to answer a question
+// about the parser's state.  An embedder driving a Parser through
+// NewFromSource/TokenStream/TokenGenerator, which is what those exist for, has
+// no way to ask "have you started yet?" except by calling one of these.
+//
+// So each answers with the value that already means "nothing here": nil, ""
+// and token.INVALID (the zero Type, which renders as "invalid").  Inside the
+// parser the branch is never taken, so this STATES the invariant rather than
+// weakening it -- once, here, instead of at each call site.  tokenLVal used to
+// carry such a restatement, `p.src.Token != nil`, one line after Location()
+// had already dereferenced that same pointer: it could not fail, and it
+// advertised a contract the rest of the file does not honour.
+
+// TokenText returns the text of the token under the cursor, or "" if no token
+// has been scanned yet.
 func (p *Parser) TokenText() string {
+	if p.src.Token == nil {
+		return ""
+	}
 	return p.src.Token.Text
 }
 
+// TokenType returns the type of the token under the cursor, or token.INVALID
+// if no token has been scanned yet.
 func (p *Parser) TokenType() token.Type {
+	if p.src.Token == nil {
+		return token.INVALID
+	}
 	return p.src.Token.Type
 }
 
@@ -899,7 +940,15 @@ func (p *Parser) TokenType() token.Type {
 // deterministic (all rows p=0.000, +-0%).  That is a real cost on the parse
 // path for no additional safety, since a Location given away exactly once
 // cannot be shared.
+//
+// A nil result means "no position": either no token has been scanned yet (see
+// the token-under-the-cursor note above, elps#430) or the token carries no
+// Location.  Callers store it on an LVal or an error, where nil Source already
+// means the same thing.
 func (p *Parser) Location() *token.Location {
+	if p.src.Token == nil {
+		return nil
+	}
 	loc := p.src.Token.Source
 	if loc == nil {
 		return nil
@@ -963,7 +1012,13 @@ func (p *Parser) QExpr(cells []*lisp.LVal) *lisp.LVal {
 func (p *Parser) tokenLVal(v *lisp.LVal) *lisp.LVal {
 	v.Source = p.Location()
 	// Set end position from the current token.
-	if v.Source != nil && p.src.Token != nil {
+	//
+	// A non-nil v.Source is by itself proof that there IS a token under the
+	// cursor: Location returns nil when p.src.Token is nil.  The `p.src.Token
+	// != nil` conjunct this condition used to carry could not fail -- and, in
+	// the shape it was written, could not have caught anything either, because
+	// Location() dereferenced p.src.Token one line above it (elps#430).
+	if v.Source != nil {
 		endLine, endCol, endPos := token.TokenEnd(p.src.Token)
 		v.Source.EndLine = endLine
 		v.Source.EndCol = endCol

--- a/parser/rdparser/token_cursor_test.go
+++ b/parser/rdparser/token_cursor_test.go
@@ -69,7 +69,7 @@ func TestAccessorsBeforeFirstScan(t *testing.T) {
 		t.Parallel()
 		p := unstartedParser()
 		require.NotPanics(t, func() {
-			assert.Equal(t, "", p.TokenText())
+			assert.Empty(t, p.TokenText())
 		})
 	})
 

--- a/parser/rdparser/token_cursor_test.go
+++ b/parser/rdparser/token_cursor_test.go
@@ -1,0 +1,155 @@
+// Copyright © 2026 The ELPS authors
+
+// Tests for the token-under-the-cursor invariant, elps#430.
+//
+// Two halves, with different status:
+//
+//   - TestAccessorsBeforeFirstScan is a CATCH.  Parser.Location(),
+//     TokenText() and TokenType() dereferenced p.src.Token unconditionally,
+//     and TokenSource.Token starts nil, so an embedder constructing a Parser
+//     through the exported API and asking it anything before parsing got
+//     "invalid memory address or nil pointer dereference".  Red on the parent
+//     commit -- it panics there -- green after.
+//
+//   - TestTokenLValEndPositionGuard is a GUARD.  The `p.src.Token != nil`
+//     conjunct removed from tokenLVal could not fail: Location() had already
+//     dereferenced that same pointer one line above it, so the guard was
+//     unreachable-as-false and its only effect was to advertise an invariant
+//     ("this may be nil here") that the rest of the file does not honour.
+//     Deleting dead code fixes no behaviour; this pins that the end positions
+//     it appeared to guard are still written for every parsed node, so the
+//     deletion is visibly inert.
+
+package rdparser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// unstartedParser is the shape from elps#430: a Parser built through the
+// exported API, driven by an embedder's own TokenStream, on which nothing has
+// been scanned yet.  This is what NewFromSource, TokenStream and TokenGenerator
+// are exported for.
+func unstartedParser() *Parser {
+	stream := TokenGenerator(func() []*token.Token {
+		return []*token.Token{{
+			Type:   token.EOF,
+			Source: &token.Location{File: "embedder", Pos: 0, Line: 1, Col: 1},
+		}}
+	})
+	return NewFromSource(NewTokenStreamSource(stream))
+}
+
+// TestAccessorsBeforeFirstScan is the CATCH.
+//
+// On the parent commit each of these panicked with a nil pointer dereference.
+// An accessor whose whole job is to report the parser's state must be able to
+// report "not started" -- the embedder has no other way to ask, and
+// token.Source's own contract says "Token returns nil if Scan has not been
+// called."
+func TestAccessorsBeforeFirstScan(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Location", func(t *testing.T) {
+		t.Parallel()
+		p := unstartedParser()
+		require.NotPanics(t, func() {
+			assert.Nil(t, p.Location(),
+				"Location must report no position before the first scan (#430)")
+		})
+	})
+
+	t.Run("TokenText", func(t *testing.T) {
+		t.Parallel()
+		p := unstartedParser()
+		require.NotPanics(t, func() {
+			assert.Equal(t, "", p.TokenText())
+		})
+	})
+
+	t.Run("TokenType", func(t *testing.T) {
+		t.Parallel()
+		p := unstartedParser()
+		require.NotPanics(t, func() {
+			assert.Equal(t, token.INVALID, p.TokenType())
+		})
+	})
+
+	// The accessors must still answer correctly once a token IS under the
+	// cursor: the nil branch states the invariant, it does not replace it.
+	t.Run("after-scan", func(t *testing.T) {
+		t.Parallel()
+		p := New(token.NewScanner("embedder.lisp", strings.NewReader("(foo)")))
+		require.NotNil(t, p.ReadToken())
+		assert.Equal(t, token.PAREN_L, p.TokenType())
+		assert.Equal(t, "(", p.TokenText())
+		loc := p.Location()
+		require.NotNil(t, loc)
+		assert.Equal(t, "embedder.lisp", loc.File)
+		assert.Equal(t, 1, loc.Line)
+		assert.Equal(t, 1, loc.Col)
+	})
+}
+
+// TestUnstartedParserParsesNormally checks the nil branch is genuinely a
+// pre-start state and not a broken parser: the same unstarted Parser, once
+// driven, behaves.
+func TestUnstartedParserParsesNormally(t *testing.T) {
+	t.Parallel()
+
+	p := New(token.NewScanner("embedder.lisp", strings.NewReader("(+ 1 2)")))
+	assert.Nil(t, p.Location(), "nothing scanned yet")
+	assert.Equal(t, token.INVALID, p.TokenType())
+
+	exprs, err := p.ParseProgram()
+	require.NoError(t, err)
+	require.Len(t, exprs, 1)
+	require.NotNil(t, exprs[0].Source)
+	assert.Equal(t, "embedder.lisp:1:1", exprs[0].Source.String())
+}
+
+// TestTokenLValEndPositionGuard is the GUARD for the deleted conjunct.
+//
+// tokenLVal writes EndLine/EndCol/EndPos under `v.Source != nil`, which is now
+// the whole condition.  That is sound because Location() returns nil whenever
+// p.src.Token is nil -- so a non-nil v.Source is itself proof there is a token
+// under the cursor, which is what the deleted `p.src.Token != nil` conjunct was
+// pretending to establish one line after Location() had dereferenced it.
+//
+// The property to hold onto is that every parsed node still gets a complete
+// span.  Nothing here failed before the deletion; this fails if the deletion
+// ever turns out to have mattered.
+func TestTokenLValEndPositionGuard(t *testing.T) {
+	t.Parallel()
+
+	const src = "(defun f (x)\n  (+ x 1))"
+	exprs, err := NewReader().Read("span.lisp", strings.NewReader(src))
+	require.NoError(t, err)
+	require.Len(t, exprs, 1)
+
+	var walk func(v *lisp.LVal)
+	n := 0
+	walk = func(v *lisp.LVal) {
+		if v == nil {
+			return
+		}
+		n++
+		require.NotNilf(t, v.Source, "node %v %q has no Source", v.Type, v.Str)
+		assert.NotZerof(t, v.Source.EndPos, "node %v %q has no end position", v.Type, v.Str)
+		assert.NotZerof(t, v.Source.EndLine, "node %v %q has no end line", v.Type, v.Str)
+		assert.NotZerof(t, v.Source.EndCol, "node %v %q has no end column", v.Type, v.Str)
+		assert.GreaterOrEqualf(t, v.Source.EndPos, v.Source.Pos,
+			"node %v %q ends before it starts", v.Type, v.Str)
+		for _, c := range v.Cells {
+			walk(c)
+		}
+	}
+	walk(exprs[0])
+	assert.Positive(t, n)
+}


### PR DESCRIPTION
Fixes #431
Fixes #430

Two defects in the same few lines: a macro expansion and its call site sharing one mutable `*token.Location`, and a `p.src.Token != nil` guard in `tokenLVal` that cannot fail. Both were filed from reading. **Both reproduce.**

## #431 — the sharing is real, and the corruption it enables is latent

Reproduced first, as instructed. `env.Loc` is set by `eval` to the `Source` of the node being evaluated, so the pointer `macroCall` handed to `stampMacroExpansion` is a `*token.Location` owned by a node in the caller's parse tree. Against `bfb6ee8`, expanding `(defconst answer 42)`:

```
--- FAIL: TestMacroExpansionDoesNotAliasCallerLocation
    Expected and actual point to the same object: 0xc000208140
      &token.Location{File:"caller.lisp", Pos:0, Line:1, Col:1, EndPos:20, EndLine:1, EndCol:21}
    a macro expansion node shares the caller's *token.Location (#431)

    expected: "caller.lisp:1:1"
    actual  : "caller.lisp:99:42"
    a write through the expansion moved the caller's recorded position (#431)

--- FAIL: TestMacroExpansionCallSiteIsPrivate
    the expansion is stamped with a Location the caller's parse tree also holds (#431)
```

An earlier probe on `(defun f (x) x)` counted **nine** expansion nodes plus the caller's node on one object, and `expansion.Source.Line = 99` moved the caller's node to line 99.

**Live or latent: latent, and I checked rather than took the issue's word for it.** Every in-place write through a `*token.Location` in non-test code:

```
parser/rdparser/parser.go   5 sites, all on nodes the reader has just built
                            (locateSynthesized, inheritEndPos, applyPrefixLocation,
                             tokenLVal, the two closing-bracket blocks) and, since
                             #426/#442, on Locations those nodes own
lisp/env.go                 3 error constructors, env.Loc.Copy() since #421
```

Everything else that touches a position — `lsp/`, `lint/`, `analysis/`, `analysis/perf/`, `mcpserver/`, `minifier/`, `formatter/`, `repl/`, `cmd/`, `lisp/x/debugger/`, `lisp/x/debugger/dapserver/`, `lisp/x/profiler/` — **reads** a `Location` and formats it into its own `Position`/`Range`/`Span`/`StepLocation` value type. There is no writer that can reach the shared object today.

So the write in step 3 of the regression test is one the test performs. It demonstrates the mechanism; it does not record an observed failure. The tests are red on the parent commit for the **aliasing**, which is the property, not for a corruption.

### Why fix it anyway, and why not the way the issue assumed

The issue weighs one option — `Copy()` per stamped node — and rejects it on cost, citing #421's measurement of a fresh `Location` per call on a hot path (+18.6% sec/op, +20.2% allocs/op geomean). That is the right verdict for that option. But it is not the only option.

**The copy has to buy a boundary between two OWNERS** — the caller's tree and the expansion — and **one object per expansion buys exactly that**:

```go
callSite := env.Loc.Copy()   // once per macro call, in macroCall
```

The N stamped nodes still share, but they now share a `Location` the expansion owns and no other tree can see, and they genuinely all sit at the call site. Collapsing that last bit of sharing is what making `LVal.Source` immutable is for, and *that* is the per-node allocation #421 ruled out. This is one allocation, next to the whole expansion tree the macro has just built.

Taking it in `macroCall` rather than inside `stampMacroExpansion` also covers `MacroExpansionContext.CallSite`, which outlives the expansion on every stamped node's `MacroExpansionInfo`; the same allocation serves both.

### Measured

Re-measured after the rebase, both arms interleaved on the same runner, `BENCH_COUNT=10`, `scripts/bench-run-arms.sh`, base = `4931c47`. The cost lands where the model says it should, and nowhere else:

```
                  │     base      │              pr               │
                  │    sec/op     │   sec/op      vs base         │
MacroDefun-4        56.57µ ±  25%   60.24µ ± 21%    ~ (p=0.481 n=10)

                  │     B/op      │     B/op      vs base         │
MacroDefun-4       33.32Ki ±   0%  34.18Ki ± 0%   +2.57% (p=0.000 n=10)

                  │   allocs/op   │  allocs/op    vs base         │
MacroDefun-4         475.0 ±   0%   486.0 ± 0%    +2.32% (p=0.000 n=10)
```

**+11 allocations for 11 `defun` calls** — the benchmark body is eleven `(defun ...)` forms, so this is exactly one `Location` per macro call and not one per stamped node. Deterministic (±0%, p=0.000), which is what an allocation-count change should look like. The pre-rebase run against `bfb6ee8` gave +2.58% / +2.32% and CI's arm64 runner gave +2.58% / +2.32%; three measurements on two architectures agree.

Every other allocation row in the tree is flat:

```
lisp             B/op geomean +0.04%   allocs/op geomean +0.03%
libjson          B/op geomean +0.04%   allocs/op geomean +0.05%
mcpserver        B/op geomean +0.25%   allocs/op geomean +0.41%
parser/rdparser  B/op geomean +0.00%   allocs/op geomean +0.00%
```

**#452 does not change how this is adjudicated, and I checked rather than assumed.** That PR makes a *timing* row over threshold a regression only when the move exceeds that row's own measured spread; allocation metrics are **explicitly exempt** from the resolution check, because they are exact rather than sampled (`scripts/testdata/benchstat-alloc-with-spread.txt` pins exactly that). Re-run under the new gate:

```
below-gate  lisp  B/op       MacroDefun-4  delta=+2.57% p=0.000 (gate 5%)
below-gate  lisp  allocs/op  MacroDefun-4  delta=+2.32% p=0.000 (gate 5%)
benchstat-gate: interpreted 35 delta row(s) + 308 no-change row(s); 10 significant
move(s) in the bad direction; 0 at or above the gate (timing 15%, allocation 5%).
```

Same classification as before the rebase: `below-gate` against the 5% allocation threshold, neither exempted nor suppressed. **Gate verdict: 0 rows at or above the gate**, exit 0.

**No waiver added, and the gate was not weakened.** The two existing waivers in `scripts/benchstat-waivers.txt` (#412/#410, `libjson/Encode`) are reported unused by this comparison and left alone.

This run landed on a noisier box than the first (sec/op geomeans swing ±10–18%, and `MacroDefun` itself reports ±25%/±21% spread), and no timing row was flagged at all — which is #452 behaving as designed on the timing side.

### Why not a lazier copy

Considered and rejected: copying only when the stamp is about to write its first node (threading a `**token.Location` or a closure through `stampGuarded`). That trades one allocation per macro call for a branch on every node of every expansion — the walk is the hot part, not the call — and it complicates a function that already carries a cycle guard. At +2.32% allocs on the macro benchmark and +0.03% geomean, the simple version is not worth defending against.

## #430 — #442 did not fix it, and both halves are real

**Did #442 already resolve it? No.** #442 changed `Location()` to move-or-copy the scanner's object and to return `nil` when `Token.Source` is nil, but the deref of `p.src.Token` itself stayed unconditional:

```go
func (p *Parser) Location() *token.Location {
	loc := p.src.Token.Source     // still unconditional on bfb6ee8
	if loc == nil { return nil }
	...
```

so the conjunct in `tokenLVal` one line later was still unreachable-as-false, exactly as filed.

**The half marked reproduce-or-close reproduces.** `TokenSource.Token` starts nil, `token.Source`'s own contract documents that state ("Token returns nil if Scan has not been called"), and `NewFromSource`, `NewTokenStreamSource`, `TokenGenerator`, `Location`, `TokenText` and `TokenType` are all exported. Against `bfb6ee8`:

```
--- FAIL: TestUnstartedParserParsesNormally
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0]
	rdparser.(*Parser).Location(...)
		parser/rdparser/parser.go:903
```

Same for `TokenText()` and `TokenType()`. An embedder driving a `Parser` through the API those constructors exist for has no way to ask "have you started yet?" except by calling one of these, and gets a segfault from an accessor whose entire job is to answer that.

So both branches of the issue's "what needs deciding" apply, and both are done:

1. The invariant is real inside the file, and is now stated once — in a note above the accessors — instead of being restated where it cannot fail. The dead conjunct is gone from `tokenLVal`, and so is the identical one in `locateSynthesized` (the issue's title says "guards", plural; it is the same shape in the same file, and leaving one would undercut the point).
2. The invariant is not the embedder's, so each accessor now answers with the value that already means "nothing here": `nil`, `""`, `token.INVALID`. Inside the parser the branch is never taken, so this states the invariant rather than weakening it.

`tokenLVal`'s condition is now `v.Source != nil` alone, which is sound *because* `Location()` returns nil when there is no token — a non-nil `v.Source` is itself proof there is one.

Also checked from the issue's list: a `TokenStream` returning an empty batch panics with `index out of range [0] with length 0` from `TokenSource.Peek`. That is the embedder violating `ReadToken`'s documented contract ("never returns an empty slice"), which the parser already treats as a programming error — `TokenChannel` panics on it explicitly. Left alone; it is evidence for (1), not a defect.

## Red, then green

| Test | Parent commit | This branch | Kind |
|---|---|---|---|
| `TestMacroExpansionDoesNotAliasCallerLocation` | FAIL (shares pointer; write moves caller) | PASS | catch — aliasing |
| `TestMacroExpansionCallSiteIsPrivate` | FAIL | PASS | catch — aliasing |
| `TestMacroCallSiteCopyPreservesNil` | FAIL (nil handling) | PASS | catch |
| `TestAccessorsBeforeFirstScan` | panic (SIGSEGV) | PASS | catch |
| `TestUnstartedParserParsesNormally` | panic (SIGSEGV) | PASS | catch |
| `TestTokenLValEndPositionGuard` | PASS | PASS | **guard** — deleting dead code fixes no behaviour; this pins that the spans it appeared to guard are still written |
| the eval harness's location watch | PASS | PASS | **guard** — see below |

The distinction that matters for #431 is not red-vs-green: the aliasing is a genuine catch. It is that the **corruption** the aliasing enables is latent, per the audit above. Said plainly in the test file header so the next reader is not misled.

## Fuzzing

Folded into the existing eval harness rather than added as a new target. When this was written `scripts/fuzz-budget-check.sh` reported **0 minutes of headroom** at 28 targets, which forced the choice; #457's eighth shard has since restored 10 minutes (29 targets, largest shard 4, 50 min required vs 60 min timeout). It stays folded in anyway, because it costs one tree walk and no extra evaluation and therefore buys the property on every input the existing targets already run.

`evalUnderBudget` now wraps `Runtime.Reader` (after `newFuzzEnv`, so the stdlib's trees are not recorded per input) and records every node's `Source` pointer and position on the way past. Post-rebase that covers **both** sides of #435's split — `FuzzEval` and the adversarial corpus under the wall clock, and the fixed corpora without one. After the budgeted evaluation completes, it asserts that evaluation neither re-pointed nor moved any of them. Every `Load*` entry point funnels through `Runtime.Reader`, so this covers the program and anything it loads at runtime; the walk is cycle-guarded and capped at 200k nodes, and a truncated watch says so in its own failure message.

This is the property #370 and #431 both broke, stated over arbitrary programs rather than over the two shapes their regression tests pin. It costs one tree walk and no extra evaluation. **It is a guard: it passes on the parent commit**, because #431's corruption is latent.

45s smoke run on the pre-rebase tree, clean:

```
fuzz: elapsed: 46s, execs: 184361 (2403/sec), new interesting: 20 (total: 1215)
PASS
```

Post-rebase, the whole corpus path runs it on every `go test`, and all of `TestEvalTerminatingSeedsComplete`, `TestEvalRunawaySeedsAreStopped`, `TestEvalAdversarialSeedsSurvive`, `TestInternalPanicMarkerIsNotForgeable` and #447's two new clock tests pass through the watch.

`FuzzParsedLocationInvariants` (#442) and `FuzzSharedTreeEval` (#457) were both considered and neither subsumes this. The first is about the reader and cannot see evaluation. The second asserts AGREEMENT — that the rendered results of evaluating a shared tree match a private tree's — plus whatever `-race` catches when two goroutines evaluate one tree; a `Source` write is invisible to both, because positions are not rendered and a single-owner write into a borrowed `Location` is not a data race at all, just silent corruption.

## Neighbourhood audit

Only what the three prior audits did not cover. **Not re-done:** #421's audit already cleared `LEnv.Lambda`, `LEnv.TaggedValue`, `CallFrame.Source`, `CallStack.Copy()`, `env.Loc = v.Source` as a hot-path borrow, `token.Scanner.LocStart/Loc`, and the read-only consumers in `lint`/`analysis/perf`/`profiler`/`FunctionInfo`; #442 covered `Parser.Location` ownership and the five parser write sites; #419 covered the reader's synthetic locations.

| Site | Verdict |
|---|---|
| `MacroExpansionContext.CallSite` | **Fixed here** — same allocation as the stamp's. Its only consumer, `debugger/inspector.go`, formats it into a string. |
| `MacroExpansionContext.DefSite` (`fun.Source`) | Borrows the LFun's `Location`, which `LEnv.Lambda` took from `env.Loc`. Read-only consumer. Downstream of `LEnv.Lambda`, which #421 reported and deliberately left; not re-filed. |
| `LEnv.Lambda`'s `Source: env.Loc` | Still present, and it is why the first draft of the #431 test failed on a `defun` expansion's LFun node: the caller's `Location` reaches the function value that way, independently of the stamp. Exactly what #421 recorded ("a copy here is a new allocation on a path that has none, per lambda … Left, reported"). **Not re-filed, not widened**; the tests here use macros whose expansions contain no lambda so they measure the stamp and not this. |
| `ParseNegative`'s `p.src.Peek().Source = p.Location()` | Audited against #442's new ownership model, which did not cover it. Sound: the call is the *first* ask about the NEGATIVE token, so it moves that token's `Location` onto the merged token and sets `locGivenAway`; the node later built from the merged token is the *second* ask and gets a private copy. No node shares. Costs one avoidable `Copy()` per negative literal — a nit, not filed. |
| `locateSynthesized`'s `tok != nil` | Dead for the same reason as `tokenLVal`'s. Removed (see #430 above). |
| The two closing-bracket blocks' `p.src.Token.Source != nil` | A different check — `Source`, not `Token` — and reachable in principle. Left. |
| `Parser.errorf` / `scanError` / `errorAtf` | `err.Source = p.Location()`, so owned-or-copied since #442, and `open.Source.Copy()` at the unclosed-bracket sites. Clean. |
| `repl/diagnostic.go`, `cmd/diagnostic.go`, `minifier`, `lint`, `analysis/perf`, `debugger/engine.go`, `dapserver/`, `profiler` | All write into their own value types (`diagnostic.Span`, `Position`, `StepLocation`, DAP frames). No writer through a borrowed `*token.Location`. Confirmed by a tree-wide grep for field assignments, not assumed. |
| **`LVal.Copy()`** | **Found by running. Filed as #446, not fixed here.** `*cp = *v` shallow-copies `Source`, so a copy shares its `*token.Location` with the original at every depth — `Cells` is deep-copied, positions are not. It matters most for `lisp.TextLoader`, whose stated purpose is to hand each evaluation a private tree. Fourth instance of the shape. Latent by the same population argument. |

## Gates

All re-run on the merged tree (`056b72f`), not carried over from before the rebase.

| Gate | Result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test -count=1 ./...` | pass |
| `golangci-lint run ./...` | **0 issues** (one `testifylint` finding on the new test was fixed, not suppressed) |
| `make go-test` | pass |
| `make test-elpscheck` | pass |
| `make test-examples` | pass |
| `elps fmt -l ./...` | clean (binary built, run, deleted before committing) |
| `elps doc -m` | clean |
| `./scripts/ci-gates-test.sh` | pass |
| `./scripts/confidentiality-guard.sh` (after `git add`) | clean |
| `./scripts/fuzz-budget-check.sh` | fits — 29 targets, 8 shards, largest shard 4, required 50 min vs timeout 60 min |
| `scripts/benchstat-gate.sh` | **0 rows at or above the gate** |
| `go test -race ./...` / `make race` | clean (see the rebase note — #447 fixed the flake this used to hit) |

### Rebased onto `4931c47`, and what that changed

Re-verified on the merged tree, not carried over. Four PRs landed while this was open: **#457** (re-landed `FuzzSharedTreeEval`, took the fuzz matrix to eight shards), **#447** (#435), **#452** (#443), and #442.

**One conflicted file, `lisp/eval_fuzz_test.go`, and the conflict was with #447 rather than against it.** That PR split the eval harness by what the caller asserts — shared body into `evalUnderBudget`, context construction into `evalContext(deadline)` — so that `FuzzEval` keeps a wall clock as a *throughput* bound while the fixed corpora moved to deterministic budgets. This branch had added its `locationWatch` to the old `evalBudgeted`.

**Both kept.** The wrapper now sits in `evalUnderBudget` alongside `main`'s `evalContext(deadline)`, so the location property is checked on *both* sides of the split rather than on whichever side the merge happened to pick.

That is sound in the direction #435 is about. #447's rule is that a **correctness** assertion must not be decided by a clock, and this is one — but a fired deadline can only cut the evaluation short, which means fewer writes and a weaker check, never a spurious mismatch. Machine load cannot turn a tree the evaluator left alone into a reported failure. #447's own `TestTerminatingSeedVerdictIsNotAFunctionOfTheClock` drives a **spent** clock (`time.Nanosecond`) through the harness, so it now exercises exactly that case, and passes.

`verify()` still runs only on the goroutine-finished branch, never the watchdog branch — more load-bearing now that the corpus path carries no deadline and reaches the watchdog on budgets alone.

**`go test -race ./...` and `make race` are now clean.** They previously hit `TestEvalTerminatingSeedsComplete/tail-recursion-bounded`, which I verified was pre-existing by reproducing it on unmodified `bfb6ee8`. #447 fixed it, so a failure there would now be a real signal rather than known noise — there was none.

## Found and filed

- **#446** — `LVal.Copy` shallow-copies `Source`, so a "copy" shares its `*token.Location` with the original, including every `TextLoader` evaluation. Found by **running** (probe output on the issue). Latent by the same argument as #431; the remedy is the same fork, and it is a fourth site for the `LVal.Source` immutability work.
- **#455** — `TestSleepInterruptedThroughEval` asserts a deterministic condition name for what is actually a race between its own 50 ms deadline and the time evaluation takes to reach the builtin. Observed **running**, once, during a full `go test -race ./...` on this branch; passed on the re-run and on base. The test's comment states an ordering ("the length cap is checked before the context is consulted at all") that holds inside the builtin but not against the evaluator's own per-step context check. Sibling of #435, different package and different mechanism. Filed with a reproduce-or-close note, not fixed here.

Not new, and deliberately not re-filed: `LEnv.Lambda`'s `Source: env.Loc` (recorded by #421's audit, still present, confirmed still reachable via a `defun` expansion's LFun), and `TokenSource.Peek` panicking with `index out of range` when a `TokenStream` violates its documented "never returns an empty slice" contract (checked from #430's list; the parser already treats that as a programming error, and `TokenChannel` panics on it explicitly).
