### PR TITLE
ci: fail the required aggregate when no upstream job reported

### DIFF
--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -693,6 +693,88 @@ assert_contains "::error::A job in this workflow did not succeed" \
 	"require-jobs: emits the ::error:: annotation naming the results" \
 	env RESULTS='success failure' bash "$REQ_JOBS"
 
+# NO RESULTS IS NOT A PASS (issue #485).
+#
+# `for r in ${RESULTS}` never enters its body when RESULTS is empty, so rc
+# stayed 0 and this -- the aggregate whose NAME is in branch protection -- said
+# "All jobs in this workflow succeeded" and exited 0 having checked nothing.
+# Every non-success result was already covered above; the one input meaning
+# "nothing reported at all" was the one that passed.
+#
+# RESULTS is `${{ join(needs.*.result, ' ') }}`. It goes empty if the `needs:`
+# list is emptied or restructured, or if the expression is mistyped --
+# `needs.*.results` silently yields "" rather than erroring.
+#
+# All three spellings of "no results" are pinned, because they arrive by
+# different routes: unset (env var never set), empty (join over no jobs), and
+# separators-only (join over empty results).
+assert_exit 1 "require-jobs: EMPTY results fails — no upstream reported is not a pass (#485)" \
+	env RESULTS='' bash "$REQ_JOBS"
+assert_exit 1 "require-jobs: UNSET results fails (#485)" \
+	env -u RESULTS bash "$REQ_JOBS"
+assert_exit 1 "require-jobs: whitespace-only results fails (#485)" \
+	env RESULTS='   ' bash "$REQ_JOBS"
+assert_contains "::error::No upstream job results were reported" \
+	"require-jobs: the empty case SAYS nothing was verified rather than failing mutely (#485)" \
+	env RESULTS='' bash "$REQ_JOBS"
+# The old wording must not survive on the empty path: "All jobs in this workflow
+# succeeded" over zero jobs is the precise false statement this fixes.
+if env RESULTS='' bash "$REQ_JOBS" 2>&1 | grep -q "All jobs in this workflow succeeded"; then
+	bad "require-jobs still claims every job succeeded on empty input (#485)"
+else
+	ok "require-jobs no longer claims every job succeeded when none reported (#485)"
+fi
+
+# NEGATIVE CONTROL for the guard above (the bar #480 set).
+#
+# Strip the emptiness guard back out of a COPY of the script and require the
+# vacuous pass to come back. Without this, the guard could be deleted or
+# weakened in a refactor and every assertion above would still pass -- the
+# check would quietly return to being unable to fail, which is the whole defect
+# class this file exists to catch.
+#
+# The copy is produced by DELETING the guard from the real script rather than
+# by keeping a fixture, so the control cannot drift away from what it guards.
+# If the block can no longer be located the control fails loudly instead of
+# silently testing nothing -- a negative control that stops finding its target
+# is itself a check that cannot fail.
+reqjobs_tmp="$(mktemp -d)"
+reqjobs_strip_rc=0
+python3 - "$REQ_JOBS" "${reqjobs_tmp}/stripped.sh" <<'PY' || reqjobs_strip_rc=$?
+import re, sys
+
+src = open(sys.argv[1]).read()
+# Remove the emptiness guard, and only that: the `if [ -z "${RESULTS// /}" ]`
+# block up to its closing `fi`.
+out, n = re.subn(
+    r'\nif \[ -z "\$\{RESULTS// /\}" \]; then\n.*?\nfi\n',
+    "\n",
+    src,
+    flags=re.S,
+)
+if n != 1:
+    sys.stderr.write("expected exactly 1 guard block, removed %d\n" % n)
+    sys.exit(3)
+open(sys.argv[2], "w").write(out)
+PY
+if [ "$reqjobs_strip_rc" -ne 0 ]; then
+	bad "negative control could not strip the empty-RESULTS guard — has it been renamed or restructured? (#485)"
+else
+	# The stripped copy must still behave normally on real input, or the control
+	# is testing a script it accidentally broke rather than the missing guard.
+	assert_exit 0 "negative-control rig: the stripped copy still passes on all-success (#485)" \
+		env RESULTS='success success' bash "${reqjobs_tmp}/stripped.sh"
+	assert_exit 1 "negative-control rig: the stripped copy still fails on a failure (#485)" \
+		env RESULTS='success failure' bash "${reqjobs_tmp}/stripped.sh"
+	# And now the point: without the guard, empty input goes green again.
+	if env RESULTS='' bash "${reqjobs_tmp}/stripped.sh" >/dev/null 2>&1; then
+		ok "negative control: REMOVING the guard restores the vacuous pass, so the assertions above are load-bearing (#485)"
+	else
+		bad "negative control did not reproduce the #485 vacuous pass — the assertions above may be passing for the wrong reason"
+	fi
+fi
+rm -rf "$reqjobs_tmp"
+
 echo "== extracted workflow bodies: bench-compare =============================="
 
 BENCH_COMPARE_SH="${SCRIPT_DIR}/bench-compare.sh"

--- a/scripts/require-jobs-succeeded.sh
+++ b/scripts/require-jobs-succeeded.sh
@@ -15,17 +15,62 @@
 # Inputs (env):
 #   RESULTS   space-separated job results, from `${{ join(needs.*.result, ' ') }}`
 #
-# Exits 0 if every result is `success`, 1 otherwise.
+# Exits 0 if every result is `success`, 1 otherwise -- including when there are
+# no results at all (see below).
 #
 # Run locally as:  RESULTS='success failure' scripts/require-jobs-succeeded.sh
 set -euo pipefail
 
 # Sourced from the environment rather than being interpolated. `-` (not `:-`)
-# so an unset RESULTS stays an empty string under `set -u`, preserving the
-# original step's behaviour exactly.
+# so an unset RESULTS stays an empty string under `set -u`.
 RESULTS="${RESULTS-}"
 
 echo "upstream job results: ${RESULTS}"
+
+# NO RESULTS IS NOT A PASS (issue #485)
+# -------------------------------------
+# The loop below is `for r in ${RESULTS}`. With RESULTS empty the body never
+# executes, `rc` stays 0, and this -- the aggregate whose name sits in branch
+# protection, the check that gates merging -- printed "All jobs in this
+# workflow succeeded" and exited 0 having verified nothing.
+#
+# Demonstrated by running, before this guard existed:
+#
+#     $ RESULTS='' bash scripts/require-jobs-succeeded.sh
+#     upstream job results:
+#     All jobs in this workflow succeeded.
+#     >>> EXIT=0
+#
+# RESULTS comes from `${{ join(needs.*.result, ' ') }}`. Empty means NO UPSTREAM
+# JOB REPORTED, which is reachable without anyone noticing:
+#
+#   * the `needs:` list is emptied or restructured during a refactor;
+#   * the expression is mistyped -- `needs.*.results` (plural) is not an error
+#     in GitHub Actions expression syntax, it silently evaluates to the empty
+#     string;
+#   * every upstream job is renamed and `needs:` is not updated to match.
+#
+# In each case the required check goes green over an empty set. That is the
+# header's own argument about skipped jobs, one level up: `failure`, `cancelled`
+# and `skipped` all mean the work was not demonstrably done -- and neither does
+# "nothing reported at all". Zero results joins that list.
+#
+# The earlier comment here noted that the empty-string behaviour was preserved
+# deliberately, to match the original inline step. It is not preserved any more:
+# matching the original exactly is worth less than the gate being able to fail.
+#
+# For an aggregate that exists solely to cover other jobs there is no legitimate
+# "nothing to check" case -- if this job is running at all, it has upstreams by
+# construction. So empty input can only mean the check could not be performed,
+# and that must be loud rather than green.
+#
+# `${RESULTS// /}` strips spaces, so a value that is only separators is caught
+# alongside the empty string.
+if [ -z "${RESULTS// /}" ]; then
+  echo "::error::No upstream job results were reported, so nothing was verified — refusing to report success. This is the required aggregate: an empty 'needs.*.result' means no job's outcome was checked, not that every job passed. Check the 'needs:' list and the RESULTS expression in the workflow."
+  exit 1
+fi
+
 rc=0
 # Unquoted on purpose: this is the one place word splitting is the point --
 # RESULTS is a space-separated list of job results.


### PR DESCRIPTION
## The bug

`scripts/require-jobs-succeeded.sh` is the body of the `required` job in `benchmark.yml` — the job whose stable name sits in branch protection, the check that gates merging.

```bash
rc=0
for r in ${RESULTS}; do
  [ "$r" = "success" ] || rc=1
done
```

With `RESULTS` empty the loop body never executes, `rc` stays 0, and the gate reports success.

## Demonstrated by running

With an actually-empty `RESULTS`, not a mock:

```
$ RESULTS='' bash scripts/require-jobs-succeeded.sh
upstream job results:
All jobs in this workflow succeeded.
>>> EXIT=0
```

Unset and whitespace-only behaved identically. After the fix, all three exit 1:

```
$ RESULTS='' bash scripts/require-jobs-succeeded.sh
upstream job results:
::error::No upstream job results were reported, so nothing was verified —
refusing to report success. This is the required aggregate: an empty
'needs.*.result' means no job's outcome was checked, not that every job
passed. Check the 'needs:' list and the RESULTS expression in the workflow.
>>> EXIT=1
```

Real inputs are unaffected: `success success` still exits 0, `success failure` still exits 1.

## Why it is reachable

`RESULTS` comes from `${{ join(needs.*.result, ' ') }}`. Empty means **no upstream job reported**, which happens without anyone noticing:

- the `needs:` list is emptied or restructured during a refactor;
- every upstream job is renamed and `needs:` is not updated to match;
- the expression is mistyped — `needs.*.results` (plural) is not an error in Actions expression syntax, it silently evaluates to the empty string.

In each case the required check goes green over an empty set.

This is the script header's own argument about skipped jobs, one level up: `failure`, `cancelled` and `skipped` all mean the work was not demonstrably done — and neither does "nothing reported at all". For an aggregate that exists solely to cover other jobs there is no legitimate "nothing to check" case: if this job is running, it has upstreams by construction. So empty input can only mean the check could not be performed.

The previous comment noted the empty-string behaviour was preserved deliberately to match the original inline step. That is no longer worth more than the gate being able to fail; the comment is updated to say so rather than leaving the reasoning stale.

For contrast, `fuzz.yml`'s `required` job compares a single `needs.fuzz.result` against `success` and so does not have this hole.

## Negative control

Per the bar #480 set. The guard is stripped back out of a **copy** of the real script and the vacuous pass must return:

```
PASS  negative-control rig: the stripped copy still passes on all-success (#485)
PASS  negative-control rig: the stripped copy still fails on a failure (#485)
PASS  negative control: REMOVING the guard restores the vacuous pass, so the
      assertions above are load-bearing (#485)
```

The copy is produced by **deleting the block from the live file**, not from a checked-in fixture, so the control cannot drift away from what it guards. If the block can no longer be located the control fails loudly rather than silently testing nothing — a negative control that stops finding its target is itself a check that cannot fail.

The rig also pins that the stripped copy still behaves correctly on real input, so a control that merely broke the script would not be mistaken for a working one.

## Gates

`go build`, `go vet`, `go test -count=1 ./...`, `go test -race ./...`, `golangci-lint run ./...` (0 issues), `elps fmt -l ./...`, `elps doc -m`, `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `confidentiality-guard.sh`, `shellcheck -S warning` — all clean.

`fuzz-budget-check.sh` unchanged: 30 targets / 8 shards / 10 min headroom.

`CI_GATES_REQUIRE_SHELLCHECK=1 ./scripts/ci-gates-test.sh` — **260 passed, 0 failed** (252 on `main` at `837ce16`; net +8).

Fixes #485

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_