### PR TITLE
Give LVal.Copy's result its own positions (#446)

### DIFF
--- a/lisp/copy_source_test.go
+++ b/lisp/copy_source_test.go
@@ -1,0 +1,299 @@
+// Copyright © 2026 The ELPS authors
+
+// Regression tests for elps#446 -- LVal.Copy sharing its *token.Location.
+//
+// LVal.Copy is documented as "creates a deep copy of the receiver", and for
+// Cells it is one: copyCells allocates a fresh *LVal per node.  Source was
+// not.  `*cp = *v` carried the *token.Location across, so the copy and the
+// original pointed at ONE mutable Location object, at every depth, and a
+// write through either moved the other.
+//
+// The caller that makes this matter is lisp.TextLoader.  It exists to hand
+// each evaluation a PRIVATE tree -- it is the entry point an embedder is
+// pointed at for a reusable parse cache, and macro_stamp_shared_ast_test.go
+// contrasts it with the Load* entry points, which do not copy.  For Cells the
+// privacy was real; for positions it was not, so every evaluation reported
+// its positions through the retained cache's objects.
+//
+// LIVE OR LATENT: latent, and checked rather than assumed -- see the
+// neighbourhood audit on the PR.  No non-test code writes THROUGH a borrowed
+// *token.Location: parser/rdparser's five write sites operate on Locations
+// the nodes they have just built own (#426/#442), lisp/env.go's three error
+// constructors take env.Loc.Copy() (#421), stampMacroExpansion ASSIGNS
+// v.Source rather than writing through it, and every position consumer
+// (lsp/, lint/, analysis/, mcpserver/, minifier/, formatter/, debugger/,
+// profiler/) reads a Location and formats it into its own value type.  So the
+// writes these tests perform are writes the TESTS perform: they demonstrate
+// the mechanism, they do not record an observed corruption.  What is a real
+// observed defect is the SHARING itself, which the tests below assert
+// directly and which failed on 5ef6106.
+//
+// Tests marked GUARD pass before the fix as well as after.  They pin
+// behaviour the fix must not break; they are not catches.
+
+package lisp_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/elpsutil"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readOne parses src and returns its single top-level expression.
+func readOne(t *testing.T, src string) *lisp.LVal {
+	t.Helper()
+	exprs, err := parser.NewReader().Read("copy-source.lisp", strings.NewReader(src))
+	require.NoError(t, err)
+	require.Len(t, exprs, 1)
+	return exprs[0]
+}
+
+// TestCopyDoesNotAliasSourceLocation is the reproduction from issue #446.
+// CATCH: both assertions failed on 5ef6106.
+func TestCopyDoesNotAliasSourceLocation(t *testing.T) {
+	orig := readOne(t, "(+ 1 2)")
+	cp := orig.Copy()
+
+	require.NotNil(t, orig.Source)
+	assert.NotSame(t, orig.Source, cp.Source,
+		"a copy shares the original's *token.Location (#446)")
+
+	cp.Source.Line = 99
+	assert.Equal(t, 1, orig.Source.Line,
+		"a write through the copy moved the original's recorded position (#446)")
+}
+
+// TestCopyDoesNotAliasSourceAtDepth pins that the separation reaches every
+// node copyCells reaches, not just the root.  The issue's probe counted the
+// root and all three cells of (+ 1 2) on one object.
+// CATCH: failed on 5ef6106 at every depth.
+func TestCopyDoesNotAliasSourceAtDepth(t *testing.T) {
+	orig := readOne(t, "(defun f (x) (let ([y (+ x 1)]) (* y y)))")
+	cp := orig.Copy()
+
+	origNodes := flatten(orig)
+	cpNodes := flatten(cp)
+	require.Len(t, cpNodes, len(origNodes), "copy has a different shape")
+	require.Greater(t, len(origNodes), 10, "test program is too small to be interesting")
+
+	shared := 0
+	for i := range origNodes {
+		if origNodes[i].Source != nil && origNodes[i].Source == cpNodes[i].Source {
+			shared++
+		}
+	}
+	assert.Zero(t, shared,
+		"%d of %d copied nodes share the original's *token.Location (#446)",
+		shared, len(origNodes))
+}
+
+// TestTextLoaderEvaluationsGetPrivatePositions is the reason #446 matters.
+// TextLoader retains one parse tree and hands each evaluation expr.Copy();
+// the copy is supposed to be private.  A builtin observes the Location the
+// evaluation actually carries.
+//
+// CATCH: on 5ef6106 both evaluations handed the builtin the RETAINED tree's
+// own *token.Location -- the same pointer, twice, and the cache's.
+func TestTextLoaderEvaluationsGetPrivatePositions(t *testing.T) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	require.NotEqual(t, lisp.LError, lisp.InitializeUserEnv(env).Type)
+
+	var seen []*token.Location
+	env.AddBuiltins(true, elpsutil.Function("probe-loc", lisp.Formals("x"),
+		func(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+			seen = append(seen, args.Cells[0].Source)
+			return lisp.Nil()
+		}))
+
+	cr := &capturingReader{inner: parser.NewReader()}
+	load, err := lisp.TextLoader(cr, "cache.lisp", strings.NewReader("(probe-loc 'sym)"))
+	require.NoError(t, err)
+	require.Len(t, cr.exprs, 1)
+
+	retained := cr.exprs[0]
+	require.Len(t, retained.Cells, 2)
+	cached := retained.Cells[1].Source
+	require.NotNil(t, cached)
+	cachedLine := cached.Line
+
+	for i := range 2 {
+		require.NotEqual(t, lisp.LError, load(env).Type, "evaluation %d failed", i)
+	}
+	require.Len(t, seen, 2)
+
+	assert.NotSame(t, cached, seen[0],
+		"the first evaluation reports its position through the retained cache's object (#446)")
+	assert.NotSame(t, cached, seen[1],
+		"the second evaluation reports its position through the retained cache's object (#446)")
+	assert.NotSame(t, seen[0], seen[1],
+		"two evaluations of the cached tree share one *token.Location (#446)")
+
+	// The corruption the sharing enables.  The write is this test's, not
+	// production code's -- see the file header.
+	seen[0].Line = 99
+	assert.Equal(t, cachedLine, cached.Line,
+		"a write through one evaluation moved the position the cache will report forever (#446)")
+	assert.Equal(t, cachedLine, seen[1].Line,
+		"a write through one evaluation moved a sibling evaluation's position (#446)")
+}
+
+// TestCopyPreservesSourcePosition pins that separating the objects does not
+// change what they say.
+// GUARD: passes before the fix.
+func TestCopyPreservesSourcePosition(t *testing.T) {
+	orig := readOne(t, "(+ 1 2)")
+	cp := orig.Copy()
+
+	origNodes := flatten(orig)
+	cpNodes := flatten(cp)
+	require.Len(t, cpNodes, len(origNodes))
+	for i := range origNodes {
+		if origNodes[i].Source == nil {
+			assert.Nil(t, cpNodes[i].Source, "node %d: nil Source became non-nil", i)
+			continue
+		}
+		require.NotNil(t, cpNodes[i].Source, "node %d: Source was dropped", i)
+		assert.Equal(t, *origNodes[i].Source, *cpNodes[i].Source,
+			"node %d: copied position differs", i)
+	}
+}
+
+// TestCopyPreservesNilSource pins that a nil Source stays nil.  A nil Source
+// means "no position recorded" throughout the tree and is distinct from a
+// zero one; token.Location.Copy is nil-preserving for that reason (#421).
+// GUARD: passes before the fix.
+func TestCopyPreservesNilSource(t *testing.T) {
+	v := lisp.SExpr([]*lisp.LVal{lisp.Symbol("a")})
+	v.Source = nil
+	v.Cells[0].Source = nil
+	cp := v.Copy()
+	assert.Nil(t, cp.Source)
+	require.Len(t, cp.Cells, 1)
+	assert.Nil(t, cp.Cells[0].Source)
+}
+
+// TestCopyKeepsSharingTheNativeSingleton pins the ONE Location that is
+// deliberately shared and must stay shared: lisp.nativeSource's process-wide
+// singleton, stamped on every natively-constructed LVal.
+//
+// Copying it would buy nothing -- it has a single owner, the process; it is
+// read-only by contract; SingletonSnapshot watches its bit pattern; and the
+// parser never leaves it in an AST (#362/#421).  It would cost a heap
+// allocation on the interpreter's hottest path, which is the +18.6% sec/op,
+// +20.2% allocs/op that #362's own comment records and rejects.  Separating
+// two owners is what the copy is for, and here there is only one.
+//
+// GUARD: passes before the fix, and pins that the fix did not "improve" it.
+func TestCopyKeepsSharingTheNativeSingleton(t *testing.T) {
+	a, b := lisp.Int(1), lisp.Int(2)
+	require.NotNil(t, a.Source)
+	require.Same(t, a.Source, b.Source, "premise: natively-constructed values share one Location")
+
+	cp := a.Copy()
+	assert.Same(t, a.Source, cp.Source,
+		"copying a native value allocated a private Location on a hot path (#362)")
+	assert.Equal(t, token.NativeFile, cp.Source.File)
+}
+
+// TestParseTreeCopyIsFullyPrivate closes the gap the native-singleton
+// exception could otherwise leave in TextLoader's guarantee.  The exception is
+// only harmless for a parse cache if a parse tree never contains that pointer,
+// which is a property #362/#421 states and parser/rdparser's
+// TestParserDoesNotAliasSharedNativeLocation guards at the reader end.  This
+// asserts the consequence at the end that consumes it: for a tree that came
+// from the reader, "no node shares" has no exceptions at all.
+// CATCH: failed on 5ef6106 (every node shared).
+func TestParseTreeCopyIsFullyPrivate(t *testing.T) {
+	const src = `(defmacro m (x) (quasiquote (+ 1 (unquote x))))
+(defun f (a &optional b) (let ([c (m a)]) (list c b '(1 2 3) #^0)))
+(f 1 2)`
+	exprs, err := parser.NewReader().Read("private.lisp", strings.NewReader(src))
+	require.NoError(t, err)
+	require.NotEmpty(t, exprs)
+
+	native, shared, total := 0, 0, 0
+	for _, expr := range exprs {
+		origNodes := flatten(expr)
+		cpNodes := flatten(expr.Copy())
+		require.Len(t, cpNodes, len(origNodes))
+		for i := range origNodes {
+			total++
+			if origNodes[i].Source == nil {
+				continue
+			}
+			if origNodes[i].Source.File == token.NativeFile {
+				native++
+			}
+			if origNodes[i].Source == cpNodes[i].Source {
+				shared++
+			}
+		}
+	}
+	require.Greater(t, total, 30, "test program is too small to be interesting")
+	assert.Zero(t, native,
+		"the reader put the shared native Location into a parse tree, so the "+
+			"exception in LVal.Copy is no longer safe for a parse cache (#362)")
+	assert.Zero(t, shared,
+		"%d of %d copied parse-tree nodes share the original's *token.Location (#446)",
+		shared, total)
+}
+
+// TestCopyDoesNotAliasSourceOfArrayNode pins that the reference types get the
+// same treatment for their OWN Source.  LArray shares its Cells backing and
+// LSortMap shares its value pointers, both deliberately, so the nodes reached
+// THROUGH them keep sharing; the node Copy() was called on must not.
+// CATCH for the array/sortmap root: failed on 5ef6106.
+func TestCopyDoesNotAliasSourceOfReferenceTypes(t *testing.T) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	require.NotEqual(t, lisp.LError, lisp.InitializeUserEnv(env).Type)
+
+	for _, src := range []string{`(vector 1 2 3)`, `(sorted-map 'a 1)`} {
+		t.Run(src, func(t *testing.T) {
+			v := env.LoadString("ref.lisp", src)
+			require.NotEqual(t, lisp.LError, v.Type, "%v", v)
+			loc := token.Location{File: "ref.lisp", Pos: 3, Line: 1, Col: 4}
+			v.Source = &loc
+
+			cp := v.Copy()
+			require.NotEqual(t, lisp.LError, cp.Type, "%v", cp)
+			assert.NotSame(t, v.Source, cp.Source,
+				"a copied %s shares the original's *token.Location (#446)", v.Type)
+			assert.Equal(t, *v.Source, *cp.Source)
+		})
+	}
+}
+
+// flatten returns v and every node reachable through Cells, in a fixed
+// pre-order, so two trees of the same shape line up index for index.
+func flatten(v *lisp.LVal) []*lisp.LVal {
+	if v == nil {
+		return nil
+	}
+	out := []*lisp.LVal{v}
+	for _, c := range v.Cells {
+		out = append(out, flatten(c)...)
+	}
+	return out
+}
+
+// capturingReader records the expressions it hands back, so a test can hold
+// the tree TextLoader retains.
+type capturingReader struct {
+	inner lisp.Reader
+	exprs []*lisp.LVal
+}
+
+func (c *capturingReader) Read(name string, r io.Reader) ([]*lisp.LVal, error) {
+	v, err := c.inner.Read(name, r)
+	c.exprs = append(c.exprs, v...)
+	return v, err
+}

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -1211,12 +1211,58 @@ func (v *LVal) equalNum(other *LVal) *LVal {
 }
 
 // Copy creates a deep copy of the receiver.
+//
+// The copy owns its positions.  Every node Copy reaches gets its own
+// *token.Location, so a write through the copy cannot move what the original
+// reports, and the reverse.  The one Location left shared is nativeSource's
+// process-wide singleton -- see the comment on the copy below.
 func (v *LVal) Copy() *LVal {
 	if v == nil {
 		return nil
 	}
 	cp := &LVal{}
 	*cp = *v // shallow copy of all fields including Map and Bytes
+	if v.Source != defaultSourceLocation {
+		// Source rides along in the struct assignment above, so without this
+		// the copy and the original hold ONE mutable *token.Location, at
+		// every depth -- Cells are deep-copied just below, positions were
+		// not.  That is issue #446, and lisp.TextLoader is what it defeats:
+		// TextLoader's entire purpose is to hand each evaluation a PRIVATE
+		// tree (it is the entry point an embedder is pointed at for a
+		// reusable parse cache; the Load* entry points do not copy), and
+		// every one of those "private" trees reported its positions through
+		// the retained cache's own objects.
+		//
+		// One Location per NODE here, where issue #431 needed only one per
+		// macro CALL, because what has to be separated is different.  There
+		// the N stamped nodes genuinely sit at one position, so a single
+		// object owned by the expansion separated the two owners.  Here each
+		// node has a position of its own, so N nodes need N objects and no
+		// cheaper framing exists; the only way to drop the allocation is to
+		// stop these objects being mutable at all, which is the LVal.Source
+		// immutability work tracked on issue #362.
+		//
+		// The single Location deliberately left shared is nativeSource's
+		// process-wide singleton, stamped on every natively-constructed
+		// LVal.  Copying it would separate nothing: a copy separates two
+		// OWNERS, and that object has exactly one -- the process.  It is
+		// read-only by contract, SingletonSnapshot watches its bit pattern,
+		// and the parser never leaves it in an AST (parser/rdparser's
+		// TestParserDoesNotAliasSharedNativeLocation), so it cannot reach a
+		// parse cache in the first place.  Copying it would instead put a
+		// heap allocation on the interpreter's hottest path, where most
+		// values are ones Go built and therefore carry it.  Measured
+		// interleaved against this branch, n=5, allocs/op: AliasStableSort
+		// +25.1%, AliasCDR +11.0%, EnvFunCallPos +9.1%, geomean +7.2% -- all
+		// past the 5% allocation gate.  Skipping it leaves the tree flat
+		// instead: the only row this change moves at all is libjson's
+		// get-nested-baseline (+3.93% allocs/op, gate 5%), whose 5000
+		// `assert` forms each copy their test expression out of the parse
+		// tree in opAssert.  That is the same trade nativeSource itself
+		// records and takes; closing it belongs to issue #362's immutability
+		// work, not here.
+		cp.Source = v.Source.Copy()
+	}
 	switch v.Type {
 	case LArray:
 		// Arrays are memory references but use Cells as backing storage.

--- a/lisp/sharedtree_fuzz_test.go
+++ b/lisp/sharedtree_fuzz_test.go
@@ -114,6 +114,73 @@ func readTree(src []byte) ([]*lisp.LVal, bool) {
 	return exprs, true
 }
 
+// copyWalkCap bounds the paired walk in copyOwnsItsPositions.  The reader's
+// own nesting and size limits keep real inputs far below it; the cap is here
+// so a pathological one costs a bounded walk rather than the whole budget, and
+// a truncated walk says so rather than reporting a silent pass.
+const copyWalkCap = 200000
+
+// copyOwnsItsPositions asserts that LVal.Copy hands back a tree that shares no
+// *token.Location with the tree it copied -- the property lisp.TextLoader's
+// "each evaluation gets a private tree" rests on (elps#446).
+//
+// The one pointer allowed to be shared is nativeSource's process-wide
+// singleton, which LVal.Copy deliberately does not separate: it has a single
+// owner, it is read-only by contract, and the reader never emits it (#362,
+// #370, and parser/rdparser's TestParserDoesNotAliasSharedNativeLocation).
+// Allowed here rather than assumed absent so that a reader change that starts
+// emitting it fails at ITS own guard, not confusingly at this one.
+//
+// Iterative rather than recursive: the walk must not be the thing that
+// overflows the goroutine stack on a deeply nested input.
+func copyOwnsItsPositions(t *testing.T, exprs []*lisp.LVal, src []byte) {
+	t.Helper()
+
+	native := lisp.Int(0).Source // the shared singleton, by construction
+	seen := 0
+	for _, orig := range exprs {
+		stack := [][2]*lisp.LVal{{orig, orig.Copy()}}
+		for len(stack) > 0 {
+			pair := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			a, b := pair[0], pair[1]
+			if a == nil || b == nil {
+				continue
+			}
+			seen++
+			if seen > copyWalkCap {
+				t.Logf("copy-ownership walk truncated at %d nodes; the rest of"+
+					" this input was not checked", copyWalkCap)
+				return
+			}
+			if a.Source != nil && a.Source == b.Source && a.Source != native {
+				t.Fatalf("LVal.Copy handed back a node sharing the original's"+
+					" *token.Location (elps#446)"+
+					"\n  node type: %v"+
+					"\n  location:  %v"+
+					"\n--- source (%d bytes) ---\n%q",
+					a.Type, a.Source, len(src), src)
+				return
+			}
+			// LArray shares its Cells backing and LSortMap shares its value
+			// pointers, both deliberately, so a copy of either legitimately
+			// reaches the same child nodes.  Descend only where Copy did.
+			if a.Type == lisp.LArray || a.Type == lisp.LSortMap {
+				continue
+			}
+			if len(a.Cells) != len(b.Cells) {
+				t.Fatalf("LVal.Copy changed a node's arity: %d cells became %d"+
+					"\n--- source (%d bytes) ---\n%q",
+					len(a.Cells), len(b.Cells), len(src), src)
+				return
+			}
+			for i := range a.Cells {
+				stack = append(stack, [2]*lisp.LVal{a.Cells[i], b.Cells[i]})
+			}
+		}
+	}
+}
+
 // sharedTreeProperty is the body of the target, factored out so the corpus
 // tests below assert exactly what the fuzzer asserts.
 func sharedTreeProperty(t *testing.T, src []byte) {
@@ -130,6 +197,15 @@ func sharedTreeProperty(t *testing.T, src []byte) {
 	if !ok {
 		return
 	}
+	// The other way a consumer gets a private tree: LVal.Copy, which is what
+	// lisp.TextLoader hands every evaluation.  Same ownership question as the
+	// rest of this target, one step earlier -- a copy that shares position
+	// OBJECTS with the tree it came from is not private, and the retained
+	// cache then reports whatever the last writer through any copy left
+	// behind (elps#446).  Asserted before evaluation so the walk sees the
+	// reader's output and nothing else.  Costs one Copy and one paired walk;
+	// no extra evaluation.
+	copyOwnsItsPositions(t, shared, src)
 
 	done := make(chan struct{})
 	var want []string

--- a/parser/rdparser/fuzz_test.go
+++ b/parser/rdparser/fuzz_test.go
@@ -302,6 +302,42 @@ func FuzzParsedLocationInvariants(f *testing.F) {
 			for _, e := range exprs {
 				check(e, nil)
 			}
+			// Property 1, one step downstream: LVal.Copy must hand back a
+			// tree that shares no position OBJECT with the tree it copied
+			// (elps#446).  `*cp = *v` carried Source across, so a "copy" and
+			// its original held one mutable Location at every depth -- which
+			// is what lisp.TextLoader's private-tree guarantee rests on.
+			//
+			// Walked through the SAME owner map the loop above filled, so
+			// this states both halves at once: no copied node may hold an
+			// original's Location, and no two copied nodes may hold one
+			// either.  Cells are descended unconditionally, exactly as the
+			// walk above does -- the reader emits no LArray or LSortMap, the
+			// two types whose children LVal.Copy deliberately shares.
+			//
+			// A node carrying lisp's shared native Location would also
+			// surface here, because a copy keeps that one pointer by design.
+			// The reader does not emit it; TestParserDoesNotAliasSharedNative
+			// Location is where that is stated (#362/#370).
+			var checkCopy func(v *lisp.LVal)
+			checkCopy = func(v *lisp.LVal) {
+				if v == nil {
+					return
+				}
+				if loc := v.Source; loc != nil {
+					if prev, dup := owner[loc]; dup {
+						t.Fatalf("formatting=%v: copied node %v %q holds the same *token.Location %v as %v %q; a copy must own its positions (#446)",
+							formatting, v.Type, v.Str, loc, prev.Type, prev.Str)
+					}
+					owner[loc] = v
+				}
+				for _, c := range v.Cells {
+					checkCopy(c)
+				}
+			}
+			for _, e := range exprs {
+				checkCopy(e.Copy())
+			}
 		}
 	})
 }


### PR DESCRIPTION
Fixes #446

`LVal.Copy` is documented as "creates a deep copy of the receiver" and is one for `Cells` — `copyCells` allocates a fresh `*LVal` per node. `Source` was not: `*cp = *v` carried the `*token.Location` across, so a "copy" and the tree it came from held **one mutable Location object at every depth**, and a write through either moved the other.

## It still reproduces on `main`

Checked first, on `5ef6106` (not on the commit the issue was filed against). Every catch below is red there:

```
--- FAIL: TestCopyDoesNotAliasSourceLocation
    Expected and actual point to the same object: 0xc0003ca730
      &token.Location{File:"copy-source.lisp", Pos:0, Line:1, Col:1, EndPos:7, EndLine:1, EndCol:8}
    a copy shares the original's *token.Location (#446)

    expected: 1
    actual  : 99
    a write through the copy moved the original's recorded position (#446)

--- FAIL: TestCopyDoesNotAliasSourceAtDepth
    Should be zero, but was 18
    18 of 18 copied nodes share the original's *token.Location (#446)

--- FAIL: TestParseTreeCopyIsFullyPrivate
    Should be zero, but was 43
    43 of 43 copied parse-tree nodes share the original's *token.Location (#446)
```

And the caller the issue says this matters for, `lisp.TextLoader` — the entry point an embedder is pointed at for a reusable parse cache, which `macro_stamp_shared_ast_test.go` contrasts with the `Load*` entry points because it copies:

```
--- FAIL: TestTextLoaderEvaluationsGetPrivatePositions
    Expected and actual point to the same object: 0xc0003cb6d0
      &token.Location{File:"cache.lisp", Pos:11, Line:1, Col:12, EndPos:15, EndLine:1, EndCol:16}
    the first evaluation reports its position through the retained cache's object (#446)
    ... the second evaluation reports its position through the retained cache's object (#446)
    ... two evaluations of the cached tree share one *token.Location (#446)

    expected: 1
    actual  : 99
    a write through one evaluation moved the position the cache will report forever (#446)
    a write through one evaluation moved a sibling evaluation's position (#446)
```

Both "private" trees handed out by one `TextLoader` reported their positions through the **same** object, and it was the retained cache's own.

## Live or latent: latent, checked rather than assumed

I re-ran the population argument on `5ef6106` rather than taking #446's or #431's word for it. Every in-place write through a `*token.Location` in non-test code, found by grepping for field assignments through a `Location` pointer:

| Site | Verdict |
|---|---|
| `parser/rdparser/parser.go` — 5 blocks (`inheritEndPos` 504-506, `applyPrefixLocation` 517-521, the two closing-bracket blocks 735-737 / 776-778, `tokenLVal` 1023-1025) | Writes into nodes the reader has just built, and since #426/#442 into `Location`s those nodes own |
| `lisp/env.go` error constructors | Take `env.Loc.Copy()` (#421) — a re-point, not a write-through |
| `lisp/x/debugger/engine.go` 976-978 (`loc.File = expr.Source.File`) | Writes into the debugger's **own** `StepLocation`; reads `Source` |
| `lsp/inlay_hints.go`, `lsp/code_actions.go`, `lsp/workspace_symbols.go` | `Source.Line == 0` comparisons, not writes |
| everything else that touches a position | Reads a `Location` and formats it into its own `Position`/`Range`/`Span` value type |

`stampMacroExpansion` **assigns** `v.Source = callSite` rather than writing through the pointer, so it re-points a copy without touching the original.

So no writer can reach the shared object today. **The writes the tests perform are writes the tests perform** — they demonstrate the mechanism, they do not record an observed corruption. What is a real observed defect is the **sharing**, which is what the assertions above are about. Said plainly in the test file header so the next reader is not misled.

## The fix, and why one Location per node is the right count here

```go
if v.Source != defaultSourceLocation {
	cp.Source = v.Source.Copy()
}
```

`(*token.Location).Copy()` already exists and is nil-preserving; no second helper.

**#456's framing does not transfer, and I checked before concluding that.** There, N stamped nodes genuinely sat at one position, so one object per macro *call* separated the two owners and the cost fell from per-node to +2.58% B/op. Here every node has a position **of its own** — the copy's node at line 1 col 12 cannot share an object with the node at line 1 col 4 — so N nodes need N objects. There is no cheaper object count. The only way to remove the allocation is to stop these objects being mutable, which is the `LVal.Source` immutability work tracked on #362 and sequenced after the v1.50.0 API break.

**Why not fix it only inside `TextLoader`.** `TextLoader` obtains its private tree *by calling* `expr.Copy()`, so the per-node cost would be identical, only narrower — and every other `Copy()` caller would keep a "deep copy" that is not one. Rejected on those grounds, not on measurement.

**The one Location deliberately left shared** is `nativeSource`'s process-wide singleton. A copy separates two **owners**, and that object has exactly one — the process. It is read-only by contract, `SingletonSnapshot` watches its bit pattern, and the parser never leaves it in an AST (`TestParserDoesNotAliasSharedNativeLocation`), so it cannot reach a parse cache in the first place. `TestParseTreeCopyIsFullyPrivate` asserts the consequence at this end: for a tree that came from the reader, "no node shares" has no exceptions at all.

## Measured

Two arms, interleaved, on the same box, `BENCH_COUNT=10`, `scripts/bench-run-arms.sh`, base = `5ef6106`.

**Caveat stated up front: this box was shared with other agents' full test runs (load average ~20 on 4 cores) for part of the window.** That makes the *timing* rows noise-dominated — `AliasStableSortSliceView` reports ±101% spread on the base arm — and I am not claiming a timing result in either direction. The allocation rows are exact counts and are unaffected by load; every one below is ±0% with p=0.000. CI's benchmark job re-measures on its own runner.

The gate's verdict:

```
below-gate  lisp     sec/op    PackageGetVal-4               delta=+8.11% p=0.029 (gate 15%)
below-gate  lisp     B/op      AliasStableSort-4             delta=+0.02% p=0.000 (gate 5%)
below-gate  lisp     allocs/op AliasStableSort-4             delta=+0.02% p=0.000 (gate 5%)
below-gate  libjson  B/op      Package/get-nested-baseline-4 delta=+4.36% p=0.000 (gate 5%)
below-gate  libjson  allocs/op Package/get-nested-baseline-4 delta=+3.93% p=0.000 (gate 5%)

benchstat-gate: interpreted 25 delta row(s) + 318 no-change row(s); 11 significant
move(s) in the bad direction; 0 at or above the gate (timing 15%, allocation 5%).
```

**Gate verdict: 0 rows at or above the gate.** No waiver added; the two existing waivers (#412/#410, `libjson/Encode`) are reported unused and left alone.

The whole cost of this change lands on **one row**, and it is explicable to the allocation: `Package/get-nested-baseline` goes 509.0k → 529.0k allocs/op, **+20,000**, and its body is 1000 iterations of 5 `assert-equal` forms. `opAssert` does `env.Eval(test.Copy())` — it copies its test expression out of the parse tree on every evaluation — so 5,000 asserts × ~4 nodes each is exactly the 20k. Every interpreter row is flat to ±0.02%, because the values the evaluator copies at runtime were built by Go and carry the native singleton, which is skipped.

`PackageGetVal`'s +8.11% sec/op is noise: the row reports ±30% spread, and its own `allocs/op` is `0.000 ± 0%` on both arms — a benchmark that allocates nothing cannot be moved by an allocation. Under #452 the move is far inside the row's own measured spread; it is below the 15% gate regardless. **Allocations are not exempt and I did not treat them as such** — the `+3.93%` row above is adjudicated against the 5% gate on its merits.

### What the exception buys, measured

To check that skipping the native singleton is doing real work rather than being asserted, I built a third arm that copies it too and measured that against this branch — interleaved, n=5, `-benchtime=10x` so the allocation counts stay exact under load:

```
                    │  this branch  │            copy-the-singleton         │
                    │   allocs/op   │   allocs/op    vs base                │
AliasCDR-4            9.047k ± ∞ ¹   10.046k ± ∞ ¹  +11.04% (p=0.008 n=5)
AliasStableSort-4     101.7k ± ∞ ¹    127.3k ± ∞ ¹  +25.12% (p=0.008 n=5)
EnvFunCallPos-4       22.06k ± ∞ ¹    24.06k ± ∞ ¹   +9.07% (p=0.008 n=5)
EnvGet-4              128.0k ± ∞ ¹    128.0k ± ∞ ¹        ~ (p=0.444 n=5)
geomean               14.71k          15.76k         +7.17%
```

Three rows past the 5% allocation gate and a +7.17% geomean. The exception is load-bearing, not a convenience.

## Red, then green

| Test | `5ef6106` | This branch | Kind |
|---|---|---|---|
| `TestCopyDoesNotAliasSourceLocation` | FAIL (shares; write moves original) | PASS | catch |
| `TestCopyDoesNotAliasSourceAtDepth` | FAIL (18 of 18 nodes) | PASS | catch |
| `TestTextLoaderEvaluationsGetPrivatePositions` | FAIL (both evaluations, the cache's own object) | PASS | catch |
| `TestParseTreeCopyIsFullyPrivate` | FAIL (43 of 43 nodes) | PASS | catch |
| `TestCopyDoesNotAliasSourceOfReferenceTypes` | FAIL (array and sorted-map roots) | PASS | catch |
| `TestSharedTreeSeedsAgree` (folded property) | FAIL on 14 of 14 seeds | PASS | catch |
| `FuzzParsedLocationInvariants` seed corpus (folded property) | FAIL on 20+ seeds | PASS | catch |
| `TestCopyPreservesSourcePosition` | PASS | PASS | **guard** — separating the objects must not change what they say |
| `TestCopyPreservesNilSource` | PASS | PASS | **guard** — nil means "no position recorded" and must stay nil |
| `TestCopyKeepsSharingTheNativeSingleton` | PASS | PASS | **guard** — pins the one exception, so a later "improvement" that copies it fails here rather than in a benchmark |

The three guards are labelled as guards in the file, not counted as catches.

## Fuzzing

Folded into two existing targets rather than adding a twenty-ninth. `scripts/fuzz-budget-check.sh` is unchanged at 29 targets / 8 shards / 10 min headroom.

**`FuzzSharedTreeEval`** (`lisp`) — the target already about who owns a parse tree. Before the shared/private evaluation, it now copies each expression and walks the pair, asserting no node of the copy holds the original's `Location`. Costs one `Copy` and one paired walk; no extra evaluation. Iterative, so the walk cannot be the thing that overflows the stack on a deeply nested input, and capped at 200k nodes with a truncated walk saying so rather than passing silently. The native singleton is allowed rather than assumed absent, so a reader change that starts emitting it fails at *its* guard (`TestParserDoesNotAliasSharedNativeLocation`) and not confusingly at this one.

**`FuzzParsedLocationInvariants`** (`parser/rdparser`) — this one already builds an `owner` map keyed by `*token.Location` for property 1 (#426: every node owns its position). Walking the **copy** through that same map states both halves of #446's property at once: no copied node may hold an original's object, and no two copied nodes may hold one either. That uniqueness half is stronger than the paired walk above, and it comes almost free from machinery that was already there.

60s smoke on each, clean:

```
FuzzSharedTreeEval           elapsed: 1m1s, execs: 263973 (2276/sec),  new interesting: 117 (total: 860)  PASS
FuzzParsedLocationInvariants elapsed: 1m1s, execs: 479352 (16008/sec), new interesting: 69 (total: 403)   PASS
```

Both seed corpora run on every `go test`, which is where the red rows in the table above come from.

## Neighbourhood audit

Only what the prior audits did not cover. **Not re-done:** #421 cleared `LEnv.Lambda`, `LEnv.TaggedValue`, `CallFrame.Source`, `CallStack.Copy()`, `env.Loc = v.Source` as a hot-path borrow, and the read-only consumers in `lint`/`analysis/perf`/`profiler`; #442 covered `Parser.Location` ownership and the five parser write sites; #419 covered the reader's synthetic locations; #456 covered `MacroExpansionContext.CallSite`/`DefSite`, `ParseNegative`, `locateSynthesized`, the closing-bracket guards, `Parser.errorf`, and the tree-wide sweep of position consumers. This PR's neighbourhood is `LVal.Copy` itself and the other shallow-copy constructors next to it.

| Site | Verdict |
|---|---|
| **`LVal.Copy`'s `Meta *SourceMeta`** | **Found by running. Filed as #466, not fixed here.** Shared by the copy — including the `[]*token.Token` slices, so for a format-preserving tree the `Location`s this PR separated on the node are still shared one level down. Probe: `cp.Meta.BlankLinesBefore = 99` moved the original's. |
| **`LVal.Copy`'s `MacroExpansion *MacroExpansionInfo`** | **Found by reading. Filed as #466 with the above.** Shared, including an `ID` documented "unique per node" and read by `debugger/engine.go` for step-into differentiation, so a copy duplicates a value whose contract is uniqueness. |
| `Quote`, `Splice`, `shallowUnquote`, `FunRef` | Four more `*cp = *v` sites in `lisp.go`. All deliberately **shallow** — they share `Cells` too, being "the same value with one flag changed" — so sharing `Source` is consistent with their contract rather than a broken promise of privacy. #446's argument does not reach them. Left, not filed. |
| `LVal.Copy`'s `Native` | `LArray` shares its `Cells` backing and `LNative`/`LBytes` share their payload, all by documented reference semantics; `LSortMap` goes through `copyMapData`. The node `Copy` was called on now gets a private `Source` in every case — `TestCopyDoesNotAliasSourceOfReferenceTypes` pins the array and sorted-map roots, and the nodes reached *through* them keep sharing, as they must. |
| `LEnv.Copy`'s `Loc` | Shallow-copied, and documented "not quite a deep copy". `Loc` is the hot-path borrow #421 recorded and deliberately left; `eval` re-**assigns** it per step rather than writing through it. Downstream of a reported finding — not re-filed. |
| `lisp/env.go:631,676` — `Source: env.Loc` | `LEnv.Lambda` / `LEnv.TaggedValue`. Exactly what #421 recorded ("a copy here is a new allocation on a path that has none, per lambda … Left, reported"). Still present, still reachable. **Not re-filed, not widened.** |
| `analysis/expander.go:173` (`cp := *e.lastPanic`) | Copies a panic value, not a `Location`. Clean. |
| `elpstest.RunBenchmark`'s `expr.Copy()` | Now separates positions too. It runs with the timer stopped, so this adds no measured cost — which is also why the benchmark suite does not exercise the parse-tree copy path directly, and why `libjson`'s `assert`-heavy row is the only one that moved. |

## Gates

All run on this branch at `8835db4`.

| Gate | Result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test -count=1 ./...` | pass |
| `go test -race ./...` | clean |
| `golangci-lint run ./...` | **0 issues** (3 `testifylint` findings on the new test were fixed, not suppressed) |
| `elps fmt -l ./...` | clean (binary built, run, deleted before committing) |
| `elps doc -m` | "All functions and exports are documented." |
| `make go-test` | pass |
| `make race` | clean |
| `make test-elpscheck` | pass |
| `make test-examples` | pass |
| `./scripts/ci-gates-test.sh` | 233 passed, 0 failed |
| `./scripts/confidentiality-guard.sh` (after `git add`) | clean |
| `./scripts/fuzz-budget-check.sh` | fits — 29 targets, 8 shards, largest shard 4, required 50 min vs 60 min timeout, 10 min headroom |
| `scripts/benchstat-gate.sh` | **0 rows at or above the gate** |

## Found and filed

- **#466** — `LVal.Copy` shallow-copies `Meta` and `MacroExpansion` as well, so a "deep copy" shares its formatting metadata (and the `*token.Token`s inside it, each with its own `Location`) and its per-node macro-expansion `ID`. The `Meta` half found by **running**, with probe output on the issue; the `MacroExpansion` half by **reading**. Latent by the same population argument as #446. Filed with a reproduce-or-close note on the consequences, and deliberately not fixed here — unlike `Source`, both fields are nil on the hot path, so the cost argument is different and the open question is whether the separation is wanted at all or whether the doc comments are what is wrong.

Not new, and deliberately not re-filed: `LEnv.Lambda`'s `Source: env.Loc` (recorded by #421's audit, confirmed still present), and the four intentionally-shallow constructors above.

## On the surviving draft

This branch started from uncommitted work left by an earlier agent that died mid-task; it left no commits, no push and no report, so none of its reasoning was recoverable. **Kept**, after re-establishing each claim from evidence: the `LVal.Copy` fix and its native-singleton exception (the exception's cost claim re-measured independently — the draft's `+25.2%` / `+9.1%` came back as `+25.12%` / `+9.07%`), the eight regression tests, and the fold into `FuzzSharedTreeEval`. **Added:** the fold into `FuzzParsedLocationInvariants`, the `#431`-vs-`#446` framing argument, the re-run of the writer-population audit on current `main`, the whole-tree benchmark measurement, and the `Meta`/`MacroExpansion` audit finding. **Corrected:** commit references pointing at the pre-rebase base, an `intrange` violation, and three `testifylint` findings.