### PR TITLE
Count TokenEnd's EndCol in bytes, so rename stops corrupting non-ASCII identifiers

### DIFF
--- a/lsp/lsp_fuzz_test.go
+++ b/lsp/lsp_fuzz_test.go
@@ -785,7 +785,7 @@ func (s *session) checkRenameSpans(a opArgs, res *protocol.WorkspaceEdit) {
 	name := rwp.Placeholder
 
 	for uri, edits := range res.Changes {
-		doc := s.srv.docs.Get(string(uri))
+		doc := s.srv.docs.Get(uri)
 		if doc == nil {
 			continue // a workspace file the harness never opened
 		}

--- a/lsp/lsp_fuzz_test.go
+++ b/lsp/lsp_fuzz_test.go
@@ -213,6 +213,11 @@ type session struct {
 	// recorded rather than raised, because the op that produced it has no way
 	// to fail the input on its own.
 	tokenErr error
+
+	// renameErr holds the first rename edit whose range did not cover the
+	// identifier being renamed (elps#463). Recorded, not raised, for the same
+	// reason as tokenErr.
+	renameErr error
 }
 
 // opArgs is the fuzzer's four bytes for one operation, already interpreted.
@@ -717,6 +722,98 @@ func (s *session) opRename(a opArgs) {
 		NewName:                    word([]byte(s.content[a.uri]), a.a, a.b),
 	})
 	s.record("rename", res, err)
+	if err == nil && res != nil {
+		s.checkRenameSpans(a, res)
+	}
+}
+
+// checkRenameSpans is the CONTENT assertion for textDocument/rename, and the
+// second exception to "NOT asserted: that any request returns a particular
+// result" -- checkTokenSpans above being the first, and the note there explains
+// why an exception is admissible at all.
+//
+// It does not say which symbol should be renamed, how many edits there should
+// be, or which files they should touch. It says that whatever the server chose
+// to replace, the range it chose has to COVER THE WHOLE IDENTIFIER. A rename is
+// the one request in the protocol whose answer is applied to the user's file
+// unread, so a range that is off by even one byte is not a cosmetic error the
+// way a wrong hover range is: it is a silent edit of a program into a different
+// program.
+//
+// elps#463. token.TokenEnd derived EndCol by counting RUNES onto Scanner's byte
+// Col, and elpsToLSPRange prefers EndCol whenever it is set, so on an
+// identifier containing a multi-byte rune every rename edit was short by
+// len-runeCount bytes. Renaming "éx" to "zz" replaced "é" and left "x", giving
+// "zzx" -- a valid program that is not the user's. Where the identifier's LAST
+// rune was multi-byte the leftover was a bare continuation byte and the file
+// stopped being valid UTF-8 at all.
+//
+// THE ORACLE is prepareRename, which the server answers from the same symbol
+// lookup rename uses and which returns the symbol's name as its Placeholder.
+// Asking it at the same position turns "is this range right?" into a comparison
+// against text the server itself named, with no second implementation of symbol
+// resolution in the test to disagree about the answer. Where prepareRename
+// declines -- a builtin, no symbol, an external with no source -- there is no
+// oracle and nothing is checked; that costs coverage only on inputs where
+// rename should have returned nothing anyway.
+//
+// Only edits against documents the SERVER holds are checked. A cross-file edit
+// may name a workspace file the harness never opened, and its content is not
+// available to compare against.
+//
+// UNITS: byte offsets, as everywhere else in this package (position.go splits
+// on "\n" and slices by byte). elps#464 is that LSP 3.16 actually specifies
+// UTF-16 code units and this server neither negotiates positionEncoding nor
+// converts; this assertion is deliberately the weaker, server-internal
+// property, which is a real property regardless of how #464 is answered -- a
+// range whose two ends are counted differently is broken before any encoding
+// question arises.
+func (s *session) checkRenameSpans(a opArgs, res *protocol.WorkspaceEdit) {
+	if s.renameErr != nil || res.Changes == nil {
+		return
+	}
+	pr, err := s.srv.textDocumentPrepareRename(s.ctx, &protocol.PrepareRenameParams{
+		TextDocumentPositionParams: a.tdpp(),
+	})
+	if err != nil || pr == nil {
+		return
+	}
+	rwp, ok := pr.(*protocol.RangeWithPlaceholder)
+	if !ok || rwp.Placeholder == "" {
+		return
+	}
+	name := rwp.Placeholder
+
+	for uri, edits := range res.Changes {
+		doc := s.srv.docs.Get(string(uri))
+		if doc == nil {
+			continue // a workspace file the harness never opened
+		}
+		doc.mu.Lock()
+		content := doc.Content
+		doc.mu.Unlock()
+		lines := strings.Split(content, "\n")
+
+		for _, e := range edits {
+			line, start, end := int(e.Range.Start.Line), int(e.Range.Start.Character), int(e.Range.End.Character)
+			if int(e.Range.End.Line) != line {
+				s.renameErr = fmt.Errorf("rename edit [%d:%d..%d:%d) on %s spans two lines; an identifier does not",
+					e.Range.Start.Line, start, e.Range.End.Line, end, uri)
+				return
+			}
+			if line >= len(lines) || start < 0 || end < start || end > len(lines[line]) {
+				s.renameErr = fmt.Errorf("rename edit [%d:%d..%d) on %s is not inside the document (%d lines)",
+					line, start, end, uri, len(lines))
+				return
+			}
+			if covered := lines[line][start:end]; covered != name {
+				s.renameErr = fmt.Errorf("rename edit [%d:%d..%d) on %s covers %q, but the identifier being renamed is %q:"+
+					" applying this edit replaces part of a name and leaves the rest (#463)",
+					line, start, end, uri, covered, name)
+				return
+			}
+		}
+	}
 }
 
 func (s *session) opPrepareRename(a opArgs) {
@@ -1021,6 +1118,9 @@ func runSession(srcA, srcB, script []byte) error {
 		if s.tokenErr != nil {
 			return s.tokenErr
 		}
+		if s.renameErr != nil {
+			return s.renameErr
+		}
 	}
 	// Any timer still armed would fire after the session is over, on a
 	// goroutine belonging to no input.
@@ -1201,6 +1301,29 @@ func FuzzLSPSession(f *testing.F) {
 	add("(defun f (x) x)\r\n(f 1)\r\n", "", allOpsScript())
 	add("(defun f (x) x)\r(f 1)", "", allOpsScript())
 	add("(defun éèê (x) x)\n(éèê 1)", "", allOpsScript())
+
+	// More NON-ASCII IDENTIFIERS, for checkRenameSpans (elps#463).  The one
+	// above already reaches the assertion, but it is a single shape: three
+	// two-byte runes.  These vary what the defect's arithmetic keys on -- how
+	// many bytes are lost is len(name)-runeCount(name), and whether the result
+	// is merely a WRONG program or is not valid UTF-8 at all depends on whether
+	// the identifier's LAST rune is multi-byte.
+	//
+	// Seeded deliberately rather than left to mutation, for the reason PR #462
+	// had to hand-seed its escaped-string case: an assertion no seed reaches is
+	// not an assertion, and random bytes rarely land on well-formed multi-byte
+	// UTF-8 inside an identifier the analyser will resolve.
+	add("(defun éx (a) a)\n(éx 1)", "", allOpsScript())                 // leading multi-byte
+	add("(defun xé (a) a)\n(xé 1)", "", allOpsScript())                 // TRAILING: leftover is a bare continuation byte
+	add("(defun 加算 (a b) (+ a b))\n(加算 1 2)", "", allOpsScript())       // three-byte runes
+	add("(defun 𝛼𝛽 (a) a)\n(𝛼𝛽 1)", "", allOpsScript())                 // four-byte runes, outside the BMP
+	add("(set λ 1)\nλ", "", allOpsScript())                             // a variable, not a function
+	add("(defun f (é) (g é))\n(defun g (x) x)", "", allOpsScript())     // ASCII name on a non-ASCII line
+	add("(in-package 'é)\n(defun é:f () 1)\n(é:f)", "", allOpsScript()) // non-ASCII package qualifier
+	// Cross-file: the definition is in A and the reference in B, so the rename
+	// has to produce edits for a document the cursor is not in.
+	add("(in-package 'demo)\n(defun éx (a) a)\n(export 'éx)",
+		"(in-package 'user)\n(use-package 'demo)\n(éx 1)", allOpsScript())
 	add("\t\t(defun f (x)\n\t\tx)", "", allOpsScript())
 	add("(defun f (x", "", allOpsScript())
 	add(";; only a comment", "", allOpsScript())
@@ -1398,6 +1521,9 @@ func TestLSPFuzzScriptReachesEveryOp(t *testing.T) {
 	}
 	if s.tokenErr != nil {
 		t.Fatalf("%v", s.tokenErr)
+	}
+	if s.renameErr != nil {
+		t.Fatalf("%v", s.renameErr)
 	}
 }
 

--- a/lsp/rename_utf8_test.go
+++ b/lsp/rename_utf8_test.go
@@ -1,0 +1,261 @@
+// Copyright © 2026 The ELPS authors
+
+package lsp
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// This file is the END-TO-END pin for elps#463: it renames, APPLIES the edits
+// the way a client does, and compares the resulting DOCUMENT TEXT.
+//
+// It is deliberately not a test about a column number.  #463 was a wrong
+// integer -- token.TokenEnd counted EndCol one per RUNE onto the byte-valued
+// Col that Scanner.LocStart produces -- but what made it the highest-priority
+// bug in the repository was not the integer.  It was that textDocument/rename
+// builds its TextEdit ranges from that integer, so the edit was NARROWER than
+// the identifier, the rename replaced a prefix and left the tail, and the user
+// got a different program with no diagnostic and nothing to un-apply.  A test
+// asserting EndCol == 11 would pass the moment the arithmetic is right and
+// would never have told anyone what was at stake; this one fails with the
+// corrupted source in the failure message.
+//
+// UNITS.  The edits are applied by treating Character as a BYTE offset, which
+// is what this server means by it (Scanner.LocStart counts bytes,
+// elpsToLSPPosition passes the column through unchanged, and position.go
+// slices lines by byte throughout).  That choice is what keeps this file about
+// elps#463 and not about elps#464.  #464 is that LSP 3.16 specifies UTF-16
+// code units and this server emits bytes without negotiating positionEncoding
+// -- a real gap, and orthogonal: applying these edits in the server's OWN
+// declared unit still corrupted the document, because Col and EndCol did not
+// agree with EACH OTHER.  No wire encoding can rescue a range whose two ends
+// are counted differently, so #463 is a defect under every answer #464 might
+// get, and fixing it settles nothing about #464.  Nothing in this file asserts
+// that bytes are the right unit to send.
+
+// applyTextEdits applies LSP TextEdits to content the way a client does,
+// interpreting Range.Character as a BYTE offset into the line (see UNITS
+// above).  Edits are applied last-first so that earlier offsets stay valid.
+func applyTextEdits(t *testing.T, content string, edits []protocol.TextEdit) string {
+	t.Helper()
+	lines := strings.Split(content, "\n")
+	// lineOffset[i] is the byte offset of the first byte of line i.  The +1 is
+	// the "\n" that Split consumed.
+	lineOffset := make([]int, len(lines)+1)
+	for i, l := range lines {
+		lineOffset[i+1] = lineOffset[i] + len(l) + 1
+	}
+	offsetOf := func(p protocol.Position) int {
+		line := int(p.Line)
+		require.Less(t, line, len(lines), "edit position names line %d of a %d-line document", line, len(lines))
+		off := lineOffset[line] + int(p.Character)
+		require.LessOrEqual(t, off, len(content), "edit position %d:%d is past the end of the document", p.Line, p.Character)
+		return off
+	}
+	type resolved struct {
+		start, end int
+		text       string
+	}
+	rs := make([]resolved, 0, len(edits))
+	for _, e := range edits {
+		r := resolved{start: offsetOf(e.Range.Start), end: offsetOf(e.Range.End), text: e.NewText}
+		require.LessOrEqual(t, r.start, r.end, "edit range is inverted")
+		rs = append(rs, r)
+	}
+	sort.Slice(rs, func(i, j int) bool { return rs[i].start > rs[j].start })
+	out := []byte(content)
+	for _, r := range rs {
+		out = append(out[:r.start], append([]byte(r.text), out[r.end:]...)...)
+	}
+	return string(out)
+}
+
+// renameAt runs textDocument/rename at a 0-based position and returns the
+// document text a client would end up with.
+func renameAt(t *testing.T, s *Server, uri, content string, line, char int, newName string) string {
+	t.Helper()
+	edit, err := s.textDocumentRename(mockContext(), &protocol.RenameParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(uri)},
+			Position:     protocol.Position{Line: safeUint(line), Character: safeUint(char)},
+		},
+		NewName: newName,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, edit, "rename returned no workspace edit")
+	edits := edit.Changes[protocol.DocumentUri(uri)]
+	require.NotEmpty(t, edits, "rename produced no edits for %s", uri)
+	return applyTextEdits(t, content, edits)
+}
+
+// TestRenameNonASCIIIdentifierRewritesWholeName is the RED test for elps#463.
+//
+// Run on 4737835, the commit this branch is based on, the six rows whose
+// IDENTIFIER is non-ASCII failed, each having replaced only a PREFIX of the
+// name.  Captured verbatim:
+//
+//	éx    -> zz  gave "(defun zzx (a) a)\n(zzx 1)\n"
+//	xé    -> zz  gave "(defun zz\xa9 (a) a)\n(zz\xa9 1)\n"
+//	éèê   -> abc gave "(defun abc\xa8ê (x) x)\n(abc\xa8ê 1)\n"
+//	λ     -> zz  gave "(set zz\xbb 1)\nzz\xbb\n"
+//	加算  -> add gave "(defun add\xa0算 (a b) (+ a b))\n(add\xa0算 1 2)\n"
+//	𝛼𝛽    -> ab  gave "(defun ab\x9b\xbc𝛽 (a) a)\n(ab\x9b\xbc𝛽 1)\n"
+//
+// The first is a well-formed program with different semantics -- the worst
+// outcome of the set, because it compiles and runs and the user has no reason
+// to look.  The other five are not valid text at all: the leftover starts
+// mid-rune, so what is left behind is a bare UTF-8 continuation byte.  Either
+// way the client applied a well-formed edit and had no way to know.
+//
+// The last three rows are GUARDS: they passed on 4737835 and pass here, and
+// are not counted as catches.  Two are plain ASCII.  The third,
+// non-ascii-earlier-on-the-line, is the more interesting one -- the LINE holds
+// a multi-byte rune but the NAME being renamed does not, and it passed on
+// 4737835 because Col was already a correct byte column and EndCol == Col+1 is
+// right for a one-byte name wherever on the line it sits.  It is here to pin
+// exactly that: the defect was in the WIDTH of the span, never in its start,
+// so a fix that adjusted starts would be wrong and this row would catch it.
+func TestRenameNonASCIIIdentifierRewritesWholeName(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		line    int
+		char    int // 0-based BYTE column of a position inside the identifier
+		newName string
+		want    string
+		guard   bool
+	}{{
+		name:    "two-byte-lead-rune",
+		content: "(defun éx (a) a)\n(éx 1)\n",
+		line:    0, char: 7,
+		newName: "zz",
+		want:    "(defun zz (a) a)\n(zz 1)\n",
+	}, {
+		name:    "two-byte-trailing-rune", // leftover is a bare continuation byte
+		content: "(defun xé (a) a)\n(xé 1)\n",
+		line:    0, char: 7,
+		newName: "zz",
+		want:    "(defun zz (a) a)\n(zz 1)\n",
+	}, {
+		name:    "all-multi-byte",
+		content: "(defun éèê (x) x)\n(éèê 1)\n",
+		line:    0, char: 7,
+		newName: "abc",
+		want:    "(defun abc (x) x)\n(abc 1)\n",
+	}, {
+		name:    "greek-variable",
+		content: "(set λ 1)\nλ\n",
+		line:    0, char: 5,
+		newName: "zz",
+		want:    "(set zz 1)\nzz\n",
+	}, {
+		name:    "three-byte-runes", // CJK: 3 bytes per rune, so the range was 2/3 short
+		content: "(defun 加算 (a b) (+ a b))\n(加算 1 2)\n",
+		line:    0, char: 7,
+		newName: "add",
+		want:    "(defun add (a b) (+ a b))\n(add 1 2)\n",
+	}, {
+		name:    "four-byte-runes", // outside the BMP
+		content: "(defun 𝛼𝛽 (a) a)\n(𝛼𝛽 1)\n",
+		line:    0, char: 7,
+		newName: "ab",
+		want:    "(defun ab (a) a)\n(ab 1)\n",
+	}, {
+		// GUARD: passed on 4737835.  The LINE is non-ASCII, the NAME is not.
+		name:    "non-ascii-earlier-on-the-line",
+		content: "(defun f (é) (g é))\n(defun g (x) x)\n(f 1)\n",
+		line:    0, char: 15,
+		newName: "h",
+		want:    "(defun f (é) (h é))\n(defun h (x) x)\n(f 1)\n",
+		guard:   true,
+	}, {
+		name:    "ascii-baseline", // GUARD: passed on 4737835
+		content: "(defun add (x y) (+ x y))\n(add 1 2)\n",
+		line:    0, char: 7,
+		newName: "sum",
+		want:    "(defun sum (x y) (+ x y))\n(sum 1 2)\n",
+		guard:   true,
+	}, {
+		name:    "ascii-longer-new-name", // GUARD: passed on 4737835
+		content: "(set x 1)\nx\n",
+		line:    0, char: 5,
+		newName: "counter",
+		want:    "(set counter 1)\ncounter\n",
+		guard:   true,
+	}} {
+		// The GUARD suffix is in the subtest NAME so that `go test -v` says
+		// which rows could have caught elps#463 and which are only pinning
+		// that it did not move: a guard that quietly reads as a catch is how a
+		// suite comes to look stronger than it is.
+		name := tc.name
+		if tc.guard {
+			name += "-GUARD"
+		}
+		t.Run(name, func(t *testing.T) {
+			s := testServer()
+			uri := fmt.Sprintf("file:///test/rename-%s.lisp", tc.name)
+			openDoc(s, uri, tc.content)
+			got := renameAt(t, s, uri, tc.content, tc.line, tc.char, tc.newName)
+
+			assert.Equal(t, tc.want, got, "rename produced a different program than the user asked for")
+			assert.True(t, utf8.ValidString(got),
+				"rename produced text that is not valid UTF-8: %q", got)
+			assert.NotContains(t, got, tc.newName+tc.newName,
+				"the new name appears doubled, which means an edit range overlapped another")
+		})
+	}
+}
+
+// TestRenameNonASCIIRoundTripsThroughTheParser is the same defect stated as a
+// property rather than as expected text: whatever the rename produces has to
+// still be the program the user had, with one name changed.  Re-analysing the
+// result and asking for the new name back is the check.
+//
+// It exists because equality against a `want` string can be satisfied by
+// writing the wrong string into the test.  This cannot: the renamed document
+// has to parse, and the symbol has to be found under its NEW name at a
+// position where the old one was.
+func TestRenameNonASCIIRoundTripsThroughTheParser(t *testing.T) {
+	for i, content := range []string{
+		"(defun éx (a) a)\n(éx 1)\n",
+		"(defun xé (a) a)\n(xé 1)\n",
+		"(defun éèê (x) x)\n(éèê 1)\n",
+		"(defun 加算 (a b) (+ a b))\n(加算 1 2)\n",
+		"(defun add (x y) (+ x y))\n(add 1 2)\n", // GUARD: ASCII, passed on 4737835
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			s := testServer()
+			uri := fmt.Sprintf("file:///test/roundtrip%d.lisp", i)
+			openDoc(s, uri, content)
+			got := renameAt(t, s, uri, content, 0, 7, "renamed")
+
+			require.True(t, utf8.ValidString(got), "renamed document is not valid UTF-8: %q", got)
+
+			// The renamed document must analyse, and the new name must be a
+			// symbol in it with as many references as the old name had.
+			s2 := testServer()
+			uri2 := uri + ".renamed"
+			openDoc(s2, uri2, got)
+			doc := s2.docs.Get(uri2)
+			require.NotNil(t, doc)
+			s2.ensureAnalysis(doc)
+			require.NotNil(t, doc.analysis, "renamed document did not analyse")
+
+			var found bool
+			for _, sym := range doc.analysis.Symbols {
+				if sym.Name == "renamed" {
+					found = true
+				}
+			}
+			assert.True(t, found, "renamed document has no symbol %q; got %q", "renamed", got)
+		})
+	}
+}

--- a/lsp/rename_utf8_test.go
+++ b/lsp/rename_utf8_test.go
@@ -5,6 +5,7 @@ package lsp
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -84,14 +85,14 @@ func renameAt(t *testing.T, s *Server, uri, content string, line, char int, newN
 	t.Helper()
 	edit, err := s.textDocumentRename(mockContext(), &protocol.RenameParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-			TextDocument: protocol.TextDocumentIdentifier{URI: protocol.DocumentUri(uri)},
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 			Position:     protocol.Position{Line: safeUint(line), Character: safeUint(char)},
 		},
 		NewName: newName,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, edit, "rename returned no workspace edit")
-	edits := edit.Changes[protocol.DocumentUri(uri)]
+	edits := edit.Changes[uri]
 	require.NotEmpty(t, edits, "rename produced no edits for %s", uri)
 	return applyTextEdits(t, content, edits)
 }
@@ -231,7 +232,7 @@ func TestRenameNonASCIIRoundTripsThroughTheParser(t *testing.T) {
 		"(defun 加算 (a b) (+ a b))\n(加算 1 2)\n",
 		"(defun add (x y) (+ x y))\n(add 1 2)\n", // GUARD: ASCII, passed on 4737835
 	} {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			s := testServer()
 			uri := fmt.Sprintf("file:///test/roundtrip%d.lisp", i)
 			openDoc(s, uri, content)

--- a/parser/rdparser/fuzz_test.go
+++ b/parser/rdparser/fuzz_test.go
@@ -224,8 +224,9 @@ func TestParserSurvivesPathologicalInput(t *testing.T) {
 	}
 }
 
-// FuzzParsedLocationInvariants states, over arbitrary input, the three
-// position properties elps#426 broke.  For every node the reader produces:
+// FuzzParsedLocationInvariants states, over arbitrary input, the position
+// properties the reader has to satisfy.  Three are the ones elps#426 broke; the
+// fourth is elps#463.  For every node the reader produces:
 //
 //  1. It owns its *token.Location.  No two distinct nodes in one parse tree
 //     may hold the same object.  Sharing is what let applyPrefixLocation move
@@ -246,6 +247,29 @@ func TestParserSurvivesPathologicalInput(t *testing.T) {
 //     reported its outer form as ending four columns before its own operand
 //     did.
 //
+//  4. Its column span agrees with its byte span.  On a node that begins and
+//     ends on ONE line, EndCol-Col == EndPos-Pos.  This is elps#463: TokenEnd
+//     derived EndCol by counting RUNES onto the byte-valued Col that
+//     Scanner.LocStart computes, so on a token holding any multi-byte rune the
+//     two ends of a single Location were counted in different units and EndCol
+//     was short by len(text)-runeCount(text).
+//
+//     It belongs HERE, at the reader, rather than only in the LSP tests where
+//     the damage showed up.  EndCol has consumers in lsp/, lint/, analysis/ and
+//     mcpserver/ that each add it to or compare it against a byte column, and
+//     one wrong producer is what made all of them wrong at once; a property
+//     stated at the producer covers the consumers that exist and the ones that
+//     have not been written.  The rename corruption it caused is pinned
+//     separately and end-to-end in
+//     lsp.TestRenameNonASCIIIdentifierRewritesWholeName -- an integer here, the
+//     user's file there.
+//
+//     Note what this does NOT say: which unit.  It says the two ends agree,
+//     which they must whatever elps#464 concludes about the UTF-16 code units
+//     LSP asks for on the wire.  A multi-line node is exempt because its column
+//     restarts at its last newline, so the two spans measure different things
+//     by construction.
+//
 // Locations are checked only for nodes that carry a real one (Pos >= 0);
 // synthetic locations are a separate invariant, pinned by
 // assertRealSourceLocations and TestParserEmitsNoSyntheticSourceLocations.
@@ -255,6 +279,26 @@ func FuzzParsedLocationInvariants(f *testing.F) {
 		"'a", "''a", "'''''test", "#'car", "#^a", "'#'car", "'#^a", "''#^a",
 		"#^#'a", "#^(+ %1 1)", "(quote x)", "(map 'list #'car '((1 2)))",
 		"(quasiquote ''(unquote-splicing '(+ 2 3)))",
+		// NON-ASCII, for invariant 4 (elps#463).  Seeded deliberately and not
+		// relied on from fuzzseed.All(), for the reason PR #462 had to seed the
+		// escaped-string case by hand: an assertion no seed reaches is not an
+		// assertion, and mutation alone is a poor way to arrive at well-formed
+		// multi-byte UTF-8 inside an identifier.  Two, three and four byte
+		// runes, in a symbol, a keyword, a string, a comment, a package
+		// qualifier, quoted and prefixed forms, and spanning a line break.
+		"(defun éx (a) a)\n(éx 1)",
+		"(set λ 1)\nλ",
+		"(defun 加算 (a b) (+ a b))\n(加算 1 2)",
+		"(defun 𝛼𝛽 (a) a)\n(𝛼𝛽 1)",
+		"'éx", "#'éx", "#^éx", "''é",
+		":é", "é:ê", "(é:ê 1)",
+		`"é"`, `"a\té"`, `"""é\nê"""`,
+		"; é\n(f é)",
+		"(f é) ; ê",
+		"(défun f (é ê) (+ é ê))",
+		"(f\n  é\n  ê)",
+		"é\r\nê",
+		"\té\t(f é)",
 	} {
 		f.Add([]byte(s))
 	}
@@ -293,6 +337,16 @@ func FuzzParsedLocationInvariants(f *testing.F) {
 								formatting, v.Type, v.Str, loc.Pos, loc.EndPos,
 								parent.Type, parent.Str, parent.Source.Pos, parent.Source.EndPos)
 						}
+					}
+				}
+				// Invariant 4 (elps#463): on a single-line node the column
+				// span and the byte span are the same span, so they have the
+				// same width.  Guarded on all four fields being tracked --
+				// the fault-tolerant parser can leave end positions unset.
+				if loc.Line > 0 && loc.Col > 0 && loc.EndLine == loc.Line && loc.EndCol > 0 && loc.EndPos > 0 {
+					if colSpan, byteSpan := loc.EndCol-loc.Col, loc.EndPos-loc.Pos; colSpan != byteSpan {
+						t.Fatalf("formatting=%v: node %v %q at %v spans %d columns (Col %d..EndCol %d) but %d bytes (Pos %d..EndPos %d); Location's ends are in different units (#463)",
+							formatting, v.Type, v.Str, loc, colSpan, loc.Col, loc.EndCol, byteSpan, loc.Pos, loc.EndPos)
 					}
 				}
 				for _, c := range v.Cells {

--- a/parser/token/token.go
+++ b/parser/token/token.go
@@ -95,15 +95,42 @@ func (typ Type) String() string {
 	return typeStrings[typ] //nolint:gosec // bounds checked above
 }
 
+// Location is a span in a source stream.
+//
+// UNITS.  Every offset and column in this struct is counted in BYTES, and
+// says so on its own line below.  The unit is not a detail: Col and EndCol
+// are subtracted from and added to each other by consumers all over the tree
+// (analysis.scopeContainingAnalysis, lsp.locContainsCol, lsp.elpsToLSPRange,
+// lint.endPosFromNode), and a value in one unit compared against a value in
+// another is wrong without being obviously wrong.  Whatever unit is chosen,
+// the four position fields have to agree on it.
+//
+// They did not.  TokenEnd derived EndCol by counting RUNES onto Scanner's
+// byte-valued Col, so on any token containing a multi-byte rune EndCol was
+// short by len(text)-utf8.RuneCountInString(text) and was in neither unit.
+// Every LSP range built from EndCol was correspondingly short, and
+// textDocument/rename -- which builds its TextEdit ranges from the same
+// helper -- therefore replaced fewer bytes than the name occupied and left
+// the tail behind: renaming "éx" to "zz" produced "zzx", a different program,
+// silently (elps#463).  The absence of a stated unit is what allowed that, so
+// the unit is stated here.
+//
+// BYTES is an INTERNAL convention, not what LSP asks for: LSP 3.16 counts a
+// position in UTF-16 code units unless client and server negotiate otherwise,
+// and this server neither offers positionEncoding nor converts anything.
+// That server-wide gap is elps#464 and is deliberately not what this comment
+// settles.  #464 is about which unit crosses the wire; the requirement here
+// is only that these four fields agree with EACH OTHER, which they must under
+// any choice #464 goes on to make.
 type Location struct {
 	File    string // a name representing the source stream
 	Path    string // a physical location which may differ from File
-	Pos     int
-	Line    int // line number (starting at 1 when tracked)
-	Col     int // line column number (starting at 1 when tracked)
-	EndPos  int // byte position past end of token/expr (0 = not tracked)
-	EndLine int // end line (1-based, 0 = not tracked)
-	EndCol  int // end column (1-based, exclusive, 0 = not tracked)
+	Pos     int    // BYTE offset of the first byte of the token/expr
+	Line    int    // line number (starting at 1 when tracked)
+	Col     int    // BYTE column within the line (1-based; 0 = not tracked)
+	EndPos  int    // BYTE offset one past the last byte (0 = not tracked)
+	EndLine int    // end line (1-based, 0 = not tracked)
+	EndCol  int    // BYTE column one past the last byte (1-based, exclusive; 0 = not tracked)
 }
 
 func (loc *Location) String() string {
@@ -163,23 +190,57 @@ func (loc *Location) Copy() *Location {
 	return &cp
 }
 
-// TokenEnd computes the end position of a token from its start position
-// and text. The end column is exclusive (one past the last character).
-// For multi-line tokens (e.g., raw strings), the line and column are
-// adjusted accordingly.
+// TokenEnd computes the end position of a token from its start position and
+// text.  All three results are in the units Location documents: endCol is an
+// exclusive BYTE column, endPos an absolute BYTE offset.  For a multi-line
+// token (a raw string) the line and column are adjusted accordingly.
+//
+// THE DEFECT (elps#463).  This used to advance col by ONE PER RUNE:
+//
+//	for _, ch := range tok.Text {
+//		if ch == '\n' { line++; col = 1 } else { col++ }
+//	}
+//
+// `range` over a string iterates runes, so that produced Col + runeCount --
+// a rune width added to the byte base Scanner.LocStart computes as
+// `startPos - s.startLinePos + 1`.  On a pure-ASCII token the two units
+// coincide and it was right by accident; on a token holding any multi-byte
+// rune it was short by len(text)-runeCount(text) and was in neither unit,
+// while endPos beside it was already byte-exact.  A field that is correct for
+// most inputs and quietly wrong for the rest is the shape of bug that reaches
+// users, and this one reached them through textDocument/rename: the edit
+// range was narrower than the identifier, so the rename replaced a prefix and
+// left the tail, turning "éx" into "zzx" rather than "zz" with no diagnostic.
+// TestRenameNonASCIIIdentifierRewritesWholeName is the end-to-end pin.
+//
+// Counting BYTES rather than runes here is the whole fix, and it is a fix
+// under either answer to elps#464 (whether the SERVER should be emitting
+// UTF-16 code units on the wire): the invariant this restores is that endCol
+// agrees with the Col it is measured from, which any wire encoding needs
+// before it can convert anything.
+//
+// The loop scans bytes rather than runes deliberately.  A byte scan is exact
+// on invalid UTF-8, where `range` yields RuneError with a width that does not
+// describe the input; '\n' cannot occur as a UTF-8 continuation byte, so
+// looking for it bytewise finds exactly the newlines a rune scan would.
 func TokenEnd(tok *Token) (endLine, endCol, endPos int) {
 	if tok == nil || tok.Source == nil {
 		return 0, 0, 0
 	}
 	line := tok.Source.Line
-	col := tok.Source.Col
-	for _, ch := range tok.Text {
-		if ch == '\n' {
+	// lineStart is the index in tok.Text of the first byte of the last line
+	// the token covers, or -1 while the token has not crossed a newline and
+	// the end column is therefore still measured from tok.Source.Col.
+	lineStart := -1
+	for i := 0; i < len(tok.Text); i++ {
+		if tok.Text[i] == '\n' {
 			line++
-			col = 1
-		} else {
-			col++
+			lineStart = i + 1
 		}
+	}
+	col := tok.Source.Col + len(tok.Text)
+	if lineStart >= 0 {
+		col = len(tok.Text) - lineStart + 1
 	}
 	return line, col, tok.Source.Pos + len(tok.Text)
 }

--- a/parser/token/token.go
+++ b/parser/token/token.go
@@ -232,7 +232,7 @@ func TokenEnd(tok *Token) (endLine, endCol, endPos int) {
 	// the token covers, or -1 while the token has not crossed a newline and
 	// the end column is therefore still measured from tok.Source.Col.
 	lineStart := -1
-	for i := 0; i < len(tok.Text); i++ {
+	for i := range len(tok.Text) {
 		if tok.Text[i] == '\n' {
 			line++
 			lineStart = i + 1

--- a/parser/token/token_test.go
+++ b/parser/token/token_test.go
@@ -94,3 +94,102 @@ func TestLocationError_Error_ExactFormat(t *testing.T) {
 	}
 	assert.Equal(t, "test.lisp:1:1: bad syntax", lerr.Error())
 }
+
+// TestTokenEndCountsBytes is the unit-level RED test for elps#463.
+//
+// TokenEnd advanced its column one per RUNE (`for _, ch := range tok.Text`)
+// onto the byte-valued Col that Scanner.LocStart computes, so the end column
+// of any token holding a multi-byte rune was short by
+// len(text)-utf8.RuneCountInString(text).  The corruption that came out of
+// that is pinned end-to-end in lsp.TestRenameNonASCIIIdentifierRewritesWholeName;
+// this is the arithmetic underneath it.
+//
+// THE INVARIANT is the last assertion in each row and the point of the whole
+// exercise: on a single-line token the column span must equal the byte span,
+// endCol-Col == endPos-Pos.  It says the two ends of a Location are counted in
+// the same unit without saying which unit that is, so it stays true under
+// whatever elps#464 decides the server should put on the wire.
+//
+// Rows marked GUARD passed before the fix -- a byte and a rune are the same
+// width in ASCII, which is exactly why this survived so long -- and are here
+// only to pin that the common case did not move.
+func TestTokenEndCountsBytes(t *testing.T) {
+	for _, tc := range []struct {
+		name                       string
+		text                       string
+		line, col, pos             int
+		wantLine, wantCol, wantPos int
+		guard                      bool
+	}{
+		{name: "ascii symbol", text: "add", line: 1, col: 8, pos: 7,
+			wantLine: 1, wantCol: 11, wantPos: 10, guard: true},
+		{name: "empty text", text: "", line: 1, col: 8, pos: 7,
+			wantLine: 1, wantCol: 8, wantPos: 7, guard: true},
+		// éx is 3 bytes / 2 runes.  Before the fix: endCol 10, one short.
+		{name: "two-byte lead rune", text: "éx", line: 1, col: 8, pos: 7,
+			wantLine: 1, wantCol: 11, wantPos: 10},
+		// 加算 is 6 bytes / 2 runes.  Before the fix: endCol 10, four short.
+		{name: "three-byte runes", text: "加算", line: 1, col: 8, pos: 7,
+			wantLine: 1, wantCol: 14, wantPos: 13},
+		// 𝛼 is 4 bytes / 1 rune.  Before the fix: endCol 9, three short.
+		{name: "astral rune", text: "𝛼", line: 1, col: 8, pos: 7,
+			wantLine: 1, wantCol: 12, wantPos: 11},
+		// A multi-line token restarts its column at the last newline, so the
+		// start column drops out and only the bytes after it count.
+		{name: "multi-line ascii", text: "\"\"\"a\nbc\"\"\"", line: 1, col: 3, pos: 2,
+			wantLine: 2, wantCol: 6, wantPos: 12, guard: true},
+		// The multi-byte rune is AFTER the last newline, so it is inside the
+		// span the column measures.  Before the fix: endCol 5, one short.
+		{name: "multi-line non-ascii after the newline", text: "\"\"\"a\né\"\"\"", line: 1, col: 3, pos: 2,
+			wantLine: 2, wantCol: 6, wantPos: 12},
+		// GUARD, and the mirror image: the multi-byte rune is BEFORE the last
+		// newline, so it drops out of the column entirely and the old rune
+		// count and the new byte count agree.  It pins that bytes on earlier
+		// lines are not counted -- the plausible over-correction of just
+		// swapping the loop for len(text).
+		{name: "non-ascii before the newline only", text: "\"\"\"é\nb\"\"\"", line: 1, col: 3, pos: 2,
+			wantLine: 2, wantCol: 5, wantPos: 12, guard: true},
+		// GUARD.  Invalid UTF-8, where a byte scan is exact and `range` yields
+		// RuneError with a width that need not describe the input.  It passed
+		// before the fix too: on THIS input `range` happens to yield three
+		// one-byte steps, so the two counts coincide.  It is here because the
+		// byte scan is a deliberate choice in TokenEnd and something should
+		// hold it, not because it caught anything.
+		{name: "invalid utf-8", text: "a\xffb", line: 1, col: 1, pos: 0,
+			wantLine: 1, wantCol: 4, wantPos: 3, guard: true},
+	} {
+		name := tc.name
+		if tc.guard {
+			name += " (GUARD)"
+		}
+		t.Run(name, func(t *testing.T) {
+			tok := &Token{
+				Type:   SYMBOL,
+				Text:   tc.text,
+				Source: &Location{File: "t.lisp", Line: tc.line, Col: tc.col, Pos: tc.pos},
+			}
+			endLine, endCol, endPos := TokenEnd(tok)
+			assert.Equal(t, tc.wantLine, endLine, "endLine")
+			assert.Equal(t, tc.wantCol, endCol, "endCol")
+			assert.Equal(t, tc.wantPos, endPos, "endPos")
+
+			// THE INVARIANT.  Only meaningful on a single-line token: across a
+			// newline the column restarts and the two spans measure different
+			// things by design.
+			if endLine == tc.line {
+				assert.Equal(t, endPos-tc.pos, endCol-tc.col,
+					"column span (%d-%d) disagrees with byte span (%d-%d): Location's fields are in different units",
+					endCol, tc.col, endPos, tc.pos)
+			}
+		})
+	}
+}
+
+// TestTokenEndNilSafe pins the two nil guards, which have no bearing on
+// elps#463 but are the only other behaviour TokenEnd has.  GUARD.
+func TestTokenEndNilSafe(t *testing.T) {
+	l, c, p := TokenEnd(nil)
+	assert.Equal(t, [3]int{0, 0, 0}, [3]int{l, c, p})
+	l, c, p = TokenEnd(&Token{Text: "abc"})
+	assert.Equal(t, [3]int{0, 0, 0}, [3]int{l, c, p})
+}


### PR DESCRIPTION
Fixes #463.

## The corruption, reproduced

On `4737835`, opening `(defun éx (a) a)\n(éx 1)\n` and renaming `éx` to `zz` returns two well-formed edits:

```
EDIT file:///…/rename.lisp [0:7..0:9] -> "zz"
EDIT file:///…/rename.lisp [1:1..1:3] -> "zz"
```

Applying them the way a client does gives:

```lisp
(defun zzx (a) a)
(zzx 1)
```

A different program, silently. There is no diagnostic and nothing to un-apply — as far as the client can tell the server answered correctly.

Where the identifier's **last** rune is multi-byte the leftover is a bare UTF-8 continuation byte and the file stops being valid text at all. All six captured from `4737835`:

| rename | result on `4737835` |
|---|---|
| `éx` → `zz` | `"(defun zzx (a) a)\n(zzx 1)\n"` — valid program, wrong semantics |
| `xé` → `zz` | `"(defun zz\xa9 (a) a)\n(zz\xa9 1)\n"` — invalid UTF-8 |
| `éèê` → `abc` | `"(defun abc\xa8ê (x) x)\n(abc\xa8ê 1)\n"` — invalid UTF-8 |
| `λ` → `zz` | `"(set zz\xbb 1)\nzz\xbb\n"` — invalid UTF-8 |
| `加算` → `add` | `"(defun add\xa0算 (a b) (+ a b))\n(add\xa0算 1 2)\n"` — invalid UTF-8 |
| `𝛼𝛽` → `ab` | `"(defun ab\x9b\xbc𝛽 (a) a)\n(ab\x9b\xbc𝛽 1)\n"` — invalid UTF-8 |

The first row is the worst of the set: it compiles and runs, so the user has no reason to look.

## The cause

`token.TokenEnd` advanced its column **one per rune**:

```go
for _, ch := range tok.Text {          // range over a string iterates RUNES
    if ch == '\n' { line++; col = 1 } else { col++ }
}
```

`range` over a string iterates runes, so this produced `Col + runeCount`. But `Col` is a **byte** offset — `Scanner.LocStart` computes it as `startPos - s.startLinePos + 1`, where both terms derive from `s.totalPos`, which `Scanner.scan` advances by `old.N`, the **byte** width of the rune. So `EndCol` was a rune count added to a byte base: right by accident on pure-ASCII tokens, and short by `len(text) - runeCount(text)` on anything else — in neither unit. `EndPos` beside it was already byte-exact.

`elpsToLSPRange` prefers `EndCol` whenever it is set, and `textDocument/rename` builds its `TextEdit` ranges from that helper, so the edit range was narrower than the identifier.

### Which field carries which unit, and how that was established

Read off the producers, not assumed:

| field | unit | established by |
|---|---|---|
| `Pos` | bytes | `Scanner.LocStart`: `startPos` derives from `s.totalPos`, advanced by `old.N` (rune byte width) in `Scanner.scan` |
| `Col` | bytes | `Scanner.LocStart`: `startPos - s.startLinePos + 1`; `startLinePos` is also a `totalPos` snapshot |
| `EndPos` | bytes | `TokenEnd`: `tok.Source.Pos + len(tok.Text)` |
| `EndCol` | **was neither** | `TokenEnd`: `Col` (bytes) `+ runeCount` |

This confirms #463's report independently.

## The fix

Count bytes, and **state the unit on every field** — the absence of a stated unit is what let the two drift. The loop now scans bytes rather than runes, which is also exact on invalid UTF-8 (where `range` yields `RuneError` with a width that need not describe the input); `\n` cannot occur as a UTF-8 continuation byte, so a byte scan finds exactly the newlines a rune scan would.

## #463 and #464 are separable, and this PR separates them

They are genuinely distinct, and the reproduction above is the evidence:

- The edits were applied by treating `Character` as a **byte** offset — the server's *own* declared unit, the one `Scanner.LocStart` produces and `position.go` slices lines by throughout. The document was **still** corrupted, because `Col` and `EndCol` did not agree with **each other**. No wire encoding can rescue a range whose two ends are counted differently.
- The invariant restored here — `EndCol - Col == EndPos - Pos` — says the two ends agree *without saying which unit they agree in*. It stays true under whatever #464 decides.
- Conversely, fixing this settles nothing about #464. The server still emits byte columns where LSP 3.16 specifies UTF-16 code units, and `glsp/protocol_3_16` still has no `positionEncoding` field to negotiate with. That gap is untouched here and remains open.

Nothing in this PR asserts that bytes are the right unit to send.

## Audit of every other `EndCol` / `EndPos` consumer

`lsp/`, `lint/`, `analysis/`, `formatter/`, `minifier/`, `parser/`, plus `mcpserver/` and `diagnostic/`. `TokenEnd` is the **only** site in the tree that added a rune count to a byte offset — confirmed by grepping every `col++` and every `EndCol`/`EndPos` reference.

**Made correct by this fix; not changed, because the defect was in the producer:**

- `lsp/position.go` — `elpsToLSPRange` (the shared helper behind `call_hierarchy.go`, `code_actions.go`, `definition.go`, `highlight.go`, `hover.go`, `linked_editing.go`, `references.go`, `rename.go`) and `locContainsCol`, whose fallback `start + len(name)` was already bytes.
- `lsp/selection_range.go`, `lsp/inlay_hints.go`, `lsp/signature.go`, `lsp/call_hierarchy.go` — all compare or emit `EndCol` alongside a byte `Col`.
- `analysis/workspace.go` `scopeContainingAnalysis` — compares an LSP-derived `col` against both `loc.Col` and `loc.EndCol`; a cursor on the last byte of a non-ASCII name was treated as outside the scope.
- `lint/lint.go`, `lint/analyzers.go` `endPosFromNode` — put `EndCol` into a `Position`; the fallback `Col + len(node.Str)` was already bytes. Flows on to `lsp/diagnostics.go` and `mcpserver/service.go`.
- `mcpserver/service.go` — two sites, same shape as the LSP ones.
- `lsp/semantic_tokens.go` `isSynthesizedPrefixHead` — `EndCol - Col == len(prefix)` compares a column span against a **byte** length. Correct-by-accident before (the prefixes `#^` and `#'` are ASCII), genuinely byte-to-byte now.

**Not affected, and why:**

- `lsp/semantic_tokens.go` `atomSpan` — #462 already takes `EndPos - Pos` deliberately and does not use `EndCol`. Unchanged; its `TestSemanticTokensNonASCIISymbolSpans` still guards the distinction.
- `formatter/printer.go` — only asks `Col == 1`, which is unit-agnostic.
- `minifier/minifier.go` — uses `Col` for ordering and identity only; never adds a length to it.
- `diagnostic/` — `diagnostic.Span` is a **separate type** with its own `Col`/`EndCol`. No producer in the tree bridges `token.Location.EndCol` into it (`cmd/diagnostic.go` and `repl/diagnostic.go` set `Col` only and leave `EndCol` zero for auto-detection), so it is out of scope for #463. It does have a unit mismatch of its own, which this audit turned up and which is filed as **#469** rather than fixed here.

## Tests: red on `4737835`, green here

- **`lsp.TestRenameNonASCIIIdentifierRewritesWholeName`** — the headline. Renames, **applies the edits**, compares the resulting document text, and asserts the result is valid UTF-8. Deliberately not a test about a column number: a test asserting `EndCol == 11` would pass the moment the arithmetic is right and would never say what was at stake. Six rows red on `4737835` with the output in the table above.
- **`lsp.TestRenameNonASCIIRoundTripsThroughTheParser`** — the same defect as a property: the renamed document must re-parse and yield the new name. Four rows red.
- **`parser/token.TestTokenEndCountsBytes`** — the arithmetic underneath, and the invariant `endCol-Col == endPos-Pos`. Four rows red.

**Guards, labelled in-file and in the subtest name (`-GUARD` / `(GUARD)`), not counted as catches:** the ASCII rows; `non-ascii-earlier-on-the-line` (multi-byte rune on the line, ASCII *name* — passed before, and pins that the defect was in the span's **width**, never its start); `non-ascii before the newline only` (pins that bytes on earlier lines are *not* counted — the plausible over-correction of simply swapping the loop for `len(text)`); `invalid utf-8`.

## Fuzzing

Both properties fold into **existing** targets — no new target, so the budget is unchanged at **29 targets / 8 shards / 10 min headroom** (`fuzz-budget-check.sh`: "the sweep fits").

**`FuzzParsedLocationInvariants` gains invariant 4** — on a single-line node, `EndCol - Col == EndPos - Pos`. Stated at the **producer**, so it covers the `EndCol` consumers in `lsp/`, `lint/`, `analysis/` and `mcpserver/` at once, and the ones not written yet.

**`FuzzLSPSession` gains `checkTokenSpans`'s sibling, `checkRenameSpans`** — every rename edit must cover the whole identifier, with `prepareRename`'s `Placeholder` as the oracle (same symbol lookup the server itself uses, so there is no second implementation in the test to disagree). This is the user-visible half: rename is the one request whose answer is applied to the file unread.

Neither says which **unit**, only that the two ends agree — so both survive #464.

**Non-ASCII seeds were required, not optional.** On `4737835` the lowest red seed in `FuzzParsedLocationInvariants` is **#131 — the first of the newly added ones**. The entire pre-existing corpus, `fuzzseed.All()` included, reached invariant 4 **zero times**. This is exactly what #462 found for its escaped-string case, and the reason the seeds are hand-written rather than left to mutation: random bytes rarely land on well-formed multi-byte UTF-8 inside an identifier the analyser will resolve.

Exec counts, clean, no false positives:

| target | execs | result |
|---|---|---|
| `FuzzParsedLocationInvariants` | 1,316,273 | clean |
| `FuzzLSPSession` | 204,497 | clean |

The 1.3M-exec parser run is the stronger evidence: invariant 4 holds for every node shape the parser produces, on arbitrary input.

## Gates

All clean: `go build ./...`, `go vet ./...`, `go test -count=1 ./...`, `go test -race ./...`, `golangci-lint run ./...` (**0 issues**), `elps fmt -l ./...`, `elps doc -m`, `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `./scripts/ci-gates-test.sh` (233 passed, 0 failed), `./scripts/confidentiality-guard.sh` (clean), `./scripts/fuzz-budget-check.sh`. The `elps` binary built for the `fmt`/`doc` gates was deleted before committing and is untracked.

`main` moved to `8402c49` (#467) while this was in flight, touching `parser/rdparser/fuzz_test.go` — one of the files here. Merged, auto-resolved, and `build` / `vet` / `test` / `race` / `golangci-lint` all re-run clean on the merge commit.

**Benchmarks.** The CI gate is the number to read, since both arms run interleaved on one runner at n=10: **`parser/rdparser` shows no significant move on any row** — `sec/op` geomean +0.08%, `B/op` +0.00%, `allocs/op` +0.00%, `B/s` -0.09%, and `Parser/scheme-math.lisp` specifically is `~ (p=0.739)`. `allocs/op` is all-samples-equal on all twelve rows, which is what a fix that allocates nothing should look like. The gate's own verdict: *"5 significant move(s) in the bad direction; 0 at or above the gate (timing 15%, allocation 5%)"* — and all five are in `lisp/` and `libjson`, packages this PR does not touch.

For the record, my local pre-push run on noisier hardware showed `Parser/scheme-math.lisp` at +13.48% (n=6), which shrank to +5.92% on a focused n=10 re-run and to nothing at all on CI. It was machine noise; I am reporting it rather than dropping it because the first figure is the one that would have looked alarming.

The gate also flags two **pre-existing** `waiver-unused` entries (`benchstat-waivers.txt:124-125`, libjson `Encode` `allocs/op` and `B/op`, elps#412/#410). They are unrelated to this change and are left alone.

## Found while doing this

**#469** — `diagnostic/renderer.go` `renderSpan` sizes its caret underline in **bytes** (`endCol - col + 1`) but indents it in **display columns** (`displayWidth`, which ranges over runes). Found by **running**: `(f 加算 1)` gets six carets under a two-rune token and they spill over the following text. Cosmetic, terminal output only, and genuinely separate from #463 — `diagnostic.Span` is its own type and nothing bridges `token.Location.EndCol` into it. Filed, not fixed here, to keep this PR to the corruption. The issue also notes a latent trap beside it: `Span.EndCol` is used with **inclusive** arithmetic while `token.Location.EndCol` is now documented **exclusive**, so the first person to wire one into the other gets an off-by-one underline.