### PR TITLE
Keep elpstest's benchmark load out of the timed region (#434)

### DIFF
--- a/elpstest/lisptest.go
+++ b/elpstest/lisptest.go
@@ -227,6 +227,11 @@ func (r *Runner) RunTestFile(t *testing.T, path string) {
 // used to determine a file basename to use in LEnv.Load().  RunBenchmark
 // returns true if the test, and any teardown function given, completed
 // successfully.
+//
+// Only the benchmark body is timed.  Building the environment, running SetupFn
+// and loading the benchmark file all happen with the timer stopped, so what a
+// Runner configures cannot change what its numbers mean: a Runner with a
+// SetupFn and a Runner without one measure the same region.
 func (r *Runner) RunBenchmark(b *testing.B, i int, path string, source io.Reader) {
 	b.StopTimer()
 	env, err := r.NewEnv(b)
@@ -236,11 +241,15 @@ func (r *Runner) RunBenchmark(b *testing.B, i int, path string, source io.Reader
 	}
 	defer env.Runtime.Stderr.(*Logger).Flush()
 
-	if r.SetupFn != nil {
-		b.StopTimer()
-		r.SetupFn(env)
-		b.StartTimer()
-	}
+	// Setup runs with the timer stopped and LEAVES it stopped.  Restarting it
+	// here would charge env.Load below -- parsing the whole benchmark file and
+	// evaluating every top-level form in it, including every benchmark
+	// definition -- to the measurement, and only for Runners that happen to
+	// set a SetupFn.  That was issue #434: this branch ended in StartTimer
+	// rather than restoring the timer to the state it found it in, so two
+	// Runners differing only in SetupFn reported numbers that were not
+	// comparable.
+	_ = r.Setup(env)
 
 	err = lisp.GoError(env.Load(filepath.Base(path), source))
 	if err != nil {

--- a/elpstest/runnerbenchmark_setup_test.go
+++ b/elpstest/runnerbenchmark_setup_test.go
@@ -1,0 +1,179 @@
+// Copyright © 2026 The ELPS authors
+
+package elpstest
+
+import (
+	"flag"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/elpsutil"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+)
+
+// This file covers issue #434: (*Runner).RunBenchmark charged the whole
+// benchmark file's load -- parsing it and evaluating every top-level form,
+// including every benchmark definition -- to the timed region, but only when
+// the Runner had a SetupFn.  The SetupFn branch ended in b.StartTimer()
+// instead of restoring the timer to the (stopped) state it found it in, so
+// env.Load ran with the timer on.
+//
+// Two Runners differing only in whether they set SetupFn therefore reported
+// numbers that were not comparable, and the difference had nothing to do with
+// the code under benchmark.  No Runner in this repository sets SetupFn, so no
+// in-tree number moved -- but elpstest is an exported package and SetupFn is
+// an exported field documented for exactly this use.
+//
+// The assertion here is not a comparison of two timings.  It observes the
+// timer directly, from inside env.Load, which makes it deterministic: a
+// *testing.B whose timer is stopped has a frozen B.Elapsed(), so sleeping
+// inside the load and differencing B.Elapsed() across the sleep yields
+// exactly zero when the load is untimed and at least the sleep when it is
+// not.  There is no threshold to tune.
+
+// loadProbeDelay is how long the probe builtin blocks inside env.Load.  It
+// only has to be long enough that a running timer's B.Elapsed() advances
+// measurably; a stopped timer's does not advance at all.
+const loadProbeDelay = 20 * time.Millisecond
+
+// loadProbeSource is a benchmark file whose top-level forms call the probe.
+// Everything before the benchmark body runs during env.Load.
+const loadProbeSource = `
+(use-package 'testing)
+
+(probe-load-timer)
+
+(benchmark-simple "probe"
+  (+ 1 1))
+`
+
+// loadTimerProbe records what the benchmark timer was doing while env.Load
+// was running.  RunBenchmark is called on the benchmark goroutine and the
+// probe runs synchronously inside it, so no synchronisation is needed.
+type loadTimerProbe struct {
+	b       *testing.B    // the benchmark currently running
+	reached bool          // the probe builtin was evaluated at least once
+	delta   time.Duration // largest B.Elapsed() advance observed across the probe's sleep
+}
+
+// loader returns a Runner.LoaderFn that loads the standard library and then
+// registers the probe builtin in the user package.
+func (p *loadTimerProbe) loader() func(*lisp.LEnv) *lisp.LVal {
+	return func(env *lisp.LEnv) *lisp.LVal {
+		if rc := lisplib.LoadLibrary(env); rc.Type == lisp.LError {
+			return rc
+		}
+		if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+			return rc
+		}
+		env.AddBuiltins(true, elpsutil.Function("probe-load-timer", lisp.Formals(),
+			func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+				before := p.b.Elapsed()
+				time.Sleep(loadProbeDelay)
+				after := p.b.Elapsed()
+				p.reached = true
+				if d := after - before; d > p.delta {
+					p.delta = d
+				}
+				return lisp.Nil()
+			}))
+		return lisp.Nil()
+	}
+}
+
+// benchtime1x forces -benchtime=1x for the duration of the test.  Each
+// RunBenchmark invocation pays loadProbeDelay of untimed sleep, and the
+// framework sizes b.N from the timed duration alone, so without this the
+// ramp would run for a long time to measure a body that does nothing.
+//
+// runbenchmark_test.go (#441) pins -test.benchtime the same way, inline and
+// for the same reason.  The two are left separate rather than unified here so
+// this change stays confined to the defect it is about.
+func benchtime1x(t *testing.T) {
+	t.Helper()
+	f := flag.Lookup("test.benchtime")
+	if f == nil {
+		return
+	}
+	prev := f.Value.String()
+	if err := f.Value.Set("1x"); err != nil {
+		t.Fatalf("set benchtime: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := f.Value.Set(prev); err != nil {
+			t.Errorf("restore benchtime: %v", err)
+		}
+	})
+}
+
+// TestRunnerRunBenchmarkDoesNotTimeLoad is the catch for #434.  The
+// with-setup subtest fails on main: env.Load runs with the timer on, so the
+// probe's B.Elapsed() advances by a full loadProbeDelay.  The no-setup
+// subtest is a GUARD -- it passes on main and pins the behaviour the fix
+// makes uniform.
+func TestRunnerRunBenchmarkDoesNotTimeLoad(t *testing.T) {
+	benchtime1x(t)
+	for _, test := range []struct {
+		name  string
+		setup func(*lisp.LEnv) *lisp.LVal
+	}{
+		{"no-setup", nil},
+		{"with-setup", func(*lisp.LEnv) *lisp.LVal { return lisp.Nil() }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			probe := &loadTimerProbe{}
+			r := &Runner{LoaderFn: probe.loader(), SetupFn: test.setup}
+			res := testing.Benchmark(func(b *testing.B) {
+				probe.b = b
+				r.RunBenchmark(b, 0, "probe_test.lisp", strings.NewReader(loadProbeSource))
+			})
+			if res.N == 0 {
+				t.Fatalf("benchmark failed; RunBenchmark reported an error")
+			}
+			if !probe.reached {
+				t.Fatalf("probe builtin was never evaluated: the benchmark file did not load," +
+					" so this test observed nothing")
+			}
+			if probe.delta != 0 {
+				t.Errorf("env.Load ran with the benchmark timer RUNNING:"+
+					" B.Elapsed() advanced %v across a %v sleep inside the load."+
+					" The whole file's parse and top-level evaluation is charged to the"+
+					" measurement (issue #434); a stopped timer advances by exactly 0.",
+					probe.delta, loadProbeDelay)
+			}
+		})
+	}
+}
+
+// TestBenchmarkElapsedFreezesWhenTimerStopped is a GUARD, not a catch: it
+// passes on main.  It pins the premise the test above depends on -- that
+// testing.B.Elapsed() does not advance while the timer is stopped and does
+// advance while it runs -- so that a change in the testing package's
+// bookkeeping fails here, saying so, rather than quietly making the probe
+// above unable to observe anything.
+func TestBenchmarkElapsedFreezesWhenTimerStopped(t *testing.T) {
+	benchtime1x(t)
+	var stopped, running time.Duration
+	res := testing.Benchmark(func(b *testing.B) {
+		b.StopTimer()
+		before := b.Elapsed()
+		time.Sleep(loadProbeDelay)
+		stopped = b.Elapsed() - before
+		b.StartTimer()
+		before = b.Elapsed()
+		time.Sleep(loadProbeDelay)
+		running = b.Elapsed() - before
+	})
+	if res.N == 0 {
+		t.Fatalf("benchmark failed")
+	}
+	if stopped != 0 {
+		t.Errorf("B.Elapsed() advanced %v with the timer stopped; expected exactly 0", stopped)
+	}
+	if running < loadProbeDelay/2 {
+		t.Errorf("B.Elapsed() advanced only %v across a %v sleep with the timer running",
+			running, loadProbeDelay)
+	}
+}


### PR DESCRIPTION
Fixes #434

## It reproduces

The issue was filed from reading and asked for the red test first, or a close.
It is real. `elpstest/runnerbenchmark_setup_test.go` added to an otherwise
unmodified `1c13c76`:

```
=== RUN   TestRunnerRunBenchmarkDoesNotTimeLoad
=== RUN   TestRunnerRunBenchmarkDoesNotTimeLoad/no-setup
=== RUN   TestRunnerRunBenchmarkDoesNotTimeLoad/with-setup
    runnerbenchmark_setup_test.go:136: env.Load ran with the benchmark timer RUNNING:
        B.Elapsed() advanced 20.240318ms across a 20ms sleep inside the load. The whole
        file's parse and top-level evaluation is charged to the measurement (issue #434);
        a stopped timer advances by exactly 0.
--- FAIL: TestRunnerRunBenchmarkDoesNotTimeLoad (0.09s)
    --- PASS: TestRunnerRunBenchmarkDoesNotTimeLoad/no-setup (0.07s)
    --- FAIL: TestRunnerRunBenchmarkDoesNotTimeLoad/with-setup (0.02s)
```

With the fix, both subtests pass.

## The detector has no threshold

The obvious red test — time a Runner with a `SetupFn` against one without and
show the numbers differ — would have been a comparison of two noisy timings,
i.e. exactly the kind of test #443/#452 spent today establishing you should not
write. This one observes the timer directly instead.

A `*testing.B` whose timer is stopped has a frozen `B.Elapsed()`. So a probe
builtin, called from a top-level form in the benchmark file and therefore
evaluated *during* `env.Load`, differences `B.Elapsed()` across a 20 ms sleep
inside itself. Untimed load: **exactly 0**. Timed load: **at least the sleep**.
The assertion is `probe.delta != 0`. There is no tolerance to tune and no way
for machine load to change the answer — a slower machine makes the non-zero
reading larger, never smaller.

`TestBenchmarkElapsedFreezesWhenTimerStopped` is a **GUARD** — it passes on
`main`, and is labelled as such in-file. It pins the premise the detector rests
on (a stopped `B.Elapsed()` does not advance; a running one does), so if the
`testing` package's bookkeeping ever changes, that fails and says so rather
than leaving the catch quietly unable to observe anything.

The `no-setup` subtest is also a guard: it passes on `main` and pins the
behaviour the fix makes uniform.

## The fix

The `SetupFn` branch ended in `b.StartTimer()` rather than restoring the timer
to the state it found it in — stopped, from the `b.StopTimer()` at the top of
`RunBenchmark`. Setup now goes through `r.Setup(env)`, which is what
`RunTest` already does, and leaves the timer alone:

```go
-	if r.SetupFn != nil {
-		b.StopTimer()
-		r.SetupFn(env)
-		b.StartTimer()
-	}
+	_ = r.Setup(env)
```

`Runner.Setup` is nil-safe, so the branch itself is redundant. The explicit
`b.StartTimer()` further down, immediately before the benchmark body is
evaluated, is unchanged and remains the only thing that starts the clock.

## Magnitude, stated honestly

`env.Load` is a fixed cost per `RunBenchmark` call, and the framework divides
the measured duration by `b.N`, so the inflation is `load_cost / b.N` rather
than a flat percentage:

- `env.Load` of `libjson_test.lisp` (322 lines, 11 benchmarks) measured at
  **~1.4 ms** best-of-5 on this machine.
- At `-benchtime=1s` on a millisecond-scale body, `b.N` reaches the hundreds
  and the inflation is a fraction of a percent.
- At `-benchtime=10x` it is ~140 µs/op — several percent of a 2 ms body.
- During the framework's ramp, where `b.N` starts at 1, it is the **whole**
  1.4 ms on top of one iteration, which is what feeds the estimate that
  chooses the final `b.N`.

So the practical harm is not a fixed inflation figure; it is that two Runners
differing only in `SetupFn` are not comparable, that the distortion grows as
the measured body gets slower, and that nothing signals any of it.

## Benchmark impact: none, and here is why that is checkable

The instruction to expect every lisp-level benchmark's numbers to move does
not apply, because the affected code path has no in-tree user:

- `SetupFn` and `TeardownFn` are set **nowhere** in this repository outside the
  new test file (`grep` across all `*.go`).
- The only in-tree caller of the `Runner.RunBenchmark` *method* is
  `RunBenchmarkFile`, reached from `libjson_test.go`'s `BenchmarkPackage` with
  a bare `&elpstest.Runner{}`.
- The ~40 `elpstest.RunBenchmark(b, source)` call sites in `lisp/` are the
  **package-level function**, a different code path entirely — the one #441
  changed — and it is untouched here.

With no `SetupFn` configured, the old code and the new code execute the same
sequence of timer calls. No measured region moves.

## Neighbourhood audit

#441's audit of this file (every place `elpstest` builds a runtime inside a
measured loop) is cited rather than redone; this PR closes the one thing that
audit found and deferred. What was examined here is narrower: **every other
`StartTimer`/`StopTimer` pair in `elpstest`.**

- **`RunBenchmarkFile`'s `$load` sub-benchmark** — builds a full runtime inside
  a timed loop with no `StopTimer`. Correct and deliberate: `$load` exists to
  measure loading. Unchanged, and #441 reached the same conclusion.
- **`RunBenchmark`'s `TeardownFn` branch** — the same shape as the one fixed
  here (`StopTimer` / call / `StartTimer` in a defer), but it runs *after* the
  benchmark body, so restoring a running timer is what the surrounding code
  would have had anyway. **Not fixed here — deliberately not widened.** It is
  not entirely harmless, though: because nothing stops the timer after the
  body, the deferred `Logger.Flush()` is inside the measurement. Measured
  directly (`B.Elapsed()` at the end of teardown against the framework's
  reported duration): **650 ns charged after teardown** on a 15.6 µs
  measurement. Filed as #474 rather than folded in.
- **The package-level `RunBenchmark`** — `StopTimer` at the top, per-iteration
  environment build and AST copy untimed, `StartTimer` immediately before the
  evaluated forms, `StopTimer` at the end of each iteration. Correct, and #441
  measured that it is (the copy shows up as 0 in `B/op`).
- **`BenchmarkParse`** — no timer manipulation, no runtime.

## Gates

Run against `1c13c76`.

| gate | result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test -count=1 ./...` | clean |
| `go test -race -count=1 ./...` | clean |
| `golangci-lint run ./...` | 0 issues |
| `elps fmt -l ./...` | clean (binary built, run, deleted before commit) |
| `elps doc -m` | clean |
| `make go-test` | clean |
| `make race` | clean |
| `make test-elpscheck` | clean |
| `make test-examples` | clean |
| `./scripts/ci-gates-test.sh` | 233 passed, 0 failed |
| `./scripts/confidentiality-guard.sh` | clean (after `git add`) |
| `./scripts/fuzz-budget-check.sh` | the sweep fits (30 targets, 8 shards, 50 min required vs 60 min timeout, 10 min headroom) |

**So the table is not read as cleaner than the run was:** the first pass of
`make test-elpscheck`, `ci-gates-test.sh` and `fuzz-budget-check.sh` failed
with `no space left on device` — the sandbox filled up mid-run, and the fuzz
check's "8 shards for 3 targets" was target discovery failing to compile rather
than targets disappearing. All three pass on a re-run after reclaiming disk,
with no change to the tree. Nothing in this PR touches any of them.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_