### PR TITLE
Split TestSleepInterruptedThroughEval by what it can prove (#455)

### DIFF
--- a/lisp/lisplib/libtime/sleep_test.go
+++ b/lisp/lisplib/libtime/sleep_test.go
@@ -7,6 +7,7 @@ package libtime_test
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -157,31 +158,123 @@ func TestSleepInterruptedByCancel(t *testing.T) {
 	}
 }
 
+// The two tests below split what used to be one, because the two properties
+// need opposite contexts and the single test asserted one of them under the
+// context that belongs to the other (issue #455).
+//
+// The cap and the context are checked in different places.  time:sleep checks
+// the length cap before it consults the context -- but only ONCE IT RUNS.
+// Getting there goes through LEnv.eval, which calls checkLimits(ctx) on every
+// step, before evaluating anything.  So for a form under a deadline the real
+// order is: read, parse, step through the call (the argument is itself a
+// call), checking the context at each step, and only then the builtin and its
+// cap.  A deadline that can expire while steps 1-3 are still running does not
+// pick "cap first"; it picks whichever came due first, and which one that is
+// is a function of machine load.
+//
+// The old test asserted sleep-limit-exceeded under a 50ms deadline and its
+// comment explained the cap-first ordering as though it governed the whole
+// path.  Under -race with the package suite running in parallel, 50ms is not
+// a lot of budget for "load a package-qualified form and evaluate two calls",
+// and it lost the race in CI, reporting context-cancelled.
+//
+// The fix is not a bigger deadline -- that is the same threshold-tuning move,
+// and it would leave the outcome a function of load.  Each test now runs
+// under the context that makes its own assertion the only reachable one.
+
+// TestSleepLimitThroughEval covers the length cap on the path an ordinary
+// ELPS program takes: source text, read and parsed, evaluated by LEnv.eval.
+//
+// There is NO deadline and nothing cancels, so the evaluator's per-step
+// checkLimits cannot produce an error at all -- it only reports a context
+// that has already erred, and context.Background() never does.  The cap is
+// the only thing left that can refuse the sleep, which makes
+// sleep-limit-exceeded the outcome regardless of how slow the machine is.
+func TestSleepLimitThroughEval(t *testing.T) {
+	t.Parallel()
+	env := sleepEnv(t, nil)
+
+	// runBounded is the whole of the timing assertion, deliberately.  A cap
+	// that slept the 292 years before reporting would not return at all, so
+	// "it returned" is the property, and runBounded's 30s is a hang detector
+	// rather than a tolerance: nothing asserts success on the strength of a
+	// wall-clock reading.  An `elapsed >= slack` check after it would be
+	// unreachable, since runBounded has already failed the test by then.
+	v, _ := runBounded(t, slack, func() *lisp.LVal {
+		// 9223372036854775807ns is time.Duration(math.MaxInt64) -- the
+		// literal from the issue, reachable from source alone.
+		return env.LoadStringContext(context.Background(), "sleep_test.lisp",
+			`(time:sleep (time:parse-duration "9223372036854775807ns"))`)
+	})
+	requireSleepLimit(t, v)
+}
+
+// evalDeadline and evalSleep are TestSleepInterruptedThroughEval's two
+// durations.  They are ordered so that the property under test is the only
+// reachable outcome, and the test checks the ordering rather than trusting
+// it:
+//
+// slack (30s) << evalDeadline (5m) < evalSleep (30m) <= DefaultMaxSleep (1h)
+//
+// evalSleep <= DefaultMaxSleep, so the length cap CANNOT refuse this sleep.
+// Only the context can.  evalDeadline < evalSleep, so the builtin's fail-fast
+// refuses on entry.  And slack << evalDeadline, so the evaluator's per-step
+// context check provably never fires: for it to fire the deadline must
+// already have passed, and runBounded fails the test ten times sooner than
+// that.  The margin is not a tuned tolerance -- any run in which the deadline
+// could expire is a run runBounded has already failed.
+const (
+	evalDeadline = 5 * time.Minute
+	evalSleep    = 30 * time.Minute
+)
+
 // TestSleepInterruptedThroughEval proves the context actually reaches the
 // builtin through ordinary evaluation, not just through a direct Go call.
 // LEnv.call bridges the evaluation context onto the environment at the
 // builtin boundary; if that bridge broke, the direct-call tests above would
 // still pass while real ELPS programs stayed unbounded.
+//
+// The evidence is the builtin's fail-fast (issue #338): a sleep the deadline
+// will outlast is refused ON ENTRY, while the context is still live.  That is
+// something only the builtin can produce -- LEnv.eval's checkLimits reports a
+// context that has ALREADY erred -- so asserting context-cancelled together
+// with a context that has not yet expired names the builtin as the source,
+// which a condition name alone cannot do.
 func TestSleepInterruptedThroughEval(t *testing.T) {
 	t.Parallel()
+	if evalSleep > lisp.DefaultMaxSleep {
+		t.Fatalf("evalSleep %v exceeds DefaultMaxSleep %v: the length cap could refuse"+
+			" this sleep and the test would pass on the wrong evidence",
+			evalSleep, lisp.DefaultMaxSleep)
+	}
+	if evalDeadline >= evalSleep {
+		t.Fatalf("evalDeadline %v is not nearer than evalSleep %v: the builtin has"+
+			" nothing to fail fast about", evalDeadline, evalSleep)
+	}
+	if slack >= evalDeadline {
+		t.Fatalf("runBounded's %v bound is not comfortably inside the %v deadline:"+
+			" the evaluator's per-step context check could fire first (issue #455)",
+			slack, evalDeadline)
+	}
+
 	env := sleepEnv(t, nil)
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), evalDeadline)
 	defer cancel()
 
-	v, elapsed := runBounded(t, slack, func() *lisp.LVal {
-		// 9223372036854775807ns is time.Duration(math.MaxInt64) -- the
-		// literal from the issue, reachable from source alone.
-		return env.LoadStringContext(ctx, "sleep_test.lisp",
-			`(time:sleep (time:parse-duration "9223372036854775807ns"))`)
+	src := fmt.Sprintf(`(time:sleep (time:parse-duration %q))`, evalSleep.String())
+	// As in TestSleepLimitThroughEval, runBounded is the only wall clock and
+	// it only detects a hang -- a sleep that was not refused on entry runs for
+	// evalSleep and never returns within slack.  The two assertions below are
+	// the ones that carry meaning, and neither reads a clock.
+	v, _ := runBounded(t, slack, func() *lisp.LVal {
+		return env.LoadStringContext(ctx, "sleep_test.lisp", src)
 	})
-	// sleep-limit-exceeded, not context-cancelled: the 292-year duration is
-	// refused by the length cap, which is checked before the context is
-	// consulted at all.  Reporting the cap is the more useful of the two --
-	// it names the thing the caller can act on (:max) rather than the
-	// deadline that merely happened to be nearer.
-	requireSleepLimit(t, v)
-	if elapsed >= slack {
-		t.Fatalf("slept %v, expected an immediate refusal", elapsed)
+	requireCancelled(t, v)
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("the %v deadline expired during a test bounded at %v (%v):"+
+			" context-cancelled here could have come from LEnv.eval's per-step check"+
+			" rather than from time:sleep, so this run proves nothing about the bridge",
+			evalDeadline, slack, err)
 	}
 }
 


### PR DESCRIPTION
Fixes #455

## It reproduces

The issue recorded one CI failure and could not reproduce it in three isolated
runs under synthetic load, so it asked for the recipe to be pinned or the issue
closed. The recipe is: the load has to be applied while the *evaluation* is
running, not while the package is being built.

On unmodified `1c13c76`, driving the old test's exact body 300 times under
`-race` with 24 spinner goroutines on 4 cores:

```
NumCPU=4 load goroutines=24
after 300 iterations: map[context-cancelled:24 sleep-limit-exceeded:276];
    max wall time for one LoadStringContext = 2.291478313s
REPRODUCED #455: 24/300 runs returned "context-cancelled" instead of "sleep-limit-exceeded"
```

**8% failure rate**, and the tail is not marginal: a single
`LoadStringContext` of `(time:sleep (time:parse-duration "…"))` took **2.29 s**
against the test's 50 ms budget — 45x over. The condition the old test asserted
was decided by machine load, exactly as the issue says.

That also explains why isolated runs did not show it. Each iteration builds its
own environment, and that build is *outside* the deadline; only the 50 ms
window from `LoadStringContext` to the builtin is exposed. It takes sustained
contention landing inside that window to lose the race, which is what a full
`-race` suite with parallel packages produces and what three quiet runs do not.

## What is not done: the deadline is not widened

Widening 50 ms to something bigger is the same move as raising a threshold, and
it leaves the outcome a function of load — a smaller function, decided the same
way. Twice today that was the wrong answer (#443/#452, #435/#447). #447 is the
model followed here: split the harness by what the caller actually asserts,
keep a wall clock only where nothing asserts success on the strength of it, and
come out **stricter** than before.

## What is done: one test becomes two, each under a context that makes its own assertion the only reachable outcome

The old test tried to prove two things at once and asserted the one its context
was wrong for. The cap and the context are checked in different places:
`time:sleep` checks the length cap before it consults the context, but only
*once it runs* — and getting there goes through `LEnv.eval`, which calls
`checkLimits(ctx)` on every step, before evaluating anything. The comment
claimed an ordering that only ever held inside the builtin.

**`TestSleepLimitThroughEval`** — the cap, on the path an ordinary ELPS program
takes. `context.Background()`, no deadline, nothing to cancel. The evaluator's
per-step check only reports a context that has *already* erred, and
`context.Background()` never does, so the cap is the only thing left that can
refuse the sleep. `sleep-limit-exceeded` is the outcome on any machine at any
speed.

**`TestSleepInterruptedThroughEval`** — keeps the name and the original purpose
(prove the context reaches the builtin through ordinary evaluation, not just
through a direct Go call), and now asserts something the old version could
not:

```
slack (30s)  <<  evalDeadline (5m)  <  evalSleep (30m)  <=  DefaultMaxSleep (1h)
```

- `evalSleep <= DefaultMaxSleep`, so the **cap cannot fire**. Only the context
  can refuse this sleep.
- `evalDeadline < evalSleep`, so the builtin's fail-fast (#338) refuses it **on
  entry**.
- `slack << evalDeadline`, so the evaluator's per-step check **provably never
  fires**: for it to fire the deadline must already have passed, and
  `runBounded` fails the test ten times sooner than that.

The test checks all three orderings itself rather than trusting the constants,
and then makes the assertion that carries the new strength:

```go
requireCancelled(t, v)
if err := ctx.Err(); err != nil {
    t.Fatalf("the %v deadline expired during a test bounded at %v (%v): ...", ...)
}
```

`context-cancelled` **while the context is still live** is something only
`time:sleep` can produce — `LEnv.eval`'s `checkLimits` reports a context that
has already erred. So the pair names the builtin as the source of the error,
which a condition name on its own never did. The old test would have passed if
`LEnv.call`'s context bridge had broken and the cap alone had refused the
sleep; this one would not.

`5m` and `30m` are not tuned tolerances. Any run in which the deadline could
expire is a run `runBounded` has already failed at 30s, so there is no load
under which the margin is the thing that decides the result.

## The wall clocks that remain, and the ones that went

`runBounded` stays and is the only clock either test reads. It is a hang
detector: a sleep that was *not* refused on entry runs for 30 minutes and never
returns, so "it returned at all" is the property, and nothing asserts success on
the strength of a reading. That is the distinction #447 drew.

Both tests dropped an `elapsed >= …` upper bound. Those checks were
unreachable, not merely redundant — `runBounded` fatals at `slack` before
control returns, so the comparison could never be true. Their intent (the sleep
was refused rather than performed) is carried by `runBounded` itself, and the
comments now say so.

## Not a product change

`libtime` is untouched. The only file that changes is `sleep_test.go`, and no
behaviour of `time:sleep`, `LEnv.eval` or the context bridge is altered — which
also means there is nothing here for the benchmark gate to move.

## Determinism, measured

Same machine, same load, three arms — 24 spinner processes on 4 cores, load
average 25–37 throughout, everything under `-race`:

| arm | runs | result |
|---|---|---|
| the old test's body, in-process loop (`main`) | 300 | **24 failures** (8%), max `LoadStringContext` 2.29 s |
| the old test itself, `go test -count=200` under external load (`main`) | 200 | **FAIL**, verbatim below |
| the two new tests, `go test -count=200` under the same external load | 400 | **0 failures**, 13.8 s |

The middle arm reproduces the CI failure the issue recorded, character for
character:

```
--- FAIL: TestSleepInterruptedThroughEval (0.05s)
    sleep_test.go:182: expected condition "sleep-limit-exceeded", got "context-cancelled"
        (<native code>: context-cancelled: context cancelled: context deadline exceeded)
FAIL	github.com/luthersystems/elps/lisp/lisplib/libtime	4.404s
```

The third arm is not "0 failures so far" in the way a widened deadline would
be. Neither new test has an outcome a slower machine can change: one has no
deadline for the evaluator to trip over, and the other's deadline is 10x
`runBounded`'s own bound, so any run in which it could matter has already been
failed as a hang.

## Neighbourhood audit

The brief: every other assertion in the repository whose outcome is a race
between a deadline and the work that has to happen before the relevant check.

- **`TestSleepMaxRaisesTheCap`** (`sleep_test.go`, 30 ms deadline) — safe. It
  calls the builtin directly, so no evaluation steps intervene; and if the
  environment build overruns the deadline the entry check produces the *same*
  `context-cancelled` the fail-fast would. Both paths satisfy the assertion.
- **`TestDoTimesHonoursContextDeadline`** (`lisp/evalinterrupt_test.go`, 50 ms)
  and **`TestDoTimesEmptyBodyRespectsContext`** (`lisp/dotimes_limit_test.go`,
  200 ms) — safe. The deadline expiring *is* the property, and neither
  environment sets a step budget (`newLimitTestEnv(t)` and `limitEnv(t)` are
  called with no configs), so nothing else can stop a 1e9/2e9-iteration loop
  first.
- **`TestContextDeadline`** (`lisp/context_test.go`, 50 ms) — safe, same shape:
  a spin builtin with only the deadline able to stop it.
- **Three `elapsed > time.Second` bounds in `sleep_test.go`** (lines 418, 480,
  544 on `main`) do have the load-dependent shape — a correctness property
  ("refused on entry, did not sleep") enforced by a wall clock, the #435
  family — and each is redundant with the `runBounded(t, slack, …)` that already
  wraps it. `TestSleepMaxThroughEval`'s is the most exposed of the three
  because it goes through `LoadString`; this PR measured a comparable
  `LoadStringContext` at 2.29 s under load, well past its 1 s bound. **Not
  changed here** — that is widening this PR into three other tests. Filed as
  #475.

## Gates

Run against `1c13c76`.

| gate | result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test -count=1 ./...` | clean |
| `go test -race -count=1 ./...` | clean |
| `golangci-lint run ./...` | 0 issues |
| `elps fmt -l ./...` | clean (binary built, run, deleted before commit) |
| `elps doc -m` | clean |
| `make go-test` | clean |
| `make race` | clean |
| `make test-elpscheck` | clean |
| `make test-examples` | clean |
| `./scripts/ci-gates-test.sh` | 233 passed, 0 failed |
| `./scripts/confidentiality-guard.sh` | clean (after `git add`) |
| `./scripts/fuzz-budget-check.sh` | the sweep fits (30 targets, 8 shards, 50 min required vs 60 min timeout, 10 min headroom) |


---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_