### PR TITLE
Correct InitializeTypedef's contract in the docs, and pin it (#433)

### DIFF
--- a/lisp/env.go
+++ b/lisp/env.go
@@ -56,6 +56,21 @@ func InitializeUserEnv(env *LEnv, config ...Config) *LVal {
 // object is not exported and it should not be handled without abstraction in
 // general because user error can break the type system.
 //
+// InitializeTypedef is a step inside InitializeUserEnv, not an alternative to
+// it.  It requires an environment that InitializeUserEnv has already
+// established: it reads env.Runtime.Package.Name, and it writes the typedef
+// into env.Runtime.Registry.Packages[env.Runtime.Registry.Lang].
+// StandardRuntime leaves Runtime.Package nil and Registry.Lang "" (and
+// Packages[""] is a nil *Package), so on a bare environment --
+// lisp.InitializeTypedef(lisp.NewEnv(nil)) -- this panics on the first of
+// those two before doing anything.
+//
+// The panics stay: under lisp/ a panic means a bug in the interpreter, or in
+// code that had no business calling this (issue #361).  Embedders establish a
+// top-level environment with InitializeUserEnv, which calls this itself; there
+// is no initialization order in which an embedder calls it directly.  See
+// issue #433.
+//
 // See LEnv.TaggedValue for more information about creating tagged-values.
 func InitializeTypedef(env *LEnv) *LVal {
 	ctor := env.builtin(&langBuiltin{"typedef-ctor", Formals("name", "ctor"), func(env *LEnv, args *LVal) *LVal {
@@ -640,9 +655,11 @@ func (env *LEnv) TaggedValue(typ *LVal, val *LVal) *LVal {
 // with the given arguments.  A typedef is an LTaggedVal itself that wraps a
 // list holding the defined type name along with a constructor.
 //
-// New requires that the system have typedef tagged-values.  Generally that
-// will be enabled by calling InitializeTypedef or InitializeUserEnv when
-// initializing the top-level enviornment.
+// New requires that the system have typedef tagged-values.  That is enabled
+// by calling InitializeUserEnv when initializing the top-level environment.
+// InitializeTypedef, which InitializeUserEnv calls, is a step inside it and
+// not a substitute for it: it panics on an environment InitializeUserEnv has
+// not already established.  See its doc comment, and issue #433.
 func (env *LEnv) New(typ *LVal, args *LVal) *LVal {
 	if typ.Type != LTaggedVal {
 		return env.Errorf("first argument is not a typedef: %v", GetType(typ))

--- a/lisp/typedef_init_test.go
+++ b/lisp/typedef_init_test.go
@@ -1,0 +1,110 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// This file pins the CONTRACT of lisp.InitializeTypedef, which issue #433 is
+// about.
+//
+// #433 is a documentation defect, not a code defect.  InitializeTypedef's
+// preconditions -- an environment whose Runtime.Package and Registry.Lang are
+// already established -- are met by exactly one thing, InitializeUserEnv, and
+// InitializeTypedef has exactly one caller in this tree, InitializeUserEnv
+// itself.  What was wrong is that LEnv.New's doc comment offered
+// InitializeTypedef as an ALTERNATIVE to InitializeUserEnv ("Generally that
+// will be enabled by calling InitializeTypedef or InitializeUserEnv"), which
+// it has never been: on a bare environment it panics before doing anything.
+//
+// The panics stay.  Issue #361 settled that policy for lisp/: "a panic in
+// lisp means this is a bug in the interpreter, or in code that had no
+// business calling this".  Downgrading these two to errors would blunt that
+// signal to serve a call no correct embedder makes, and the doc comment was
+// the only thing telling anyone to make it.
+//
+// Every test below is a GUARD -- all of them pass on main.  They exist so the
+// documented contract cannot drift away from the code silently: if someone
+// later adds the nil guards (a legitimate but larger change, per #433), these
+// fail and point at the doc comments that must change with them.
+
+// requirePanics runs fn and returns the recovered value, failing if fn did
+// not panic.
+func requirePanics(t *testing.T, what string, fn func()) (recovered any) {
+	t.Helper()
+	defer func() {
+		recovered = recover()
+		if recovered == nil {
+			t.Errorf("%s: expected a panic, got none;"+
+				" if the nil guards were added deliberately, InitializeTypedef's and"+
+				" LEnv.New's doc comments must stop saying it panics (issue #433)", what)
+		}
+	}()
+	fn()
+	return nil
+}
+
+// TestInitializeTypedefRequiresRuntimePackage is a GUARD: it passes on main.
+// It pins the first of the two unguarded dereferences #433 records -- the
+// env.Runtime.Package.Name read in LEnv.builtin -- which is what a bare
+// lisp.InitializeTypedef(lisp.NewEnv(nil)) hits.  StandardRuntime leaves
+// Runtime.Package nil.
+func TestInitializeTypedefRequiresRuntimePackage(t *testing.T) {
+	env := lisp.NewEnv(nil)
+	if env.Runtime.Package != nil {
+		t.Fatalf("expected StandardRuntime to leave Runtime.Package nil, got %v;"+
+			" this test can no longer observe the precondition it is about", env.Runtime.Package)
+	}
+	v := requirePanics(t, "InitializeTypedef on a bare environment", func() {
+		lisp.InitializeTypedef(env)
+	})
+	if v != nil && !strings.Contains(strings.ToLower(fmt.Sprint(v)), "nil pointer") {
+		t.Errorf("panicked with %v; expected the nil Runtime.Package dereference", v)
+	}
+}
+
+// TestInitializeTypedefRequiresRegistryLang is a GUARD: it passes on main.
+// It pins the SECOND unguarded dereference #433 records, the one the first
+// hides.  Registry.Lang is "" until InitializeUserEnv sets it, and
+// Packages[""] is a nil *Package -- the same shape as issue #425.  Giving the
+// runtime a package (so LEnv.builtin succeeds) but no Lang exposes it: the
+// panic then comes from (*Package).Put, not from LEnv.builtin.
+func TestInitializeTypedefRequiresRegistryLang(t *testing.T) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Registry.DefinePackage(lisp.DefaultLangPackage)
+	env.Runtime.Package = env.Runtime.Registry.Packages[lisp.DefaultLangPackage]
+	if env.Runtime.Registry.Lang != "" {
+		t.Fatalf("expected Registry.Lang to be empty before InitializeUserEnv, got %q",
+			env.Runtime.Registry.Lang)
+	}
+	if env.Runtime.Registry.Packages[env.Runtime.Registry.Lang] != nil {
+		t.Fatalf("expected Packages[%q] to be nil; this test can no longer observe"+
+			" the precondition it is about", env.Runtime.Registry.Lang)
+	}
+	requirePanics(t, "InitializeTypedef with no Registry.Lang", func() {
+		lisp.InitializeTypedef(env)
+	})
+}
+
+// TestInitializeTypedefAfterInitializeUserEnv is the positive control for the
+// two guards above: the precondition the doc comments now state is not only
+// necessary but sufficient.  Without this, a change that made
+// InitializeTypedef panic unconditionally would keep both guards passing.
+func TestInitializeTypedefAfterInitializeUserEnv(t *testing.T) {
+	env := lisp.NewEnv(nil)
+	if rc := lisp.InitializeUserEnv(env); rc.Type == lisp.LError {
+		t.Fatalf("initialize-user-env: %v", rc)
+	}
+	rc := lisp.InitializeTypedef(env)
+	if rc.Type == lisp.LError {
+		t.Fatalf("InitializeTypedef on an initialized environment: %v", rc)
+	}
+	if !rc.IsNil() {
+		t.Errorf("expected nil, got %v", rc)
+	}
+}


### PR DESCRIPTION
Fixes #433

## Verdict: it reproduces, and the honest remedy is the documentation

Stated plainly, because "documentation fix" can read as quietly downgrading a
report: **the panic is real, it is kept, and only the comments change.**

Reproduced verbatim on `1c13c76` (current `main`) with nothing else in the
tree — `lisp.InitializeTypedef(lisp.NewEnv(nil))`:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x4d1c44]

goroutine 1 [running]:
github.com/luthersystems/elps/lisp.(*LEnv).builtin(0xc00008e080, {0x553a68, 0xc0000a41e0})
	/workspace/wt-433/lisp/env.go:691 +0xc4
github.com/luthersystems/elps/lisp.InitializeTypedef(0xc00008e080)
	/workspace/wt-433/lisp/env.go:61 +0xf0
```

Same two line numbers the issue records. The issue's second claim reproduces
too, and it is the one that was worth checking, because the first dereference
hides it. Give the runtime a `Package` so `LEnv.builtin` succeeds but leave
`Registry.Lang` at `""`, and the fault moves down the function:

```
recovered: runtime error: invalid memory address or nil pointer dereference
github.com/luthersystems/elps/lisp.(*Package).put(...)
	lisp/package.go:169
github.com/luthersystems/elps/lisp.(*Package).Put(...)
	lisp/package.go:144 +0x18e
github.com/luthersystems/elps/lisp.InitializeTypedef(...)
	lisp/env.go:99 +0x31f
```

`Packages[""]` is a nil `*Package` — the shape #425 swept for and #440 fixed
the last unguarded instance of.

The reachability claim the issue flagged as "from reading, worth re-checking"
also holds: `InitializeTypedef` has exactly one caller in the tree,
`InitializeUserEnv` at `lisp/env.go:35`, which establishes both preconditions
at lines 26–28 before calling it. There are no other references anywhere in
the repository, including docs and `.lisp` sources.

## Why the panics stay

#361 settled this for `lisp/`: "a panic in `lisp` means this is a bug in the
interpreter, or in code that had no business calling this." Guarding these two
would blunt that signal in order to serve a call that no correct embedder
makes — and the only thing that ever told an embedder to make it was the
comment on `LEnv.New`:

> New requires that the system have typedef tagged-values.  Generally that
> will be enabled by calling **InitializeTypedef or InitializeUserEnv** when
> initializing the top-level enviornment.

`InitializeTypedef` is not an alternative to `InitializeUserEnv`; it is a step
inside it, and `InitializeUserEnv` is the only thing that establishes its
preconditions. So the defect is the sentence, and the sentence is what
changes. `LEnv.New`'s comment now names `InitializeUserEnv` alone and says why
the other is not a substitute; `InitializeTypedef`'s own comment states the
two things it requires, which two dereferences read them, and that the panic
is deliberate.

The alternative — making `InitializeTypedef` independently callable — is
rejected rather than deferred. It would need both guards plus a decision about
what a half-initialized registry should mean, to enable an initialization
order nothing needs.

## The tests are guards, all three

Labelled as such in-file: **every one of them passes on `main`.** This PR has
no catch, because there is no live code defect to catch. What they buy is that
the contract now stated in prose cannot drift away from the code silently:

- `TestInitializeTypedefRequiresRuntimePackage` pins the first dereference
  (`env.Runtime.Package.Name` in `LEnv.builtin`), and first asserts that
  `StandardRuntime` really does leave `Runtime.Package` nil — so if that ever
  changes the test says it can no longer observe its own precondition instead
  of passing for a new reason.
- `TestInitializeTypedefRequiresRegistryLang` pins the second, the one the
  first hides, by supplying a `Package` but no `Lang`.
- `TestInitializeTypedefAfterInitializeUserEnv` is the positive control. Without
  it, a change that made `InitializeTypedef` panic unconditionally would leave
  both guards green.

If someone later adds the nil guards, the two panic guards fail with a message
naming the doc comments that must change with them.

## The draft worktree

A previous agent left a rebase-stale worktree (branch
`claude/fix-433-initializetypedef`, based on `ed2538c`, seven commits behind).
Its reasoning was unrecoverable, so every claim in it was re-established from
scratch against `1c13c76` before anything was reused.

**Kept:** the shape of the remedy (docs, not code), the three-test guard
structure, and most of the prose. **Discarded:** a hand-rolled `toString`
helper for rendering recovered panic values (`fmt.Sprint` does the same job),
and some of the emphasis in the `InitializeTypedef` comment. The comment was
rewritten rather than taken as-is.

## Neighbourhood audit

The question this PR's audit asks is narrower than #425's, which swept
`Registry.Packages` indexes across the tree and whose conclusion (#440: the
`libtesting` one was the last unguarded index) is cited rather than redone.
Here the question is: **does anything else in the tree offer an embedder an
entry point it cannot accept?**

- **Nothing else does.** `InitializeUserEnv` and `InitializeTypedef` are the
  only `Initialize*` functions in `lisp/`, and the four doc-comment mentions of
  `InitializeUserEnv` outside these two are all correct.
- **`AddMacros` / `AddSpecialOps` / `AddBuiltins`** share the precondition —
  each reaches `env.Runtime.Package` — and would panic the same way on a bare
  environment. Their comments do not claim otherwise, so this is a silence
  rather than a misdirection, and it is left alone: no comment invites the
  call, and #361 already documents the `elpsutil` boundary as the place an
  embedder gets a named error instead.
- **`elpsutil.go:128`** already documents the nil `Runtime.Package` case for
  the loader entry points (from #361's merge), so the two descriptions are
  consistent with each other.

## Gates

Run against `1c13c76`.

| gate | result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test -count=1 ./...` | clean |
| `go test -race -count=1 ./...` | clean |
| `golangci-lint run ./...` | 0 issues |
| `elps fmt -l ./...` | clean (binary built, run, deleted before commit) |
| `elps doc -m` | clean |
| `make go-test` | clean |
| `make race` | clean |
| `make test-elpscheck` | clean |
| `make test-examples` | clean |
| `./scripts/ci-gates-test.sh` | 233 passed, 0 failed |
| `./scripts/confidentiality-guard.sh` | clean (after `git add`) |
| `./scripts/fuzz-budget-check.sh` | the sweep fits (30 targets, 8 shards, 50 min required vs 60 min timeout, 10 min headroom) |

No benchmark arm was run: this change is two comments and one test file, and
it adds no code to any measured path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_