### PR TITLE
libelpspath: stop ?del! scrambling the source a view aliases (#471), and sweep the view axis

### DIFF
--- a/lisp/lisplib/libelpspath/libelpspath_test.lisp
+++ b/lisp/lisplib/libelpspath/libelpspath_test.lisp
@@ -145,3 +145,88 @@
   (append! view 99)
   (assert-equal (vector 1 2 3 99) view)
   (assert-equal (vector 1 2 3 4 5) src))
+
+;;; ---- issue #471: a delete through a view must not touch the source ----
+;;;
+;;; A view is an ordinary array LVal whose cells are a window onto a longer
+;;; sequence, so the mutating builtins accept one and cannot tell.  The two
+;;; deleteMutate paths used to compact IN PLACE, shifting the tail left
+;;; through the aliased source's own backing array.  The view's answer came
+;;; out right -- a left shift copies before it overwrites -- and only the
+;;; source was wrecked, which is why nothing caught it.
+;;;
+;;; The source cannot shrink, so there is no "correct" amount for it to
+;;; change: the requirement is that it does not change at all.
+
+(test-let* "?del! index through a kernel slice view leaves the source alone"
+  ((src (vector 1 2 3 4 5))
+   (view (slice 'vector src 0 3)))
+  (elpspath:?del! view 0)
+  (assert-equal (vector 2 3) view)
+  (assert-equal (vector 1 2 3 4 5) src))
+
+(test-let* "?del! range through a kernel slice view leaves the source alone"
+  ((src (vector 1 2 3 4 5))
+   (view (slice 'vector src 0 3)))
+  (elpspath:?del! view '(range 0 1))
+  (assert-equal (vector 2 3) view)
+  (assert-equal (vector 1 2 3 4 5) src))
+
+; The other producer of a view in the tree is this package's own range Get,
+; and it reaches the same defect by a route that never mentions `slice`.
+(test-let* "?del! through elpspath's own range view leaves the source alone"
+  ((src (vector 1 2 3 4 5))
+   (view (elpspath:? src '(range 0 3))))
+  (elpspath:?del! view 0)
+  (assert-equal (vector 2 3) view)
+  (assert-equal (vector 1 2 3 4 5) src))
+
+; A view does not have to be anchored at 0, and the shift landed wherever the
+; window did: this arm reported (vector 1 2 4 5 5) before the fix.
+(test-let* "?del! through an offset view leaves the source alone"
+  ((src (vector 1 2 3 4 5))
+   (view (slice 'vector src 2 5)))
+  (elpspath:?del! view 0)
+  (assert-equal (vector 4 5) view)
+  (assert-equal (vector 1 2 3 4 5) src))
+
+; A full-length view aliases just as completely as a partial one; the window
+; being the whole sequence is not the same as owning it.  Reported
+; (vector 2 3 4 5 5) before the fix.
+(test-let* "?del! through a full-length view leaves the source alone"
+  ((src (vector 1 2 3 4 5))
+   (view (slice 'vector src 0 5)))
+  (elpspath:?del! view 0)
+  (assert-equal (vector 2 3 4 5) view)
+  (assert-equal (vector 1 2 3 4 5) src))
+
+; A view reached through a document, rather than bound to a variable the
+; caller thinks of as a view.
+(test-let* "?del! through a view stored in a document leaves the source alone"
+  ((src (vector 1 2 3 4 5))
+   (doc (sorted-map "v" (slice 'vector src 0 3))))
+  (elpspath:?del! doc "v" 0)
+  (assert-equal (vector 2 3) (elpspath:? doc "v"))
+  (assert-equal (vector 1 2 3 4 5) src))
+
+; The controls that separate #471 from what is expected and from what was
+; already fixed.  These are GUARDS: they pass both before and after the fix,
+; and exist so the semantics around it are re-decided rather than drifted.
+;
+; Assigning an element through a view is ordinary aliasing and is documented:
+; setMutate does cells[index] = newIn, and a view shares its elements.
+(test-let* "?set! at an index through a view does reach the source"
+  ((src (vector 1 2 3 4 5))
+   (view (slice 'vector src 0 3)))
+  (elpspath:?set! view 0 97)
+  (assert-equal (vector 97 2 3) view)
+  (assert-equal (vector 97 2 3 4 5) src))
+
+; The range splice was the same defect and was fixed earlier; it builds its
+; result in a slice it allocates.
+(test-let* "?set! range splice through a view does not reach the source"
+  ((src (vector 1 2 3 4 5))
+   (view (slice 'vector src 0 3)))
+  (elpspath:?set! view '(range 0 1) (vector 90 91))
+  (assert-equal (vector 90 91 2 3) view)
+  (assert-equal (vector 1 2 3 4 5) src))

--- a/lisp/lisplib/libelpspath/path.go
+++ b/lisp/lisplib/libelpspath/path.go
@@ -893,11 +893,39 @@ func (s *indexPath) deleteMutate(in *lisp.LVal) (*lisp.LVal, error) {
 	if err != nil {
 		return nil, err
 	}
-	index, ok := resolveIndex(len(cells), s.index)
+	n := len(cells)
+	index, ok := resolveIndex(n, s.index)
 	if !ok {
 		return lisp.Nil(), nil
 	}
-	vals := append(cells[:index], cells[index+1:]...)
+	// IMPORTANT: the compaction is built in a slice this function allocates,
+	// not by shifting cells down inside their own backing array.
+	//
+	// `append(cells[:index], cells[index+1:]...)` writes the tail one position
+	// to the left THROUGH cells' array. That array does not belong to this
+	// function whenever in is a VIEW over a longer sequence -- and the
+	// mutating builtins accept one, because a view is an ordinary array LVal
+	// (the kernel's (slice 'vector ...), or this package's own rangePath.Get).
+	// The shift then lands in the aliased source, which cannot shrink, so it
+	// is left scrambled rather than shortened:
+	//
+	//	(set 'v (vector 1 2 3 4 5))
+	//	(set 'w (slice 'vector v 0 3))
+	//	(?del! w 0)
+	//	  view (vector 2 3)   src (vector 2 3 3 4 5)   <- 1 gone, 3 duplicated
+	//
+	// Nothing raised, and the ANSWER was right: a left shift copies before it
+	// overwrites, so the view came out correct while the source was wrecked.
+	// That is why neither the suite nor the fuzzer caught it -- see issue
+	// #471, and rangePath.setMutate, which carries this same comment because
+	// its overlap corrupted its own answer and so was found immediately.
+	//
+	// This is the same class as #369/#373 but no capacity clamp reaches it:
+	// the write is WITHIN len, not past it. The capacity below is exact, so
+	// the cost is one allocation on a path that previously did none.
+	vals := make([]*lisp.LVal, 0, n-1)
+	vals = append(vals, cells[:index]...)
+	vals = append(vals, cells[index+1:]...)
 	storeCells(in, vals)
 	return in, nil
 }
@@ -1070,10 +1098,23 @@ func (s *rangePath) deleteMutate(in *lisp.LVal) (*lisp.LVal, error) {
 	if err != nil {
 		return nil, err
 	}
-	vals := cells[:from]
-	if to < n {
-		vals = append(vals, cells[to:]...)
-	}
+	// IMPORTANT: allocated rather than compacted in place, for exactly the
+	// reason indexPath.deleteMutate above spells out -- `append(cells[:from],
+	// cells[to:]...)` shifts the tail left through a backing array this
+	// function does not own when in is a view, scrambling the source it
+	// aliases (issue #471). Both delete paths had it; the range one reaches it
+	// through '(range a b) rather than an integer step:
+	//
+	//	(?del! w '(range 0 1))   ->   src (vector 2 3 3 4 5)
+	//
+	// The old code skipped the append entirely when to == n, which is why a
+	// delete of a suffix -- including the whole view -- was accidentally
+	// correct: there was no tail to shift. Only a delete with a non-empty tail
+	// wrote through, which narrowed the shapes that could expose it without
+	// making any of them safe.
+	vals := make([]*lisp.LVal, 0, n-(to-from))
+	vals = append(vals, cells[:from]...)
+	vals = append(vals, cells[to:]...)
 	storeCells(in, vals)
 	return in, nil
 }

--- a/lisp/lisplib/libelpspath/path_bench_delete_test.go
+++ b/lisp/lisplib/libelpspath/path_bench_delete_test.go
@@ -1,0 +1,91 @@
+// Copyright © 2026 The ELPS authors
+
+package libelpspath
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// BenchmarkDeleteCompaction measures what the #471 fix costs.
+//
+// The fix replaced an in-place compaction — which allocated nothing, because
+// it shifted the tail down inside the caller's own array — with one that
+// builds the result in a slice of its own.  That is one allocation on a path
+// that previously did none, so it is measured rather than asserted to be
+// free.  Issue #452's rule applies: allocations are not exempt from the gate,
+// and a clamp or a copy that forces one has to show the number.
+//
+// The two arms alternate inside a single process, as BenchmarkCycleGuardCost
+// does, so machine drift moves both together and benchstat -col /arm reads
+// the difference rather than the noise.  The "inplace" arm is the pre-fix
+// body, kept alive as inPlaceViewDelete in path_view_alias_test.go and pinned
+// to the shipped answer by TestInPlaceReplicaMatchesTheShippedAnswer — so the
+// comparison is against what actually used to run, not a sketch of it.
+//
+// Both arms are given a fresh sequence per iteration, since both consume the
+// one they are handed.  The allocation that setup costs is charged to both
+// equally and is what the /arm comparison cancels.
+func BenchmarkDeleteCompaction(b *testing.B) {
+	steps := []struct {
+		name string
+		step *lisp.LVal
+	}{
+		{"index", lisp.Int(0)},
+		{"range1", rangeStep(0, 1)},
+		{"range3", rangeStep(0, 3)},
+	}
+	arms := []struct {
+		name string
+		del  viewDeleteFn
+	}{
+		{"allocating", shippedViewDelete},
+		{"inplace", inPlaceViewDelete},
+	}
+	for _, n := range []int{4, 16, 64} {
+		for _, st := range steps {
+			for _, arm := range arms {
+				name := "n=" + itoa(n) + "/step=" + st.name + "/arm=" + arm.name
+				b.Run(name, func(b *testing.B) {
+					// The elements are built once.  Per iteration the work
+					// slice is refilled by copy -- no allocation, and the same
+					// cost in both arms -- so the /arm delta is the
+					// compaction's own allocation and nothing else.  A
+					// StopTimer'd setup would not do: b.ReportAllocs counts
+					// allocations whether the timer runs or not, and a fresh
+					// n-element slice per iteration would bury the single
+					// allocation this benchmark exists to measure.
+					template := make([]*lisp.LVal, n)
+					for i := range template {
+						template[i] = lisp.Int(i)
+					}
+					work := make([]*lisp.LVal, n)
+
+					b.ReportAllocs()
+					for b.Loop() {
+						copy(work, template)
+						seq := lisp.Array(nil, work[0:n:n])
+						if _, err := arm.del(st.step, seq); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/lisp/lisplib/libelpspath/path_fuzz_test.go
+++ b/lisp/lisplib/libelpspath/path_fuzz_test.go
@@ -4,6 +4,7 @@ package libelpspath
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
@@ -73,6 +74,25 @@ import (
 //     source's elements before `a` and ENDS with the source's elements from
 //     `b` on, by value and in order.  Only the middle is theirs to change.
 //     See "THE RESULT AXIS" below for why this had to be added.
+//  7. A view is written only where the path points.  The same operation is
+//     run a second time against a VIEW — an array LVal whose cells are a
+//     window onto a longer backing array, which is what the kernel's
+//     (slice 'vector ...) and this package's rangePath.Get hand out — and
+//     the backing array may come back changed only at the positions the step
+//     names.  See viewWitness for why the harness's own documents cannot
+//     express this and why issue #471 therefore survived every campaign.
+//
+// THE OWNERSHIP AXIS (issue #471).  Invariants 1-6 watch documents the
+// harness BUILT, whose cells belong to nobody else.  A write that runs off
+// the end of what the path named lands in the harness's own array and no
+// invariant can see it.  #471 is exactly that write: the two deleteMutate
+// paths compacted with `append(cells[:i], cells[i+1:]...)`, shifting the tail
+// left through the caller's array — harmless on a document the operation
+// owns, and on a view it scrambles the longer sequence the view aliases.  The
+// answer stayed correct (a left shift copies before it overwrites), so
+// invariants 1-3 passed; no list was touched, so 4 passed; the mutating ops
+// are exempt from 5; and the ends survived, so 6 passed.  Seven invariants
+// are not more than six unless the seventh sees a shape the others cannot.
 //
 // THE RESULT AXIS (issue found in review of #402).  Invariants 1-5 all watch
 // the INPUT: they ask whether the document was left alone, never whether the
@@ -158,6 +178,19 @@ func FuzzPathEngine(f *testing.F) {
 			f.Add(seed)
 		}
 	}
+	// Invariant 7's seeds.  Added deliberately, and they are the whole
+	// difference between the property running and not running: the drivers
+	// above reach newViewWitness's shape ZERO times, because it needs a
+	// vector document AND a step sequence of length exactly one AND a step
+	// that names a strict, non-empty subset of that vector's positions, and
+	// nothing above lines all three up.  A property the corpus never reaches
+	// is a property that cannot fail, which is the failure mode #462 and #470
+	// both hit.  TestViewWitnessSeedsAreReached pins that these do reach it.
+	//
+	// One per operation per step form, found by search over short inputs.
+	for _, seed := range viewWitnessSeeds {
+		f.Add(seed)
+	}
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		env := fuzzPathEnv(t)
@@ -180,11 +213,27 @@ func FuzzPathEngine(f *testing.F) {
 		// rendered now or there is nothing left to compare against.
 		splice, spliceOK := newSpliceOracle(doc, steps)
 
+		// Invariant 7 setup, taken BEFORE the call for the same reason and a
+		// sharper one: the witness copies the document's cells, and a "!"
+		// operation run first would have already shrunk the document, so the
+		// window built afterwards is a different — and typically too small —
+		// shape than the one the property is about.  Built after the call,
+		// this property silently passes on a tree that has #471 in it.
+		witness, witnessOK := newViewWitness(doc, steps)
+
+		// The new value is drawn once and shared by both arms, so the view
+		// arm below exercises the same operation the main arm did rather than
+		// a second, unrelated draw from the generator.
+		var newVal *lisp.LVal
+		if op.needsValue {
+			newVal = g.value()
+		}
+
 		args := make([]*lisp.LVal, 0, len(steps)+2)
 		args = append(args, doc)
 		args = append(args, steps...)
 		if op.needsValue {
-			args = append(args, g.value())
+			args = append(args, newVal)
 		}
 
 		fun := env.GetGlobal(lisp.Symbol("elpspath:" + op.name))
@@ -231,7 +280,188 @@ func FuzzPathEngine(f *testing.F) {
 					splice.prefix, splice.suffix, result)
 			}
 		}
+
+		// Invariant 7.  Run the same operation again on a VIEW of the same
+		// shape, and require it to write only where its path points.
+		if witnessOK {
+			viewArgs := make([]*lisp.LVal, 0, len(steps)+2)
+			viewArgs = append(viewArgs, witness.view)
+			viewArgs = append(viewArgs, steps...)
+			if op.needsValue {
+				viewArgs = append(viewArgs, newVal)
+			}
+			_ = env.FunCall(fun, lisp.SExpr(viewArgs))
+			if why := witness.check(); why != "" {
+				t.Fatalf("%s through a view wrote into the backing array it does"+
+					" not own: %s\n--- steps ---\n%s\n--- view ---\n%s",
+					op.name, why, renderSteps(steps), witness.view)
+			}
+		}
 	})
+}
+
+// viewWitness is invariant 7's apparatus (issue #471).
+//
+// WHY THIS AXIS EXISTS.  Every document invariants 1-6 watch is one the
+// harness built and OWNS: its cells belong to no one else, so a write that
+// runs off the end of what the path named lands in the harness's own array
+// and is invisible.  A real caller has a second shape the harness never
+// produced -- a VIEW: an ordinary array LVal whose cells are a window onto a
+// LONGER sequence, handed out by the kernel's (slice 'vector ...) or by this
+// package's own rangePath.Get.  Mutating builtins accept one, because there
+// is nothing in an LVal that says "view".
+//
+// The alias battery has the same hole from the other side, and says so: it
+// writes through COPIES, and a view is not a copy.  So the one shape in which
+// an in-place compaction is visible was outside both.  That is why #471 --
+// `append(cells[:index], cells[index+1:]...)` shifting a view's tail left
+// through the aliased source's array -- survived every campaign and every
+// battery run, and was found by hand instead.
+//
+// THE PROPERTY.  A path operation applied to a view may change the backing
+// array only at the positions its path NAMES: {i} for an integer step,
+// [from,to) for a range step, nothing for a step that resolves to no
+// position.  Everything else in that array belongs to a sequence the caller
+// never passed.
+//
+// It is stated as "named positions" rather than "no change at all" because
+// element assignment through a view is legitimate and documented: (?set! w 0
+// 97) sets the source's element 0, exactly as writing through any alias
+// does.  #471 is not that.  It shifted every element after the deleted one,
+// so positions the path never named moved -- which this catches while
+// leaving the legitimate write alone.
+//
+// It is deliberately a SUB-property and applies only to the isolated
+// single-step-on-a-vector shape, the same restriction newSpliceOracle takes:
+// a longer path reaches its view through intermediate Gets whose own aliasing
+// is a separate question, and an oracle that guessed at those would report
+// false positives rather than find defects.
+type viewWitness struct {
+	view     *lisp.LVal
+	backing  []*lisp.LVal
+	snapshot []*lisp.LVal
+	named    map[int]bool
+	window   int
+}
+
+// newViewWitness builds a view over a padded copy of doc's cells, plus the
+// before-snapshot and the set of positions the step is allowed to touch.
+//
+// The view is built over a COPY of the document rather than the document
+// itself so that the extra call cannot disturb the assertions invariants 1-6
+// have already made about doc.
+//
+// The window is clamped three-index, so the view carries no spare capacity:
+// this is #471 and not #369/#373, and the clamp keeps the two apart.  A
+// capacity-retention bug would need an append past len to show; every write
+// this catches is WITHIN len, which is why no clamp anywhere prevents it.
+func newViewWitness(doc *lisp.LVal, steps []*lisp.LVal) (*viewWitness, bool) {
+	if len(steps) != 1 || doc.Type != lisp.LArray || len(doc.Cells) != 2 {
+		return nil, false
+	}
+	if doc.Cells[0].Len() > 1 {
+		return nil, false
+	}
+	named, ok := namedPositions(len(doc.Cells[1].Cells), steps[0])
+	if !ok {
+		return nil, false
+	}
+	cp, err := copyLVal(doc)
+	if err != nil || cp.Type != lisp.LArray || len(cp.Cells) != 2 {
+		return nil, false
+	}
+	cells := cp.Cells[1].Cells
+	n := len(cells)
+	if n == 0 {
+		// An empty window has no interior to shift and no elements to lose.
+		return nil, false
+	}
+	// The tail is what makes this a view rather than a whole sequence.  Its
+	// markers are disjoint from everything the generators produce, so a
+	// marker that moves names the defect instead of describing a coincidence.
+	const viewPad = 3
+	backing := make([]*lisp.LVal, n+viewPad)
+	copy(backing, cells)
+	for i := n; i < len(backing); i++ {
+		backing[i] = lisp.String(fmt.Sprintf("V%d", i-n))
+	}
+	snapshot := make([]*lisp.LVal, len(backing))
+	copy(snapshot, backing)
+	return &viewWitness{
+		view:     lisp.Array(nil, backing[0:n:n]),
+		backing:  backing,
+		snapshot: snapshot,
+		named:    named,
+		window:   n,
+	}, true
+}
+
+// namedPositions is the set of backing positions a single step points at.
+// It borrows resolveIndex and validateRange so the oracle agrees with the
+// engine about WHICH positions are meant; neither is implicated in #471, and
+// an oracle that disagreed about bounds would report false positives.
+func namedPositions(n int, step *lisp.LVal) (map[int]bool, bool) {
+	out := map[int]bool{}
+	switch step.Type {
+	case lisp.LInt:
+		if i, ok := resolveIndex(n, step.Int); ok {
+			out[i] = true
+		}
+		return out, true
+	case lisp.LSExpr:
+		if len(step.Cells) != 3 {
+			return nil, false
+		}
+		if head := step.Cells[0]; head.Type != lisp.LSymbol || head.Str != "range" {
+			return nil, false
+		}
+		lo, hi := step.Cells[1], step.Cells[2]
+		if lo.Type != lisp.LInt || hi.Type != lisp.LInt {
+			return nil, false
+		}
+		from, to, err := validateRange(n, lo.Int, hi.Int, false)
+		if err != nil {
+			// A range the engine refuses names nothing and must write nothing.
+			return out, true
+		}
+		for i := from; i < to; i++ {
+			out[i] = true
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+// check reports the first backing position that moved without being named.
+func (w *viewWitness) check() string {
+	for i := range w.snapshot {
+		if w.backing[i] == w.snapshot[i] || w.named[i] {
+			continue
+		}
+		where := fmt.Sprintf("position %d, inside the view's window", i)
+		if i >= w.window {
+			where = fmt.Sprintf("position %d, PAST the view's window of %d", i, w.window)
+		}
+		// Identity as well as rendering: two different elements can print the
+		// same (a vector of nils is the common case), and then a report that
+		// quoted only the text would read "changed from () to ()".
+		return fmt.Sprintf("%s changed from %s (%p) to %s (%p), and the path does not"+
+			" name it (named: %v) — the operation compacted through the source's"+
+			" array instead of one of its own",
+			where, w.snapshot[i], w.snapshot[i], w.backing[i], w.backing[i],
+			sortedNamed(w.named))
+	}
+	return ""
+}
+
+func sortedNamed(named map[int]bool) []int {
+	out := make([]int, 0, len(named))
+	for i := range named {
+		out = append(out, i)
+	}
+	sort.Ints(out)
+	return out
 }
 
 // spliceOracle holds the two ends of a sequence document that a single
@@ -777,4 +1007,112 @@ func TestPathGenCoverage(t *testing.T) {
 			t.Errorf("generator never produced a %s step: %v", form, stepForms)
 		}
 	}
+}
+
+// viewWitnessSeeds are the inputs that reach invariant 7's shape: a vector
+// document, a single step, and a step that names some but not all of the
+// vector's positions -- the configuration in which a compaction through the
+// source's array is observable.  One per operation per step form.
+//
+// They are byte strings written in this file, found by searching short random
+// inputs for the shape.  No seed is derived from any downstream corpus.
+var viewWitnessSeeds = [][]byte{
+	{0x62, 0xce, 0xe1, 0x20, 0xb4, 0xdb, 0xe0, 0x47, 0x15},                                     // ? index
+	{0xbd, 0x46, 0x4b, 0x50, 0x58, 0x2b, 0x10, 0xb7, 0x1b, 0x94, 0x4a, 0xbb, 0x16},             // ? range
+	{0xd3, 0xa6, 0xe1, 0x10, 0x94, 0x27, 0x20, 0x78, 0x11},                                     // ?set! index
+	{0x08, 0xbe, 0x6f, 0x83, 0x1a, 0xd0, 0x54, 0x5e, 0xf6, 0xcb, 0x07, 0xc4, 0x84, 0x99, 0xee}, // ?set! range
+	{0x3a, 0xa6, 0x4b, 0x40, 0x9a, 0x13, 0x90, 0xe1, 0xdd},                                     // ?set index
+	{0x10, 0xee, 0x15, 0x76, 0x60, 0xca, 0x38, 0x88, 0x5c, 0x9b, 0xdc, 0xae, 0xa3, 0x6b, 0x7a}, // ?set range
+	{0x0a, 0x3e, 0x81, 0x7c, 0xfb, 0x50, 0xb0, 0x5c, 0xe5, 0x81},                               // ?del! index
+	{0x9d, 0x8e, 0xab, 0x2c, 0xba, 0xe8, 0x20, 0xc5, 0xb7, 0xbd, 0x88, 0x6d, 0xf8, 0xed, 0xb4}, // ?del! range
+	{0x2e, 0x9e, 0x15, 0xd8, 0xc8, 0x1a, 0x46, 0xa9, 0x99},                                     // ?del index
+	{0xd6, 0xde, 0xc3, 0x8a, 0xf9, 0x13, 0x02, 0x20, 0x0f, 0x7b, 0xeb, 0xad, 0x43, 0x47},       // ?del range
+	{0x67, 0x36, 0x39, 0x25, 0x54, 0x09, 0x77, 0xe8, 0x16, 0xcd},                               // ?nil! index
+	{0x67, 0xce, 0x99, 0x92, 0xd6, 0xd0, 0xdb, 0xc4, 0xb7, 0xbb, 0x51, 0x93, 0x65},             // ?nil! range
+	{0x61, 0xb6, 0x75, 0xa0, 0xb8, 0xf0, 0xb0, 0x99, 0x1f},                                     // ?nil index
+	{0xfb, 0x66, 0xff, 0xa0, 0x94, 0x5c, 0x52, 0x28, 0x01, 0x2b, 0x0d, 0x6e, 0x4f},             // ?nil range
+}
+
+// TestViewWitnessSeedsAreReached is invariant 7's own gate, in the spirit of
+// TestPathGenCoverage and TestEnumeratePathsCoversEveryStepForm.
+//
+// A fuzz invariant that no input reaches is not an invariant, it is a comment
+// that compiles -- and nothing about that is visible from a green fuzz run.
+// This asserts two separate things, because they fail separately:
+//
+//  1. The general drivers reach the shape ZERO times.  That is not a defect
+//     to fix, it is the measurement that justifies viewWitnessSeeds existing;
+//     if it ever stops being zero this test says so rather than leaving the
+//     seeds looking like superstition.
+//  2. Every viewWitnessSeed does reach it, and between them they cover all
+//     seven operations and both sequence step forms.
+func TestViewWitnessSeedsAreReached(t *testing.T) {
+	t.Parallel()
+
+	reach := func(data []byte) (int, string, bool) {
+		g := &pathGen{b: data, budget: pathGenBudget}
+		opIdx := int(g.next()) % numPathOps
+		doc := g.doc(0)
+		steps := g.steps(doc)
+		if _, ok := newViewWitness(doc, steps); !ok {
+			return 0, "", false
+		}
+		form := "other"
+		if len(steps) == 1 {
+			switch steps[0].Type { //nolint:exhaustive // only the two sequence step forms reach the witness
+			case lisp.LInt:
+				form = "index"
+			case lisp.LSExpr:
+				form = "range"
+			}
+		}
+		return opIdx, form, true
+	}
+
+	drivers := [][]byte{
+		{}, {0x00}, {0x01, 0x02, 0x03},
+		{0x10, 0x21, 0x32, 0x43, 0x54},
+		{0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa},
+		{0x05, 0x00, 0x07, 0x01, 0x02, 0x00, 0x03, 0x09},
+		{0x02, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99},
+		{0x07, 0x03, 0x01, 0x04, 0x01, 0x05, 0x09, 0x02, 0x06},
+	}
+	generic := 0
+	for op := range numPathOps {
+		for _, d := range drivers {
+			if _, _, ok := reach(append([]byte{byte(op)}, d...)); ok { //nolint:gocritic // deliberate new slice per seed
+				generic++
+			}
+		}
+	}
+	if generic != 0 {
+		t.Logf("NOTE: %d of the general drivers now reach invariant 7; the dedicated"+
+			" seeds are no longer the only route (not a failure)", generic)
+	}
+
+	ops := map[string]bool{}
+	forms := map[string]bool{}
+	for i, seed := range viewWitnessSeeds {
+		opIdx, form, ok := reach(seed)
+		if !ok {
+			t.Errorf("viewWitnessSeeds[%d] no longer reaches invariant 7: the property"+
+				" it guards is not being exercised", i)
+			continue
+		}
+		ops[pathOps[opIdx].name] = true
+		forms[form] = true
+	}
+	for _, op := range pathOps {
+		if !ops[op.name] {
+			t.Errorf("no seed reaches invariant 7 for %s", op.name)
+		}
+	}
+	for _, form := range []string{"index", "range"} {
+		if !forms[form] {
+			t.Errorf("no seed reaches invariant 7 with a %s step", form)
+		}
+	}
+	t.Logf("invariant 7 reached by %d/%d dedicated seeds across %d operations and %d step forms;"+
+		" general drivers reach it %d times",
+		len(viewWitnessSeeds), len(viewWitnessSeeds), len(ops), len(forms), generic)
 }

--- a/lisp/lisplib/libelpspath/path_view_alias_test.go
+++ b/lisp/lisplib/libelpspath/path_view_alias_test.go
@@ -290,28 +290,6 @@ func TestViewMutateBattery(t *testing.T) {
 	}
 }
 
-// TestViewDeleteBattery is the requirement: a delete through a view writes
-// only where its path points.
-func TestViewDeleteBattery(t *testing.T) {
-	t.Parallel()
-
-	ran, failures := runViewBattery(t, shippedViewDelete)
-	require.Greater(t, ran, 100,
-		"the view battery deleted through only %d views: it is passing because "+
-			"it is not writing", ran)
-	if len(failures) == 0 {
-		t.Logf("view battery: %d deletes through a view, none wrote outside the step's own positions", ran)
-		return
-	}
-	const sample = 8
-	msgs := failures
-	if len(msgs) > sample {
-		msgs = append(msgs[:sample:sample], fmt.Sprintf("... and %d more", len(failures)-sample))
-	}
-	t.Errorf("%d deletes through a view wrote into the backing array (#471):\n%s",
-		len(failures), strings.Join(msgs, "\n"))
-}
-
 // TestViewBatteryDetectsInPlaceCompaction is the red-proof.  Without it a
 // clean TestViewDeleteBattery would be consistent with a battery that never
 // writes anywhere observable.

--- a/lisp/lisplib/libelpspath/path_view_alias_test.go
+++ b/lisp/lisplib/libelpspath/path_view_alias_test.go
@@ -1,0 +1,445 @@
+// Copyright © 2026 The ELPS authors
+
+package libelpspath
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// The aliasing battery for issue #471: the VIEW axis.
+//
+// path_alias_test.go's battery writes through COPIES, and says so in its own
+// header.  A view is not a copy, and the difference is the whole of #471.
+//
+// A view is an ordinary array LVal whose cells are a WINDOW onto a longer
+// backing array.  Two producers hand one out — the kernel's
+// (slice 'vector ...) and this package's own rangePath.Get — and nothing in
+// an LVal marks it, so every mutating builtin accepts one and cannot tell.
+// The copy battery has no arm that mutates a view, so the one shape in which
+// an in-place compaction is observable was outside it entirely.  #471 lived
+// in exactly that unreachable place: `append(cells[:index], cells[index+1:]...)`
+// shifted the view's tail left THROUGH the source's array, so
+//
+//	(set 'v (vector 1 2 3 4 5))
+//	(set 'w (slice 'vector v 0 3))
+//	(?del! w 0)
+//	  view (vector 2 3)   src (vector 2 3 3 4 5)
+//
+// The source cannot shrink, so it was not shortened — it was scrambled, with
+// 1 gone and 3 duplicated, and nothing raised.
+//
+// THE PROPERTY.  A mutating operation on a view may change the backing array
+// only at the positions its path NAMES.  It is stated that way, rather than
+// as "must not change the source", because element assignment through a view
+// is legitimate and documented: (?set! w 0 97) sets the source's element 0,
+// exactly as writing through any alias does.  #471 is not that — it moved
+// every element after the deleted one, positions no path named.
+//
+// Red-proof: TestViewBatteryDetectsInPlaceCompaction runs the identical sweep
+// against replicas of the pre-#471 in-place bodies and requires it to fail.
+// A battery that cannot fail is not evidence — the rule this file exists
+// because the copy battery followed everywhere except here.
+
+// viewDeleteFn is the delete-through-a-view under test.  The battery runs the
+// shipped operation; the red-proof substitutes a replica of the pre-#471
+// in-place compaction.
+type viewDeleteFn func(step *lisp.LVal, in *lisp.LVal) (*lisp.LVal, error)
+
+// shippedViewDelete is the real thing, reached exactly as a builtin reaches
+// it.
+func shippedViewDelete(step *lisp.LVal, in *lisp.LVal) (*lisp.LVal, error) {
+	p, err := argToStep(step)
+	if err != nil {
+		return nil, err
+	}
+	return p.DeleteMutate(in)
+}
+
+// inPlaceViewDelete replicates the two deleteMutate bodies as they stood
+// before #471 was fixed: the compaction built by appending onto the input's
+// own prefix.
+//
+// It is a replica rather than a git revert so the red-proof runs in the same
+// binary as the green one.  TestInPlaceReplicaMatchesTheShippedAnswer pins
+// that it differs from the shipped code only in what it writes THROUGH — the
+// answer it returns is identical, which is precisely why the defect was
+// silent.
+func inPlaceViewDelete(step *lisp.LVal, in *lisp.LVal) (*lisp.LVal, error) {
+	if err := errMutateList(in); err != nil {
+		return nil, err
+	}
+	cells, err := toCells(in)
+	if err != nil {
+		return nil, err
+	}
+	n := len(cells)
+	switch p := mustStep(step).(type) {
+	case *indexPath:
+		index, ok := resolveIndex(n, p.index)
+		if !ok {
+			return lisp.Nil(), nil
+		}
+		vals := append(cells[:index], cells[index+1:]...) //nolint:gocritic // the pre-#471 body, on purpose
+		storeCells(in, vals)
+		return in, nil
+	case *rangePath:
+		from, to, err := validateRange(n, p.from, p.to, p.implicitTo)
+		if err != nil {
+			return nil, err
+		}
+		vals := cells[:from]
+		if to < n {
+			vals = append(vals, cells[to:]...)
+		}
+		storeCells(in, vals)
+		return in, nil
+	default:
+		return nil, fmt.Errorf("unsupported replica step: %T", p)
+	}
+}
+
+func mustStep(step *lisp.LVal) Path {
+	p, err := argToStep(step)
+	if err != nil {
+		panic(fmt.Sprintf("bad step %v: %v", step, err))
+	}
+	return p
+}
+
+// viewWindow is one view under test: a window onto a longer backing array,
+// plus the before-snapshot of that array.
+type viewWindow struct {
+	view     *lisp.LVal
+	backing  []*lisp.LVal
+	snapshot []*lisp.LVal
+	n        int
+}
+
+// newViewWindow builds an n-element view over an (n+pad)-element array.
+//
+// The window is clamped three-index, exactly as the kernel's slice and
+// rangePath.Get produce it, so the view carries NO spare capacity.  That
+// keeps this battery aimed at #471 and not at #369/#373: every write it can
+// catch is within len, where no capacity clamp reaches.
+func newViewWindow(n, pad int) *viewWindow {
+	backing := make([]*lisp.LVal, n+pad)
+	for i := range backing {
+		if i < n {
+			backing[i] = lisp.Int(i)
+		} else {
+			backing[i] = lisp.String(fmt.Sprintf("PAD%d", i-n))
+		}
+	}
+	snapshot := make([]*lisp.LVal, len(backing))
+	copy(snapshot, backing)
+	return &viewWindow{
+		view:     lisp.Array(nil, backing[0:n:n]),
+		backing:  backing,
+		snapshot: snapshot,
+		n:        n,
+	}
+}
+
+// changedOutside lists the backing positions that moved without being named.
+//
+// Identity, not value: a correct operation never rewrites a position it does
+// not name, so pointer comparison is both the strictest available check and
+// free of false positives from two equal-valued elements.
+func (w *viewWindow) changedOutside(named map[int]bool) []int {
+	var out []int
+	for i := range w.snapshot {
+		if w.backing[i] == w.snapshot[i] || named[i] {
+			continue
+		}
+		out = append(out, i)
+	}
+	return out
+}
+
+func (w *viewWindow) render() string {
+	parts := make([]string, len(w.backing))
+	for i, c := range w.backing {
+		parts[i] = c.String()
+	}
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
+// viewSteps is the step set swept: every in-range index, both signs, and a
+// spread of ranges including empty ones, suffixes and the whole window.
+func viewSteps(n int) []*lisp.LVal {
+	var steps []*lisp.LVal
+	for i := range n {
+		steps = append(steps, lisp.Int(i))
+		steps = append(steps, lisp.Int(i-n)) // the same position, named negatively
+	}
+	for from := 0; from <= n; from++ {
+		for to := from; to <= n; to++ {
+			steps = append(steps, rangeStep(from, to))
+		}
+	}
+	return steps
+}
+
+// runViewBattery sweeps window sizes, pad sizes and steps, applying del and
+// reporting every case in which the backing array moved somewhere the step
+// did not name.
+func runViewBattery(t *testing.T, del viewDeleteFn) (int, []string) {
+	t.Helper()
+	var failures []string
+	ran := 0
+	for _, n := range []int{1, 2, 3, 4, 5} {
+		for _, pad := range []int{0, 1, 3} {
+			for _, step := range viewSteps(n) {
+				w := newViewWindow(n, pad)
+				named, ok := namedPositions(n, step)
+				if !ok {
+					continue
+				}
+				if _, err := del(step, w.view); err != nil {
+					continue
+				}
+				ran++
+				if bad := w.changedOutside(named); len(bad) > 0 {
+					failures = append(failures, fmt.Sprintf(
+						"n=%d pad=%d step=%s: backing positions %v moved and the step names %v\n  before: %s\n  after:  %s",
+						n, pad, step, bad, sortedNamed(named),
+						renderCells(w.snapshot), w.render()))
+				}
+			}
+		}
+	}
+	return ran, failures
+}
+
+func renderCells(cells []*lisp.LVal) string {
+	parts := make([]string, len(cells))
+	for i, c := range cells {
+		parts[i] = c.String()
+	}
+	return "[" + strings.Join(parts, " ") + "]"
+}
+
+// viewMutateOps are the three in-place builtins, each reached through a view.
+//
+// Delete is the one #471 was in, but a clean verdict about the package has to
+// cover the other two as well: they write through the same toCells backing
+// and the same storeCells, and nothing but this sweep would say so.
+//
+// The expectation differs per operation and that is the point of stating the
+// property as "only the positions the path names":
+//
+//   - ?set! and ?nil! at an INDEX legitimately write the source's element at
+//     that index.  That is ordinary aliasing, it is documented, and the
+//     battery permits exactly it and nothing more.
+//   - ?set! and ?nil! at a RANGE write nothing, because setMutate builds its
+//     splice in a slice it allocates (fixed earlier, same class as #471).
+//   - ?del! writes nothing, after this change.
+var viewMutateOps = []struct {
+	name string
+	run  viewDeleteFn
+}{
+	{"?del!", shippedViewDelete},
+	{"?set!", func(step *lisp.LVal, in *lisp.LVal) (*lisp.LVal, error) {
+		p, err := argToStep(step)
+		if err != nil {
+			return nil, err
+		}
+		return p.SetMutate(in, lisp.Vector([]*lisp.LVal{lisp.String("W0"), lisp.String("W1")}))
+	}},
+	{"?nil!", func(step *lisp.LVal, in *lisp.LVal) (*lisp.LVal, error) {
+		p, err := argToStep(step)
+		if err != nil {
+			return nil, err
+		}
+		return p.NilMutate(in)
+	}},
+}
+
+// TestViewMutateBattery is the requirement for all three mutating operations:
+// through a view, each writes only where its path points.
+func TestViewMutateBattery(t *testing.T) {
+	t.Parallel()
+
+	for _, op := range viewMutateOps {
+		t.Run(op.name, func(t *testing.T) {
+			t.Parallel()
+			ran, failures := runViewBattery(t, op.run)
+			require.Greater(t, ran, 100,
+				"%s: the view battery ran only %d cases", op.name, ran)
+			if len(failures) > 0 {
+				const sample = 8
+				msgs := failures
+				if len(msgs) > sample {
+					msgs = append(msgs[:sample:sample],
+						fmt.Sprintf("... and %d more", len(failures)-sample))
+				}
+				t.Errorf("%s: %d operations through a view wrote outside the step's own"+
+					" positions:\n%s", op.name, len(failures), strings.Join(msgs, "\n"))
+				return
+			}
+			t.Logf("%s: %d operations through a view, none wrote outside the step's own positions",
+				op.name, ran)
+		})
+	}
+}
+
+// TestViewDeleteBattery is the requirement: a delete through a view writes
+// only where its path points.
+func TestViewDeleteBattery(t *testing.T) {
+	t.Parallel()
+
+	ran, failures := runViewBattery(t, shippedViewDelete)
+	require.Greater(t, ran, 100,
+		"the view battery deleted through only %d views: it is passing because "+
+			"it is not writing", ran)
+	if len(failures) == 0 {
+		t.Logf("view battery: %d deletes through a view, none wrote outside the step's own positions", ran)
+		return
+	}
+	const sample = 8
+	msgs := failures
+	if len(msgs) > sample {
+		msgs = append(msgs[:sample:sample], fmt.Sprintf("... and %d more", len(failures)-sample))
+	}
+	t.Errorf("%d deletes through a view wrote into the backing array (#471):\n%s",
+		len(failures), strings.Join(msgs, "\n"))
+}
+
+// TestViewBatteryDetectsInPlaceCompaction is the red-proof.  Without it a
+// clean TestViewDeleteBattery would be consistent with a battery that never
+// writes anywhere observable.
+func TestViewBatteryDetectsInPlaceCompaction(t *testing.T) {
+	t.Parallel()
+
+	ran, failures := runViewBattery(t, inPlaceViewDelete)
+	require.Greater(t, ran, 100,
+		"the red-proof deleted through only %d views", ran)
+	require.NotEmpty(t, failures,
+		"the pre-#471 in-place compaction must fail this battery, or a clean run "+
+			"of TestViewDeleteBattery proves nothing")
+	t.Logf("red-proof: the pre-#471 in-place compaction writes outside the step's "+
+		"positions in %d of %d cases, e.g.\n%s", len(failures), ran, failures[0])
+}
+
+// TestInPlaceReplicaMatchesTheShippedAnswer pins the replica as a replica.
+//
+// The two must return the SAME value for every case in the sweep and differ
+// only in what they write through — that identity is the whole reason #471
+// was silent, and it is also what makes the red-proof above evidence about
+// the shipped code rather than about a straw man that is merely broken.
+func TestInPlaceReplicaMatchesTheShippedAnswer(t *testing.T) {
+	t.Parallel()
+
+	compared := 0
+	for _, n := range []int{1, 2, 3, 4, 5} {
+		for _, step := range viewSteps(n) {
+			// No pad: with nothing aliased beyond the window the two bodies
+			// have nowhere to differ, so any difference is in the answer.
+			a := newViewWindow(n, 0)
+			b := newViewWindow(n, 0)
+			gotA, errA := shippedViewDelete(step, a.view)
+			gotB, errB := inPlaceViewDelete(step, b.view)
+			require.Equalf(t, errA == nil, errB == nil,
+				"n=%d step=%s: replica and shipped disagree on error", n, step)
+			if errA != nil {
+				continue
+			}
+			compared++
+			require.Equalf(t, gotA.String(), gotB.String(),
+				"n=%d step=%s: the replica is not a replica — it returns a different answer",
+				n, step)
+		}
+	}
+	require.Greater(t, compared, 50, "compared only %d cases", compared)
+	t.Logf("replica returns the shipped answer in all %d compared cases; it differs "+
+		"only in what it writes through", compared)
+}
+
+// TestIssue471Reproduction is the issue's own example at the Go surface, both
+// step forms, both producers.
+func TestIssue471Reproduction(t *testing.T) {
+	t.Parallel()
+
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = nil
+
+	for _, tc := range []struct {
+		name string
+		step *lisp.LVal
+	}{
+		{"index", lisp.Int(0)},
+		{"range", rangeStep(0, 1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, producer := range []string{"kernel-slice", "elpspath-range"} {
+				t.Run(producer, func(t *testing.T) {
+					backing := make([]*lisp.LVal, 5)
+					for i := range backing {
+						backing[i] = lisp.Int(i + 1)
+					}
+					src := lisp.Array(nil, backing)
+
+					var view *lisp.LVal
+					if producer == "kernel-slice" {
+						// what (slice 'vector src 0 3) hands back: a clamped
+						// window onto src's own array
+						view = lisp.Array(nil, backing[0:3:3])
+					} else {
+						got, err := Range(0, 3, false).Get(src)
+						require.NoError(t, err)
+						view = got
+					}
+
+					res := callBuiltin(env, BuiltinQueryDeleteMutate, view, tc.step)
+					require.NotEqualf(t, lisp.LError, res.Type, "?del! errored: %v", res)
+
+					require.Equal(t, "(vector 2 3)", res.String(),
+						"the view's own answer was always correct; that is why this was silent")
+					require.Equal(t, "(vector 1 2 3 4 5)", src.String(),
+						"deleting through a view scrambled the source it aliases (#471)")
+				})
+			}
+		})
+	}
+}
+
+// TestViewStepsCoverBothForms is the battery's own gate: viewSteps is its
+// only source of steps, so a form missing from it is a whole route the sweep
+// silently cannot reach — the lesson TestEnumeratePathsCoversEveryStepForm
+// records for the copy battery.
+func TestViewStepsCoverBothForms(t *testing.T) {
+	t.Parallel()
+
+	forms := map[string]int{}
+	negatives := 0
+	for _, s := range viewSteps(4) {
+		switch s.Type { //nolint:exhaustive // viewSteps emits exactly these two
+		case lisp.LInt:
+			forms["index"]++
+			if s.Int < 0 {
+				negatives++
+			}
+		case lisp.LSExpr:
+			forms["range"]++
+		}
+	}
+	for _, want := range []string{"index", "range"} {
+		require.Positivef(t, forms[want], "viewSteps emits no %s step: %v", want, forms)
+	}
+	require.Positive(t, negatives,
+		"viewSteps emits no negative index, so the fold in resolveIndex is unswept here")
+	t.Logf("viewSteps(4): %s", stepFormSummary(forms, negatives))
+}
+
+func stepFormSummary(forms map[string]int, negatives int) string {
+	return "index=" + strconv.Itoa(forms["index"]) +
+		" (negative=" + strconv.Itoa(negatives) + ")" +
+		" range=" + strconv.Itoa(forms["range"])
+}


### PR DESCRIPTION
Fixes #471.

Based on `main`, not on #472's branch: #472 merged while this was in progress, so `libelpspath` is on `main` at `1c13c76` and #471 is a live defect on the default branch rather than one about to land. The branch was reset onto `main` and the fix reapplied; the diff is five files, all under `lisp/lisplib/libelpspath/`.

## Verdict

**`libelpspath` is clean apart from #471.** The four families were swept with probes that were run, not read. #471 reproduced, was fixed, and its reach turned out wider than filed. Nothing else in the package writes through storage it does not own, retains a caller's container, shares a `*token.Location`, or walks a cyclic value unguarded. What was checked and found clean is listed below, because a clean verdict is only worth what the probes behind it are worth.

One correction to the issue as filed: #471 is **not** limited to strict sub-windows.

## #471

`indexPath.deleteMutate` and `rangePath.deleteMutate` compacted in place, through the input's own backing array:

```go
vals := append(cells[:index], cells[index+1:]...)
vals := cells[:from]; vals = append(vals, cells[to:]...)
```

Both appends shift the tail left **through** `cells`' array. That array is not the function's to write whenever `in` is a **view** — an ordinary array `LVal` whose cells are a window onto a longer sequence, which the kernel's `(slice 'vector …)` and this package's own `rangePath.Get` both hand out, and which nothing in an `LVal` marks.

Reproduced **running**, on the rebased tree:

```lisp
(set 'v (vector 1 2 3 4 5))
(set 'w (slice 'vector v 0 3))
(elpspath:?del! w 0)
;; view (vector 2 3)   src (vector 2 3 3 4 5)
```

`v` was never named by the operation. It did not shrink — it cannot — it was scrambled: `1` gone, `3` duplicated, nothing raised.

**The answer was right, which is why nothing caught it.** A left shift copies before it overwrites, so the view came out correct and only the aliased source was damaged. That is the whole difference from `rangePath.setMutate`, which had the identical defect and was found immediately because its overlap corrupted its own answer.

No capacity clamp reaches it: #369/#373 close appends **past** `len`, and this writes **within** `len`.

### Two shapes the issue did not list

Found **running**, while sweeping around the reported ones:

| shape | before | after |
|---|---|---|
| **full-length view** — `(slice 'vector v 0 5)` on a 5-element `v` | `src (vector 2 3 4 5 5)` | `src (vector 1 2 3 4 5)` |
| **view of a view** — `(slice 'vector (slice 'vector v 0 4) 0 2)` | `mid (vector 2 2 3 4)`, `src (vector 2 2 3 4 5)` | both intact |

The full-length case matters for the framing: a window covering the whole sequence aliases just as completely as a partial one. "Being the whole sequence" is not the same as owning it, so a fix conditioned on the window being shorter than its backing array would have been wrong.

Cases that were **accidentally** correct before the fix, and are correct on purpose now: deleting a suffix (including the whole window) shifts nothing, because there is no tail to move. Only a delete with a non-empty tail wrote through. That narrowed the shapes that could expose it without making any of them safe.

### The fix

Both paths build the compaction in a slice they allocate, with an exact capacity, and hand it to `storeCells` as before. A delete through a view now leaves the source completely alone. The change is ~10 lines of code in two functions.

The issue also floats making `?del!` on a view an **error**. Not done, and deliberately: there is no reliable way to ask an `LVal` whether it is a view — `cap` is not it, since the kernel clamps its own producers — so the test would be both unsound and a behaviour change. Allocating is what the issue proposes and it is sufficient.

## Everything else: what was checked, and how

Every row was **run**. Where a family is clean by construction rather than by probe, that is said explicitly.

| family | probe | result |
|---|---|---|
| **#369/#373 sequence views** | audited every slice expression in the package's four non-test files, then checked `len == cap` for every `(from,to)` on lengths 0..8, both shapes | **clean.** `rangePath.Get` is the *only* function returning a sub-sequence of a caller's array, and its clamp holds in all 162 cases |
| **#362/#366/#426/#431/#446 `*token.Location`** | grep for `token.`, `.Source`, `.Copy()` across non-test sources | **clean, by construction.** Zero references. The package never reads, writes or retains a position; its constructors take `nativeSource()`'s shared singleton, which the kernel's own snapshot guard already watches |
| **#437/#444 caller-supplied containers** | passed each of the 7 builtins an argument array with spare capacity holding a sentinel, across 4 step shapes; separately mutated a caller's `[]Path` after `Chain` had consumed it | **clean.** No builtin replaced an element of the caller's array or appended into its spare capacity; `Chain` neither retains nor writes the caller's slice (`expandPaths` always rebuilds) |
| **#390/#391/#393 unguarded walks** | 21 cyclic shapes through all 7 builtins out of process: direct self-containing vector, cycle nested inside a map, cycle as the *new value* of a set, self-containing sorted-map, and a mutual two-vector cycle | **clean.** All 21 raised a catchable condition; the process survived. The Go-embedder route that bypasses `okSimpleType` is guarded too (`Set`/`Delete`/`Nil` via the exported `Path` all refuse) |
| **guard does not over-reject** | deep acyclic values at depths 10/63/64/65/200/5000, and a DAG with a repeated sibling buried past `cycleGuardDepth` | **clean.** All accepted and copied in full — the guard costs no correctness on the shapes it must not refuse |
| **#395 shallow-copy-claiming-deep** | the package's own `TestCopyHelpersAgreeOnNestingDepth` plus the copy battery | **clean.** All copy entry points route through `copyGuarded` |
| **#397/#364/#420 unsynchronised state** | enumerated package-level state; 16 goroutines each building an env, loading the package and running 150 operations, under `-race` | **clean.** The only package-level state is the read-only `builtins` templates and an immutable error. The cycle guard's map is a caller-owned local (`var st cycleState`) per walk, never shared. Formals templates verified byte-identical and pointer-identical after 20 loads |

### The `rangePath.Get` clamp on `main`

Checked rather than assumed, since it was written against a premise (`slice` retains capacity) that #373 had already invalidated. It is present as `cells[from:to:to]`, which is `len == cap`, i.e. exactly what `lisp.clampCap` produces. Verified by running: `len == cap` for every `(from,to)` pair on lengths 0..8 for both vectors and lists, and `(append! (? v '(range 0 3)) 99)` leaves `v` alone. **Correct, and not re-touched here.**

## Closing the two blind spots

The fix alone would leave in place the reason it was missed. Two things could have seen this and neither did, for the same reason.

**The alias battery writes through copies.** A view is not a copy, and it had no arm that mutates one — the issue names this as a coverage gap. `path_view_alias_test.go` adds the axis.

The property is: **a mutating operation on a view may change the backing array only at the positions its path names.** Stated that way rather than "must not touch the source", because element assignment through a view is legitimate and documented — `(?set! w 0 97)` does set the source's element 0. #471 is not that: it moved every element after the deleted one, positions no path named. That formulation catches #471 everywhere it is reachable while permitting the aliasing that is meant to work.

- 255 cases per operation across window sizes, pads and every index and range step, for all three mutating operations. All clean.
- **Red-proof**: the same sweep against a replica of the pre-#471 bodies fails **57 of 255**.
- `TestInPlaceReplicaMatchesTheShippedAnswer` pins the replica as a replica — identical answers in all 85 comparable cases, differing only in what it writes through. That identity *is* the defect's silence, and it makes the red-proof evidence about the shipped code rather than about a straw man that is merely broken.

**The fuzzer's documents are all harness-built**, so their cells belong to nobody else and a write past what the path named lands in the harness's own array. `FuzzPathEngine` gains **invariant 7**, folded into the existing target rather than added as a new one.

Two things were needed and either alone is insufficient:

- **Order.** Built *after* the main call, the witness copies a document a `!` operation has already shrunk, so the window is too small to show an unnamed shift — the property passes on a tree that has #471 in it. It is now taken before the call, like the splice oracle. This was caught by testing the red arm, not by reasoning.
- **Seeds.** The general drivers reach the shape **zero** times: it needs a vector document *and* exactly one step *and* a step naming a strict non-empty subset of the positions, and nothing in the existing corpus lines all three up. 14 dedicated seeds — one per operation per step form — were found by search over short inputs.

`TestViewWitnessSeedsAreReached` pins both facts, including the zero, so the seeds do not later look like superstition.

**Red before green**, verified: with the fix reverted the seed corpus fails on the `?del!` index and `?del!` range seeds; restored, green.

```
--- FAIL: FuzzPathEngine/seed#62
    ?del! through a view wrote into the backing array it does not own:
    position 1, inside the view's window changed from () (0xc0000efd50) to () (0xc0000efdc0),
    and the path does not name it (named: [0])
```

Fuzz budget is unchanged — still 30 targets over 8 shards, required 50 min, **headroom 10 min**, and `.github/` is untouched (`shard: [1..8]`).

The lisp-visible arms in `libelpspath_test.lisp` cover both producers, both step forms, offset and full-length windows, and a view reached through a document — plus two **guard** arms that pass in both directions (element assignment through a view still reaching the source; the range splice still not), so the semantics around the fix are re-decided rather than drifted.

## Benchmarks

The fix trades an allocation for correctness, so it is measured rather than asserted to be free. Both arms alternate inside one process; `benchstat -col /arm`, base column is the allocating (fixed) arm, so a negative number is the old in-place arm being cheaper.

**Allocations: exactly +1 per delete, every row, no exceptions.**

```
                                  │ allocating  │              inplace               │
                                  │  allocs/op  │ allocs/op   vs base                │
DeleteCompaction/n=4/step=index     10.000 ± 0%   9.000 ± 0%  -10.00% (p=0.000 n=12)
DeleteCompaction/n=16/step=index    10.000 ± 0%   9.000 ± 0%  -10.00% (p=0.000 n=12)
DeleteCompaction/n=64/step=index    10.000 ± 0%   9.000 ± 0%  -10.00% (p=0.000 n=12)
  (all nine rows identical: 10 vs 9)
```

`B/op` grows with the sequence, as a copied slice must: +24 B at n=4, +128 B at n=16, +512 B at n=64 — 8 bytes per element pointer.

**Time: geomean +7.1%, worst row +12.5%, all under the 15% threshold.**

```
                                  │  allocating  │               inplace                │
DeleteCompaction/n=4/step=index     592.7n ± 15%   585.8n ± 11%        ~ (p=0.219 n=12)
DeleteCompaction/n=16/step=index    809.3n ±  8%   707.9n ±  3%  -12.52% (p=0.000 n=12)
DeleteCompaction/n=64/step=index    1.278µ ±  2%   1.198µ ±  1%   -6.22% (p=0.000 n=12)
geomean                             844.6n         785.0n         -7.06%
```

Worth recording per #452: a first pass at `-benchtime=200x` reported one row at **-34.5% (p=0.005)** with ±21%/±19% spreads — a move that exceeds its own row's spread, and so would have been reported as a real regression. At `-benchtime=50000x` that same row is `~ (p=0.219)`. It was measurement noise, and the rule that a move must beat its row's spread does not by itself protect against an under-iterated benchmark.

This is a micro-benchmark of the delete step alone, so it is the worst case. Cross-base rows below.

### Cross-base rows: zero, and why that is not reassurance

Every benchmark that exists on both `1c13c76` and this branch is **unchanged on both allocation metrics** — `~ (p=1.000 n=6)`, "all samples are equal", on `B/op` and `allocs/op` alike, including all four `BuiltinDelCopyDeep` depths.

That zero needs its explanation stated rather than banked, because on its own it would be a false reassurance:

```
$ grep -oE 'lisp\.Int|rangeStep' path_bench_test.go path_bench_depth_test.go
(no output)
```

**The existing benchmark suite never passes an integer or range step.** Every step in it is a map key, so no benchmark on `main` reaches `indexPath.deleteMutate` or `rangePath.deleteMutate` at all. The rows are unchanged because they do not execute the changed code — not because the change is free. `BenchmarkDeleteCompaction` is added for exactly that reason, and it is where the real +1 allocation shows.

Timing on the cross-base rows is all `~` except `Copy` at -1.6%, i.e. an improvement, and the spreads run to ±77% — this sandbox sat at load average ~24 on 4 cores throughout, from other tenants. **CI's benchmark job is the authoritative gate here**: it pins `GOMAXPROCS`, measures both arms in-job on the bench runner, and applies #443's resolution check. The allocation numbers above are load-independent and exact, and they are the ones this change is actually about.

## Gates

All run on this branch at `1c13c76` + these commits.

| gate | result |
|---|---|
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test -count=1 ./...` | ok, exit 0, 37 packages |
| `go test -race -count=1 ./...` | ok, exit 0, no `DATA RACE` |
| `golangci-lint run ./...` | **0 issues** |
| `elps fmt -l ./...` | no output, exit 0 (binary deleted before commit) |
| `elps doc -m` | `All functions and exports are documented.` |
| `make go-test` | exit 0 |
| `make race` | exit 0 |
| `make test-elpscheck` | exit 0 — the singleton integrity checks are also the strongest evidence for the `*token.Location` row above |
| `make test-examples` | exit 0 |
| `./scripts/ci-gates-test.sh` | **233 passed, 0 failed** (see note) |
| `./scripts/confidentiality-guard.sh` | `confidentiality guard: clean` |
| `./scripts/fuzz-budget-check.sh` | 30 targets / 8 shards, required 50 min, **headroom 10 min** — unchanged |

`FuzzPathEngine`, 5 minutes on this branch: **1,508,405 execs**, 546 new interesting inputs (corpus 72 → 618), `PASS`, no new crashers in `testdata/`.

### A note on `ci-gates-test.sh`, and a defect it exposed

The **first** run of it on this branch reported `226 passed, 7 failed` — all in fuzz target *discovery*, naming targets in packages this PR does not touch (`FuzzEval`, `FuzzLexer`, `FuzzParseProgram`, `FuzzLoadJSON`, `FuzzMinifySource`, `FuzzFormat`), with `FuzzPathEngine` unaffected. A re-run on the identical tree gave `233 passed, 0 failed`, matching `main`. The first run was on a cold build cache; the failures are transient and environmental, not caused by this diff.

What is **not** transient is that they were silent. `scripts/fuzz.sh`:

```sh
list_targets() {
	go test ${tagflags+"${tagflags[@]}"} -list '^Fuzz' "$1" 2>/dev/null | grep -E '^Fuzz[A-Za-z0-9_]*$'
}
```

stderr goes to `/dev/null` and the exit status is discarded, so a package that fails to build is indistinguishable from a package with no fuzz targets. Demonstrated **running**, in a throwaway module:

```
--- ./good     targets discovered: [FuzzGoodOne FuzzGoodTwo]
--- ./broken   targets discovered: [<none>]
broken pkg exit status: 1        # discarded by list_targets
```

`fuzz.sh` guards the *total-zero* case ("a fuzz gate that runs nothing cannot fail — treating as an error") but nothing guards *partial* loss, which is the same failure mode one notch quieter: I observed 8 of 30 targets vanish behind a green-looking discovery. Filed separately with this reproducer rather than fixed here — it is in `scripts/`, outside this package's scope.
