### PR TITLE
lsp: measure a semantic token from the source span, and give the reader's ' no token (#449)

### DIFF
--- a/lsp/lsp_fuzz_test.go
+++ b/lsp/lsp_fuzz_test.go
@@ -770,11 +770,11 @@ func (s *session) opSemanticTokens(a opArgs) {
 	res, err := s.srv.textDocumentSemanticTokensFull(s.ctx, &protocol.SemanticTokensParams{TextDocument: a.ident()})
 	s.record("semanticTokens", res, err)
 	if err == nil && res != nil {
-		s.checkTokenBounds(a.uri, res.Data)
+		s.checkTokenSpans(a.uri, res.Data)
 	}
 }
 
-// checkTokenBounds is the one CONTENT assertion this target makes, and the
+// checkTokenSpans is the one CONTENT assertion this target makes, and the
 // exception to "NOT asserted: that any request returns a particular result".
 //
 // It is admissible here because it does not say what the answer should be. It
@@ -797,7 +797,23 @@ func (s *session) opSemanticTokens(a opArgs) {
 // two-column span, so "#'foo" told the editor to decorate 13 characters of a
 // 5-character line. This assertion was left out of the target when that defect
 // was filed, because with it in place the target was red on its own seeds.
-func (s *session) checkTokenBounds(uri string, data []protocol.UInteger) {
+//
+// COVERAGE, ADDED FOR elps#449.  Bounds alone was too weak to be the whole
+// property.  It asks that a token name SOME text in the document; it does not
+// ask that it name the RIGHT text, and both defects in elps#449 were strictly
+// in bounds -- a quoted symbol's token slid one character left onto the ' and
+// stopped one character short of the symbol, and a string's length was measured
+// on the DECODED value so `"x\ty"` got five characters of a six-character
+// literal.  Every such token satisfies the bound and misinforms the editor.
+//
+// coverageDefect (semantic_tokens_span_test.go) is the stronger question, asked
+// of the same decoded triples: does the text a token claims look like the atom
+// it is classifying?  It is still checkable from the response alone and still
+// says nothing about which answer is right -- a token may be a variable or a
+// function, but it may not start on reader punctuation, span two atoms, or stop
+// in the middle of a string literal.  One definition of the property, shared
+// with the table tests next door, so the fuzzer and they cannot drift.
+func (s *session) checkTokenSpans(uri string, data []protocol.UInteger) {
 	if s.tokenErr != nil {
 		return
 	}
@@ -829,9 +845,21 @@ func (s *session) checkTokenBounds(uri string, data []protocol.UInteger) {
 		}
 		// A CRLF document keeps its "\r" in the line; the editor does too, so
 		// it is part of the line for this purpose.
-		if char+length > len(lines[line]) {
+		if char < 0 || length < 0 || char+length > len(lines[line]) {
 			s.tokenErr = fmt.Errorf("semantic token [%d:%d,+%d) overruns line %d, which is %d bytes: %q (%s)",
 				line, char, length, line, len(lines[line]), lines[line], uri)
+			return
+		}
+		cov := tokenCoverage{
+			tok: rawToken{
+				line: line, startChar: char, length: length,
+				tokenType: int(data[i+3]),
+			},
+			covered: lines[line][char : char+length],
+		}
+		if msg := coverageDefect(cov, lines[line]); msg != "" {
+			s.tokenErr = fmt.Errorf("semantic token [%d:%d,+%d) covers %q: %s (%s)",
+				line, char, length, cov.covered, msg, uri)
 			return
 		}
 	}
@@ -1196,6 +1224,25 @@ func FuzzLSPSession(f *testing.F) {
 	add("'#^0", "", allOpsScript())
 	add("(list #'car\n      #'cdr)", "", allOpsScript())
 	add("(lisp:function foo)", "", allOpsScript()) // longhand: not synthesized
+
+	// The shapes the COVERAGE half of checkTokenSpans exists for (elps#449).
+	//
+	// The quoted-atom half is already reached without these: `uses` above is
+	// "(in-package 'user)\n(use-package 'demo)\n...", and on 5ef6106 each of
+	// those quoted symbols covers "'use" and "'dem" respectively. The ESCAPED
+	// STRING half is reached by nothing in the corpus -- no seed here or in
+	// fuzzseed contains a string literal with an escape in it, and a literal
+	// without one has len(v.Str)+2 exactly right -- so the property would have
+	// held by the corpus never asking. Seeded rather than left to the mutator,
+	// which has to produce a balanced pair of quotes AND a backslash escape
+	// inside it before the length is ever wrong.
+	add(`(f "x\ty")`, "", allOpsScript())
+	add(`(f "a\nb" c)`, "", allOpsScript()) // escaped \n, not a newline
+	add(`(f """raw""" c)`, "", allOpsScript())
+	add("(f \"\"\"a\nb\"\"\" c)", "", allOpsScript()) // genuinely multi-line
+	add("(list 'a 'b)", "", allOpsScript())           // one-character quoted symbols
+	add("' a", "", allOpsScript())                    // whitespace after the prefix
+	add("'\na", "", allOpsScript())                   // and a newline after it
 
 	// Document B as the WORKSPACE FILE that defines a macro and document A as
 	// the file that calls it. This is the only shape that reaches

--- a/lsp/semantic_tokens.go
+++ b/lsp/semantic_tokens.go
@@ -88,8 +88,9 @@ func (s *Server) textDocumentSemanticTokensFull(_ *glsp.Context, params *protoco
 	symbolRefs := buildSymbolRefsMap(analysisResult)
 
 	var tokens []rawToken
+	src := &sourceText{content: content}
 	for _, expr := range ast {
-		collectSemanticTokens(expr, symbolDefs, symbolRefs, content, &tokens)
+		collectSemanticTokens(expr, symbolDefs, symbolRefs, src, &tokens)
 	}
 
 	// Sort by position (line, then character).
@@ -111,36 +112,38 @@ func collectSemanticTokens(
 	v *lisp.LVal,
 	defs map[symbolKey]*analysis.Symbol,
 	refs map[symbolKey]*analysis.Symbol,
-	content string,
+	src *sourceText,
 	tokens *[]rawToken,
 ) {
 	if v == nil || v.Source == nil || v.Source.Line == 0 {
 		return
 	}
 
+	// The NODE's position, which is what the analysis result is keyed by --
+	// buildSymbolDefsMap and buildSymbolRefsMap index by Source.Line/Col -- and
+	// which for a quoted atom is the quote, not the atom.  atomSpan below gives
+	// the position of the TEXT; classifySymbol must keep using this one or a
+	// quoted symbol stops matching its own analysis entry.
 	line := v.Source.Line - 1 // convert to 0-based
 	col := max(v.Source.Col-1, 0)
 
 	switch v.Type {
 	case lisp.LInt, lisp.LFloat:
-		length := tokenLength(v, content)
+		tokLine, tokCol, length := atomSpan(v, src, 1)
 		*tokens = append(*tokens, rawToken{
-			line: line, startChar: col, length: length,
+			line: tokLine, startChar: tokCol, length: length,
 			tokenType: semTokenNumber,
 		})
 
 	case lisp.LString:
-		// String length includes quotes.
-		length := len(v.Str) + 2
-		// For multi-line strings, just highlight the first line.
-		if strings.Contains(v.Str, "\n") {
-			lines := strings.Split(content, "\n")
-			if line < len(lines) {
-				length = len(lines[line]) - col
-			}
-		}
+		// The length comes from the SPAN, not from v.Str.  v.Str is the string
+		// after escape processing, so len(v.Str)+2 measured the decoded value:
+		// "x\ty" is six characters of source and three of value, and the token
+		// came out one short (elps#449).  The span is the source, escapes and
+		// all, and it is also what makes a raw literal's """ delimiters count.
+		tokLine, tokCol, length := atomSpan(v, src, len(v.Str)+2)
 		*tokens = append(*tokens, rawToken{
-			line: line, startChar: col, length: length,
+			line: tokLine, startChar: tokCol, length: length,
 			tokenType: semTokenString,
 		})
 
@@ -151,17 +154,17 @@ func collectSemanticTokens(
 			return
 		}
 		name := v.Str
-		length := len(name)
+		tokLine, tokCol, length := atomSpan(v, src, len(name))
 		tokType, mods := classifySymbol(name, line, col, defs, refs)
 		*tokens = append(*tokens, rawToken{
-			line: line, startChar: col, length: length,
+			line: tokLine, startChar: tokCol, length: length,
 			tokenType: tokType, modifiers: mods,
 		})
 
 	case lisp.LSExpr:
 		// For quoted lists like '(a b c), just recurse into children.
 		for _, child := range v.Cells {
-			collectSemanticTokens(child, defs, refs, content, tokens)
+			collectSemanticTokens(child, defs, refs, src, tokens)
 		}
 		return
 
@@ -337,35 +340,158 @@ func symbolKindToTokenType(kind analysis.SymbolKind) int {
 	}
 }
 
-// tokenLength computes the display length of a token. Falls back to
-// heuristics when source end info is unavailable.
-func tokenLength(v *lisp.LVal, content string) int {
-	if v.Source.EndCol > 0 && v.Source.EndLine == v.Source.Line {
-		return v.Source.EndCol - v.Source.Col
-	}
-	// Fall back: extract from source text.
-	lines := strings.Split(content, "\n")
-	line := v.Source.Line - 1
-	col := v.Source.Col - 1
-	if line >= 0 && line < len(lines) && col >= 0 && col < len(lines[line]) {
-		// Scan forward to find end of number/atom.
-		end := col
-		for end < len(lines[line]) && !isDelimiter(lines[line][end]) {
-			end++
-		}
-		if end > col {
-			return end - col
-		}
-	}
-	return 1
+// sourceText is a document, split into lines only if something asks for them.
+//
+// Almost every atom is located from its span alone and never touches the text;
+// the lines are wanted only for a reader prefix and for the first line of a
+// multi-line literal.  Splitting lazily keeps a document with neither at the
+// cost it had before this file started consulting the source at all.
+type sourceText struct {
+	content string
+	lines   []string
+	split   bool
 }
 
-func isDelimiter(c byte) bool {
-	switch c {
-	case ' ', '\t', '\n', '\r', '(', ')', '[', ']', '"', ';':
-		return true
+func (s *sourceText) Lines() []string {
+	if !s.split {
+		s.lines = strings.Split(s.content, "\n")
+		s.split = true
 	}
-	return false
+	return s.lines
+}
+
+// lineLen is the length of line l IN BYTES, or -1 if l is not a line of s.
+//
+// Bytes, because that is the unit every position in this package is counted
+// in: token.Location.Col is "byte offset within the line, plus one" (see
+// Scanner.LocStart), elpsToLSPPosition passes it through untouched, and
+// position.go slices lines by byte throughout.  See atomSpan on why this is
+// not the unit LSP asks for.
+func (s *sourceText) lineLen(l int) int {
+	lines := s.Lines()
+	if l < 0 || l >= len(lines) {
+		return -1
+	}
+	return len(lines[l])
+}
+
+// byteAt returns the byte at 0-based column c of line l, and whether there is
+// one.
+func (s *sourceText) byteAt(l, c int) (byte, bool) {
+	lines := s.Lines()
+	if l < 0 || l >= len(lines) || c < 0 || c >= len(lines[l]) {
+		return 0, false
+	}
+	return lines[l][c], true
+}
+
+// atomSpan locates the source text an ATOM occupies: its 0-based line, its
+// 0-based start column, and its length in bytes.
+//
+// It is the answer to elps#449, and the two things it does that taking a
+// length from a name or a decoded value does not are:
+//
+// THE LENGTH COMES FROM THE SOURCE SPAN.  Location.EndPos-Pos is the width of
+// the atom as the scanner measured it, in the same byte unit Col is counted
+// in.  So escape sequences count as the characters they are written with --
+// "x\ty" is six bytes of source and three of value, and len(v.Str)+2 gave it a
+// five-character token (elps#449) -- a raw literal's """ delimiters count, and
+// a \U escape counts as its twelve characters rather than the four bytes it
+// decodes to.
+//
+// Note that EndCol is NOT used, deliberately: TokenEnd derives it by counting
+// RUNES onto a Col that counts BYTES, so on a line with any multi-byte text it
+// is in neither unit.  EndPos and Pos are both byte offsets and their
+// difference is exact.
+//
+// A multi-line literal keeps the existing behaviour of being highlighted on its
+// first line only, but whether a literal IS multi-line is now decided by the
+// span rather than by looking for a newline in the DECODED value.  The old test
+// took a single-line "a\nb" -- one line of source, an escape, not a newline --
+// for a multi-line literal and gave it "the rest of the line", so the token ran
+// past the closing quote and over whatever followed.
+//
+// THE READER'S ' IS NOT PART OF THE ATOM.  rdparser.applyPrefixLocation moves a
+// quoted atom's Col back onto the quote so that 'a reports the position a
+// reader would point at, which leaves the atom starting one column inside its
+// own span.  PR #448 settled what a reader prefix gets -- no token, with those
+// characters left to the client's syntax grammar, which is the right owner for
+// punctuation the server has nothing to add about -- and cited ' as the
+// precedent #' and #^ were being made to match.  Skipping the quote here is
+// that same decision applied to the prefix that occasioned it: afterwards none
+// of ' , #' and #^ is inside any semantic token, and the atom after the prefix
+// gets exactly its own.
+//
+// ON UNITS AND LSP.  LSP 3.16 counts a position in UTF-16 code units unless
+// client and server negotiate otherwise, and this server neither offers
+// positionEncoding nor converts anything: every column it emits, from every
+// handler, is a byte offset.  That is a server-wide gap, filed separately; it
+// is not something a length can fix locally, and a length in some other unit
+// would only be inconsistent with the column it is added to.  What this
+// function guarantees is that a length is in the SAME unit as its start.
+//
+// fallbackLen is used when the node has no usable end position, which the
+// fault-tolerant parser can in principle produce; it is the length the case in
+// question computed before this function existed.
+func atomSpan(v *lisp.LVal, src *sourceText, fallbackLen int) (line, col, length int) {
+	loc := v.Source
+	line = loc.Line - 1
+	col = max(loc.Col-1, 0)
+
+	skipped := 0
+	if v.Quoted {
+		line, col, skipped = skipReaderQuote(src, line, col)
+	}
+
+	switch {
+	case loc.EndPos > loc.Pos && loc.EndLine-1 == line:
+		if n := loc.EndPos - loc.Pos - skipped; n > 0 {
+			return line, col, n
+		}
+	case loc.EndLine-1 > line:
+		// The atom continues onto a later line, which only a multi-line
+		// literal does.  Highlight its first line.
+		if n := src.lineLen(line) - col; n > 0 {
+			return line, col, n
+		}
+	}
+	return line, col, fallbackLen
+}
+
+// skipReaderQuote advances past a ' prefix that applyPrefixLocation folded into
+// a quoted atom's location, together with any whitespace or comment between the
+// quote and the atom -- "' a" and "'\na" are both legal, and with comments
+// preserved the reader allows one in the gap too.  It returns the atom's
+// position and the number of BYTES skipped, which is what the prefix costs the
+// span.
+//
+// It moves nothing unless the position really is a quote, so a node that is
+// Quoted for some other reason, or whose column does not line up with the text
+// the request was computed against, is left exactly where it was.
+func skipReaderQuote(src *sourceText, line, col int) (int, int, int) {
+	if c, ok := src.byteAt(line, col); !ok || c != '\'' {
+		return line, col, 0
+	}
+	startLine, startCol := line, col
+	skipped := 1
+	col++
+	for line < len(src.Lines()) {
+		c, ok := src.byteAt(line, col)
+		switch {
+		case !ok: // end of line: the newline is one byte too
+			line, col, skipped = line+1, 0, skipped+1
+		case c == ';': // a comment runs to the end of the line
+			skipped += src.lineLen(line) - col + 1
+			line, col = line+1, 0
+		case c == ' ' || c == '\t' || c == '\r' || c == '\f' || c == '\v':
+			col, skipped = col+1, skipped+1
+		default:
+			return line, col, skipped
+		}
+	}
+	// Nothing but space after the quote, so there is no atom to point at.
+	// Leave the caller where it started rather than off the end of the file.
+	return startLine, startCol, 0
 }
 
 // deltaEncode converts sorted raw tokens into the LSP delta-encoded format.

--- a/lsp/semantic_tokens_span_test.go
+++ b/lsp/semantic_tokens_span_test.go
@@ -1,0 +1,430 @@
+// Copyright © 2026 The ELPS authors
+
+package lsp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/internal/fuzzseed"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// This file holds the COVERAGE property for semantic tokens, which is strictly
+// stronger than the bounds property elps#428 / PR #448 added next door in
+// semantic_tokens_bounds_test.go.
+//
+// Bounds asks only that a token name SOME text in the document.  Coverage asks
+// that it name the RIGHT text: that the characters a token claims are the
+// source atom the server is classifying, and not its neighbours or half of
+// itself.  Both defects in elps#449 are in bounds and so invisible to the
+// weaker property -- they are wrong-but-in-range highlighting, which is why the
+// assertion PR #448 added to FuzzLSPSession does not go red on either.
+//
+// UNITS.  Byte offsets, because that is the unit the server emits: the scanner
+// sets token.Location.Col to a byte offset within the line (Scanner.LocStart),
+// elpsToLSPPosition passes it through unchanged, and position.go slices lines
+// by byte throughout.  LSP 3.16 actually specifies UTF-16 code units by default
+// and this server neither negotiates positionEncoding nor converts, so its
+// columns are wrong for any non-ASCII line whatever this file asserts.  That is
+// a server-wide gap, filed separately and not fixable by a length; what these
+// tests can and do insist on is that a length be measured in the same unit as
+// the column it is added to.
+
+// tokenCoverage is one decoded token together with the source text it claims.
+type tokenCoverage struct {
+	tok     rawToken
+	covered string
+}
+
+// semanticTokenDefects decodes a semanticTokens/full response back to absolute
+// (line, startChar, length) triples and returns a description of every token
+// that does not cover the source atom it is classifying.
+//
+// It checks:
+//
+//  1. BOUNDS -- the token lies inside its line (the property PR #448 added).
+//  2. NO READER PUNCTUATION -- no token starts on a ' , which is the prefix
+//     rdparser.applyPrefixLocation folds into a quoted atom's location.  PR
+//     #448 decided a reader prefix gets no semantic token; this is that
+//     decision expressed as a property (elps#449 part a).
+//  3. ONE ATOM -- a non-string token contains no delimiter, so it names one
+//     atom and not an atom plus whatever follows it.
+//  4. WHOLE LITERALS -- a string token starts at a quote delimiter and ends at
+//     the matching one, or, being the first line of a multi-line literal, runs
+//     to the end of its line (elps#449 part b, and the escaped-newline
+//     overshoot found while fixing it).
+func semanticTokenDefects(content string, data []protocol.UInteger) []string {
+	lines := strings.Split(content, "\n")
+	var bad []string
+	for _, tok := range decodeTokens(data) {
+		if tok.line < 0 || tok.line >= len(lines) {
+			bad = append(bad, fmt.Sprintf("token [%d:%d,+%d) is on line %d, but the document has %d lines",
+				tok.line, tok.startChar, tok.length, tok.line, len(lines)))
+			continue
+		}
+		// A CRLF document keeps its "\r"; the editor treats it as part of the
+		// line and so does this.
+		line := lines[tok.line]
+		end := tok.startChar + tok.length
+		if tok.startChar < 0 || tok.length < 0 || end > len(line) {
+			bad = append(bad, fmt.Sprintf("token [%d:%d,+%d) overruns line %d (%d bytes: %q)",
+				tok.line, tok.startChar, tok.length, tok.line, len(line), line))
+			continue
+		}
+		c := tokenCoverage{tok: tok, covered: line[tok.startChar:end]}
+		if msg := coverageDefect(c, line); msg != "" {
+			bad = append(bad, fmt.Sprintf("token [%d:%d,+%d) covers %q: %s",
+				tok.line, tok.startChar, tok.length, c.covered, msg))
+		}
+	}
+	return bad
+}
+
+// coverageDefect returns "" if c covers a source atom, and otherwise says what
+// is wrong with it.
+//
+// WHAT IS DELIBERATELY NOT ASSERTED: that a token's neighbours are delimiters.
+// The obvious stronger rule -- "a token must not stop where a word character
+// continues" -- is WRONG against this parser, because it is fault-tolerant and
+// splits malformed input into genuinely adjacent atoms with nothing between
+// them.  fuzzseed.All() has several: "1.2.3" reads as the float 1.2 followed by
+// the symbol .3, and "0x" as the int 0 followed by the symbol x.  Both tokens
+// name exactly the text they were computed from, so flagging them would be a
+// false positive on input committed to this repository.  What is left below is
+// checkable from the response alone and true of every correct token.
+func coverageDefect(c tokenCoverage, line string) string {
+	if c.tok.length == 0 {
+		return "empty token"
+	}
+	if c.covered[0] == '\'' {
+		// The reader's ' prefix.  It is punctuation the server has nothing to
+		// say about; PR #448 suppressed the #' and #^ heads for exactly that
+		// reason and cited ' as the precedent it was matching.
+		return "starts on a ' , which is reader punctuation and not part of the atom"
+	}
+	if c.tok.tokenType == semTokenString {
+		return stringLiteralDefect(c, line)
+	}
+	// Every other token names one atom, and an atom stops at a delimiter, so a
+	// token containing one covers more than the thing it classifies.
+	if i := strings.IndexAny(c.covered, " \t()[]\";'"); i >= 0 {
+		return fmt.Sprintf("contains the delimiter %q at offset %d, so it spans more than one atom",
+			c.covered[i:i+1], i)
+	}
+	return ""
+}
+
+// stringLiteralDefect checks a string token against the literal it claims.
+//
+// The server highlights only the FIRST LINE of a multi-line literal, so a token
+// with no closing delimiter is admissible exactly when it runs to the end of
+// its line.  Anything else means the length did not come from the source.
+func stringLiteralDefect(c tokenCoverage, line string) string {
+	var delim string
+	switch {
+	case strings.HasPrefix(c.covered, `"""`):
+		delim = `"""`
+	case strings.HasPrefix(c.covered, `"`):
+		delim = `"`
+	default:
+		return "string token does not start at a quote delimiter"
+	}
+	raw := delim == `"""`
+	body := c.covered[len(delim):]
+	closeAt := -1
+	for i := 0; i < len(body); {
+		if !raw && body[i] == '\\' {
+			i += 2
+			continue
+		}
+		if strings.HasPrefix(body[i:], delim) {
+			closeAt = i
+			break
+		}
+		i++
+	}
+	if closeAt < 0 {
+		if c.tok.startChar+c.tok.length == len(line) {
+			return "" // first line of a multi-line literal
+		}
+		return "the literal is not closed and the token does not run to the end of the line"
+	}
+	if want := 2*len(delim) + closeAt; want != len(c.covered) {
+		return fmt.Sprintf("the literal closes after %d characters but the token claims %d", want, len(c.covered))
+	}
+	return ""
+}
+
+// TestSemanticTokensCoverQuotedAtoms is the RED test for elps#449 part (a).
+//
+// rdparser.applyPrefixLocation moves a quoted atom's Col back onto the ' so
+// that 'a reports the position a reader would point at, but the LSymbol case
+// still took its length from len(v.Str), which does not include the quote, so
+// the token started one character early and ended one character early.
+//
+// Run on ed2538c, the commit this branch is based on.  RED -- these failed:
+//
+//	'foo                    [0:0,+3) covers "'fo"
+//	'a                      [0:0,+1) covers "'"
+//	(list 'a 'b)            [0:6,+1) and [0:9,+1) each cover "'"
+//	(error 'type-error 1)   [0:7,+10) covers "'type-erro"
+//	'"x"                    [0:0,+3) covers "'\"x"
+//	'42                     [0:0,+3) covers "'42"
+//	' a  ' \n a  ':kw  'foo:bar  (f '(a b) 'c)
+//
+// GUARD -- '#^0 passed on ed2538c, where PR #448 put it, and still passes.
+func TestSemanticTokensCoverQuotedAtoms(t *testing.T) {
+	s := testServer()
+	for i, content := range []string{
+		"'foo",
+		"'a",
+		"(list 'a 'b)",
+		"(error 'type-error 1)",
+		`'"x"`,
+		"'42",
+		"' a",
+		"'\na",
+		"':kw",
+		"'foo:bar",
+		"(f '(a b) 'c)",
+		"'#^0", // GUARD (PR #448)
+	} {
+		t.Run(fmt.Sprintf("%d/%q", i, content), func(t *testing.T) {
+			data := tokensFor(t, s, fmt.Sprintf("file:///test/quoted%d.lisp", i), content)
+			for _, msg := range semanticTokenDefects(content, data) {
+				t.Errorf("%s", msg)
+			}
+		})
+	}
+}
+
+// TestSemanticTokensQuotedAtomExactSpans pins the DECISION taken for elps#449
+// part (a): the token covers the ATOM, and the ' gets no token at all, rather
+// than the token being widened to cover "'a".
+//
+// This is the call PR #448 made for #^ and #' -- reader punctuation the server
+// cannot say anything true about is left to the client's syntax grammar -- and
+// #448 cited ' as the precedent it was being made consistent with.  Widening
+// instead would have made that citation false, because the quote would then be
+// painted with the SYMBOL's classification: variable-coloured in 'a,
+// function-coloured in 'car, keyword-coloured in 'if.  None of those says
+// anything about a quote.
+//
+// All RED on ed2538c.
+func TestSemanticTokensQuotedAtomExactSpans(t *testing.T) {
+	s := testServer()
+	for i, tc := range []struct {
+		content string
+		want    []rawToken
+	}{
+		{"'a", []rawToken{{line: 0, startChar: 1, length: 1, tokenType: semTokenVariable}}},
+		{"'foo", []rawToken{{line: 0, startChar: 1, length: 3, tokenType: semTokenVariable}}},
+		{"'42", []rawToken{{line: 0, startChar: 1, length: 2, tokenType: semTokenNumber}}},
+		{`'"x"`, []rawToken{{line: 0, startChar: 1, length: 3, tokenType: semTokenString}}},
+		// Whitespace between the prefix and the atom is legal, and the atom
+		// still gets its own token -- on its own line if it moved to one.
+		{"' a", []rawToken{{line: 0, startChar: 2, length: 1, tokenType: semTokenVariable}}},
+		{"'\na", []rawToken{{line: 1, startChar: 0, length: 1, tokenType: semTokenVariable}}},
+		{"(list 'a 'b)", []rawToken{
+			{line: 0, startChar: 1, length: 4, tokenType: semTokenFunction},
+			{line: 0, startChar: 7, length: 1, tokenType: semTokenVariable},
+			{line: 0, startChar: 10, length: 1, tokenType: semTokenVariable},
+		}},
+		// GUARD: a quoted LIST is not an atom.  The prefix was never inside a
+		// child's span, and the children are unaffected either way.
+		{"'(a b)", []rawToken{
+			{line: 0, startChar: 2, length: 1, tokenType: semTokenVariable},
+			{line: 0, startChar: 4, length: 1, tokenType: semTokenVariable},
+		}},
+	} {
+		t.Run(fmt.Sprintf("%d/%q", i, tc.content), func(t *testing.T) {
+			assertTokens(t, tokensFor(t, s, fmt.Sprintf("file:///test/qspan%d.lisp", i), tc.content), tc.want)
+		})
+	}
+}
+
+// TestSemanticTokensCoverStringLiterals is the RED test for elps#449 part (b).
+//
+// The LString case computed len(v.Str)+2, and v.Str is the string AFTER escape
+// processing, so every escape sequence was counted as the bytes it decodes to.
+// Run on ed2538c.  RED:
+//
+//	(f "x\ty")     [0:3,+5) covers "\"x\\ty"      -- 1 short
+//	"a\tb\tc"      [0:0,+7) covers "\"a\\tb\\t"   -- 2 short
+//	"\U0001F600"   [0:0,+6) covers "\"\\U000"     -- 6 short
+//	"""raw"""      [0:0,+5) covers "\"\"\"ra"     -- 4 short, the """ delimiters
+//	(f """r""" c)  [0:3,+3) covers "\"\"\""
+//	(f "a\nb" c)   [0:3,+9) covers "\"a\\nb\" c)" -- 3 LONG, see below
+//
+// The last row is a third symptom, not named in elps#449 and found by running
+// this property while fixing it: the multi-line branch tested the DECODED value
+// for a newline, so a single-line literal containing the ESCAPE \n took that
+// branch and was handed "the rest of the line", running past its own closing
+// quote and over everything after it.  It is an OVERSHOOT, which elps#449 says
+// cannot happen here ("Always an undershoot").
+//
+// GUARD -- these passed on ed2538c: "x", "é", "😀", a genuine multi-line raw
+// literal, and an unterminated "abc (which produces no token at all).
+func TestSemanticTokensCoverStringLiterals(t *testing.T) {
+	s := testServer()
+	for i, content := range []string{
+		`(f "x\ty")`,
+		`"a\tb\tc"`,
+		`"\U0001F600"`,
+		`(f "a\nb" c)`,
+		`"""raw"""`,
+		`(f """r""" c)`,
+		`"x"`,                  // GUARD
+		`"é"`,                  // GUARD
+		`"😀"`,                  // GUARD
+		"\"\"\"a\nb\"\"\"",     // GUARD
+		"\"\"\"é\nb\"\"\"",     // GUARD
+		"(f \"\"\"a\nb\"\"\")", // GUARD
+		`"abc`,                 // GUARD: no token at all
+	} {
+		t.Run(fmt.Sprintf("%d/%q", i, content), func(t *testing.T) {
+			data := tokensFor(t, s, fmt.Sprintf("file:///test/str%d.lisp", i), content)
+			for _, msg := range semanticTokenDefects(content, data) {
+				t.Errorf("%s", msg)
+			}
+		})
+	}
+}
+
+// TestSemanticTokensStringExactSpans pins the lengths part (b)'s fix produces,
+// including the ones that were already right so that a later change cannot
+// trade one class of literal for another.
+func TestSemanticTokensStringExactSpans(t *testing.T) {
+	s := testServer()
+	for i, tc := range []struct {
+		content string
+		want    []rawToken
+	}{
+		{`"x"`, []rawToken{{line: 0, startChar: 0, length: 3, tokenType: semTokenString}}},           // GUARD
+		{`"x\ty"`, []rawToken{{line: 0, startChar: 0, length: 6, tokenType: semTokenString}}},        // RED: was 5
+		{`"a\tb\tc"`, []rawToken{{line: 0, startChar: 0, length: 9, tokenType: semTokenString}}},     // RED: was 7
+		{`"\U0001F600"`, []rawToken{{line: 0, startChar: 0, length: 12, tokenType: semTokenString}}}, // RED: was 6
+		{`"""raw"""`, []rawToken{{line: 0, startChar: 0, length: 9, tokenType: semTokenString}}},     // RED: was 5
+		// RED: the escaped \n took the multi-line branch and swallowed the rest
+		// of the line.
+		{`(f "a\nb" c)`, []rawToken{
+			{line: 0, startChar: 1, length: 1, tokenType: semTokenVariable},
+			{line: 0, startChar: 3, length: 6, tokenType: semTokenString},
+			{line: 0, startChar: 10, length: 1, tokenType: semTokenVariable},
+		}},
+		// GUARD: measured in BYTES, like the columns they are added to.  "é" is
+		// four bytes of source and "😀" six, and len(v.Str)+2 already got both
+		// right, so a fix in some other unit would have broken them.
+		{`"é"`, []rawToken{{line: 0, startChar: 0, length: 4, tokenType: semTokenString}}},
+		{`"😀"`, []rawToken{{line: 0, startChar: 0, length: 6, tokenType: semTokenString}}},
+		// GUARD: a genuinely multi-line literal still gets its first line only.
+		{"\"\"\"a\nb\"\"\"", []rawToken{{line: 0, startChar: 0, length: 4, tokenType: semTokenString}}},
+		{"\"\"\"é\nb\"\"\"", []rawToken{{line: 0, startChar: 0, length: 5, tokenType: semTokenString}}},
+	} {
+		t.Run(fmt.Sprintf("%d/%q", i, tc.content), func(t *testing.T) {
+			assertTokens(t, tokensFor(t, s, fmt.Sprintf("file:///test/sspan%d.lisp", i), tc.content), tc.want)
+		})
+	}
+}
+
+// TestSemanticTokensNonASCIISymbolSpans is a GUARD.  All of it passed on
+// ed2538c and all of it must keep passing.
+//
+// It is here because the obvious way to write elps#449's fix -- take the length
+// from Location.EndCol-Col, the way the number case did -- is WRONG, and this
+// is the test that says so.  TokenEnd derives EndCol by counting RUNES onto a
+// Col that counts BYTES, so EndCol-Col is a rune width while every column
+// beside it is a byte offset.  For "déf" that is 3 against a 4-byte symbol.
+// The fix uses EndPos-Pos, which is byte-to-byte, instead.
+//
+// (EndCol being in neither unit is a defect in its own right, filed separately;
+// elpsToLSPRange uses it directly, so it is not only this file's problem.)
+func TestSemanticTokensNonASCIISymbolSpans(t *testing.T) {
+	s := testServer()
+	for i, tc := range []struct {
+		content string
+		want    []rawToken
+	}{
+		{"déf", []rawToken{{line: 0, startChar: 0, length: 4, tokenType: semTokenVariable}}},
+		{"(déf 1)", []rawToken{
+			{line: 0, startChar: 1, length: 4, tokenType: semTokenVariable},
+			{line: 0, startChar: 6, length: 1, tokenType: semTokenNumber},
+		}},
+		{"(f é x)", []rawToken{
+			{line: 0, startChar: 1, length: 1, tokenType: semTokenVariable},
+			{line: 0, startChar: 3, length: 2, tokenType: semTokenVariable},
+			{line: 0, startChar: 6, length: 1, tokenType: semTokenVariable},
+		}},
+		// RED on ed2538c: the quote, not the guard.
+		{"'déf", []rawToken{{line: 0, startChar: 1, length: 4, tokenType: semTokenVariable}}},
+	} {
+		t.Run(fmt.Sprintf("%d/%q", i, tc.content), func(t *testing.T) {
+			assertTokens(t, tokensFor(t, s, fmt.Sprintf("file:///test/uni%d.lisp", i), tc.content), tc.want)
+		})
+	}
+}
+
+// TestSemanticTokensCoverSeedCorpus runs the coverage property over every seed
+// committed to this repository, which is how elps#428 was found.
+//
+// RED on ed2538c on 22 of them (433 offending tokens), including ELPS sources
+// ships: (in-package 'foo), (error 'type-error ...) and (set 'method-table ...)
+// all put the token on the quote.
+func TestSemanticTokensCoverSeedCorpus(t *testing.T) {
+	s := testServer()
+	for i, seed := range fuzzseed.All() {
+		content := string(seed)
+		data := tokensFor(t, s, fmt.Sprintf("file:///test/cseed%d.lisp", i), content)
+		for _, msg := range semanticTokenDefects(content, data) {
+			t.Errorf("seed %d %q: %s", i, content, msg)
+		}
+	}
+}
+
+// TestSemanticTokensPrefixesEmitNoToken states, for all three reader prefixes
+// at once, what PR #448's TestSemanticTokensQuotePrefixEmitsNoToken meant to
+// say.  That test asserted only that no token was exactly [0:0,+1) -- which
+// 'foo passed while covering "'fo" -- so it could not have caught part (a).
+//
+// GUARD for #^ and #' (PR #448 landed those); RED on ed2538c for ' .
+func TestSemanticTokensPrefixesEmitNoToken(t *testing.T) {
+	s := testServer()
+	for i, content := range []string{
+		"'foo", "'a", "'42", `'"x"`,
+		"#'foo", "#^a", // GUARD
+		"(list 'a #'car #^b)",
+	} {
+		t.Run(fmt.Sprintf("%d/%q", i, content), func(t *testing.T) {
+			data := tokensFor(t, s, fmt.Sprintf("file:///test/prefix%d.lisp", i), content)
+			for _, tok := range decodeTokens(data) {
+				if tok.line != 0 {
+					continue
+				}
+				for j := tok.startChar; j < tok.startChar+tok.length && j < len(content); j++ {
+					if content[j] == '\'' ||
+						(content[j] == '#' && j+1 < len(content) && (content[j+1] == '\'' || content[j+1] == '^')) {
+						t.Errorf("token [%d:%d,+%d) covers reader punctuation at byte %d of %q",
+							tok.line, tok.startChar, tok.length, j, content)
+					}
+				}
+			}
+		})
+	}
+}
+
+// assertTokens compares a decoded token stream against an exact expectation.
+func assertTokens(t *testing.T, data []protocol.UInteger, want []rawToken) {
+	t.Helper()
+	got := decodeTokens(data)
+	if len(got) != len(want) {
+		t.Fatalf("got %d tokens %+v, want %d %+v", len(got), got, len(want), want)
+	}
+	for i := range got {
+		if got[i].line != want[i].line || got[i].startChar != want[i].startChar ||
+			got[i].length != want[i].length || got[i].tokenType != want[i].tokenType {
+			t.Errorf("token %d: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}

--- a/lsp/semantic_tokens_span_test.go
+++ b/lsp/semantic_tokens_span_test.go
@@ -414,6 +414,56 @@ func TestSemanticTokensPrefixesEmitNoToken(t *testing.T) {
 	}
 }
 
+// TestSemanticTokensQuotedDefinitionKeepsItsModifier pins the COUPLING this
+// fix has to leave alone, and it is the one thing about part (a) that is not
+// visible in the tokens' spans.
+//
+// A quoted atom now has TWO positions: the node's, which applyPrefixLocation
+// put on the ', and the atom's, one or more bytes to the right.  The token
+// takes the second.  classifySymbol must keep taking the FIRST, because the
+// analysis result is keyed by the node's position -- buildSymbolDefsMap indexes
+// analysis.Symbol.Source, and for "(set 'x 1)" that Source is column 6, the
+// quote, not column 7.  Look the atom's column up instead and the map misses.
+//
+// A miss is SILENT.  classifySymbol falls through to its name-based default and
+// returns semTokenVariable, which is also what symbolKindToTokenType returns
+// for the SymVariable it failed to find -- so the token TYPE is unchanged and
+// only the "definition" modifier disappears.  Nothing else in this file would
+// notice: assertTokens compares types, not modifiers.  Verified by running,
+// with classifySymbol switched to the atom's column: the whole lsp package
+// stays green and this one token quietly goes from mods=1 to mods=0.
+//
+// So the modifier is asserted here explicitly.  Editors use it to italicise or
+// embolden a defining occurrence; losing it on every "(set 'x ...)" in a file
+// is a real change, and it should cost a red test rather than nothing at all.
+//
+// RED on 5ef6106 for the SPAN -- there the token is [0:5,+1), on the quote, so
+// the atom has none.  The modifier half of it is the guard.
+func TestSemanticTokensQuotedDefinitionKeepsItsModifier(t *testing.T) {
+	s := testServer()
+	const content = "(set 'x 1)\nx"
+	data := tokensFor(t, s, "file:///test/qdef.lisp", content)
+	var found bool
+	for _, tok := range decodeTokens(data) {
+		if tok.line != 0 || tok.startChar != 6 {
+			continue
+		}
+		found = true
+		if tok.length != 1 {
+			t.Errorf("quoted definition token is [0:6,+%d), want +1 (the atom, not the quote)", tok.length)
+		}
+		if tok.modifiers&semModDefinition == 0 {
+			t.Errorf("quoted definition token [0:6,+%d) has modifiers=%d, want the definition bit (%d) set: "+
+				"classifySymbol must be given the NODE's column (the quote), which is what the "+
+				"analysis result is keyed by, and not the atom's",
+				tok.length, tok.modifiers, semModDefinition)
+		}
+	}
+	if !found {
+		t.Errorf("no token at [0:6) for %q: the quoted definition lost its token entirely", content)
+	}
+}
+
 // assertTokens compares a decoded token stream against an exact expectation.
 func assertTokens(t *testing.T, data []protocol.UInteger, want []rawToken) {
 	t.Helper()


### PR DESCRIPTION
Fixes #449.

## The design decision for (a): the `'` is not inside the symbol's token

#449 leaves this open — the token could cover `'a` (2 characters, from the quote) or `a` (1 character, starting after it). **This PR gives the token to the atom and gives the `'` no token at all.**

That is the call PR #448 made for the other two reader prefixes, and its stated reason applies here unchanged. A semantic token is a claim about the meaning of the text it covers, and the only claim available for a quote is the one `classifySymbol` derives from *the symbol beside it*. Widen the token to `'a` and the quote gets painted with the symbol's classification: variable-coloured in `'a`, function-coloured in `'car`, keyword-coloured in `'if`. None of those says anything true about a quote. #448 rejected exactly that reasoning for `#^` and `#'` — a two-character token whose colour is "an accident of the standard library" — and suppressed them instead, leaving the punctuation to the client's syntax grammar.

It is also what makes #448's own justification true. `isSynthesizedPrefixHead` says the suppression "makes the three reader prefixes agree, since `'` already produces no token of its own". That was true only in the narrow sense that no *node* sits at the quote. In the emitted tokens the quote was very much painted: `'42` covered `'42` as a number, and `'a` covered **only** the `'`, as a variable. After this change the citation is accurate — none of `'`, `#'`, `#^` is inside any semantic token, and the atom after the prefix gets exactly its own.

Both halves of #449 still reproduced on `5ef6106`, i.e. after #448, #442 and #456 landed. Captured by running:

| document | on `5ef6106` | covers | now |
|---|---|---|---|
| `'a` | `[0:0,+1)` | `'` | `[0:1,+1)` → `a` |
| `'foo` | `[0:0,+3)` | `'fo` | `[0:1,+3)` → `foo` |
| `(error 'type-error 1)` | `[0:7,+10)` | `'type-erro` | `[0:8,+10)` → `type-error` |
| `(f "x\ty")` | `[0:3,+5)` | `"x\ty` | `[0:3,+6)` → `"x\ty"` |
| `"\U0001F600"` | `[0:0,+6)` | `"\U000` | `[0:0,+12)` → the whole literal |
| `"""raw"""` | `[0:0,+5)` | `"""ra` | `[0:0,+9)` → the whole literal |

## (b), and a third symptom the issue did not have

Length now comes from `EndPos - Pos` — the span the scanner measured — instead of `len(v.Str)+2`, which measured the string *after* escape processing.

Found by running the new property while fixing (b), and **not** in #449: the multi-line branch tested the *decoded* value for a newline, so a single-line literal containing the **escape** `\n` took it and was handed "the rest of the line".

```
(f "a\nb" c)   ->  [0:3,+9)  covering  "a\nb" c)
```

That runs past its own closing quote and over everything after it. #449 states "Always an undershoot (a source escape is never shorter than what it decodes to), so the tail of the literal is left unhighlighted rather than the token running past the closing quote" — that is not so; this one overshoots by 3. Whether a literal is multi-line is now decided by the span (`EndLine > Line`) rather than by looking for a newline in the value.

## `EndCol` is not used, deliberately — and neither is UTF-16

The obvious way to write this fix is `EndCol - Col`, the way the number case already did. That is wrong. `token.TokenEnd` derives `EndCol` by ranging over `tok.Text`, which counts **runes**, and adds them to a `Col` that `Scanner.LocStart` computes as `startPos - startLinePos + 1`, a **byte** offset. `EndCol - Col` is therefore a rune width laid on a byte base. For the 4-byte symbol `déf` it is 3. `EndPos` and `Pos` are both byte offsets and their difference is exact, so the fix uses those. `TestSemanticTokensNonASCIISymbolSpans` is the guard that says so.

On **position encoding**: LSP counts a position in UTF-16 code units by default, and this server does not comply — every column it emits, from every handler, is a byte offset, and `elpsToLSPPosition` passes `Col` through untouched. It cannot negotiate its way out either: the server is built on `glsp/protocol_3_16`, whose `ServerCapabilities` has no `positionEncoding` field at all (that arrived in LSP 3.17), so UTF-16 is not optional for it.

This PR does **not** change that, on purpose. A length is added to a start; emitting a UTF-16 length against a byte start would produce a token that is wrong in a new and less predictable way. What the fix guarantees is that **a length is in the same unit as the column it is added to** — bytes, throughout, consistent with `position.go`, the bounds assertion #448 added, and every other handler. The encoding gap is server-wide, is not fixable by a length, and is filed separately.

## Tests: red-then-green

`lsp/semantic_tokens_span_test.go` is new. Everything in it was run against `5ef6106` and the real output is recorded in the file; anything that passed there is labelled `GUARD` in place.

- **Red on `5ef6106`**: 6 test functions, 30 failing subtests. Over the committed seed corpus, **22 of 118 seeds, 433 offending tokens** — including ELPS source this repository ships (`(in-package 'foo)`, `(error 'type-error ...)`, `(set 'method-table ...)`). Now **0 of 118**.
- **Guards** (passed on `5ef6106`, must keep passing): `'#^0` and the `#^`/`#'` suppression from #448; `"x"`, `"é"`, `"😀"` (byte-measured, and `len(v.Str)+2` already got them right, so a fix in some other unit would have broken them); a genuinely multi-line raw literal; an unterminated `"abc`; `déf` and friends.
- `TestSemanticTokensPrefixesEmitNoToken` replaces what #448's `TestSemanticTokensQuotePrefixEmitsNoToken` meant to say. That test asserted only that no token was exactly `[0:0,+1)` — which `'foo` passed while covering `'fo` — so it could not have caught (a).
- `TestSemanticTokensQuotedDefinitionKeepsItsModifier` pins a coupling that is otherwise **silent**. A quoted atom now has two positions, and `classifySymbol` must keep using the node's (the quote) because that is what `buildSymbolDefsMap` keys on — for `(set 'x 1)` the analysis `Source` is column 6, the quote, not column 7. Verified by running: substitute the atom's column and the entire `lsp` package stays green, because the lookup miss falls through to `semTokenVariable`, which is also what the found symbol maps to. Only the `definition` modifier disappears, and nothing asserted modifiers.

## The fuzz assertion is now coverage, not bounds

#448 put `checkTokenBounds` into `FuzzLSPSession`. A bounds check cannot catch either defect here: both are strictly in bounds. Bounds asks that a token name *some* text; it does not ask that it name the *right* text.

`checkTokenSpans` now also asks `coverageDefect` — the same predicate the table tests use, one definition, so the fuzzer and they cannot drift. It is still checkable from the response alone and still says nothing about which answer is right: a token may be a variable or a function, but it may not start on reader punctuation, span two atoms, or stop in the middle of a string literal.

What it deliberately does **not** assert is that a token's neighbours are delimiters. That stronger rule is wrong against this fault-tolerant parser, which splits malformed input into genuinely adjacent atoms: `1.2.3` reads as the float `1.2` then the symbol `.3`, and `0x` as `0` then `x`. Both are in `fuzzseed.All()`, both tokens name exactly the text they were computed from, and flagging them would be a false positive on input committed here.

**Seeds.** The quoted-atom half needed none — the existing `uses` document is `(in-package 'user)\n(use-package 'demo)\n…` and goes red on `5ef6106` at `'use`/`'dem`. The escaped-string half is reached by nothing in the corpus (no seed here or in `fuzzseed` contains a string literal with an escape, and a literal without one has `len(v.Str)+2` exactly right), so it is seeded rather than left to a mutator that would have to produce a balanced pair of quotes *and* a backslash escape inside them.

Verified red on `5ef6106` (`seed#0`, `seed#18`, `seed#25`, …) and green here.

**Exec counts:** `-fuzztime=300s` → **159,793 execs**, 381 new interesting inputs, 0 failures. A longer run continuing from that corpus is reported in a comment below. `scripts/fuzz-budget-check.sh` unchanged at 29 targets / 8 shards / 10 min headroom (no target added).

## Neighbourhood audit

Every place in `lsp/` that derives a length from a decoded or name string rather than from the node's span:

- The `elpsToLSPRange(loc, nameLen)` callers — `call_hierarchy.go` ×4, `code_actions.go`, `definition.go` ×2, `highlight.go` ×2, `hover.go` ×2, `linked_editing.go` ×2, `references.go` ×3, `rename.go` ×3 — are **span-first**: `elpsToLSPRange` uses `EndLine`/`EndCol` whenever present and takes `nameLen` only as a fallback. Cleared by #448's audit; not redone here.
- `position.go` `locContainsCol` (`end := start + len(name)`, overridden by `loc.EndCol` when set) and `selection_range.go` `locContainsPosition` (`endCol = startCol + 1` only when `EndLine == 0`) are the same shape — span-first, name as fallback.
- `semantic_tokens.go` `isSynthesizedPrefixHead` is span-based already (#448).

So the two in `collectSemanticTokens` were the only remaining instances of the #449 class, and both are fixed.

The audit did surface a **different** defect in the span-first path itself, which is why this fix avoids `EndCol`: every one of those callers consumes `EndCol` directly, and `EndCol` is rune-counted onto a byte `Col`. Filed separately rather than widened into this PR.

## Gates

`go build`, `go vet`, `go test -count=1`, `go test -race`, `golangci-lint run` (0 issues), `elps fmt -l`, `elps doc -m`, `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `scripts/ci-gates-test.sh` (233 passed / 0 failed), `scripts/confidentiality-guard.sh` (clean), `scripts/fuzz-budget-check.sh` (fits, 10 min headroom) — all clean.

Benchmark gate: the diff touches `lsp/` only, and no benchmark exists in `lsp/` — the benchmarked packages (`parser/rdparser`, `mcpserver`, `lisp`, `lisp/lisplib/libjson`) are untouched, so no timing or allocation row is reachable from this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_