### PR TITLE
Re-land the shared-tree ownership fuzzer that PR #432 lost, plus the shard it now needs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -61,7 +61,7 @@ permissions:
 
 jobs:
   fuzz:
-    name: Fuzz shard ${{ matrix.shard }}/6
+    name: Fuzz shard ${{ matrix.shard }}/7
     runs-on: ubuntu-latest
     strategy:
       # Sharded so wall clock is set by the LARGEST shard rather than by the
@@ -81,7 +81,7 @@ jobs:
       # or a single failure costs the whole night's coverage.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6]
+        shard: [1, 2, 3, 4, 5, 6, 7]
     # DERIVED, not remembered. scripts/fuzz-budget-check.sh asserts
     #
     #     ceil(targets / shards) x FUZZTIME + overhead <= timeout-minutes
@@ -107,6 +107,16 @@ jobs:
     # and restores the 10 minutes. Prefer adding a shard to raising the
     # timeout: shards are parallel, so it cuts wall clock instead of extending
     # the backstop.
+    #
+    # AND IT HAPPENED AGAIN, WHICH IS WHY THE SEVENTH SHARD IS HERE. main
+    # arrived at 26 targets over 6 shards: ceil(26/6) = 5 x 10m + 10m = 60
+    # against a 60-minute timeout. Zero headroom, gate green, sweep one slow
+    # shard away from being cut off mid-target -- exactly the state the
+    # paragraph above describes, re-entered by ordinary target growth. The
+    # 27th target lands in this change, so the seventh shard lands with it:
+    # ceil(27/7) = 4 x 10m + 10m = 50, and the 10 minutes are back. Adding
+    # the target without the shard would have left the gate green and the
+    # headroom at zero for the second time.
     #
     # Do not raise this by hand to make a red gate green -- run
     # `make fuzz-budget-check`, which prints the arithmetic and the options.
@@ -172,7 +182,7 @@ jobs:
         run: ./scripts/fuzz-budget-check.sh
 
       - name: Fuzz
-        run: ./scripts/fuzz.sh --shard ${{ matrix.shard }}/6
+        run: ./scripts/fuzz.sh --shard ${{ matrix.shard }}/7
 
       # Only from main/schedule: a corpus grown from an unmerged branch would
       # otherwise be handed to every other PR.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -61,7 +61,7 @@ permissions:
 
 jobs:
   fuzz:
-    name: Fuzz shard ${{ matrix.shard }}/7
+    name: Fuzz shard ${{ matrix.shard }}/8
     runs-on: ubuntu-latest
     strategy:
       # Sharded so wall clock is set by the LARGEST shard rather than by the
@@ -81,7 +81,7 @@ jobs:
       # or a single failure costs the whole night's coverage.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     # DERIVED, not remembered. scripts/fuzz-budget-check.sh asserts
     #
     #     ceil(targets / shards) x FUZZTIME + overhead <= timeout-minutes
@@ -182,7 +182,7 @@ jobs:
         run: ./scripts/fuzz-budget-check.sh
 
       - name: Fuzz
-        run: ./scripts/fuzz.sh --shard ${{ matrix.shard }}/7
+        run: ./scripts/fuzz.sh --shard ${{ matrix.shard }}/8
 
       # Only from main/schedule: a corpus grown from an unmerged branch would
       # otherwise be handed to every other PR.

--- a/lisp/sharedtree_fuzz_test.go
+++ b/lisp/sharedtree_fuzz_test.go
@@ -1,0 +1,254 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/internal/fuzzseed"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+)
+
+// Fuzzing OWNERSHIP of the parse tree, which no other target in this
+// repository covers.
+//
+// FuzzEval hands every evaluation its own freshly-read source, so each input
+// gets a private AST and any write the evaluator makes into that AST is
+// invisible: the tree is thrown away immediately afterwards.  The property
+// that matters downstream is the opposite one.  A reader result is a value
+// callers hold onto -- substrate reads a phylum once and evaluates it under
+// more than one environment, the LSP and the linter analyse a tree the parser
+// already handed out, and mcpserver's workspace index keeps parsed documents
+// alive across requests.  If evaluation writes into the tree it was given,
+// the SECOND consumer of that tree sees a program that is no longer the one
+// the reader produced.
+//
+// That failure mode is not hypothetical here.  Four separate defects with
+// exactly this shape were found and fixed in this repository: macro expansion
+// aliasing the form it expands (elps#396), the reader emitting nodes macro
+// expansion writes into (elps#370), sequence views writing through into their
+// source (elps#369/#373), and env.Loc aliasing (elps#362/#366).  Each was a
+// tree that two consumers shared and one of them mutated.
+//
+// # The invariant
+//
+// Evaluating a tree must not change what that tree means.  Stated
+// operationally, and in the two independent ways it can break:
+//
+//   - AGREEMENT.  Evaluating a shared tree must produce what evaluating a
+//     private tree produces.  This holds without the race detector, so the
+//     nightly sweep tests it at full fuzzing speed: a mutation that corrupts
+//     the tree shows up as a diverging result on the second or third
+//     evaluation of it.
+//
+//   - NO CONCURRENT WRITE.  The evaluations run on separate goroutines over
+//     one tree, so `go test -race` over the seed corpus (make race) reports
+//     any write into a shared node directly, with both stacks, rather than
+//     waiting for the corruption to become observable.  This is the shape
+//     that found elps#370.
+//
+// A source that does not parse is skipped -- that is the parser targets'
+// business.  A source whose FIRST evaluation errors is still checked: an
+// error is a value, and two evaluations of one tree must produce the SAME
+// error.
+//
+// # Budgets
+//
+// Identical to FuzzEval's, and for the same reason: evaluation is
+// Turing-complete, so every run here is bounded by the interpreter's own step,
+// tail-iteration, physical-height, nesting and allocation limits plus a
+// context deadline.  The per-input cost is a small multiple of FuzzEval's
+// because the same source is evaluated sharedRuns+1 times.
+
+// sharedRuns is how many goroutines evaluate the shared tree at once.  Two is
+// enough for the race detector to see a conflicting pair, and keeping it small
+// keeps the per-input cost near FuzzEval's.
+const sharedRuns = 2
+
+// evalTreeOnce evaluates every expression of exprs under a fresh environment
+// and returns the rendered results.  exprs may be shared with other
+// goroutines; nothing here may write to it.
+func evalTreeOnce(exprs []*lisp.LVal) ([]string, error) {
+	env, _, rc := newFuzzEnv()
+	if rc != nil {
+		return nil, errFromLVal(rc)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), fuzzDeadline)
+	defer cancel()
+	out := make([]string, 0, len(exprs))
+	for _, e := range exprs {
+		v := env.EvalContext(ctx, e)
+		if v == nil {
+			return nil, errNilResult
+		}
+		if lisp.IsInternalPanic(v) {
+			return nil, errInternalPanic
+		}
+		out = append(out, v.String())
+	}
+	return out, nil
+}
+
+type constErr string
+
+func (e constErr) Error() string { return string(e) }
+
+const (
+	errNilResult     = constErr("evaluation returned a nil LVal")
+	errInternalPanic = constErr("evaluation recovered a Go panic")
+)
+
+func errFromLVal(v *lisp.LVal) error { return constErr(v.String()) }
+
+// readTree reads src into a parse tree, or reports that it does not parse.
+func readTree(src []byte) ([]*lisp.LVal, bool) {
+	exprs, err := parser.NewReader().Read("fuzz", bytes.NewReader(src))
+	if err != nil {
+		return nil, false
+	}
+	return exprs, true
+}
+
+// sharedTreeProperty is the body of the target, factored out so the corpus
+// tests below assert exactly what the fuzzer asserts.
+func sharedTreeProperty(t *testing.T, src []byte) {
+	t.Helper()
+
+	shared, ok := readTree(src)
+	if !ok {
+		return
+	}
+	// Baseline over a PRIVATE tree read from the same bytes.  Read
+	// separately rather than deep-copied so the baseline is exactly what a
+	// first-and-only consumer of the reader would get.
+	private, ok := readTree(src)
+	if !ok {
+		return
+	}
+
+	done := make(chan struct{})
+	var want []string
+	var wantErr error
+	var got [sharedRuns][]string
+	var gotErr [sharedRuns]error
+
+	go func() {
+		defer close(done)
+		want, wantErr = evalTreeOnce(private)
+		var wg sync.WaitGroup
+		// Ranged over the arrays themselves rather than over sharedRuns: the
+		// bound is then the array's own length, which the bounds-check
+		// analyser can see (gosec G602 cannot, when the bound is a const).
+		for i := range got {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				got[i], gotErr[i] = evalTreeOnce(shared)
+			}(i)
+		}
+		wg.Wait()
+	}()
+
+	// The evaluations are budgeted, but a budget only stops code that reaches
+	// a check; a builtin that loops inside Go is step-blind.  The watchdog is
+	// what turns "this terminates" into an assertion.  Denominated in
+	// SCHEDULED time so a starved process is not charged to the evaluator.
+	select {
+	case <-done:
+	case <-time.After(watchdogTimeout * (sharedRuns + 1)):
+		t.Fatalf("shared-tree evaluation did not terminate\n--- source (%d bytes) ---\n%q", len(src), src)
+		return
+	}
+
+	if wantErr != nil {
+		// The baseline itself could not be evaluated (nil result or a
+		// recovered Go panic).  FuzzEval owns that assertion; reporting it
+		// here too would duplicate its findings.
+		return
+	}
+	for i := range got {
+		if gotErr[i] != nil {
+			t.Fatalf("evaluating the SHARED tree failed where the private tree did not: %v"+
+				"\n--- source (%d bytes) ---\n%q", gotErr[i], len(src), src)
+			return
+		}
+		if len(got[i]) != len(want) {
+			t.Fatalf("shared tree produced %d results, private tree produced %d"+
+				"\n--- source (%d bytes) ---\n%q", len(got[i]), len(want), len(src), src)
+			return
+		}
+		for j := range want {
+			if got[i][j] != want[j] {
+				t.Fatalf("evaluating a SHARED parse tree changed the program's meaning"+
+					"\n  expression %d, shared run %d"+
+					"\n  private tree: %s"+
+					"\n  shared tree:  %s"+
+					"\n--- source (%d bytes) ---\n%q",
+					j, i, want[j], got[i][j], len(src), src)
+				return
+			}
+		}
+	}
+}
+
+// FuzzSharedTreeEval asserts that evaluating a parse tree does not change what
+// that tree means to the next consumer of it.
+func FuzzSharedTreeEval(f *testing.F) {
+	for _, src := range fuzzseed.EvalTerminating() {
+		f.Add([]byte(src))
+	}
+	for _, src := range fuzzseed.EvalAdversarial() {
+		f.Add([]byte(src))
+	}
+	// Macro-heavy shapes: expansion is where every aliasing defect found so
+	// far has lived, because it is the one part of evaluation that builds new
+	// forms out of the caller's own parse-tree nodes.
+	for _, src := range sharedTreeSeeds() {
+		f.Add([]byte(src))
+	}
+	f.Fuzz(func(t *testing.T, src []byte) {
+		sharedTreeProperty(t, src)
+	})
+}
+
+// sharedTreeSeeds are programs whose evaluation re-uses caller-supplied
+// fragments: macro definitions and calls, quasiquote splicing, and nested
+// expansions.  A tree is only corruptible if something writes into it, and
+// these are the shapes that write.
+func sharedTreeSeeds() []string {
+	return []string{
+		`(defmacro m (x) (quasiquote (+ 1 (unquote x)))) (m 2) (m (m 3))`,
+		`(defmacro twice (e) (quasiquote (list (unquote e) (unquote e)))) (twice (+ 1 2))`,
+		`(defmacro ident (x) x) (ident (ident (ident 1)))`,
+		`(defmacro splice (xs) (quasiquote (list (unquote-splicing xs)))) (splice '(1 2 3))`,
+		`(defmacro q (x) (quote (quote x))) (q 1)`,
+		`(defun f (x) (+ x 1)) (f 1) (f 2)`,
+		`(set 'v '(1 2 3)) (append v 4) v`,
+		`(defmacro when2 (c &rest body) (quasiquote (if (unquote c) (progn (unquote-splicing body)) ())))
+		 (when2 true 1 2 3)`,
+		`(let ([x '(1 2 3)]) (list (nth x 0) (slice x 0 2) x))`,
+		`(sorted-map 'a 1 'b 2)`,
+		`(defmacro outer (x) (quasiquote (defmacro inner (y) (quasiquote (list (unquote (unquote x)) (unquote y))))))`,
+		`'#^0`,
+		`(lambda (x) x)`,
+		`(handler-bind ([error (lambda (c &rest r) 'handled)]) (error 'boom))`,
+	}
+}
+
+// TestSharedTreeSeedsAgree runs the hand-written seeds through the same
+// property outside fuzzing, so a regression is caught by `make test` and, with
+// the race detector, by `make race`.
+func TestSharedTreeSeedsAgree(t *testing.T) {
+	t.Parallel()
+	for _, src := range sharedTreeSeeds() {
+		t.Run(src, func(t *testing.T) {
+			t.Parallel()
+			sharedTreeProperty(t, []byte(src))
+		})
+	}
+}

--- a/lisp/testdata/fuzz/FuzzSharedTreeEval/cfba74b0f2cbb127
+++ b/lisp/testdata/fuzz/FuzzSharedTreeEval/cfba74b0f2cbb127
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("(aref(vector))")


### PR DESCRIPTION
**PR #432 is marked merged on GitHub, and its content is not on `main`.** This re-lands it.

## What happened

Merging #432 returned `{"merged": true, "sha": "87abbcd"}`. That commit exists, but it is **not an ancestor of `main`**:

```
PR#429 67eb5b6 : ON MAIN
PR#432 87abbcd : *** MISSING FROM MAIN ***
PR#440 eeb1cbe : ON MAIN
PR#441 8c65cc5 : ON MAIN
PR#439 f7abcbf : ON MAIN
PR#442 bfb6ee8 : ON MAIN
```

The cause is visible in the parentage: `87abbcd`'s parent is `472acb7`, a squash of #429 that is **not** the `67eb5b6` squash of #429 that `main` actually carries. #432 was squashed onto a stale `main` pointer, two lineages existed briefly, and the one carrying #432 lost. Nothing on GitHub reflects this — the PR reads as merged and closed.

Confirmed by content, not just ancestry: `lisp/sharedtree_fuzz_test.go` is **absent** from `main`, and `main` still reads `shard: [1, 2, 3, 4, 5, 6]`.

This is the second instance of "merged on GitHub, absent from `main`" today. The first was the four-PR chain rescued by #416, where the stack merged into its own branches instead of the default branch. Different mechanism, same end state, and both were invisible from the PR list.

## What this PR contains

1. **`87abbcd` cherry-picked verbatim** onto current `main`. Clean, no conflicts — `FuzzSharedTreeEval`, its checked-in corpus entry, and the seventh shard.
2. **An eighth shard**, because #432's arithmetic is now stale.

## Why the eighth shard

#432 added the seventh at 27 targets: `ceil(27/7) = 4 x 10m + 10m = 50`, restoring 10 minutes.

`main` has since reached **29** targets. Re-landing #432 unchanged gives:

```
targets discovered      29
shards                  7
largest shard           5 target(s)
required                60 min
timeout-minutes         60 min
headroom                0 min
fuzz-budget-check: the sweep fits.
```

Zero headroom, and **the gate still reports "the sweep fits"** — its comparison is `needed > timeout`, so a sweep sized at exactly the timeout passes. `fuzz.yml`'s own comment documents this ("a sweep sized at exactly timeout-minutes PASSES"), and observed shard durations already vary from 4m25s to 5m42s, so a sweep at exactly the ceiling is one slow shard from being cut off mid-target.

With the eighth shard:

```
targets discovered      29
shards                  8
largest shard           4 target(s)
required                50 min
timeout-minutes         60 min
headroom                10 min
```

That the check passes at zero headroom is itself worth fixing — the budget gate should treat a zero margin as a failure, or at least warn. That belongs with the gate-reliability work in #443 rather than here.

## Why the target matters

`FuzzEval` hands every input a private AST, so any write the evaluator makes into that tree is invisible — the tree is discarded immediately after. The property that matters downstream is the opposite one: a reader result is a value callers hold onto, and four defects of exactly that shape were found and fixed today (#396, #370, #369/#373, #362/#366).

`FuzzSharedTreeEval` reads the same bytes twice, evaluates the private tree once for a baseline, then evaluates the **shared** tree on two goroutines under independent environments and requires all three to agree — at value level (works at full fuzzing speed) and under the race detector (the shape that found #370). 522,950 execs post-fix with no counterexample.

## Verification

On the re-landed tree: `go build ./...` clean, `go vet ./...` clean, `go test -count=1 ./lisp/...` exit 0, `FuzzSharedTreeEval` seed corpus passes, `confidentiality-guard.sh` clean, `fuzz-budget-check.sh` as quoted above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_