### PR TITLE
fuzzwatch: write down the stall-vs-share boundary, and guard the floor

### DIFF
--- a/internal/fuzzwatch/callsite_guard_test.go
+++ b/internal/fuzzwatch/callsite_guard_test.go
@@ -1,0 +1,383 @@
+// Copyright © 2026 The ELPS authors
+
+package fuzzwatch
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// GUARD, not a catch. Every call site in the tree already clears the floor by
+// 50x or more, so this test passes on main and always has. It is here to stop
+// a budget arriving BELOW the floor later, which is the specific mistake #453
+// exists to prevent and the one PR #447 had to measure its way out of.
+//
+// It is a source scan rather than a check inside New because New is called
+// from inside f.Fuzz bodies: a panic there would be recorded as a crasher and
+// attributed to the input, which is a worse failure than the one being
+// prevented. A test failure names the file and the number and says why.
+//
+// The evaluator below is deliberately small. It understands the shapes the
+// repository actually uses -- a duration constant, a sum of them, a literal
+// multiple of time.Second -- and REFUSES anything else rather than guessing.
+// An unrecognised shape fails the test asking for the evaluator to be taught,
+// because silently skipping call sites it cannot read is exactly how a guard
+// like this rots into one that cannot fail.
+
+// budgetSite is one evaluated fuzzwatch.New call.
+type budgetSite struct {
+	Pos    token.Position
+	Budget time.Duration
+}
+
+// budgetsIn returns every fuzzwatch.New budget in f that could be evaluated,
+// plus a description of each one that could not. Shared by the repository scan
+// and by the negative control below, so the control exercises the same code
+// path the real guard runs on.
+func budgetsIn(fset *token.FileSet, f *ast.File) (sites []budgetSite, unreadable []string) {
+	consts := durationConsts(f)
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "New" {
+			return true
+		}
+		if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "fuzzwatch" {
+			return true
+		}
+		if len(call.Args) != 1 {
+			return true
+		}
+		pos := fset.Position(call.Pos())
+		d, ok := evalDuration(call.Args[0], consts)
+		if !ok {
+			unreadable = append(unreadable,
+				fmt.Sprintf("%s:%d: %s", pos.Filename, pos.Line, exprString(call.Args[0])))
+			return true
+		}
+		sites = append(sites, budgetSite{Pos: pos, Budget: d})
+		return true
+	})
+	return sites, unreadable
+}
+
+const floorDiagnosis = "fuzzwatch resolves scheduler STALL above %s, not CPU SHARE: measured on 4 cores\n" +
+	"    under 200 spinners it reported lost=0s while real work ran 103x slower at 0.9%% share.\n" +
+	"    A budget this tight cannot tell 'the machine was busy' from 'the code hung', so it will\n" +
+	"    fire on innocent inputs under load. PR #447 measured exactly this for a 2s budget and\n" +
+	"    rejected it; see #453 and the fuzzwatch package doc."
+
+func TestEveryBudgetIsAboveTheHonestFloor(t *testing.T) {
+	root := repoRoot(t)
+
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "testdata", "node_modules", "_examples":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// The probe under internal/fuzzwatch/probe is a manual reproduction
+		// harness for the #453 measurement; it deliberately uses a short
+		// budget because measuring the instrument is its whole purpose.
+		if strings.Contains(filepath.ToSlash(path), "/internal/fuzzwatch/") {
+			return nil
+		}
+		b, rerr := os.ReadFile(path) //nolint:gosec // path comes from WalkDir over the module root, not from input
+		if rerr != nil {
+			return rerr
+		}
+		if strings.Contains(string(b), "fuzzwatch.New(") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+
+	// A scan that finds nothing reports "all call sites are fine", which is
+	// the same output as a scan that works. The floor makes the two different.
+	const wantAtLeast = 8
+	if len(files) < wantAtLeast {
+		t.Fatalf("found fuzzwatch.New in only %d file(s) (%v), expected at least %d -- "+
+			"the scan is broken, not the tree", len(files), files, wantAtLeast)
+	}
+
+	checked := 0
+	for _, path := range files {
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			t.Errorf("%s: parse: %v", path, perr)
+			continue
+		}
+		sites, unreadable := budgetsIn(fset, f)
+		for _, u := range unreadable {
+			t.Errorf("%s: cannot evaluate the budget expression. Teach evalDuration this shape "+
+				"rather than leaving the call site unchecked -- an unreadable call site is an "+
+				"unguarded one.", u)
+		}
+		for _, s := range sites {
+			checked++
+			if s.Budget < MinHonestBudget {
+				t.Errorf("%s:%d: fuzzwatch budget is %s, below MinHonestBudget (%s).\n    "+floorDiagnosis,
+					s.Pos.Filename, s.Pos.Line, s.Budget, MinHonestBudget, tolerance*tick)
+			}
+		}
+	}
+
+	if checked == 0 {
+		t.Fatalf("scanned %d file(s) containing fuzzwatch.New but evaluated no budgets", len(files))
+	}
+	t.Logf("checked %d fuzzwatch budget(s) across %d file(s) against a %s floor",
+		checked, len(files), MinHonestBudget)
+}
+
+// NEGATIVE CONTROL for the guard above. The repository scan passes today and
+// is expected to pass forever, which makes it indistinguishable from a scan
+// that has quietly stopped looking -- the failure shape this codebase keeps
+// finding. So drive the same evaluator over a synthetic file holding exactly
+// the budget #435 proposed and #447 rejected, and require it to be caught.
+func TestTheFloorGuardCanFail(t *testing.T) {
+	const src = `package p
+
+import (
+	"time"
+
+	"github.com/luthersystems/elps/internal/fuzzwatch"
+)
+
+const proposedWatchdog = 2 * time.Second
+
+func f() {
+	_ = fuzzwatch.New(proposedWatchdog)          // the #435 proposal
+	_ = fuzzwatch.New(500 * time.Millisecond)    // tighter still
+	_ = fuzzwatch.New(30 * time.Second)          // a house-sized budget
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "synthetic_test.go", src, 0)
+	if err != nil {
+		t.Fatalf("parsing the fixture: %v", err)
+	}
+
+	sites, unreadable := budgetsIn(fset, file)
+	if len(unreadable) != 0 {
+		t.Fatalf("the evaluator could not read the fixture: %v", unreadable)
+	}
+	if len(sites) != 3 {
+		t.Fatalf("found %d budgets in the fixture, want 3: %v", len(sites), sites)
+	}
+
+	var caught []time.Duration
+	var passed []time.Duration
+	for _, s := range sites {
+		if s.Budget < MinHonestBudget {
+			caught = append(caught, s.Budget)
+		} else {
+			passed = append(passed, s.Budget)
+		}
+	}
+
+	if want := []time.Duration{2 * time.Second, 500 * time.Millisecond}; !slices.Equal(caught, want) {
+		t.Errorf("guard caught %v, want %v -- it cannot detect a sub-floor budget", caught, want)
+	}
+	if want := []time.Duration{30 * time.Second}; !slices.Equal(passed, want) {
+		t.Errorf("guard passed %v, want %v -- it would red the build on a correctly sized budget", passed, want)
+	}
+}
+
+// repoRoot walks up from the working directory to the module root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod found above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// durationConsts collects file-level `name = <duration expr>` declarations so a
+// budget written as an identifier can be resolved. Only same-file declarations
+// are understood; every call site in this repository declares its watchdog
+// beside itself, and a cross-package constant would be reported as
+// unevaluatable rather than assumed safe.
+func durationConsts(f *ast.File) map[string]time.Duration {
+	out := map[string]time.Duration{}
+	// Two passes, so `callDeadline + watchdogGrace` resolves regardless of the
+	// order the two constants are declared in.
+	for range 2 {
+		for _, decl := range f.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || (gd.Tok != token.CONST && gd.Tok != token.VAR) {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || len(vs.Names) != len(vs.Values) {
+					continue
+				}
+				for i, name := range vs.Names {
+					if d, ok := evalDuration(vs.Values[i], out); ok {
+						out[name.Name] = d
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// evalDuration understands the shapes this repository writes budgets in, and
+// nothing else. Returning false is a request to be taught, not permission to
+// skip.
+func evalDuration(e ast.Expr, consts map[string]time.Duration) (time.Duration, bool) {
+	switch v := e.(type) {
+	case *ast.Ident:
+		d, ok := consts[v.Name]
+		return d, ok
+
+	case *ast.ParenExpr:
+		return evalDuration(v.X, consts)
+
+	case *ast.BinaryExpr:
+		// `N * time.Second`, `time.Second * N`, and sums/differences of
+		// durations. A product of two durations is meaningless, so the
+		// multiply arm requires exactly one side to be a plain integer.
+		switch v.Op { //nolint:exhaustive // only the operators a duration expression can use; everything else is refused below
+		case token.ADD, token.SUB:
+			l, lok := evalDuration(v.X, consts)
+			r, rok := evalDuration(v.Y, consts)
+			if !lok || !rok {
+				return 0, false
+			}
+			if v.Op == token.SUB {
+				return l - r, true
+			}
+			return l + r, true
+
+		case token.MUL:
+			if n, ok := evalInt(v.X); ok {
+				if d, ok := evalDuration(v.Y, consts); ok {
+					return time.Duration(n) * d, true
+				}
+			}
+			if n, ok := evalInt(v.Y); ok {
+				if d, ok := evalDuration(v.X, consts); ok {
+					return time.Duration(n) * d, true
+				}
+			}
+			return 0, false
+		}
+		return 0, false
+
+	case *ast.SelectorExpr:
+		pkg, ok := v.X.(*ast.Ident)
+		if !ok || pkg.Name != "time" {
+			return 0, false
+		}
+		switch v.Sel.Name {
+		case "Nanosecond":
+			return time.Nanosecond, true
+		case "Microsecond":
+			return time.Microsecond, true
+		case "Millisecond":
+			return time.Millisecond, true
+		case "Second":
+			return time.Second, true
+		case "Minute":
+			return time.Minute, true
+		case "Hour":
+			return time.Hour, true
+		}
+		return 0, false
+	}
+	return 0, false
+}
+
+func evalInt(e ast.Expr) (int64, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.INT {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(strings.ReplaceAll(lit.Value, "_", ""), 0, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func exprString(e ast.Expr) string {
+	var sb strings.Builder
+	if err := printExpr(&sb, e); err != nil {
+		return "<unprintable>"
+	}
+	return sb.String()
+}
+
+func printExpr(sb *strings.Builder, e ast.Expr) error {
+	switch v := e.(type) {
+	case *ast.Ident:
+		sb.WriteString(v.Name)
+	case *ast.BasicLit:
+		sb.WriteString(v.Value)
+	case *ast.ParenExpr:
+		sb.WriteString("(")
+		if err := printExpr(sb, v.X); err != nil {
+			return err
+		}
+		sb.WriteString(")")
+	case *ast.SelectorExpr:
+		if err := printExpr(sb, v.X); err != nil {
+			return err
+		}
+		sb.WriteString("." + v.Sel.Name)
+	case *ast.BinaryExpr:
+		if err := printExpr(sb, v.X); err != nil {
+			return err
+		}
+		sb.WriteString(" " + v.Op.String() + " ")
+		if err := printExpr(sb, v.Y); err != nil {
+			return err
+		}
+	case *ast.CallExpr:
+		if err := printExpr(sb, v.Fun); err != nil {
+			return err
+		}
+		sb.WriteString("(...)")
+	default:
+		sb.WriteString("<expr>")
+	}
+	return nil
+}

--- a/internal/fuzzwatch/fuzzwatch.go
+++ b/internal/fuzzwatch/fuzzwatch.go
@@ -56,6 +56,64 @@
 // exactly the configured budget, and every target detects precisely what it
 // detected before. Detection is reduced only on a machine that is not running
 // us -- where the alternative is not detection but a coin flip.
+//
+// # What this does NOT measure: CPU share
+//
+// This instrument resolves scheduler STALL -- intervals during which the
+// process ran not at all. It does not measure CPU SHARE, and under Linux CFS
+// the two come apart completely. Do not reach for it as a load-aware budget.
+//
+// A stall is visible here only if it exceeds tolerance*tick, i.e. 400ms. What
+// starvation actually looks like on a busy machine is not one 400ms freeze but
+// a few microseconds of CPU handed out every millisecond, forever -- and every
+// one of those gaps is far below the resolution floor. Worse, the heartbeat
+// goroutine is by construction almost entirely idle, and CFS gives a waking,
+// near-idle task excellent latency no matter how long the run queue is. The
+// probe is precisely the kind of task starvation does not touch. It reports a
+// healthy machine while the worker beside it gets nothing.
+//
+// Measured on the 4-core sandbox, 200 competing spinners (load average > 50):
+//
+//   - The #453 probe -- create a Budget, sleep 3s, Check -- reports
+//     "wall=3.003s scheduled=3.003s lost=0s longest=0s". Zero lost time, under
+//     load heavy enough to make the machine unusable.
+//
+//   - A fixed lump of CPU work that takes 169ms on the idle box took 17.375s
+//     under that load: a 103x slowdown, at 0.9% CPU share. Over that window
+//     fuzzwatch charged 300ms as lost and reported scheduled=17.357s. It
+//     described a process that was starved for seventeen seconds as one that
+//     ran normally for seventeen seconds. A repeat run was starker still --
+//     12.279s for the same work at 1.2% share, reported as
+//     "12.66s scheduled, 0s lost". Not under-counted: not counted at all.
+//
+// So "scheduled time" is a truthful name only for the failure mode this
+// package was built for -- a process genuinely frozen (VM steal, cgroup
+// throttling with long periods, an SMR pause), where the gaps are seconds and
+// land well above the 400ms floor. Against that, it works as designed. Against
+// contention it degenerates to the wall clock, silently.
+//
+// # The regime in which it is honest, and the floor
+//
+// The nine (now eleven) watchdogs using this package are unaffected, because
+// they are sized 20,000x-90,000x above the mean work they bound: FuzzEval
+// averages 0.33ms per input against 30s, FuzzApplyStdlib 0.73ms against 15s,
+// FuzzSchemaValidate 0.91ms against 20s. A 100x slowdown still leaves two to
+// three orders of magnitude of headroom, so whether the instrument
+// distinguishes stall from share never arises. That headroom -- not the
+// accounting -- is what makes those targets robust.
+//
+// A budget close to the work it bounds gets no such protection, and this
+// package cannot supply it. That is not hypothetical: the first proposed fix
+// in #435 was to give a 2s budget this treatment, at ~57x headroom rather than
+// ~90,000x. PR #447 measured it, found it does not work, and rejected it for
+// that reason; #453 records the general boundary. Do not re-propose it.
+//
+// [MinHonestBudget] is the floor, enforced by a guard test over every call
+// site in the repository. If you want a budget below it, this is the wrong
+// instrument -- measure utime+stime deltas from /proc/self/stat against wall
+// clock instead, and note that those over-count whenever several goroutines of
+// the process are legitimately busy (parallel subtests), so it is not a
+// drop-in replacement either.
 package fuzzwatch
 
 import (
@@ -86,6 +144,27 @@ const (
 	// the honest answer for it.
 	hardWallFactor = 4
 )
+
+// MinHonestBudget is the smallest budget this instrument may be used for.
+//
+// It is not a property of the accounting -- New will happily construct
+// anything -- but of what the accounting can SEE. Stalls shorter than
+// tolerance*tick (400ms) are invisible, and CPU starvation, which is the
+// common case on a busy runner, is invisible at any duration; see the package
+// doc for the measurement. A watchdog is therefore only as trustworthy as its
+// headroom over the work it bounds, and below this floor there is not enough
+// headroom left for "the machine was busy" and "the code hung" to be
+// distinguishable at all.
+//
+// 10s is chosen to sit just under the smallest budget in the tree (15s, in
+// lisp/cycle_fuzz_test.go and lisp/lisplib/fuzz_test.go) and far above the
+// 2s budget that #435 proposed and PR #447 measured and rejected. It is a
+// backstop against a new call site, not a target to design against: every
+// existing watchdog clears it by 50x or more because it is sized against
+// sub-millisecond work, which is the property that actually makes it sound.
+//
+// TestEveryBudgetIsAboveTheHonestFloor enforces this across the repository.
+const MinHonestBudget = 10 * time.Second
 
 // monitor accumulates scheduler stall observed by a heartbeat goroutine.
 //

--- a/internal/fuzzwatch/share_probe_test.go
+++ b/internal/fuzzwatch/share_probe_test.go
@@ -1,0 +1,101 @@
+// Copyright © 2026 The ELPS authors
+
+package fuzzwatch
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCPUShareProbe is the reproduction harness for #453. It is SKIPPED by
+// default: it needs deliberate external CPU contention to say anything, and
+// under CI's own load it would be a coin flip either way.
+//
+// To run it, load the machine and set the variable:
+//
+//	for i in $(seq 1 200); do ( while :; do :; done ) & done
+//	FUZZWATCH_SHARE_PROBE=1 go test -run TestCPUShareProbe -v ./internal/fuzzwatch/
+//	kill %1 %2 ... # or: pkill -f 'while :'
+//
+// What it demonstrates, measured on the 4-core sandbox with 200 spinners:
+//
+//	A sleep-window probe (the #453 probe)
+//	  wall=3.003s scheduled=3.003s lost=0s longest=0s
+//	B cpu-bound probe
+//	  wall to complete=17.375s (169ms unloaded)  cpu=0.150s  share=0.9%
+//	  fuzzwatch says: scheduled=17.357s lost=300ms
+//
+// A 103x slowdown at 0.9% CPU share, reported as seventeen seconds of normal
+// scheduled execution. That is the boundary the package doc describes, and the
+// reason MinHonestBudget exists. This test asserts NOTHING -- the numbers
+// depend entirely on the load you apply -- it only prints, so that the next
+// person can re-derive the boundary instead of taking the doc's word for it.
+func TestCPUShareProbe(t *testing.T) {
+	if os.Getenv("FUZZWATCH_SHARE_PROBE") == "" {
+		t.Skip("set FUZZWATCH_SHARE_PROBE=1, under external CPU load, to run the #453 probe")
+	}
+
+	const window = 3 * time.Second
+	const workIters = 200_000_000
+
+	// A: exactly the probe in the issue -- a Budget with nothing but a sleep
+	// in it. The heartbeat goroutine is near-idle, which is precisely the kind
+	// of task CFS keeps latency good for, so no stall is ever seen.
+	b := New(window)
+	c0 := cpuSeconds(t)
+	time.Sleep(window)
+	cpu := cpuSeconds(t) - c0
+	verdict, _, rep := b.Check()
+	t.Logf("A sleep-window probe: %s", rep)
+	t.Logf("A verdict=%v starved=%v; process consumed %.3fs of CPU over the window",
+		verdict, rep.Starved(), cpu)
+
+	// B: the same budget over CPU-BOUND work. This is what a fuzz target
+	// actually does, and where stall and share come apart.
+	b2 := New(window)
+	c2 := cpuSeconds(t)
+	t0 := time.Now()
+	x := 0
+	for i := range workIters {
+		x += i * i
+		x ^= x >> 3
+	}
+	took := time.Since(t0)
+	cpu2 := cpuSeconds(t) - c2
+	_ = x
+	_, _, rep2 := b2.Check()
+	t.Logf("B cpu-bound probe: %d iterations took %v using %.3fs of CPU (share %.1f%%)",
+		workIters, took.Round(time.Millisecond), cpu2, 100*cpu2/took.Seconds())
+	t.Logf("B fuzzwatch says: %s", rep2)
+}
+
+// cpuSeconds reads utime+stime for this process out of /proc/self/stat. Linux
+// only; the probe is skipped by default so a non-Linux run never reaches it.
+func cpuSeconds(t *testing.T) float64 {
+	t.Helper()
+	b, err := os.ReadFile("/proc/self/stat")
+	if err != nil {
+		t.Skipf("no /proc/self/stat on this platform: %v", err)
+	}
+	s := string(b)
+	// comm is parenthesised and may contain spaces, so fields are counted from
+	// after the final ')'.
+	i := strings.LastIndex(s, ")")
+	if i < 0 || i+2 >= len(s) {
+		t.Fatalf("unparsable /proc/self/stat")
+	}
+	f := strings.Fields(s[i+2:])
+	if len(f) < 13 {
+		t.Fatalf("/proc/self/stat has %d fields after comm, want >= 13", len(f))
+	}
+	ut, err1 := strconv.ParseFloat(f[11], 64)
+	st, err2 := strconv.ParseFloat(f[12], 64)
+	if err1 != nil || err2 != nil {
+		t.Fatalf("parsing utime/stime: %v %v", err1, err2)
+	}
+	const userHZ = 100
+	return (ut + st) / userHZ
+}


### PR DESCRIPTION
Fixes #453

## Verdict: the instrument is right, the documentation was not

#453 reproduces, and more sharply than it was filed. **No behaviour change to `fuzzwatch`.** It is correct for what it claims to detect — a process genuinely frozen, where gaps land well above the 400ms resolution floor. It is simply not, and cannot be, a load-aware budget. What was missing is a written boundary and something that stops the next person crossing it.

## Reproduced

On the 4-core sandbox with 200 spinners (`for i in $(seq 1 200); do ( while :; do :; done ) & done`, load average > 50):

**Probe A — the issue's probe, a `Budget` and a 3s sleep:**

```
wall=3.003s scheduled=3.003s lost=0s longest=0s
verdict=hung starved=false
```

Zero lost time, under load heavy enough to make the machine unusable. Confirms the filing exactly.

**Probe B — the same budget over CPU-bound work**, which is what a fuzz target actually does:

| run | work (169ms unloaded) | CPU share | fuzzwatch reported |
|---|---|---|---|
| 1 | 17.375s (103x slower) | 0.9% | `scheduled=17.357s lost=300ms` |
| 2 | 12.279s (73x slower) | 1.2% | `scheduled=12.66s lost=0s` |

The second run is the sharper one: a process that received 0.15s of CPU across 12.66s of wall clock was reported as having run normally throughout. Not under-counted — **not counted at all**.

## Why, structurally

Two independent reasons, neither a bug:

1. A stall is only visible above `tolerance * tick` = **400ms**. Starvation on a busy machine is not one long freeze but a few microseconds of CPU handed out every millisecond, forever. Every one of those gaps is below the floor.
2. The heartbeat goroutine is, by construction, almost entirely idle — and CFS gives a waking, near-idle task excellent latency no matter how long the run queue is. The probe is precisely the kind of task starvation does not touch.

So "scheduled time" is a truthful name only against the failure mode the package was built for (VM steal, cgroup throttling, an SMR pause). Against contention it degenerates to the wall clock, silently.

## Why the eleven live watchdogs are fine

They are sized 20,000x–90,000x above the mean work they bound — FuzzEval 0.33ms against 30s, FuzzApplyStdlib 0.73ms against 15s, FuzzSchemaValidate 0.91ms against 20s. A 100x slowdown still leaves two to three orders of magnitude spare, so whether the instrument separates stall from share never arises.

That headroom, **not the accounting**, is what makes them sound. That is the thing worth writing down, because it is exactly the assumption a tighter budget would quietly drop.

## What this PR adds

- **Package doc**: a "What this does NOT measure: CPU share" section carrying the measurements above, the mechanism, and the regime in which the instrument is honest.
- **`MinHonestBudget = 10s`**: names the floor. Just under the smallest live budget (15s, `lisp/cycle_fuzz_test.go` and `lisp/lisplib/fuzz_test.go`) and far above the 2s that #435 proposed. A backstop against a new call site, not a target to design against.
- **`TestEveryBudgetIsAboveTheHonestFloor`**: AST-scans every `fuzzwatch.New` in the repository — 11 sites, all evaluated, none skipped — and fails below the floor. A source scan rather than a check inside `New`, because `New` runs inside `f.Fuzz` bodies where a panic would be recorded as a crasher and blamed on the input. A budget expression the evaluator cannot read fails asking to be taught, rather than being silently skipped.
- **`TestTheFloorGuardCanFail`**: its negative control.
- **`TestCPUShareProbe`**: the reproduction harness, skipped unless `FUZZWATCH_SHARE_PROBE=1`, since it needs external load to mean anything. It asserts nothing and only prints, so the boundary can be re-derived rather than believed.

## Explicitly rejected

**Direction 3 in the issue — measuring share via `/proc/self/stat` utime+stime — is not implemented.** PR #447 (#435) already measured that a fuzzwatch-based scheduled-time budget does not work and rejected it; that measurement is the origin of this issue and is not re-proposed. A share-based instrument additionally over-counts whenever several goroutines of the process are legitimately busy (parallel subtests), so it is not a drop-in, and there is no call site that needs it: every live budget clears the floor by 50x or more. The doc records the option and its caveat for whoever arrives with a concrete need.

**No threshold was loosened and no watchdog was retuned.** Nothing here changes when any target fires.

## Red, then green

`TestEveryBudgetIsAboveTheHonestFloor` is a **guard** — it passes on `main` and is labelled as such in-file. Its ability to fire is demonstrated two ways.

Against a real call site, with `cycleWatchdog` temporarily set to the 2s #435 proposed:

```
--- FAIL: TestEveryBudgetIsAboveTheHonestFloor (0.04s)
    lisp/cycle_fuzz_test.go:86: fuzzwatch budget is 2s, below MinHonestBudget (10s).
        fuzzwatch resolves scheduler STALL above 400ms, not CPU SHARE: measured on 4 cores
        under 200 spinners it reported lost=0s while real work ran 103x slower at 0.9% share.
        A budget this tight cannot tell 'the machine was busy' from 'the code hung', so it will
        fire on innocent inputs under load. PR #447 measured exactly this for a 2s budget and
        rejected it; see #453 and the fuzzwatch package doc.
```

Restored, it reports `checked 11 fuzzwatch budget(s) across 11 file(s) against a 10s floor` and passes. `TestTheFloorGuardCanFail` runs the same evaluator over a synthetic file on every CI run, so the control does not depend on anyone remembering to repeat the experiment.

## Gates

`go build`, `go vet`, `go test -count=1`, `go test -race`, `golangci-lint run` (0 issues), `elps fmt -l`, `elps doc -m`, `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `./scripts/ci-gates-test.sh` (205/0), `./scripts/confidentiality-guard.sh`, `./scripts/fuzz-budget-check.sh` (unchanged, 10 min headroom). No workflow or `scripts/` files touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_