### PR TITLE
ci: stop the confidentiality guard reporting clean when it scanned nothing

### DIFF
--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -1978,6 +1978,123 @@ case "$req_out" in
 esac
 
 echo
+echo "== confidentiality guard: it must be able to FAIL ========================"
+
+# scripts/confidentiality-guard.sh had no behavioural coverage here at all --
+# only `bash -n` and shellcheck, which prove it parses, not that it works.
+#
+# It reported "clean" and exited 0 in four distinct situations where it had
+# scanned nothing (issue #486): outside a repository, on a corrupt index, on a
+# dangling .git gitdir pointer, and over a tree whose tracked files are absent
+# from the working directory. The first three come back from `git grep` as exit
+# >=2, which the old truthiness test (`if matches="$(git grep ...)"`) routed
+# into the clean branch; the fourth comes back as exit 1, which is
+# indistinguishable from a genuinely clean tree by status alone.
+#
+# THE FORBIDDEN TERM IS NEVER WRITTEN LITERALLY, here or anywhere else. Every
+# fixture below constructs it at runtime from the same octal codes the guard
+# itself uses, and every one of them lives in a throwaway repository under
+# $TMPDIR -- never in this worktree, so nothing can ever be committed.
+GUARD_SH="${SCRIPT_DIR}/confidentiality-guard.sh"
+
+if [ ! -x "$GUARD_SH" ]; then
+	bad "scripts/confidentiality-guard.sh is missing or not executable"
+elif ! command -v git >/dev/null 2>&1; then
+	echo "SKIP  git unavailable — confidentiality guard assertions not run"
+else
+	guard_tmp="$(mktemp -d)"
+
+	# new_repo <dir> -- a throwaway git repo with one ordinary tracked file, so
+	# the guard has something real to scan.
+	new_repo() {
+		mkdir -p "$1"
+		git -C "$1" init -q
+		git -C "$1" config user.email guard@example.invalid
+		git -C "$1" config user.name "guard test"
+		printf 'package main\n\nfunc main() {}\n' >"$1/main.go"
+		git -C "$1" add -A
+		git -C "$1" -c commit.gpgsign=false commit -qm fixture
+	}
+
+	# (1) POSITIVE CONTROL -- the guard must still pass on a clean tree.
+	# Without this the assertions below are equally satisfied by a guard that
+	# fails on everything, which nobody could keep green.
+	new_repo "${guard_tmp}/clean"
+	assert_exit 0 "confidentiality guard: a clean tree passes (#486)" \
+		env -C "${guard_tmp}/clean" bash "$GUARD_SH"
+
+	# (2) NEGATIVE CONTROL -- the guard must still CATCH a real violation.
+	# This is the assertion that proves the exit-2 paths added for #486 did not
+	# turn the guard into something that merely never says "found". The term is
+	# assembled at runtime, exactly as the guard assembles it.
+	new_repo "${guard_tmp}/dirty"
+	guard_term="$(printf '\141\143\162\145')"
+	printf '// see the %s-handler for details\n' "$guard_term" \
+		>"${guard_tmp}/dirty/violation.go"
+	git -C "${guard_tmp}/dirty" add -A
+	git -C "${guard_tmp}/dirty" -c commit.gpgsign=false commit -qm violation
+	assert_exit 1 "confidentiality guard: a real bounded occurrence is still CAUGHT (#486)" \
+		env -C "${guard_tmp}/dirty" bash "$GUARD_SH"
+	assert_contains "violation.go" \
+		"confidentiality guard: the hit names the offending file (#486)" \
+		env -C "${guard_tmp}/dirty" bash "$GUARD_SH"
+
+	# (3) A substring word must still NOT trip it -- the boundary behaviour the
+	# guard's own self-test asserts, pinned end-to-end over a real tree so a
+	# future widening of the pattern fails here rather than in someone's PR.
+	new_repo "${guard_tmp}/substr"
+	printf 'const w = "massacre wiseacre acreage"\n' >"${guard_tmp}/substr/words.go"
+	git -C "${guard_tmp}/substr" add -A
+	git -C "${guard_tmp}/substr" -c commit.gpgsign=false commit -qm words
+	assert_exit 0 "confidentiality guard: substring words do not false-positive (#486)" \
+		env -C "${guard_tmp}/substr" bash "$GUARD_SH"
+
+	# (4) THE #486 PATHS. Each of these made the guard print "clean" and exit 0.
+	# Exit 2 (not 1) is asserted deliberately: "could not run" is a different
+	# outcome from "found the term", and conflating them would leave CI unable
+	# to tell a broken guard from a real violation.
+
+	# 4a. Not a repository at all.
+	mkdir -p "${guard_tmp}/norepo"
+	assert_exit 2 "confidentiality guard: OUTSIDE a repository refuses to report clean (#486)" \
+		env -C "${guard_tmp}/norepo" bash "$GUARD_SH"
+
+	# 4b. Corrupt index -- git grep exits 128.
+	new_repo "${guard_tmp}/badindex"
+	printf 'GARBAGE' >"${guard_tmp}/badindex/.git/index"
+	assert_exit 2 "confidentiality guard: a CORRUPT INDEX refuses to report clean (#486)" \
+		env -C "${guard_tmp}/badindex" bash "$GUARD_SH"
+
+	# 4c. Dangling gitdir pointer -- the shape a broken worktree/submodule has.
+	new_repo "${guard_tmp}/badgitdir"
+	rm -rf "${guard_tmp}/badgitdir/.git"
+	printf 'gitdir: /nonexistent/gitdir\n' >"${guard_tmp}/badgitdir/.git"
+	assert_exit 2 "confidentiality guard: a DANGLING gitdir refuses to report clean (#486)" \
+		env -C "${guard_tmp}/badgitdir" bash "$GUARD_SH"
+
+	# 4d. Tracked files absent from the working tree. git grep reads the WORKING
+	# TREE and skips missing files silently, so this returns exit 1 -- byte-for-
+	# byte the "clean" answer. Only the coverage check distinguishes it, which
+	# is why that check is load-bearing rather than belt-and-braces.
+	new_repo "${guard_tmp}/nocheckout"
+	rm -f "${guard_tmp}/nocheckout/main.go"
+	assert_exit 2 "confidentiality guard: an UNPOPULATED working tree refuses to report clean (#486)" \
+		env -C "${guard_tmp}/nocheckout" bash "$GUARD_SH"
+	assert_contains "ZERO readable files" \
+		"confidentiality guard: the empty scan SAYS nothing was looked at (#486)" \
+		env -C "${guard_tmp}/nocheckout" bash "$GUARD_SH"
+
+	# (5) The clean message must state the scan's extent. "clean" on its own is
+	# the string that was printed over zero files; a count makes an empty scan
+	# visible in the log even if some future path slips past the checks above.
+	assert_contains "files scanned" \
+		"confidentiality guard: a clean result reports HOW MUCH was scanned (#486)" \
+		env -C "${guard_tmp}/clean" bash "$GUARD_SH"
+
+	rm -rf "$guard_tmp"
+fi
+
+echo
 echo "== every job declares timeout-minutes ===================================="
 
 # A job with no `timeout-minutes` inherits GitHub's 360-minute default, which

--- a/scripts/confidentiality-guard.sh
+++ b/scripts/confidentiality-guard.sh
@@ -27,7 +27,31 @@
 
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# Exit codes:
+#   0  scanned the tree, term not present
+#   1  the term was FOUND
+#   2  the guard could not run (see "a guard that cannot scan" below)
+#
+# Exit 2 matches the convention scripts/fuzz.sh and scripts/fuzz-budget-check.sh
+# already use: a gate that cannot read its inputs must not report a pass.
+
+# The repository root, checked (issue #486).
+#
+# This was `cd "$(git rev-parse --show-toplevel)"`. A command substitution's
+# failure does NOT trip `set -e` when it is only an ARGUMENT, and `cd ""` is a
+# silent no-op that succeeds -- so when git could not identify a repository the
+# script simply carried on in whatever directory it happened to be started
+# from, and scanned that instead.
+REPO_TOP=""
+rev_rc=0
+REPO_TOP="$(git rev-parse --show-toplevel 2>&1)" || rev_rc=$?
+if [ "$rev_rc" -ne 0 ] || [ -z "$REPO_TOP" ]; then
+	echo "confidentiality guard: cannot locate the repository root (git rev-parse exit ${rev_rc})" >&2
+	[ -n "$REPO_TOP" ] && printf '%s\n' "$REPO_TOP" | sed 's/^/  | /' >&2
+	echo "confidentiality guard: refusing to report clean -- nothing was scanned." >&2
+	exit 2
+fi
+cd "$REPO_TOP"
 
 # Forbidden term, assembled from octal codes so it never appears literally.
 TERM_="$(printf '\141\143\162\145')"
@@ -53,15 +77,83 @@ for fixture in "$TERM_" "$UP" "def-${TERM_}-route" "${TERM_}:helper" "(${TERM_})
 	fi
 done
 
+# --- a guard that cannot scan must not report clean (issue #486) -------------
+#
+# The self-test above proves the PATTERN works. It says nothing about whether
+# the scan below actually reaches any content -- and silence from `git grep`
+# was being read as proof of absence in two different ways:
+#
+#   1. `git grep` exits >=2 on ERROR (not a repository, unreadable object, bad
+#      pathspec, I/O error). The old code was `if matches="$(git grep ...)"`,
+#      so any error made the `if` false, execution fell through, and the script
+#      printed "clean" and exited 0. `2>/dev/null` hid the reason as well.
+#
+#   2. `git grep` exits 1 both when the tree is genuinely clean AND when there
+#      is nothing to look at. Exit status alone cannot tell those apart, so an
+#      empty or unpopulated tree reads as a pass.
+#
+# All four were confirmed by running the guard, unmodified, and watching it
+# print "confidentiality guard: clean" and exit 0:
+#
+#   * outside a repository            -> git grep exit 128   (case 1)
+#   * corrupt .git/index              -> git grep exit 128   (case 1)
+#   * .git gitdir pointer dangling    -> git grep exit 128   (case 1)
+#   * tracked files absent from the
+#     working tree (git grep reads
+#     the working tree, and skips
+#     missing files in silence)       -> git grep exit 1     (case 2)
+#
+# So the scan is bounded on both sides: prove it can SEE the tree, then handle
+# all three of its exit classes explicitly rather than by truthiness.
+
+# How many files the scan can actually read. Same mechanism as the real scan --
+# `git grep` over the same pathspec -- so this measures the scan itself rather
+# than something adjacent to it that might succeed while the scan does not.
+# `-I` skips binaries; '.' matches any file with at least one character.
+scan_err="$(mktemp)"
+trap 'rm -f "$scan_err"' EXIT
+seen_rc=0
+seen="$(git grep -IlE '.' -- . 2>"$scan_err")" || seen_rc=$?
+if [ "$seen_rc" -gt 1 ]; then
+	echo "confidentiality guard: the tree could not be read (git grep exit ${seen_rc})" >&2
+	sed 's/^/  | /' "$scan_err" >&2
+	echo "confidentiality guard: refusing to report clean -- nothing was scanned." >&2
+	exit 2
+fi
+n_seen="$(printf '%s' "$seen" | grep -c . || true)"
+if [ "$n_seen" -eq 0 ]; then
+	echo "confidentiality guard: the scan matched ZERO readable files in $(pwd)." >&2
+	echo "confidentiality guard: an empty scan cannot demonstrate the term is absent," >&2
+	echo "confidentiality guard: it only demonstrates that nothing was looked at." >&2
+	echo "confidentiality guard: refusing to report clean." >&2
+	exit 2
+fi
+
 # --- scan the tracked tree ---------------------------------------------------
 
-# git grep exits 0 when it finds a match, 1 when clean.
-if matches="$(git grep -inE "$PATTERN" -- . 2>/dev/null)"; then
+# git grep exits 0 on a match, 1 when clean, and >=2 on error. All three are
+# handled explicitly: relying on truthiness put the error case in the "clean"
+# branch, which is the whole of #486.
+grep_rc=0
+matches="$(git grep -inE "$PATTERN" -- . 2>"$scan_err")" || grep_rc=$?
+case "$grep_rc" in
+0)
 	echo "confidentiality guard: forbidden term found at the following locations:" >&2
 	# file:line only; deliberately do not echo the matched text.
 	printf '%s\n' "$matches" | cut -d: -f1,2 >&2
 	echo "confidentiality guard: remove the term before merging (ask a maintainer if unsure which term this is)." >&2
 	exit 1
-fi
+	;;
+1)
+	# Genuinely clean -- and, thanks to the coverage check above, clean over a
+	# tree we know was actually read.
+	;;
+*)
+	echo "confidentiality guard: git grep failed (exit ${grep_rc})" >&2
+	sed 's/^/  | /' "$scan_err" >&2
+	echo "confidentiality guard: refusing to report clean -- the scan did not complete." >&2
+	exit 2
+	;;
+esac
 
-echo "confidentiality guard: clean"
+echo "confidentiality guard: clean (${n_seen} files scanned)"


### PR DESCRIPTION
Filed **by reading**, flagged reproduce-or-close. **It reproduces** — in four distinct situations, each confirmed by running the guard unmodified and watching it print `confidentiality guard: clean` and exit 0.

## The filed cause is real

The old code tested truthiness:

```bash
if matches="$(git grep -inE "$PATTERN" -- . 2>/dev/null)"; then
```

`git grep` also exits ≥2 on error, which makes the `if` false, so execution fell through to the clean message — and `2>/dev/null` hid the reason. Reachable three ways, all verified by running:

| condition | `git grep` | guard said |
|---|---|---|
| outside a repository | exit 128 | `clean`, exit 0 |
| corrupt `.git/index` | exit 128 | `clean`, exit 0 |
| dangling `.git` gitdir pointer | exit 128 | `clean`, exit 0 |

The issue rated this lower because the pattern self-test covers the likeliest cause of a grep error. That reasoning holds — but it only covers *pattern-related* errors, and the reachable paths above are environmental, so the exposure is real rather than theoretical.

## Two further findings from reproducing it

**1. The first case does not need `git grep` to fail at all.** The script opened with:

```bash
cd "$(git rev-parse --show-toplevel)"
```

A command substitution's failure does not trip `set -e` when it is only an *argument*, and `cd ""` is a silent no-op that succeeds. So when git could not identify a repository, the guard carried on in whatever directory it started from and scanned that instead.

**2. Checking the exit status is not sufficient.** `git grep` exits 1 both when a tree is genuinely clean and when there is nothing to look at, so status alone cannot separate them:

| condition | `git grep` | guard said |
|---|---|---|
| tracked files absent from the working tree | **exit 1** | `clean`, exit 0 |

`git grep` reads the **working tree** and skips missing files silently. This is the same "empty input reads as success" shape as #484/#485, and it needs a coverage check rather than an exit code — the fix suggested in the issue would not have caught it.

## The fix

The scan is bounded on both sides:

- the repository root is resolved and **checked**, so the guard cannot scan a directory it did not mean to;
- the scan first proves it can **see** the tree, using the same `git grep` mechanism over the same pathspec, so it measures the real scan rather than something adjacent that might succeed while the scan does not;
- all three exit classes are then handled **explicitly** instead of by truthiness.

A guard that cannot read its inputs exits **2**, matching the convention in `fuzz.sh` and `fuzz-budget-check.sh`. Exit 2 rather than 1 is deliberate: "could not run" is a different outcome from "found the term", and conflating them would leave CI unable to tell a broken guard from a real violation.

The clean message now states the extent of the scan — `confidentiality guard: clean (626 files scanned)` — so an empty scan is visible in the log even if some future path slips past the checks.

## Coverage and controls

The guard previously had **no behavioural coverage** in `ci-gates-test.sh` — only `bash -n` and shellcheck, which prove it parses, not that it works. Ten assertions are added.

Verified red-then-green at the suite level: with the old guard swapped back in, the six new assertions fail and the two controls stay green.

```
PASS  confidentiality guard: a clean tree passes (#486)
PASS  confidentiality guard: a real bounded occurrence is still CAUGHT (#486)
PASS  confidentiality guard: the hit names the offending file (#486)
PASS  confidentiality guard: substring words do not false-positive (#486)
FAIL  ... OUTSIDE a repository refuses to report clean — want exit 2, got 0
FAIL  ... a CORRUPT INDEX refuses to report clean — want exit 2, got 0
FAIL  ... a DANGLING gitdir refuses to report clean — want exit 2, got 0
FAIL  ... an UNPOPULATED working tree refuses to report clean — want exit 2, got 0
FAIL  ... the empty scan SAYS nothing was looked at
FAIL  ... a clean result reports HOW MUCH was scanned
```

The **negative control** is assertion 2: a real bounded occurrence must still be caught. That is what proves the new exit-2 paths did not turn the guard into something which merely never says "found". Assertion 1 (clean tree passes) and 3 (substring words do not false-positive) pin the other direction, so the guard cannot pass by failing on everything.

**The forbidden term is never written literally.** Every fixture constructs it at runtime from the same octal codes the guard itself uses, inside throwaway repositories under `$TMPDIR` — never in this worktree, so nothing can ever be committed.

## Gates

`go build`, `go vet`, `go test -count=1 ./...`, `go test -race ./...`, `golangci-lint run ./...` (0 issues), `elps fmt -l ./...`, `elps doc -m`, `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `shellcheck -S warning` — all clean.

`fuzz-budget-check.sh` unchanged: 30 targets / 8 shards / 10 min headroom.

`CI_GATES_REQUIRE_SHELLCHECK=1 ./scripts/ci-gates-test.sh` — **262 passed, 0 failed** (252 on `main` at `837ce16`; net +10).

Fixes #486

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_