### PR TITLE
fuzz: make a package that fails to build fail target discovery

### DIFF
--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -1607,6 +1607,81 @@ else
 	fi
 	rm -rf "$shard_tmp"
 
+	# Issue #479: a package that FAILS TO BUILD must not look like a package
+	# with no fuzz targets.
+	#
+	# Discovery used to be `go test -list ... 2>/dev/null | grep`, discarding
+	# both stderr and exit status, so an uncompilable package contributed zero
+	# targets exactly as a target-free one does -- silently. Observed for real:
+	# 8 of 30 targets vanished on a cold cache and the sweep still exited 0.
+	#
+	# Tested against a THROWAWAY MODULE rather than by breaking this repo,
+	# because the assertion needs a genuinely uncompilable package and doing
+	# that in-tree would break every other check in this file. fuzz.sh derives
+	# its REPO_ROOT from its own location, so a copy inside the scratch module
+	# operates entirely on that module.
+	#
+	# Both directions are asserted. Only the pair is meaningful: "broken
+	# fails" alone is also satisfied by a discovery step that fails on
+	# everything, which would be a gate nobody can keep green.
+	disc_tmp="$(mktemp -d)"
+	mkdir -p "${disc_tmp}/scripts" "${disc_tmp}/notargets" "${disc_tmp}/hastarget"
+	cp "${SCRIPT_DIR}/fuzz.sh" "${disc_tmp}/scripts/fuzz.sh"
+	cat >"${disc_tmp}/go.mod" <<-EOF
+		module example.invalid/fuzzdisc
+
+		go $(awk '/^go /{print $2; exit}' "${REPO_ROOT}/go.mod")
+	EOF
+	# Compiles, and has no fuzz targets at all. Must be accepted in silence:
+	# most packages in any repo look like this, so a discovery step that
+	# complained here would be unusable.
+	cat >"${disc_tmp}/notargets/notargets.go" <<-'EOF'
+		package notargets
+
+		// Greet is ordinary code with no fuzz target anywhere near it.
+		func Greet() string { return "hello" }
+	EOF
+	# Compiles and defines a target, so the green case has something to find
+	# (fuzz.sh treats a repo with zero targets as an error in its own right).
+	cat >"${disc_tmp}/hastarget/hastarget_test.go" <<-'EOF'
+		package hastarget
+
+		import "testing"
+
+		func FuzzScratch(f *testing.F) {
+			f.Add("seed")
+			f.Fuzz(func(t *testing.T, s string) { _ = s })
+		}
+	EOF
+
+	assert_exit 0 "a package with NO fuzz targets is not mistaken for a broken one (#479)" \
+		"${disc_tmp}/scripts/fuzz.sh" --list
+	assert_contains "FuzzScratch" \
+		"the scratch module's one real target IS discovered (#479)" \
+		"${disc_tmp}/scripts/fuzz.sh" --list
+
+	# Now break a package for real -- a type error, not a mock.
+	mkdir -p "${disc_tmp}/broken"
+	cat >"${disc_tmp}/broken/broken.go" <<-'EOF'
+		package broken
+
+		// Deliberately uncompilable: the point of the assertion below.
+		func Broken() int { return "not an int" }
+	EOF
+	assert_exit 2 "a package that does NOT COMPILE fails discovery instead of contributing zero targets (#479)" \
+		"${disc_tmp}/scripts/fuzz.sh" --list
+	assert_contains "FAILED TO BUILD" \
+		"the build failure SAYS it was a build failure (#479)" \
+		"${disc_tmp}/scripts/fuzz.sh" --list
+	assert_contains "not an int" \
+		"the compiler's own error is replayed, not swallowed (#479)" \
+		"${disc_tmp}/scripts/fuzz.sh" --list
+	# The sweep itself, not just --list: the discovery path is shared, and it
+	# is the sweep that would otherwise go green having fuzzed nothing.
+	assert_exit 2 "the SWEEP also refuses to run over a partially-built tree (#479)" \
+		env FUZZTIME=1s "${disc_tmp}/scripts/fuzz.sh" --shard 1/1
+	rm -rf "$disc_tmp"
+
 	# A shard spec that cannot be read must not silently run a SUBSET and exit
 	# 0 -- indistinguishable from a clean full sweep.
 	for bad_spec in "0/4" "5/4" "abc" "1/0"; do

--- a/scripts/fuzz-budget-check.sh
+++ b/scripts/fuzz-budget-check.sh
@@ -120,8 +120,20 @@ to_minutes() {
 per_target_minutes="$(to_minutes "$sched_fuzztime")" || exit 2
 
 # Discovery, from the same code path the sweep uses.
-if ! targets="$("${SCRIPT_DIR}/fuzz.sh" --list 2>/dev/null)"; then
+#
+# stderr is CAPTURED AND REPLAYED, not discarded (issue #479). fuzz.sh reports
+# a package that failed to build on stderr and exits non-zero; with `2>/dev/null`
+# this printed the bare line "scripts/fuzz.sh --list failed" and threw away the
+# build errors that say WHICH package and WHY -- turning an actionable compile
+# error into a dead end, and re-hiding on this side exactly what fuzz.sh was
+# fixed to make loud.
+discovery_err="$(mktemp)"
+trap 'rm -f "$discovery_err"' EXIT
+if ! targets="$("${SCRIPT_DIR}/fuzz.sh" --list 2>"$discovery_err")"; then
 	echo "fuzz-budget-check: scripts/fuzz.sh --list failed" >&2
+	sed 's/^/  | /' "$discovery_err" >&2
+	echo "fuzz-budget-check: no trustworthy target count, so no budget can be" >&2
+	echo "fuzz-budget-check: derived -- refusing to report that the sweep fits." >&2
 	exit 2
 fi
 n_targets="$(printf '%s\n' "$targets" | grep -c . || true)"

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -206,11 +206,59 @@ hard_timeout=$((fuzz_seconds + FUZZ_TIMEOUT_SLACK))
 
 cd "$REPO_ROOT" || exit 2
 
+# Created BEFORE discovery, not after: discovery needs somewhere to put the
+# stderr of the `go list` / `go test -list` probes so it can be replayed to the
+# operator when one of them fails (issue #479).
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
 # list_targets prints the Fuzz* targets defined in one package.  `go test
 # -list` prints the matching names followed by a summary line ("ok <pkg> ..."),
 # so the output is filtered to bare target names.
+#
+# Silence must not be able to mean "no targets here" (issue #479)
+# ---------------------------------------------------------------
+# This used to be a single pipeline ending in `2>/dev/null | grep`, which threw
+# away BOTH the stderr and the exit status of `go test -list`. A package that
+# failed to BUILD therefore contributed zero targets in a way that was
+# byte-for-byte identical to a package that legitimately HAS none: no message,
+# no non-zero status, just a shorter list. Observed for real -- 8 of 30 targets
+# disappeared on a cold cache -- and the sweep still exited 0, so the fuzz job
+# went green having never run them.
+#
+# It compounds with the budget gate: scripts/fuzz-budget-check.sh derives the
+# job's timeout-minutes from THIS count, so a build failure quietly shrank the
+# number the backstop was computed from. The gate was checking arithmetic over
+# a target count that was not real.
+#
+# So the two cases are now separated explicitly:
+#
+#   exit 0  -- the package compiled. Zero matching targets is a legitimate
+#              answer and is returned as an empty list.
+#   exit 1  -- `go test -list` failed. The package did NOT compile (or its
+#              dependencies did not). The caller records it and the run dies;
+#              the captured stderr is replayed so the build error is visible
+#              rather than inferred from a count that looks a bit low.
+#
+# The distinction is the whole point: "no targets" and "no build" are the same
+# empty output, and only the exit status tells them apart.
 list_targets() {
-	go test ${tagflags+"${tagflags[@]}"} -list '^Fuzz' "$1" 2>/dev/null | grep -E '^Fuzz[A-Za-z0-9_]*$'
+	local pkg="$1" rc=0 out
+	out="$(go test ${tagflags+"${tagflags[@]}"} -list '^Fuzz' "$pkg" 2>"${tmpdir}/list.err")" || rc=$?
+	if [ "$rc" -ne 0 ]; then
+		{
+			echo "fuzz.sh: target discovery FAILED for ${pkg} (go test -list exit ${rc})"
+			sed 's/^/    | /' "${tmpdir}/list.err"
+		} >&2
+		return 1
+	fi
+	# `|| true`: grep exits 1 when nothing matches, and for a package that
+	# built cleanly that means "this package has no fuzz targets" -- an
+	# ordinary, correct answer. Letting grep's status escape here would put
+	# every target-free package into the build-failure branch above and make
+	# the loud path meaningless by firing it constantly.
+	printf '%s\n' "$out" | grep -E '^Fuzz[A-Za-z0-9_]*$' || true
+	return 0
 }
 
 # Import path AND source directory in one pass: the directory is where
@@ -218,11 +266,28 @@ list_targets() {
 # Resolving it lazily per target would re-invoke `go list` once per target.
 declare -A pkg_dir=()
 declare -a pkg_list=()
+# Same treatment as list_targets, and for the same reason (issue #479): this
+# also used to be `2>/dev/null` inside a process substitution, so its exit
+# status was unobservable. `go list` reports a package whose NON-test source
+# does not parse by writing to stderr and exiting non-zero while still printing
+# the packages it could load -- so the broken one simply never entered
+# pkg_list, was never probed for targets, and vanished without trace.
+go_list_rc=0
+go_list_out="$(go list ${tagflags+"${tagflags[@]}"} -f '{{.ImportPath}}'$'\t''{{.Dir}}' "${packages[@]}" 2>"${tmpdir}/golist.err")" || go_list_rc=$?
+if [ "$go_list_rc" -ne 0 ]; then
+	{
+		echo "fuzz.sh: go list failed for ${packages[*]} (exit ${go_list_rc})"
+		sed 's/^/    | /' "${tmpdir}/golist.err"
+		echo "fuzz.sh: a package that cannot be LOADED cannot be searched for fuzz"
+		echo "fuzz.sh: targets, and skipping it would silently shrink the sweep."
+	} >&2
+	exit 2
+fi
 while IFS=$'\t' read -r _ip _dir; do
 	[ -n "$_ip" ] || continue
 	pkg_dir["$_ip"]="$_dir"
 	pkg_list+=("$_ip")
-done < <(go list ${tagflags+"${tagflags[@]}"} -f '{{.ImportPath}}'$'\t''{{.Dir}}' "${packages[@]}" 2>/dev/null)
+done <<<"$go_list_out"
 if [ "${#pkg_list[@]}" -eq 0 ]; then
 	echo "fuzz.sh: no packages matched ${packages[*]}" >&2
 	exit 2
@@ -233,12 +298,45 @@ fi
 # stream past would make a target's shard depend on how many targets happened to
 # precede it.
 declare -a all_pairs=()
+declare -a broken_pkgs=()
 for pkg in "${pkg_list[@]}"; do
-	mapfile -t targets < <(list_targets "$pkg")
-	for target in "${targets[@]}"; do
+	# Command substitution rather than `mapfile < <(list_targets ...)`: process
+	# substitution runs in a subshell whose exit status the parent never sees,
+	# which is precisely how the build failure went unnoticed. `if cmd_sub`
+	# evaluates the status HERE, in the main shell, where it can be acted on.
+	if ! targets_out="$(list_targets "$pkg")"; then
+		broken_pkgs+=("$pkg")
+		continue
+	fi
+	while IFS= read -r target; do
+		# A clean package with no targets yields one empty line from the
+		# here-string; that is not a target.
+		[ -n "$target" ] || continue
 		all_pairs+=("${pkg}	${target}")
-	done
+	done <<<"$targets_out"
 done
+
+# A package that did not build is a HOLE in the sweep, not a package with
+# nothing to fuzz -- and the sweep must not be able to report success over a
+# target list it knows is incomplete. Fail before any fuzzing starts, and name
+# every broken package rather than only the first, so one CI run tells the
+# whole story instead of one package per run.
+if [ "${#broken_pkgs[@]}" -gt 0 ]; then
+	{
+		echo
+		echo "fuzz.sh: ${#broken_pkgs[@]} package(s) FAILED TO BUILD during target discovery:"
+		for pkg in "${broken_pkgs[@]}"; do
+			echo "    ${pkg}"
+		done
+		echo
+		echo "fuzz.sh: their fuzz targets, if any, were NOT discovered and would NOT"
+		echo "fuzz.sh: have been run. Refusing to continue: a sweep that silently"
+		echo "fuzz.sh: skips a package is indistinguishable from one that covered it,"
+		echo "fuzz.sh: and scripts/fuzz-budget-check.sh derives the job timeout from"
+		echo "fuzz.sh: this same count. Fix the build errors above and re-run."
+	} >&2
+	exit 2
+fi
 if [ "${#all_pairs[@]}" -gt 0 ]; then
 	# Guarded: `printf '%s\n'` with NO arguments still prints one newline, so
 	# an unguarded sort turns "no targets" into one empty target -- which made
@@ -344,9 +442,6 @@ run_target() {
 		done
 	fi
 }
-
-tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' EXIT
 
 total=0
 failed=0


### PR DESCRIPTION
Fixes #479

## The defect

`scripts/fuzz.sh` discovered targets with:

```bash
go test -list '^Fuzz' "$pkg" 2>/dev/null | grep -E '^Fuzz[A-Za-z0-9_]*$'
```

which discards **both** the stderr and the exit status of `go test -list`. A package that failed to build therefore contributed zero targets in a way byte-for-byte identical to a package that legitimately has none: no message, no non-zero status, just a shorter list.

Silence must not be able to mean "no targets here".

## Reproduced on a real broken package

A type error added to `lisp/lisplib/libjson` — a package carrying **5** fuzz targets, including the JSON decoder that reads chaincode state:

```
$ ./scripts/fuzz.sh --list          # BEFORE
fuzz.sh: 25 target(s) discovered
>>> EXIT=0                          # was 30. Five gone. Silent.

$ ./scripts/fuzz-budget-check.sh    # BEFORE
  targets discovered      25
fuzz-budget-check: the sweep fits.
>>> EXIT=0
```

Not a mock — an actual `cannot use "this is not an int" (untyped string constant) as int value` compile error. The sweep would have gone green having never fuzzed those five targets.

After the fix, all three consumers (`--list`, the budget check, and the sweep itself) exit non-zero and replay the compiler's own error:

```
fuzz.sh: target discovery FAILED for .../lisp/lisplib/libjson (go test -list exit 1)
    | lisp/lisplib/libjson/number_test.go:497:27: cannot use "this is not an int" ...

fuzz.sh: 1 package(s) FAILED TO BUILD during target discovery:
    github.com/luthersystems/elps/lisp/lisplib/libjson
>>> EXIT=2
```

Restoring the file returns discovery to 30 targets, exit 0.

## How the two cases are separated

Exit status is the only thing that ever distinguished them:

| | meaning | behaviour |
|---|---|---|
| `exit 0` | the package compiled | zero matching targets is a legitimate answer; returns an empty list |
| `exit 1` | `go test -list` failed | the package did not compile — recorded, stderr replayed, run dies before fuzzing |

`grep` exiting 1 on no-match is explicitly **not** treated as failure — otherwise every target-free package would enter the loud path and render it meaningless. **24 of this repo's 42 packages have no fuzz targets**, and all 24 correctly stay silent.

## Three call sites carried the defect

* `list_targets` — above.
* the `go list` building `pkg_list` — also `2>/dev/null`, and also inside a **process substitution whose exit status the parent never sees**. A package whose non-test source does not parse never entered the list and was never probed.
* `fuzz-budget-check.sh` consumed `fuzz.sh --list 2>/dev/null`, printing a bare `--list failed` and discarding the build errors naming which package and why — re-hiding on that side exactly what `fuzz.sh` is fixed here to make loud.

The discovery loop moves from `mapfile < <(list_targets ...)` to `if targets_out="$(list_targets ...)"`, because process substitution runs in a subshell whose status the parent cannot observe — mechanically how this went unnoticed. Every broken package is named, not just the first.

## Why this compounds with #458

`fuzz-budget-check.sh` derives the job's `timeout-minutes` from this same count, so a build failure quietly shrank the number the backstop was computed from. **The budget gate was checking arithmetic over a target count that was not real.** (#458 is the other half, in PR #481. The two touch `fuzz-budget-check.sh` in well-separated regions.)

## Tests

Six assertions in `ci-gates-test.sh` driving a **throwaway module** rather than breaking this repo — `fuzz.sh` derives `REPO_ROOT` from its own location, so a copy inside the scratch module operates only on it. Both directions are asserted, because "broken fails" alone would also be satisfied by discovery that fails on everything:

* a package with no fuzz targets is **not** mistaken for a broken one
* the scratch module's one real target **is** discovered
* a package that does not compile **fails** discovery
* the failure says it was a build failure
* the compiler's own error is replayed, not swallowed
* the **sweep** also refuses to run over a partially-built tree

## Gates

`./scripts/ci-gates-test.sh` — **239 passed, 0 failed**. `go build`, `go vet`, `go test -count=1 ./...`, `go test -race ./...` all clean. `shellcheck` clean (zero new findings vs `main`). Shell-only change; no Go sources touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_