### PR TITLE
ci: require one FUZZTIME of margin in the fuzz budget gate

### DIFF
--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -1539,6 +1539,47 @@ else
 	assert_exit 1 "unsharding (one shard, whole sweep serial) FAILS" \
 		env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
 
+	# Issue #458: the zero-headroom case. The condition used to be
+	# `needed > timeout`, so a sweep sized at EXACTLY timeout-minutes printed
+	# "the sweep fits" and exited 0 -- while being one slow shard away from
+	# the silently-truncated run this whole gate exists to prevent (observed
+	# shard durations vary 4m25s to 5m42s). It must now fail.
+	#
+	# The timeout is DERIVED from what the check itself reports as `required`
+	# rather than hardcoded, so this control cannot go stale as targets are
+	# added. Hardcoding the number here would reproduce the exact
+	# hand-maintained-constant defect the gate was built to kill.
+	#
+	# One invocation, both numbers: the check re-runs full target discovery
+	# (`go test -list` over every package), which is tens of seconds.
+	budget_report="$("$BUDGET" 2>/dev/null)"
+	budget_required="$(awk '$1 == "required" && $2 ~ /^[0-9]+$/ { print $2 }' <<<"$budget_report")"
+	budget_margin="$(awk '$1 == "required" && $2 == "margin" { print $3 }' <<<"$budget_report")"
+	if [ -z "$budget_required" ] || [ -z "$budget_margin" ]; then
+		bad "could not read 'required' / 'required margin' from the budget check's own output"
+	else
+		cp "$FUZZ_WF" "$budget_wf"
+		sed -i "s/^    timeout-minutes: [0-9]*\$/    timeout-minutes: ${budget_required}/" "$budget_wf"
+		assert_exit 1 "a sweep sized at EXACTLY timeout-minutes FAILS -- zero headroom is not a fit (#458)" \
+			env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
+
+		# ...and exactly one FUZZTIME above that passes. The PAIR is the
+		# point: it pins the boundary at one FUZZTIME of margin, so neither
+		# dropping the margin nor inflating it past the derived quantum can
+		# pass this file.
+		cp "$FUZZ_WF" "$budget_wf"
+		sed -i "s/^    timeout-minutes: [0-9]*\$/    timeout-minutes: $((budget_required + budget_margin))/" "$budget_wf"
+		assert_exit 0 "one FUZZTIME above 'required' is the smallest timeout that passes (#458)" \
+			env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
+
+		# One minute below that boundary must still fail, which is what makes
+		# the assertion above a boundary and not just "a big number passes".
+		cp "$FUZZ_WF" "$budget_wf"
+		sed -i "s/^    timeout-minutes: [0-9]*\$/    timeout-minutes: $((budget_required + budget_margin - 1))/" "$budget_wf"
+		assert_exit 1 "one minute short of a full FUZZTIME of margin still FAILS (#458)" \
+			env FUZZ_WORKFLOW="$budget_wf" "$BUDGET"
+	fi
+
 	cp "$FUZZ_WF" "$budget_wf"
 	sed -i '/^    timeout-minutes: [0-9]*$/d' "$budget_wf"
 	assert_exit 2 "a fuzz job with NO timeout-minutes is unreadable, not fine" \

--- a/scripts/fuzz-budget-check.sh
+++ b/scripts/fuzz-budget-check.sh
@@ -19,11 +19,46 @@
 #
 # So the number is derived here instead of remembered:
 #
-#     ceil(targets / shards) x FUZZTIME + overhead  <=  timeout-minutes
+#     ceil(targets / shards) x FUZZTIME + overhead + FUZZTIME  <=  timeout-minutes
+#     \___________________ needed ____________________/  \_ margin _/
 #
 # and CI fails when it stops holding. `ceil(targets/shards)` is the largest
 # shard, which is what sets wall clock for a matrix -- the shards run in
 # parallel, so the total is irrelevant.
+#
+# Why the trailing margin (issue #458)
+# ------------------------------------
+# This condition used to be `needed > timeout` with no margin, so a sweep sized
+# at EXACTLY timeout-minutes printed "the sweep fits" and exited 0. Zero
+# headroom is not a fit. Two things make it a truncated sweep:
+#
+#   * The estimate is not the observation. OVERHEAD_MINUTES is a fixed guess
+#     and per-target cost is not constant -- observed shard durations already
+#     vary from 4m25s to 5m42s. A budget that is exactly consumed on paper is
+#     over-run in practice by whichever shard runs slow.
+#   * A truncated sweep is silent. The job is cancelled partway through, the
+#     last targets in the largest shard never execute, and the run looks the
+#     same as a finished one. That is the precise failure this gate exists to
+#     prevent, so passing at zero headroom made the gate unable to report it.
+#
+# The margin is DERIVED, not chosen. `needed` is
+# `ceil(targets/shards) x FUZZTIME + overhead`; the only term that moves as the
+# repo grows is `ceil(targets/shards)`, an integer. Adding targets therefore
+# steps `needed` up in units of exactly one FUZZTIME -- never a fraction of
+# one. So:
+#
+#   * a margin SMALLER than one FUZZTIME cannot survive the next step: the very
+#     next target that pushes the largest shard up by one lands straight past
+#     the timeout, which is the stale-matrix accident this gate is for;
+#   * one FUZZTIME is thus the smallest margin that is still standing after the
+#     next target lands, which is the whole job of a backstop.
+#
+# It is not a round number picked to feel safe -- it is the quantum this
+# arithmetic moves in. Concretely, at the 30 targets / 8 shards / 60 min that
+# main carries today: needed = 4 x 10 + 10 = 50, margin = 10, and 60 <= 60
+# holds with nothing to spare. That is deliberate. One FUZZTIME is at once the
+# minimum the derivation allows and the maximum the current matrix can pay, so
+# the gate is as tight as it can be without being wrong in either direction.
 #
 # Everything is read from the sources of truth rather than passed in: targets
 # from `scripts/fuzz.sh --list` (the same discovery the sweep uses), and the
@@ -34,8 +69,10 @@
 # Usage:  scripts/fuzz-budget-check.sh
 #
 # Exit codes:
-#   0  the budget fits
-#   1  it does not -- raise timeout-minutes, add shards, or lower FUZZTIME
+#   0  the budget fits, with at least one FUZZTIME of margin
+#   1  it does not -- add shards, lower FUZZTIME, or (last resort) raise
+#      timeout-minutes.  Exiting 1 at zero headroom is intentional: see the
+#      margin note above.
 #   2  the inputs could not be read (missing workflow, no targets discovered,
 #      unparsable duration).  2 rather than 0 on purpose: a budget gate that
 #      cannot read its inputs must not report "fits".
@@ -141,6 +178,31 @@ fi
 per_shard=$(((n_targets + shards - 1) / shards))
 needed=$((per_shard * per_target_minutes + OVERHEAD_MINUTES))
 
+# One FUZZTIME, because that is the step `needed` moves in when a target is
+# added (see the margin note in the header). Anything less is a margin that the
+# next target walks straight through.
+margin=$per_target_minutes
+required_timeout=$((needed + margin))
+
+# The smallest shard count that would satisfy the constraint, so the failure
+# message can name the actual remedy instead of leaving the reader to solve for
+# it -- the preferred fix is adding shards, and "add shards" without a number
+# invites picking one at random. Bounded above by n_targets: more shards than
+# targets draws empty shards, which fuzz.sh rejects outright.
+next_better_shards() {
+	local s ps
+	for ((s = shards + 1; s <= n_targets; s++)); do
+		ps=$(((n_targets + s - 1) / s))
+		if [ $((ps * per_target_minutes + OVERHEAD_MINUTES + margin)) -le "$timeout_minutes" ]; then
+			echo "$s"
+			return 0
+		fi
+	done
+	# Sharding alone cannot fix it: even one target per shard costs
+	# FUZZTIME + overhead + margin. Say so rather than naming a bogus count.
+	echo "no shard count (not even ${n_targets}, one target each)"
+}
+
 echo "fuzz-budget-check:"
 echo "  targets discovered      ${n_targets}"
 echo "  shards                  ${shards}"
@@ -148,28 +210,69 @@ echo "  largest shard           ${per_shard} target(s)"
 echo "  scheduled FUZZTIME      ${sched_fuzztime} (${per_target_minutes} min/target)"
 echo "  fixed overhead          ${OVERHEAD_MINUTES} min"
 echo "  required                ${needed} min"
+echo "  required margin         ${margin} min (one FUZZTIME -- the next target's cost)"
+echo "  required + margin       ${required_timeout} min"
 echo "  timeout-minutes         ${timeout_minutes} min"
 
-if [ "$needed" -gt "$timeout_minutes" ]; then
+if [ "$required_timeout" -gt "$timeout_minutes" ]; then
+	# Two distinct states end up here and they read very differently to a
+	# human, so say which one this is. "Over by 10" and "exactly on the line"
+	# both have to fail, but only the first is obviously broken on sight --
+	# the second is the one that used to pass, and a reader who is told only
+	# "does not fit" while the arithmetic plainly says 60 <= 60 will assume
+	# the gate is wrong rather than that the headroom is gone.
+	if [ "$needed" -gt "$timeout_minutes" ]; then
+		cat >&2 <<-EOF
+
+			fuzz-budget-check: the nightly sweep does NOT fit in its timeout.
+
+			  ${per_shard} x ${per_target_minutes} min + ${OVERHEAD_MINUTES} min = ${needed} min > ${timeout_minutes} min
+		EOF
+	else
+		cat >&2 <<-EOF
+
+			fuzz-budget-check: the nightly sweep fits with NO usable margin.
+
+			  ${per_shard} x ${per_target_minutes} min + ${OVERHEAD_MINUTES} min = ${needed} min
+			  vs timeout-minutes ${timeout_minutes} min -- headroom $((timeout_minutes - needed)) min,
+			  which is less than the ${margin} min (one FUZZTIME) a sweep must keep spare.
+
+			This is not a rounding complaint. \`needed\` grows in steps of exactly
+			one FUZZTIME, so the next fuzz target to land pushes this over the
+			timeout outright -- and observed shard durations already vary from
+			4m25s to 5m42s, so a budget that is exactly consumed on paper is
+			over-run in practice by whichever shard runs slow.
+		EOF
+	fi
 	cat >&2 <<-EOF
-
-		fuzz-budget-check: the nightly sweep does NOT fit in its timeout.
-
-		  ${per_shard} x ${per_target_minutes} min + ${OVERHEAD_MINUTES} min = ${needed} min > ${timeout_minutes} min
 
 		Left alone, the job is cancelled partway through and the last targets in
 		the largest shard never run -- silently, because a truncated sweep looks
 		exactly like a finished one.
 
-		Fix by one of:
-		  * raise timeout-minutes on the fuzz job to at least ${needed}
-		  * add shards to strategy.matrix.shard (parallel, so this cuts wall clock)
+		Fix by one of, in order of preference:
+		  * add shards to strategy.matrix.shard -- they are parallel, so this
+		    cuts wall clock rather than extending the backstop. ${shards} shards
+		    currently; $(next_better_shards) would bring this back under.
 		  * lower the scheduled FUZZTIME
+		  * raise timeout-minutes on the fuzz job to at least ${required_timeout}
+		    (${needed} needed + ${margin} margin). LAST RESORT: raising the
+		    backstop to make a red gate green is the same move as raising a
+		    benchmark threshold -- it silences the gate instead of the problem.
 	EOF
 	exit 1
 fi
 
 headroom=$((timeout_minutes - needed))
 echo "  headroom                ${headroom} min"
-echo "fuzz-budget-check: the sweep fits."
+
+# Report how many more targets this matrix absorbs before the gate goes red, so
+# the number is in front of whoever is adding one. `needed` steps by one
+# FUZZTIME each time ceil(targets/shards) increments, i.e. every `shards`
+# targets; spare_steps is how many such steps still fit inside the headroom
+# after the mandatory margin is set aside.
+spare_steps=$(((headroom - margin) / per_target_minutes))
+slack_targets=$((per_shard * shards - n_targets + spare_steps * shards))
+echo "  room for                ${slack_targets} more target(s) before this gate goes red"
+echo "fuzz-budget-check: the sweep fits, with ${headroom} min headroom (>= ${margin} min margin)."
 exit 0


### PR DESCRIPTION
Fixes #458

## The defect

`scripts/fuzz-budget-check.sh` compared `needed > timeout`, so a sweep sized at **exactly** `timeout-minutes` printed `the sweep fits` and exited 0. `.github/workflows/fuzz.yml` documents this in its own comments — twice, because ordinary target growth re-entered the state after it was first described.

Zero headroom is not a fit:

* **The estimate is not the observation.** `OVERHEAD_MINUTES` is a fixed guess and per-target cost is not constant — observed shard durations already vary **4m25s to 5m42s**. A budget exactly consumed on paper is over-run in practice by whichever shard runs slow.
* **A truncated sweep is silent.** The job is cancelled partway through, the last targets in the largest shard never execute, and the run looks exactly like a finished one. That is the failure this gate exists to catch — so passing at zero headroom made the gate structurally unable to report its own subject.

## Red, then green — on real state

The stale 6-shard matrix at `main`'s real 30 targets, against the **unfixed** script:

```
  required                60 min
  timeout-minutes         60 min
  headroom                0 min
fuzz-budget-check: the sweep fits.
>>> EXIT=0
```

It printed `headroom 0 min` and then `the sweep fits`. With the fix, the same state exits 1.

Across shard counts at 30 targets:

| shards | `ceil(30/s)` | needed | headroom | result |
|---|---|---|---|---|
| 6 | 5 | 60 | 0 | **FAIL** (exit 1) |
| 7 | 5 | 60 | 0 | **FAIL** (exit 1) |
| 8 | 4 | 50 | 10 | PASS (exit 0) |

Note 7 shards also fails: `ceil(30/7) = 5`, so seven shards is *also* zero headroom at today's target count. (Seven shards passed when it landed, at 27 targets — `ceil(27/7) = 4`.) Both failure messages name **8** as the remedy, which is what `main` actually carries.

## Why one FUZZTIME, and not a round number

`needed = ceil(targets/shards) × FUZZTIME + overhead`. The only term that moves as the repo grows is `ceil(targets/shards)`, an integer — so `needed` steps up in units of **exactly one FUZZTIME**, never a fraction. A margin smaller than one FUZZTIME cannot survive the next target that pushes the largest shard up by one, which is precisely the stale-matrix accident. One FUZZTIME is the smallest margin still standing after the next target lands.

It is also the **largest** margin `main` can currently pay: at 30 targets over 8 shards, `50 + 10 = 60 <= 60` holds with nothing to spare. Tight in both directions on purpose.

`timeout-minutes` is deliberately **not** raised — that is the same move as raising a benchmark threshold. The failure message now says so explicitly and orders the remedies with "add shards" first, computing the specific shard count that would work.

## Tests

Three boundary controls in `ci-gates-test.sh`, deriving the timeout from what the check itself reports as `required` rather than hardcoding it — hardcoding would reproduce the very hand-maintained-constant defect this gate exists to kill:

* a sweep sized at exactly `timeout-minutes` **fails**
* one FUZZTIME above that **passes**
* one minute below that boundary still **fails**

The pair pins the boundary, so neither dropping the margin nor inflating it past the derived quantum can pass this file.

## Gates

`./scripts/ci-gates-test.sh` — **236 passed, 0 failed**. `shellcheck` clean (zero new findings vs `main`). `./scripts/fuzz-budget-check.sh` passes on `main`'s state with 10 min headroom. Shell-only change; no Go sources touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_