### PR TITLE
CI: bound every job with timeout-minutes, and delete the apt-get that wedged

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -79,6 +79,18 @@ jobs:
   gates:
     name: CI Gate Self-Test
     runs-on: ubuntu-latest
+    # 10 minutes against an observed 17-22s. Not a performance budget -- a
+    # liveness bound. This job is aggregated into the REQUIRED check below, and
+    # a required check that is stuck `in_progress` never goes red: the PR sits
+    # at mergeable_state=blocked with a spinner, indistinguishable from "CI is
+    # still warming up", forever. That is not hypothetical -- on PR #459 this
+    # job wedged in `apt-get` for 50 minutes and blocked the PR with no red
+    # signal, until someone thought to watch the clock.
+    #
+    # `queue-watchdog` below does NOT cover this. It watches for a job that
+    # never STARTS. This one started fine and then wedged mid-step, which only
+    # a job-level timeout can bound.
+    timeout-minutes: 10
     env:
       # This job has no Go toolchain on purpose -- see the comment above: it
       # must be fast and must report even when the benchmark job is cancelled.
@@ -89,13 +101,35 @@ jobs:
       # "-fuzz must carry -fuzztime" scan, the workflow-shape guards and
       # shellcheck -- still runs here.
       CI_GATES_SKIP_GO: "1"
+      # shellcheck is PREINSTALLED on the ubuntu-latest image, so the gate
+      # script's `command -v shellcheck` branch is always taken here. Without
+      # this variable the script only prints "SKIP shellcheck not installed"
+      # when it is absent -- a silent downgrade that would turn a shell-lint
+      # gate into nothing at all the day the image drops the package. Setting
+      # it makes absence LOUD (red), which is the whole point of running the
+      # lint in CI. See the shellcheck block in scripts/ci-gates-test.sh.
+      CI_GATES_REQUIRE_SHELLCHECK: "1"
     steps:
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
 
-      - name: Install shellcheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
-
+      # There is deliberately NO `apt-get install shellcheck` step here.
+      #
+      # It never installed anything. Every run logged
+      #     shellcheck is already the newest version (0.9.0-1).
+      #     0 upgraded, 0 newly installed, 0 to remove
+      # because shellcheck ships in the ubuntu-latest image. What the step DID
+      # do was make this job -- part of a required check -- depend on reaching
+      # five package repositories (azure.archive.ubuntu.com,
+      # packages.microsoft.com, dl.google.com and friends) over the network on
+      # every single PR, for no benefit. On PR #459 one of those fetches hung
+      # and the job sat in `apt-get update` for 50 minutes.
+      #
+      # Deleting it removes the wedge at the source rather than merely bounding
+      # it: the timeout-minutes above is the backstop, this is the fix. The
+      # tool's presence is now asserted by the gate script itself, via
+      # CI_GATES_REQUIRE_SHELLCHECK, so dropping the install cannot silently
+      # drop the lint.
       - name: Run CI gate self-test
         run: bash scripts/ci-gates-test.sh
 
@@ -167,6 +201,14 @@ jobs:
     # NOTE: `runs-on` cannot read the `env` context, which is why this is a
     # literal plus a `vars` override rather than a workflow-level env var.
     runs-on: ${{ vars.BENCH_RUNNER || '2vcpu-ubuntu-2204-arm' }}
+    # 45 minutes against an observed 10m25s for BENCH_COUNT=10 interleaved
+    # rounds on the 2vcpu ARM runner. Deliberately loose -- benchmark wall time
+    # legitimately moves with the runner and with how many benchmarks the tree
+    # carries, and this bound exists to stop a hang holding the required check
+    # open, not to police benchmark duration. If it ever fires, read it as "the
+    # job wedged", not "the benchmarks got slower"; the budget to re-derive is
+    # BENCH_COUNT, not this number.
+    timeout-minutes: 45
     steps:
       # Two working trees, measured on the SAME runner in the SAME job. This
       # replaces the cached-baseline design, which compared this PR against
@@ -317,6 +359,11 @@ jobs:
   required:
     name: "Required: benchmark"
     runs-on: ubuntu-latest
+    # 5 minutes against an observed 6s (checkout plus one bash assertion).
+    # This is the job whose NAME is in branch protection, so it is the one job
+    # here for which "stuck in_progress" and "blocks the PR forever" are the
+    # same sentence.
+    timeout-minutes: 5
     needs: [gates, queue-watchdog, benchmark]
     if: always()
     steps:

--- a/.github/workflows/elps.yml
+++ b/.github/workflows/elps.yml
@@ -21,6 +21,11 @@ jobs:
   lint-and-test:
     name: Lint & Test
     runs-on: ubuntu-latest
+    # 30 minutes against an observed 3m57s (golangci-lint, make test,
+    # make race, elpscheck, elps fmt/lint/doc). `make race` alone is ~2m and is
+    # the part most sensitive to a slow runner, so the headroom is deliberate.
+    # A liveness bound, not a performance budget.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
@@ -80,6 +85,10 @@ jobs:
   build-windows:
     name: Build (Windows)
     runs-on: windows-latest
+    # 20 minutes against an observed 1m06s. Windows runners have the
+    # slowest and most variable image/toolchain setup of the pool, hence the
+    # wide margin on an otherwise trivial build+vet.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
@@ -115,6 +124,9 @@ jobs:
   required:
     name: "Required: build & test"
     runs-on: ubuntu-latest
+    # 5 minutes against an observed 2s. This job's name is the one in
+    # branch protection; wedged here means the PR is blocked with no red.
+    timeout-minutes: 5
     needs: [lint-and-test, build-windows]
     if: always()
     steps:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -245,6 +245,11 @@ jobs:
   required:
     name: "Required: fuzz"
     runs-on: ubuntu-latest
+    # 5 minutes for one bash assertion over the matrix result. The `fuzz` job
+    # above already carries its own derived timeout-minutes; this aggregate had
+    # none, and it is the job whose NAME is in branch protection -- so a wedge
+    # here blocks the PR with a spinner and no red signal (#468).
+    timeout-minutes: 5
     needs: fuzz
     if: always()
     steps:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -89,6 +89,9 @@ jobs:
   required:
     name: "Required: govulncheck"
     runs-on: ubuntu-latest
+    # 5 minutes for one bash assertion over `needs` results. The scanning
+    # job above already carries timeout-minutes: 15.
+    timeout-minutes: 5
     needs: [govulncheck]
     if: always()
     steps:

--- a/.github/workflows/tree-sitter.yml
+++ b/.github/workflows/tree-sitter.yml
@@ -36,6 +36,9 @@ jobs:
   test:
     name: Tree-sitter Tests
     runs-on: ubuntu-latest
+    # 20 minutes for a Go module download plus `go test ./...` over the
+    # grammar package. A liveness bound, not a performance budget.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
@@ -74,6 +77,8 @@ jobs:
   required:
     name: "Required: tree-sitter"
     runs-on: ubuntu-latest
+    # 5 minutes for one bash assertion over `needs` results.
+    timeout-minutes: 5
     needs: [test]
     if: always()
     steps:

--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -9,6 +9,11 @@ jobs:
   build-binaries:
     name: Build elps (${{ matrix.target }})
     runs-on: ubuntu-latest
+    # A cross-compile per matrix leg. 20 minutes is a liveness bound: the
+    # `go build` is seconds, but Go module download reaches the network and
+    # this workflow gates a release, so a wedged leg stalls the publish with
+    # nothing going red until GitHub's 6h default expires.
+    timeout-minutes: 20
     strategy:
       matrix:
         include:
@@ -53,6 +58,10 @@ jobs:
     name: Publish (${{ matrix.target }})
     needs: build-binaries
     runs-on: ubuntu-latest
+    # `npm ci` and `npx vsce publish` both talk to third-party registries
+    # (npm, the VS Code Marketplace) which can and do hang. 20 minutes turns
+    # that into a red leg instead of a release that never finishes.
+    timeout-minutes: 20
     strategy:
       matrix:
         include:
@@ -102,6 +111,8 @@ jobs:
     name: Publish (universal)
     needs: build-binaries
     runs-on: ubuntu-latest
+    # Same third-party-registry exposure as publish-platform above.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -1862,6 +1862,171 @@ case "$req_out" in
 esac
 
 echo
+echo "== every job declares timeout-minutes ===================================="
+
+# A job with no `timeout-minutes` inherits GitHub's 360-minute default, which
+# for a REQUIRED check is indistinguishable from no bound at all: a check stuck
+# `in_progress` never goes red. The PR sits at mergeable_state=blocked behind a
+# spinner, with no failure to notice, no notification, and nothing to tell it
+# apart from "CI is still warming up" except watching the clock.
+#
+# Observed for real (#468): `CI Gate Self-Test` wedged in `apt-get update` for
+# 50 minutes on PR #459 -- a job whose normal runtime is 17-22 seconds -- while
+# every other check on the board sat green. Cancelling and re-running cleared
+# it in 17s, so nothing about the change under test was involved.
+#
+# The `queue-watchdog` in benchmark.yml does NOT cover this. It watches for a
+# job that never STARTS; timeout-minutes is the only instrument that bounds a
+# job which started and then wedged mid-step. The two are complements, and the
+# repository had only one of them.
+#
+# This is a LIVENESS rule, not a performance budget. The values in the
+# workflows are deliberately several times the observed runtime; the question
+# each one answers is "has this wedged?", never "is this fast enough?". Raising
+# one because a job legitimately got slower is fine. Deleting one is not.
+timeout_probe() { # <root> -- prints PASS/FAIL lines plus __COUNTS__
+	python3 - "$1" <<'PY_INNER'
+import glob, os, sys
+
+root = sys.argv[1]
+try:
+    import yaml
+except ImportError:
+    print("__SKIP__ pyyaml unavailable")
+    sys.exit(0)
+
+# GitHub's implicit default. Declaring it explicitly buys nothing, so a job
+# that "declares" 360 is treated as undeclared rather than waved through on a
+# technicality.
+GITHUB_DEFAULT_MINUTES = 360
+
+failures, passes = [], []
+files = sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.y*ml")))
+if not files:
+    print("__SKIP__ no workflow files found under {}".format(root))
+    sys.exit(0)
+
+for f in files:
+    base = os.path.basename(f)
+    try:
+        doc = yaml.safe_load(open(f))
+    except Exception:  # noqa: BLE001 -- the YAML-parse guard above owns this
+        continue
+    if not isinstance(doc, dict):
+        continue
+
+    jobs = {k: v for k, v in (doc.get("jobs") or {}).items() if isinstance(v, dict)}
+    if not jobs:
+        continue
+
+    bounded = 0
+    for jid, spec in sorted(jobs.items()):
+        name = str(spec.get("name") or jid)
+        # A reusable-workflow call cannot carry timeout-minutes; the bound has
+        # to live in the called workflow's own jobs, which this same guard
+        # covers when that workflow is in this repository.
+        if "uses" in spec and "steps" not in spec:
+            bounded += 1
+            continue
+
+        raw = spec.get("timeout-minutes")
+        if raw is None:
+            failures.append(
+                f"{base}: job {name!r} declares no timeout-minutes, so it inherits "
+                f"GitHub's {GITHUB_DEFAULT_MINUTES}-minute default. A wedged step leaves the "
+                f"check pending, and a check that is pending is never red -- if this job "
+                f"feeds a required check it blocks the PR silently (#468)."
+            )
+            continue
+
+        # `timeout-minutes: ${{ ... }}` is legal YAML and legal Actions, but it
+        # is not checkable here, so it is accepted and named rather than
+        # silently counted as a pass.
+        if isinstance(raw, str) and "${{" in raw:
+            passes.append(f"{base}: job {name!r} bounds itself with an expression ({raw})")
+            bounded += 1
+            continue
+
+        try:
+            mins = int(raw)
+        except (TypeError, ValueError):
+            failures.append(f"{base}: job {name!r} has a non-numeric timeout-minutes ({raw!r})")
+            continue
+
+        if mins <= 0:
+            failures.append(f"{base}: job {name!r} has timeout-minutes: {mins}, which is not a bound")
+        elif mins >= GITHUB_DEFAULT_MINUTES:
+            failures.append(
+                f"{base}: job {name!r} has timeout-minutes: {mins}, at or above GitHub's "
+                f"{GITHUB_DEFAULT_MINUTES}-minute default -- that is the same as declaring nothing."
+            )
+        else:
+            bounded += 1
+
+    if bounded and not [x for x in failures if x.startswith(base + ":")]:
+        passes.append(f"{base}: all {bounded} job(s) declare a timeout-minutes bound")
+
+for p_ in passes:
+    print(f"PASS  {p_}")
+for f_ in failures:
+    print(f"FAIL  {f_}")
+print(f"__COUNTS__ {len(passes)} {len(failures)}")
+PY_INNER
+}
+
+to_out="$(timeout_probe "$REPO_ROOT")"
+case "$to_out" in
+	__SKIP__*) echo "SKIP  job timeout guard ($to_out)" ;;
+	*)
+		echo "$to_out" | grep -v '^__COUNTS__' || true
+		to_counts="$(echo "$to_out" | sed -n 's/^__COUNTS__ //p')"
+		if [ -n "$to_counts" ]; then
+			read -r to_pass to_fail <<<"$to_counts"
+			pass=$((pass + to_pass))
+			fail=$((fail + to_fail))
+		else
+			bad "job timeout guard did not run"
+		fi
+
+		# NEGATIVE CONTROL. The rule above is the kind that passes forever
+		# because it is looking at the wrong thing -- which is precisely the
+		# failure this whole script exists to catch, and precisely how the
+		# original benchstat grep stayed dead for 473 runs. So prove it fires:
+		# strip the bound from one real job in a throwaway copy of the tree and
+		# require the guard to report it. A green run below means the guard
+		# reported the tree clean AND demonstrated it can report otherwise.
+		TO_SANDBOX="$(mktemp -d)"
+		mkdir -p "${TO_SANDBOX}/.github/workflows"
+		cp "$REPO_ROOT"/.github/workflows/*.y*ml "${TO_SANDBOX}/.github/workflows/" 2>/dev/null || true
+		# benchmark.yml carries the job from #468 itself. Strip the FIRST
+		# job-level bound in it, whatever its value -- keyed on shape rather
+		# than on a literal, so re-sizing a timeout cannot quietly disarm the
+		# control.
+		neg_wf="${TO_SANDBOX}/.github/workflows/benchmark.yml"
+		if [ -f "$neg_wf" ] && grep -qE '^    timeout-minutes: [0-9]+$' "$neg_wf" &&
+			sed -i '0,/^    timeout-minutes: [0-9]\+$/{/^    timeout-minutes: [0-9]\+$/d}' "$neg_wf"; then
+			neg_out="$(timeout_probe "$TO_SANDBOX")"
+			neg_counts="$(echo "$neg_out" | sed -n 's/^__COUNTS__ //p')"
+			read -r _ neg_fail <<<"${neg_counts:-0 0}"
+			if [ "${neg_fail:-0}" -ge 1 ]; then
+				ok "negative control: a job whose timeout-minutes is deleted IS reported (${neg_fail} finding(s))"
+			else
+				bad "negative control: deleting a job's timeout-minutes was NOT reported — this guard cannot fail"
+			fi
+			if echo "$neg_out" | grep -q 'declares no timeout-minutes'; then
+				ok "negative control: the finding names the unbounded job and says why it matters"
+			else
+				bad "negative control: the guard fired but not with the unbounded-job diagnosis"
+				echo "$neg_out" | sed 's/^/        | /'
+			fi
+		else
+			bad "negative control: could not construct an unbounded-job fixture"
+		fi
+		rm -rf "$TO_SANDBOX"
+		;;
+esac
+
+echo
 echo "== shell lint on every script in scripts/ ================================"
 
 # DISCOVERED, not enumerated. This was a hardcoded five-entry array, and the
@@ -1902,8 +2067,17 @@ if command -v shellcheck >/dev/null 2>&1; then
 		bad "shellcheck -S warning reported findings"
 		echo "$sc_out" | sed 's/^/        | /'
 	fi
+elif [ -n "${CI_GATES_REQUIRE_SHELLCHECK:-}" ]; then
+	# In CI the tool is expected to be present (it ships in the ubuntu-latest
+	# image), so absence is a broken environment, not a reason to shrug. Left
+	# as a SKIP this would silently downgrade the shell lint to nothing at all
+	# the day the image drops the package, and the board would stay green --
+	# the same "a gate that cannot fail" shape this whole script exists to
+	# prevent. The benchmark.yml `gates` job sets this variable; the install
+	# step it replaced is gone deliberately (#468), so this IS the backstop.
+	bad "shellcheck not installed, but CI_GATES_REQUIRE_SHELLCHECK is set — ${#OWNED_SCRIPTS[@]} scripts went unlinted"
 else
-	echo "SKIP  shellcheck not installed"
+	echo "SKIP  shellcheck not installed (set CI_GATES_REQUIRE_SHELLCHECK=1 to make this fatal)"
 fi
 
 # Same treatment for the .cjs helpers. ci-queue-watchdog.cjs already had a


### PR DESCRIPTION
Fixes #468

## The failure

`CI Gate Self-Test` declared no `timeout-minutes`, so it inherited GitHub's 360-minute default. On PR #459 it wedged in `apt-get update` for **50 minutes** against a normal runtime of 17-22 seconds. Because the job feeds a **required** check, the PR sat at `mergeable_state: blocked` behind a spinner — a required check stuck `in_progress` never goes red, so there was no failure to notice and nothing to distinguish it from "CI is still warming up".

The existing `queue-watchdog` does not cover this. It watches for a job that never *starts*; this one started fine and wedged mid-step. The two instruments are complements and the repo had only one of them.

## Three changes

### 1. The wedge is deleted at the source, not merely bounded

The `Install shellcheck` step never installed anything. Every run logged:

```
shellcheck is already the newest version (0.9.0-1).
0 upgraded, 0 newly installed, 0 to remove and 9 not upgraded.
```

(from the `gates` job of run 31924651040 — this is the normal, successful case)

shellcheck ships in the `ubuntu-latest` image. All the step did was make a required check depend on reaching five package repositories — `azure.archive.ubuntu.com`, `packages.microsoft.com`, `dl.google.com` and friends — over the network on every single PR, for no benefit. One of those fetches hung and cost #459 fifty minutes.

Removing it cannot silently drop the shell lint. `ci-gates-test.sh` previously degraded to `SKIP shellcheck not installed` if the tool were absent, so the job now sets `CI_GATES_REQUIRE_SHELLCHECK=1` and the script fails loudly instead. Locally, with the variable unset, it still skips — developers without shellcheck are not blocked.

### 2. Every job in every workflow now declares `timeout-minutes`

The audit the issue asked for found **thirteen** unbounded jobs, not one:

| workflow | jobs that had no bound | now |
|---|---|---|
| `benchmark.yml` | `CI Gate Self-Test` | 10 (obs. 17-22s) |
| | `Benchmark Comparison` | 45 (obs. 10m25s) |
| | `Required: benchmark` | 5 (obs. 6s) |
| `elps.yml` | `Lint & Test` | 30 (obs. 3m57s) |
| | `Build (Windows)` | 20 (obs. 1m06s) |
| | `Required: build & test` | 5 (obs. 2s) |
| `fuzz.yml` | `Required: fuzz` | 5 |
| `govulncheck.yml` | `Required: govulncheck` | 5 |
| `tree-sitter.yml` | `Tree-sitter Tests` | 20 |
| | `Required: tree-sitter` | 5 |
| `vscode-publish.yml` | all three publish jobs | 20 each |

Four of these are `Required: *` aggregates — the exact jobs whose names are in branch protection, and therefore the ones for which "wedged" and "blocks the PR forever" are the same sentence.

Every value is documented in-file as a **liveness bound, not a performance budget**: the question each answers is "has this wedged?", never "is this fast enough?". Raising one because a job legitimately got slower is fine; deleting one is not.

### 3. The rule is enforced, so it cannot regress

`scripts/ci-gates-test.sh` now checks that every job in every workflow declares a bound, that it parses as a positive integer, and that it is below 360 — declaring GitHub's own default is the same as declaring nothing. A job added later cannot arrive unbounded.

It ships with a **negative control**: the guard is re-run against a copy of `benchmark.yml` with one bound stripped and must report it. A shape guard that only ever reports success is the precise defect this script was written after (the dead `grep -E '^\S.*\+$'` that passed for 473 runs), so the guard proves it can fail on every run.

## Red, then green

The new rule run against `main`'s workflows at `8749a34`, with only the gate script taken from this branch:

```
== every job declares timeout-minutes ====================================
PASS  govulncheck-scheduled.yml: all 1 job(s) declare a timeout-minutes bound
PASS  release-tag.yml: all 1 job(s) declare a timeout-minutes bound
FAIL  benchmark.yml: job 'Benchmark Comparison' declares no timeout-minutes ...
FAIL  benchmark.yml: job 'CI Gate Self-Test' declares no timeout-minutes ...
FAIL  benchmark.yml: job 'Required: benchmark' declares no timeout-minutes ...
FAIL  elps.yml: job 'Build (Windows)' ...
FAIL  elps.yml: job 'Lint & Test' ...
FAIL  elps.yml: job 'Required: build & test' ...
FAIL  fuzz.yml: job 'Required: fuzz' ...
FAIL  govulncheck.yml: job 'Required: govulncheck' ...
FAIL  tree-sitter.yml: job 'Required: tree-sitter' ...
FAIL  tree-sitter.yml: job 'Tree-sitter Tests' ...
FAIL  vscode-publish.yml: job 'Build elps (${{ matrix.target }})' ...
FAIL  vscode-publish.yml: job 'Publish (${{ matrix.target }})' ...
FAIL  vscode-publish.yml: job 'Publish (universal)' ...

ci-gates-test: 209 passed, 13 failed
```

With this branch's workflows:

```
PASS  benchmark.yml: all 4 job(s) declare a timeout-minutes bound
PASS  elps.yml: all 3 job(s) declare a timeout-minutes bound
PASS  fuzz.yml: all 2 job(s) declare a timeout-minutes bound
PASS  govulncheck-scheduled.yml: all 1 job(s) declare a timeout-minutes bound
PASS  govulncheck.yml: all 2 job(s) declare a timeout-minutes bound
PASS  release-tag.yml: all 1 job(s) declare a timeout-minutes bound
PASS  tree-sitter.yml: all 2 job(s) declare a timeout-minutes bound
PASS  vscode-publish.yml: all 3 job(s) declare a timeout-minutes bound
PASS  negative control: a job whose timeout-minutes is deleted IS reported (1 finding(s))
PASS  negative control: the finding names the unbounded job and says why it matters

ci-gates-test: 215 passed, 0 failed
```

The `CI_GATES_REQUIRE_SHELLCHECK` arm, demonstrated with shellcheck masked out of `PATH`:

```
--- absent + CI_GATES_REQUIRE_SHELLCHECK=1 (expect red) ---
FAIL  shellcheck not installed, but CI_GATES_REQUIRE_SHELLCHECK is set — 14 scripts went unlinted
ci-gates-test: 214 passed, 1 failed

--- absent, variable unset (expect skip, still green) ---
SKIP  shellcheck not installed (set CI_GATES_REQUIRE_SHELLCHECK=1 to make this fatal)
ci-gates-test: 214 passed, 0 failed
```

On `main` that second case is what CI would silently have done had the image ever dropped the package.

## Note on merge sequencing

This touches `.github/workflows/fuzz.yml` — **one addition**, `timeout-minutes: 5` on the `Required: fuzz` aggregate job. It does not touch `scripts/fuzz.sh`, `scripts/fuzz-budget-check.sh`, the `fuzz` job, or the shard matrix, so it should not conflict with the concurrent work on #458/#479, but the file is shared.

## Gates

`go build`, `go vet`, `go test -count=1`, `go test -race`, `golangci-lint run` (0 issues), `elps fmt -l`, `elps doc -m`, `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `./scripts/ci-gates-test.sh` (215/0), `./scripts/confidentiality-guard.sh`, `./scripts/fuzz-budget-check.sh` (30 targets / 8 shards / 10 min headroom, unchanged), `shellcheck -S warning` on the modified script. `actionlint` is not available in this sandbox; all eight workflows parse under the gate script's YAML guard.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_