### PR TITLE
Stop LintFileWithAnalysis stamping Filename into the caller's config (#444)

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -650,6 +650,13 @@ func (l *Linter) LintFileWithContext(source []byte, filename string, semantics *
 // LintFileWithAnalysis parses, analyzes, and lints a source file in one call.
 // This is a convenience that runs semantic analysis and passes the result to
 // all analyzers.
+//
+// cfg is not modified. The filename is stamped on a shallow copy
+// (analysis.ConfigForFile), so one config may be reused across files and
+// shared between goroutines. Issue #444: this used to assign cfg.Filename in
+// place, which left the caller's config naming whichever file ran last and
+// raced two goroutines linting different files through one config. A nil cfg
+// is analysed as a zero config.
 func (l *Linter) LintFileWithAnalysis(source []byte, filename string, cfg *analysis.Config) ([]Diagnostic, error) {
 	s := token.NewScanner(filename, bytes.NewReader(source))
 	p := rdparser.New(s)
@@ -659,11 +666,8 @@ func (l *Linter) LintFileWithAnalysis(source []byte, filename string, cfg *analy
 		return nil, fmt.Errorf("%s: %w", filename, err)
 	}
 
-	if cfg == nil {
-		cfg = &analysis.Config{}
-	}
-	cfg.Filename = filename
-	result := analysis.Analyze(exprs, cfg)
+	// ConfigForFile handles a nil cfg, so there is no nil branch here.
+	result := analysis.Analyze(exprs, analysis.ConfigForFile(cfg, filename))
 
 	return l.LintFileWithContext(source, filename, result)
 }

--- a/lint/lint_config_alias_test.go
+++ b/lint/lint_config_alias_test.go
@@ -1,0 +1,102 @@
+// Copyright © 2026 The ELPS authors
+
+package lint
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/luthersystems/elps/analysis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLintFileWithAnalysis_DoesNotMutateCallerConfig is the regression test for
+// issue #444. It is a CATCH: it fails on main.
+//
+// LintFileWithAnalysis took a *analysis.Config the caller owns and wrote
+// cfg.Filename into it before analysing. After the call the caller's config
+// named a file the caller never asked about, so any later analysis through
+// that config was attributed to the wrong file — and two goroutines linting
+// different files through one config wrote the field unsynchronised.
+func TestLintFileWithAnalysis_DoesNotMutateCallerConfig(t *testing.T) {
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerUndefinedSymbol}}
+
+	t.Run("zero config keeps its zero Filename", func(t *testing.T) {
+		cfg := &analysis.Config{}
+		_, err := l.LintFileWithAnalysis([]byte(`(+ 1 2)`), "a.lisp", cfg)
+		require.NoError(t, err)
+		assert.Empty(t, cfg.Filename,
+			"LintFileWithAnalysis stamped the linted filename into the caller's config")
+	})
+
+	t.Run("a config that already names a file keeps that name", func(t *testing.T) {
+		cfg := &analysis.Config{Filename: "owned-by-caller.lisp"}
+		_, err := l.LintFileWithAnalysis([]byte(`(+ 1 2)`), "a.lisp", cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "owned-by-caller.lisp", cfg.Filename,
+			"the caller's Filename was overwritten with the linted file")
+	})
+
+	t.Run("reused config is not carrying the previous file", func(t *testing.T) {
+		cfg := &analysis.Config{}
+		_, err := l.LintFileWithAnalysis([]byte(`(+ 1 2)`), "first.lisp", cfg)
+		require.NoError(t, err)
+		_, err = l.LintFileWithAnalysis([]byte(`(+ 1 2)`), "second.lisp", cfg)
+		require.NoError(t, err)
+		assert.Empty(t, cfg.Filename,
+			"after two calls the caller's config names whichever file ran last")
+	})
+}
+
+// TestLintFileWithAnalysis_ConcurrentSharedConfig is the -race half of issue
+// #444 and is also a CATCH: under -race on main it reports a genuine DATA RACE
+// on analysis.Config.Filename, written from two goroutines at lint.go:665.
+//
+// The shape is an embedder that builds one analysis.Config (as
+// BuildAnalysisConfig hands back) and lints several files through it in
+// parallel. Nothing in the signature or doc comment warned that the config was
+// written to, so this is the natural way to use the method.
+func TestLintFileWithAnalysis_ConcurrentSharedConfig(t *testing.T) {
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerUndefinedSymbol}}
+	cfg := &analysis.Config{}
+
+	files := []string{"a.lisp", "b.lisp", "c.lisp", "d.lisp"}
+	var wg sync.WaitGroup
+	for _, name := range files {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := l.LintFileWithAnalysis([]byte(`(defun foo () 1)`), name, cfg)
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestLintFileWithAnalysis_AttributesDiagnosticsToTheLintedFile is a GUARD
+// (passes on main): copying the config must not cost the filename its effect.
+// Diagnostics still carry the file that was linted, and the nil-config path
+// still works.
+func TestLintFileWithAnalysis_AttributesDiagnosticsToTheLintedFile(t *testing.T) {
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerUndefinedSymbol}}
+
+	t.Run("with a caller config", func(t *testing.T) {
+		cfg := &analysis.Config{}
+		diags, err := l.LintFileWithAnalysis([]byte(`(unknown-fn 1)`), "target.lisp", cfg)
+		require.NoError(t, err)
+		require.NotEmpty(t, diags)
+		for _, d := range diags {
+			assert.Equal(t, "target.lisp", d.Pos.File)
+		}
+	})
+
+	t.Run("with a nil config", func(t *testing.T) {
+		diags, err := l.LintFileWithAnalysis([]byte(`(unknown-fn 1)`), "target.lisp", nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, diags)
+		for _, d := range diags {
+			assert.Equal(t, "target.lisp", d.Pos.File)
+		}
+	})
+}


### PR DESCRIPTION
`lint.LintFileWithAnalysis` took a `*analysis.Config` the caller owns and wrote a field of it before analysing:

```go
if cfg == nil {
	cfg = &analysis.Config{}
}
cfg.Filename = filename        // writes into the caller's config
result := analysis.Analyze(exprs, cfg)
```

Two consequences for an embedder that holds one config and lints several files: concurrent calls race on `Filename`, and after any call the caller's config names a file the caller never asked about, so later analysis through that config is attributed to the wrong file.

This is #437's family with a different mechanism — a struct field rather than a container — and #450's audit named it as such.

## Reproduction

Confirmed on `main` at `5ef6106`, with the tests this PR adds.

The mutation half, `go test ./lint/ -run TestLintFileWithAnalysis_ -count=1`:

```
--- FAIL: TestLintFileWithAnalysis_DoesNotMutateCallerConfig/zero_config_keeps_its_zero_Filename
    Error:      	Should be empty, but was a.lisp
    Messages:   	LintFileWithAnalysis stamped the linted filename into the caller's config
--- FAIL: TestLintFileWithAnalysis_DoesNotMutateCallerConfig/a_config_that_already_names_a_file_keeps_that_name
    Error:      	Not equal:
    	            	expected: "owned-by-caller.lisp"
    	            	actual  : "a.lisp"
    Messages:   	the caller's Filename was overwritten with the linted file
--- FAIL: TestLintFileWithAnalysis_DoesNotMutateCallerConfig/reused_config_is_not_carrying_the_previous_file
    Error:      	Should be empty, but was second.lisp
    Messages:   	after two calls the caller's config names whichever file ran last
```

The race half is reproduced, not asserted. `go test ./lint/ -run TestLintFileWithAnalysis_ConcurrentSharedConfig -race -count=1` on `main`:

```
==================
WARNING: DATA RACE
Write at 0x00c0001ca4f0 by goroutine 10:
  github.com/luthersystems/elps/lint.(*Linter).LintFileWithAnalysis()
      lint/lint.go:665 +0x3cd
  github.com/luthersystems/elps/lint.TestLintFileWithAnalysis_ConcurrentSharedConfig.func1()
      lint/lint_config_alias_test.go:70 +0x144

Previous write at 0x00c0001ca4f0 by goroutine 13:
  github.com/luthersystems/elps/lint.(*Linter).LintFileWithAnalysis()
      lint/lint.go:665 +0x3cd
  github.com/luthersystems/elps/lint.TestLintFileWithAnalysis_ConcurrentSharedConfig.func1()
      lint/lint_config_alias_test.go:70 +0x144

Goroutine 10 (running) created at:
  github.com/luthersystems/elps/lint.TestLintFileWithAnalysis_ConcurrentSharedConfig()
      lint/lint_config_alias_test.go:68 +0x22d
==================
--- FAIL: TestLintFileWithAnalysis_ConcurrentSharedConfig (0.01s)
    testing.go:1617: race detected during execution of test
```

`lint.go:665` is `cfg.Filename = filename`. Note the concurrent test passes on `main` **without** `-race` — the race is only visible under the detector, which is why it is written as a `-race` reproduction rather than an assertion about the outcome.

`TestLintFileWithAnalysis_AttributesDiagnosticsToTheLintedFile` is a **guard**, labelled in-file: it passes on `main` and pins that copying the config does not cost the filename its effect — diagnostics still carry the file that was linted, on both the caller-config and nil-config paths.

## Fix

The repo already had the fix one package over. `analysis.ConfigForFile(cfg, filename)` shallow-copies the config and stamps `Filename` on the copy; `analysis.AnalyzeFile` has always gone through it, and #439 routed mcpserver's lint tool through it for this exact reason.

```go
result := analysis.Analyze(exprs, analysis.ConfigForFile(cfg, filename))
```

`ConfigForFile` handles a nil `cfg`, so the `if cfg == nil` branch goes away with the write. The doc comment now states that `cfg` is not modified, since the signature gives no hint either way.

No in-tree behaviour changes: both callers are sequential (`LintFiles` loops with one config, `cmd/lint.go`'s stdin path calls it once) and neither reads `cfg.Filename` back. Nothing else in the tree reads it either.

## Neighbourhood audit

Every other place `lint`/`analysis` writes into a caller-supplied struct.

#450's audit already cleared the **container** cases — caller-supplied maps and slices retained or appended to (`analysis.Analyze`'s `ExtraGlobals`/`WorkspaceRefs` borrow, `PrescanWorkspace`/`remapPackageMap`, `mcpserver.buildWorkspaceState`, `lsp.buildWorkspaceIndex`, `SortDefinitions`, `ScanConfig`'s borrowed slices, `mergePerfConfig`). Not redone here; that audit stands.

This audit covers the remaining shape: a write to a **field** of a pointer the caller owns. Every such assignment in `lint`, `analysis`, `lsp` and `mcpserver`, and where its target comes from:

* `lint/lint.go:449` — `acfg.WorkspaceRefs = ...` in `BuildAnalysisConfig`, on the config that function allocates and returns. Not caller-supplied.
* `lsp/server.go:391,399` — `cfg.MacroExpander` / `cfg.WorkspaceRefs` on the config literal built a few lines above in `buildWorkspaceIndex`. Locally owned; it is stored on the server afterwards, and per-file analysis off it already goes through `ConfigForFile`.
* `lsp/formatting.go:34,38` and `mcpserver/service.go:2200` — `cfg.IndentSize` on a `formatter.DefaultConfig()` allocated in the same function.
* `mcpserver/service.go:499-526` — `mergePerfConfig`, which starts from `clonePerfConfig(s.perfConfig)` and copies every caller-supplied slice and map into it. The house pattern.
* `analysis.Analyze` and `analysis.ScanWorkspaceRefs` only ever read `cfg`; `ConfigForFile` writes only to the copy it allocates.
* `Pass.Report`/`ReportWithNotes`/`ReportNode`/`Reportf` write to the `Pass`, which the linter constructs per run.

`LintFileWithAnalysis` was the only one writing through to a caller's struct, which is what the issue predicted.

## Benchmarks

No benchmark exercises this path — `BenchmarkLintTool` goes through mcpserver's lint tool, which since #439 calls `analysis.ConfigForFile` directly rather than `LintFileWithAnalysis`, and there is no `lint`-package benchmark. The change adds one `analysis.Config` struct copy per file linted, on a path that already parses and fully analyses that file. `scripts/benchstat-gate.sh` was left to CI.

## Gates

All clean, no flakes in this run — including `make race` and `make go-test`, which did not hit the known #435 wall-clock flake this time.

`go build ./...`, `go vet ./...`, `go test -count=1 ./...`, `go test -race ./...`, `golangci-lint run ./...` (0 issues), `elps fmt -l ./...` (clean, binary deleted before commit), `elps doc -m` (all functions and exports documented), `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `./scripts/ci-gates-test.sh` (233 passed, 0 failed), `./scripts/confidentiality-guard.sh` (clean), `./scripts/fuzz-budget-check.sh`:

```
  targets discovered      29
  shards                  8
  largest shard           4 target(s)
  scheduled FUZZTIME      10m (10 min/target)
  required                50 min
  timeout-minutes         60 min
  headroom                10 min
fuzz-budget-check: the sweep fits.
```

Fixes #444
