### PR TITLE
parser: keep the lexer watchdog from outranking the real check

### DIFF
--- a/parser/lexer/fuzz_test.go
+++ b/parser/lexer/fuzz_test.go
@@ -4,6 +4,8 @@ package lexer_test
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -33,30 +35,46 @@ import (
 // multi-token emission (emitMacroChar) can never trip it.
 const maxTokenSlack = 8
 
-// lexAll drains the lexer and returns the tokens read.  It fails the test if
+// lexAll drains the lexer and returns the tokens read.  It reports an error if
 // the lexer emits more tokens than the input can justify, which is how a
 // non-consuming loop shows up.
-func lexAll(t *testing.T, src []byte) []*token.Token {
-	t.Helper()
+//
+// It returns an error rather than calling t.Fatal, because
+// TestLexerTerminatesOnUndecodableInput runs it on a WORKER GOROUTINE.
+// testing.T.FailNow -- which t.Fatal calls -- is documented as usable only
+// from the goroutine running the test: from anywhere else it runs
+// runtime.Goexit on the caller and the test itself keeps going.  Here that had
+// teeth.  The worker died without ever sending on its channel, so the 30s
+// watchdog below ran to completion and reported "lexer did not terminate" for
+// a lexer that had terminated perfectly well -- 30 seconds to print the wrong
+// diagnosis, for each of the eight inputs.  Returning the error puts the
+// verdict back on the test goroutine, where a genuine contract violation
+// fails in microseconds and says what it actually was.
+//
+// Note that this bound -- tokens emitted against bytes consumed -- is the real
+// termination check for the lexer, not the clock.  It is deterministic, it
+// cannot be perturbed by machine load, and it names the defect.  The watchdog
+// downstream is only a backstop for a wedge this cannot see.
+func lexAll(src []byte) ([]*token.Token, error) {
 	lx := lexer.New(token.NewScanner("fuzz", bytes.NewReader(src)))
 	limit := len(src) + maxTokenSlack
 	var out []*token.Token
 	for {
 		toks := lx.ReadToken()
 		if len(toks) == 0 {
-			t.Fatal("ReadToken returned an empty slice, violating the TokenStream contract")
+			return out, errors.New("ReadToken returned an empty slice, violating the TokenStream contract")
 		}
 		for _, tok := range toks {
 			if tok == nil {
-				t.Fatal("ReadToken returned a nil token")
+				return out, errors.New("ReadToken returned a nil token")
 			}
 			out = append(out, tok)
 			if tok.Type == token.EOF || tok.Type == token.ERROR || tok.Type == token.INVALID {
-				return out
+				return out, nil
 			}
 		}
 		if len(out) > limit {
-			t.Fatalf("lexer emitted %d tokens for %d bytes of input without terminating "+
+			return out, fmt.Errorf("lexer emitted %d tokens for %d bytes of input without terminating "+
 				"(last token %v %q): it is not consuming input",
 				len(out), len(src), out[len(out)-1].Type, out[len(out)-1].Text)
 		}
@@ -70,7 +88,10 @@ func FuzzLexer(f *testing.F) {
 		f.Add(src)
 	}
 	f.Fuzz(func(t *testing.T, src []byte) {
-		toks := lexAll(t, src)
+		toks, err := lexAll(src)
+		if err != nil {
+			t.Fatal(err)
+		}
 		for i, tok := range toks {
 			if tok.Source == nil {
 				t.Fatalf("token %d (%v %q) has no source location", i, tok.Type, tok.Text)
@@ -100,18 +121,45 @@ func TestLexerTerminatesOnUndecodableInput(t *testing.T) {
 		"(a\xffb)",
 	} {
 		t.Run(src, func(t *testing.T) {
-			done := make(chan []*token.Token, 1)
+			type lexed struct {
+				toks []*token.Token
+				err  error
+			}
+			done := make(chan lexed, 1)
 			go func() {
-				done <- lexAll(t, []byte(src))
+				toks, err := lexAll([]byte(src))
+				done <- lexed{toks: toks, err: err}
 			}()
 			select {
-			case toks := <-done:
-				last := toks[len(toks)-1]
+			case r := <-done:
+				// Reported HERE, on the test goroutine.  lexAll deliberately
+				// returns its error instead of calling t.Fatal; see the note
+				// on the helper for what happened when it did not.
+				if r.err != nil {
+					t.Fatal(r.err)
+				}
+				last := r.toks[len(r.toks)-1]
 				switch last.Type {
 				case token.EOF, token.ERROR, token.INVALID:
 				default:
 					t.Fatalf("lexer stopped on %v, want EOF/ERROR/INVALID", last.Type)
 				}
+
+			// WALL CLOCK, deliberately -- not internal/fuzzwatch (#454).
+			//
+			// Three reasons.  The inputs here are eight fixed byte strings,
+			// not mutator output, and they lex in microseconds: this is a
+			// closed regression set, not a fuzz target.  Non-termination is
+			// already caught deterministically by lexAll's token-per-byte
+			// limit, which needs no clock at all; this arm only covers a lexer
+			// that BLOCKS rather than loops, and nothing in it can block.
+			//
+			// And converting would buy nothing measurable.  fuzzwatch resolves
+			// scheduler stall above 400ms, not CPU share; #453 measured it
+			// reporting lost=0s while real work ran 73-103x slower at ~1% CPU
+			// share.  Under the only load that could threaten a 30s bound it
+			// reports scheduled == wall, so a converted watchdog fires at
+			// exactly the moment this one does.
 			case <-time.After(30 * time.Second):
 				t.Fatal("lexer did not terminate")
 			}

--- a/parser/rdparser/fuzz_test.go
+++ b/parser/rdparser/fuzz_test.go
@@ -214,6 +214,29 @@ func TestParserSurvivesPathologicalInput(t *testing.T) {
 				}()
 				select {
 				case <-done:
+
+				// WALL CLOCK, deliberately -- not internal/fuzzwatch (#454).
+				//
+				// The watchdogs that DO use fuzzwatch all bound
+				// mutator-generated input inside an f.Fuzz body, where the
+				// input set is open and a hang is a live possibility.  This is
+				// not that: fuzzseed.Pathological() is a fixed, checked-in
+				// corpus of inputs already known to terminate, replayed as a
+				// regression test.  Slowest subtest measured: 0.12s against
+				// this 30s bound.
+				//
+				// Converting would also buy nothing measurable.  fuzzwatch
+				// resolves scheduler stall above 400ms, not CPU share; #453
+				// measured it reporting lost=0s while real work ran 73-103x
+				// slower at ~1% CPU share.  Under the only load that could
+				// threaten a 30s bound it reports scheduled == wall, so a
+				// converted watchdog would fire at exactly the moment this one
+				// does -- the same clock, wearing a hat.
+				//
+				// Note also that parse() takes no *testing.T and this
+				// goroutine only closes a channel, so unlike the lexer's
+				// former lexAll(t, ...) there is no way for the worker to
+				// report a verdict from the wrong goroutine.
 				case <-time.After(30 * time.Second):
 					// A leaked goroutine is acceptable here: the run has
 					// already failed and the alternative is a hung CI job.


### PR DESCRIPTION
Fixes #454

#454 was filed from reading and asked for reproduce-or-close. **The filed concern does not hold — the two `time.After` uses are correct in context and are not converted.** Reproducing it did surface a real defect at one of the two sites, which this PR fixes.

## Why the two are not converted

The issue frames them as two of thirteen watchdogs of one shape, two never converted. They are not the same shape:

| | the eleven `fuzzwatch` sites | the two `time.After` sites |
|---|---|---|
| context | inside an `f.Fuzz` body | plain `Test` functions |
| input | mutator-generated, open set | fixed checked-in corpora |
| hang | a live possibility | already known to terminate |

All eleven `fuzzwatch.New` call sites bound mutator-generated input — four via helpers (`runSessionBudgeted`, `debugEvalBudgeted` and friends) called from fuzz bodies. The two cited sites are `TestLexerTerminatesOnUndecodableInput` (eight literal byte strings) and `TestParserSurvivesPathologicalInput` (`fuzzseed.Pathological()`), replaying closed regression corpora. Slowest subtest measured: **0.12s against a 30s bound**.

Converting also buys nothing measurable, which #453 now quantifies: fuzzwatch resolves scheduler *stall* above 400ms, not CPU *share*. Under 200 spinners on 4 cores it reported `lost=0s` while real work ran 73–103x slower at ~1% CPU share. Under the only load that could threaten a 30s bound it reports `scheduled == wall`, so a converted watchdog fires at exactly the moment these do — the same clock, wearing a hat.

Both sites now carry that reasoning in-file, which is the second remedy #454 itself offered ("add a one-line comment at each site saying the wall clock is deliberate here and why").

## What reproducing it found

`TestLexerTerminatesOnUndecodableInput` ran `lexAll(t, ...)` **on a worker goroutine**, and `lexAll` called `t.Fatal` in four places:

```go
done := make(chan []*token.Token, 1)
go func() {
    done <- lexAll(t, []byte(src))   // lexAll calls t.Fatal internally
}()
```

`testing.T.FailNow` — which `t.Fatal` calls — is documented as usable only from the goroutine running the test. From anywhere else it runs `runtime.Goexit` on the caller and the test itself keeps going. So the worker died without ever sending on its channel, the 30s watchdog ran to completion, and a genuine `TokenStream` contract violation was reported as **"lexer did not terminate"** — for a lexer that had terminated perfectly well.

The watchdog outranked the check it was meant to backstop. `lexAll`'s token-per-byte limit is the *real* termination check here: deterministic, load-independent, and it names the defect. The clock is only a backstop for a lexer that blocks rather than loops.

### Red, then green

With a contract violation injected into `lexAll` (`return`/`t.Fatal` on non-empty input), running all eight subtests:

**Before — on `main`:**
```
8 subtests reporting "lexer did not terminate"
real    4m1.439s
```

Each subtest waits out its own 30s watchdog and prints the wrong diagnosis.

**After — this branch:**
```
--- FAIL: TestLexerTerminatesOnUndecodableInput (0.00s)
    --- FAIL: TestLexerTerminatesOnUndecodableInput/abc\xff (0.00s)
        fuzz_test.go:140: INJECTED: pretend the TokenStream contract was violated
    --- FAIL: TestLexerTerminatesOnUndecodableInput/\xff (0.00s)
        fuzz_test.go:140: INJECTED: pretend the TokenStream contract was violated
    ...
real    0m0.708s
```

**340x faster, and the diagnosis is the actual violation.**

## The change

- `lexAll` returns `([]*token.Token, error)` instead of calling `t.Fatal`; the verdict is taken on the test goroutine.
- `FuzzLexer` already called it correctly (on the test goroutine) and is updated for the new signature.
- Both watchdog sites gain the deliberate-wall-clock rationale.
- The rdparser site has no equivalent problem — `parse()` takes no `*testing.T` and its goroutine only closes a channel — and is otherwise unchanged.

## Neighbourhood audit

I scanned every `*_test.go` in the repository for `t.Fatal`-family calls reachable from a `go func()` body, directly or through a `*testing.T`-taking helper. The scanner finds **exactly this one site** on `main` and none after the fix (its one remaining report is a false positive: a same-named `lexAll` in `package lexer`'s `literal_test.go`, which is not called from a goroutine).

Two further things turned up under load and are **filed separately rather than folded in here** — see the issues linked below. Neither is touched by this PR.

## Gates

`go build`, `go vet`, `go test -count=1`, `go test -race`, `golangci-lint run` (0 issues), `elps fmt -l`, `elps doc -m`, `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `./scripts/ci-gates-test.sh` (205/0), `./scripts/confidentiality-guard.sh`, `./scripts/fuzz-budget-check.sh` (unchanged). No workflow or `scripts/` files touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_