### PR TITLE
lisp: give LVal.Copy's result its own Meta and MacroExpansion

### DIFF
--- a/lisp/copy_meta_test.go
+++ b/lisp/copy_meta_test.go
@@ -1,0 +1,414 @@
+// Copyright © 2026 The ELPS authors
+
+// Regression tests for elps#466 -- LVal.Copy sharing Meta and MacroExpansion.
+//
+// #446 (PR #467) separated LVal.Source, and the comment it left on Copy now
+// says "the copy owns its positions".  The same `*cp = *v` carried the other
+// two metadata pointers across untouched, so that sentence was true of the
+// node and false one level down: SourceMeta holds []*token.Token, every token
+// holds a *token.Location, and both trees reached the same objects.
+//
+// WHY THIS IS THE CODE AND NOT THE DOC COMMENT.  #466 leaves that open --
+// "these are metadata ABOUT a node which a copy legitimately shares" is a
+// coherent reading, and if it were the right one then Copy's doc comment and
+// MacroExpansionInfo.ID's would be what needed fixing.  The evidence says it
+// is the right reading for exactly one of the three pointers:
+//
+//   - SourceMeta is not a description of a node, it is per-node MUTABLE state
+//     that the parser writes in place at a dozen sites, and that
+//     rdparser.hoistOperandComments MOVES between nodes (append onto outer,
+//     `= nil` on inner).  The parser already special-cases two LVals holding
+//     one *SourceMeta -- the `outer.Meta == inner.Meta` guard, whose comment
+//     explains that moving the comments would move them onto themselves.  An
+//     in-tree guard against a state means the state is an anomaly, and
+//     LVal.Copy manufactured it deliberately.  The comment-hoist test below
+//     performs that exact move through a copy and watches the ORIGINAL's
+//     rendered output change.
+//
+//   - MacroExpansionInfo is per node too (the ID is what distinguishes one
+//     node from another), so the struct is separated.
+//
+//   - Its embedded *MacroExpansionContext genuinely is shared metadata: it
+//     describes the macro CALL, it is documented "shared across all nodes in
+//     one expansion", and #456 already made its CallSite an object the
+//     expansion owns.  It stays shared, and the context test below pins that.
+//
+// The one place the doc comment WAS the thing that was wrong is
+// MacroExpansionInfo.ID, documented "unique per node".  LVal.Copy cannot
+// honour that under any implementation -- it takes no *Runtime and so has no
+// counter to draw a fresh ID from -- so the comment now says what is true and
+// names the consumer that cares (lisp/x/debugger's stepper, which steps on
+// MacroID changing).  TestCopyDuplicatesTheMacroExpansionID pins it.
+//
+// LIVE OR LATENT: latent, on the same population argument #467 records.  The
+// parser's Meta writes all happen on nodes it has just built, before anything
+// can have copied them, and no non-test caller of LVal.Copy writes through
+// Meta or MacroExpansion afterwards.  So the writes these tests perform are
+// the TESTS' writes; they demonstrate the mechanism.  What is observed rather
+// than demonstrated is the SHARING, which the tests assert directly and which
+// failed on 95e2e1a.
+//
+// Tests marked GUARD pass before the fix as well as after.  They pin
+// behaviour the fix must not break; they are not catches.
+
+package lisp_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/formatter"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/rdparser"
+	"github.com/luthersystems/elps/parser/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readFormatting parses src in format-preserving mode, which is the only mode
+// that populates Meta at all.
+func readFormatting(t *testing.T, src string) []*lisp.LVal {
+	t.Helper()
+	sc := token.NewScanner("copy-meta.lisp", strings.NewReader(src))
+	exprs, err := rdparser.NewFormatting(sc).ParseProgram()
+	require.NoError(t, err)
+	require.NotEmpty(t, exprs)
+	return exprs
+}
+
+// metaSource is the probe from issue #466: one form with a leading comment and
+// an inline trailing comment, so Meta carries both a []*token.Token and a
+// single *token.Token.
+const metaSource = "; lead\n(+ 1 2) ; trail\n"
+
+// TestCopyDoesNotAliasSourceMeta is the reproduction from issue #466.
+// CATCH: both assertions failed on 95e2e1a.
+func TestCopyDoesNotAliasSourceMeta(t *testing.T) {
+	orig := readFormatting(t, metaSource)[0]
+	require.NotNil(t, orig.Meta, "premise: format-preserving parsing populates Meta")
+
+	cp := orig.Copy()
+	require.NotNil(t, cp.Meta, "the copy lost its formatting metadata")
+	assert.NotSame(t, orig.Meta, cp.Meta,
+		"a copy shares the original's *SourceMeta (#466)")
+
+	was := orig.Meta.BlankLinesBefore
+	cp.Meta.BlankLinesBefore = was + 99
+	assert.Equal(t, was, orig.Meta.BlankLinesBefore,
+		"a write through the copy moved the original's formatting metadata (#466)")
+}
+
+// TestCopyDoesNotAliasMetaCommentTokens is the half that reopens #446.  Each
+// comment token holds a *token.Location, so a shared token means the copy and
+// the original reach one mutable position object -- exactly what #446/#467
+// separated on the node, still shared one level down through Meta.
+// CATCH: every assertion failed on 95e2e1a.
+func TestCopyDoesNotAliasMetaCommentTokens(t *testing.T) {
+	orig := readFormatting(t, metaSource)[0]
+	require.NotEmpty(t, orig.Meta.LeadingComments, "premise: the leading comment was recorded")
+	require.NotNil(t, orig.Meta.TrailingComment, "premise: the trailing comment was recorded")
+
+	cp := orig.Copy()
+	require.Len(t, cp.Meta.LeadingComments, len(orig.Meta.LeadingComments))
+
+	for i := range orig.Meta.LeadingComments {
+		a, b := orig.Meta.LeadingComments[i], cp.Meta.LeadingComments[i]
+		assert.NotSame(t, a, b, "LeadingComments[%d]: copy shares the original's *token.Token (#466)", i)
+		assert.Equal(t, a.Text, b.Text, "LeadingComments[%d]: text differs", i)
+		if a.Source != nil {
+			require.NotNil(t, b.Source)
+			assert.NotSame(t, a.Source, b.Source,
+				"LeadingComments[%d]: copy shares the original's *token.Location, reopening #446 through Meta", i)
+			assert.Equal(t, *a.Source, *b.Source, "LeadingComments[%d]: position differs", i)
+		}
+	}
+
+	assert.NotSame(t, orig.Meta.TrailingComment, cp.Meta.TrailingComment,
+		"TrailingComment: copy shares the original's *token.Token (#466)")
+	assert.Equal(t, orig.Meta.TrailingComment.Text, cp.Meta.TrailingComment.Text)
+	if orig.Meta.TrailingComment.Source != nil {
+		assert.NotSame(t, orig.Meta.TrailingComment.Source, cp.Meta.TrailingComment.Source,
+			"TrailingComment: copy shares the original's *token.Location (#446 through Meta)")
+	}
+
+	// The corruption the sharing enables.  The write is this test's.
+	cp.Meta.LeadingComments[0].Source.Line = 9999
+	assert.NotEqual(t, 9999, orig.Meta.LeadingComments[0].Source.Line,
+		"a write through the copy's comment token moved the original's recorded position (#466)")
+}
+
+// TestCopyDoesNotAliasMetaAtDepth pins that the separation reaches every node
+// Copy reaches, not just the root -- the shape #446's depth test had.
+// CATCH: failed on 95e2e1a at every node that carried a Meta.
+func TestCopyDoesNotAliasMetaAtDepth(t *testing.T) {
+	const src = `; top
+(defun f (x) ; on the formals
+  ; on the body
+  (let ([y (+ x 1)])
+    (* y y)))
+`
+	orig := readFormatting(t, src)[0]
+	cp := orig.Copy()
+
+	origNodes := flatten(orig)
+	cpNodes := flatten(cp)
+	require.Len(t, cpNodes, len(origNodes), "copy has a different shape")
+	require.Greater(t, len(origNodes), 10, "test program is too small to be interesting")
+
+	shared, withMeta := 0, 0
+	for i := range origNodes {
+		if origNodes[i].Meta == nil {
+			assert.Nil(t, cpNodes[i].Meta, "node %d: nil Meta became non-nil", i)
+			continue
+		}
+		withMeta++
+		if origNodes[i].Meta == cpNodes[i].Meta {
+			shared++
+		}
+	}
+	require.Positive(t, withMeta, "no node carried a Meta; the test observed nothing")
+	assert.Zero(t, shared,
+		"%d of %d copied nodes with metadata share the original's *SourceMeta (#466)",
+		shared, withMeta)
+}
+
+// TestCopyMetaSurvivesACommentHoist is the consequence, stated as OUTPUT
+// rather than as a pointer comparison.
+//
+// rdparser.hoistOperandComments moves a node's LeadingComments onto another
+// node: append onto the destination, `= nil` on the source.  That is a write
+// the parser really performs -- it is the fix for the comment loss described
+// in its own doc comment -- and it is destructive.  Performed through a copy
+// while a shared *SourceMeta is in place, it deletes the comment from the
+// ORIGINAL tree, and the original then formats without it.
+//
+// The move here is this test's, not the parser's (the parser runs before
+// anything can copy).  What the test shows is what the shared object COSTS
+// when a writer does reach it: not a debugging curiosity, a comment silently
+// dropped from a file `elps fmt` rewrites.
+//
+// CATCH: on 95e2e1a the original's formatted output lost its leading comment.
+func TestCopyMetaSurvivesACommentHoist(t *testing.T) {
+	exprs := readFormatting(t, metaSource)
+	orig := exprs[0]
+	before := string(formatter.FormatProgram([]*lisp.LVal{orig}, nil, nil))
+	require.Contains(t, before, "; lead", "premise: the comment is in the formatted output")
+
+	cp := orig.Copy()
+	// Exactly what hoistOperandComments does, performed on the copy.
+	moved := cp.Meta.LeadingComments
+	require.NotEmpty(t, moved)
+	cp.Meta.LeadingComments = nil
+
+	after := string(formatter.FormatProgram([]*lisp.LVal{orig}, nil, nil))
+	assert.Equal(t, before, after,
+		"moving comments off the COPY changed how the ORIGINAL formats (#466):\nbefore:\n%s\nafter:\n%s",
+		before, after)
+	assert.Contains(t, after, "; lead",
+		"the original tree lost a source comment because a copy hoisted it (#466)")
+}
+
+// TestCopyMetaCommentSlicesArePrivate is the slice-header half of the same
+// property: even without touching a token, appending to one tree's comment
+// list must not be visible in the other's.  A shared backing array can make
+// an append visible through both headers.
+// CATCH: failed on 95e2e1a (one header, so the append was simply shared).
+func TestCopyMetaCommentSlicesArePrivate(t *testing.T) {
+	orig := readFormatting(t, metaSource)[0]
+	cp := orig.Copy()
+
+	origLen := len(orig.Meta.LeadingComments)
+	require.Positive(t, origLen)
+
+	cp.Meta.LeadingComments = append(cp.Meta.LeadingComments,
+		&token.Token{Type: token.COMMENT, Text: "; added"})
+	assert.Len(t, orig.Meta.LeadingComments, origLen,
+		"appending to the copy's LeadingComments changed the original's (#466)")
+}
+
+// TestCopyPreservesMetaContent pins that separating the objects does not
+// change what they say.  A fix that dropped Meta, or that materialised an
+// empty one, would pass every NotSame assertion above.
+// GUARD: passes before the fix.
+func TestCopyPreservesMetaContent(t *testing.T) {
+	orig := readFormatting(t, "; lead\n\n[foo 1] ; trail\n")[0]
+	cp := orig.Copy()
+	require.NotNil(t, cp.Meta)
+
+	assert.Equal(t, orig.Meta.OriginalText, cp.Meta.OriginalText)
+	assert.Equal(t, orig.Meta.BracketType, cp.Meta.BracketType)
+	assert.Equal(t, orig.Meta.BlankLinesBefore, cp.Meta.BlankLinesBefore)
+	assert.Equal(t, orig.Meta.BlankLinesAfterComments, cp.Meta.BlankLinesAfterComments)
+	assert.Equal(t, orig.Meta.PrecedingSpaces, cp.Meta.PrecedingSpaces)
+	assert.Equal(t, orig.Meta.NewlineBefore, cp.Meta.NewlineBefore)
+	assert.Equal(t, orig.Meta.ClosingBracketNewline, cp.Meta.ClosingBracketNewline)
+	assert.Len(t, cp.Meta.LeadingComments, len(orig.Meta.LeadingComments))
+	assert.Len(t, cp.Meta.InnerTrailingComments, len(orig.Meta.InnerTrailingComments))
+
+	// And the copy formats identically, which is the property a reader of
+	// Meta actually depends on.
+	assert.Equal(t,
+		string(formatter.FormatProgram([]*lisp.LVal{orig}, nil, nil)),
+		string(formatter.FormatProgram([]*lisp.LVal{cp}, nil, nil)),
+		"a copy formats differently from the tree it copied")
+}
+
+// TestCopyPreservesNilMeta pins that a nil Meta stays nil.  Nil means "not
+// parsed in format-preserving mode" and every reader branches on it;
+// materialising a zero SourceMeta would make an ordinary parse tree look
+// format-preserving and would put an allocation on the hot path.
+// GUARD: passes before the fix.
+func TestCopyPreservesNilMeta(t *testing.T) {
+	v := lisp.SExpr([]*lisp.LVal{lisp.Symbol("a"), lisp.Int(1)})
+	require.Nil(t, v.Meta, "premise: a natively-built value has no Meta")
+	cp := v.Copy()
+	assert.Nil(t, cp.Meta)
+	require.Len(t, cp.Cells, 2)
+	for i, c := range cp.Cells {
+		assert.Nil(t, c.Meta, "cell %d gained a Meta", i)
+	}
+}
+
+// TestCopyPreservesNilComments pins that nil comment slices stay nil rather
+// than becoming empty non-nil ones.  Not cosmetic: it is what keeps a copy of
+// a Meta with no comments from allocating two slice headers per node on the
+// formatting path.
+// GUARD: passes before the fix (there was one Meta, so its nil slices were
+// trivially the original's).  It is here so the fix cannot buy separation by
+// materialising empty slices per node.
+func TestCopyPreservesNilComments(t *testing.T) {
+	v := lisp.Symbol("a")
+	v.Meta = &lisp.SourceMeta{OriginalText: "a"}
+	cp := v.Copy()
+	require.NotNil(t, cp.Meta)
+	assert.Nil(t, cp.Meta.LeadingComments)
+	assert.Nil(t, cp.Meta.InnerTrailingComments)
+	assert.Nil(t, cp.Meta.TrailingComment)
+}
+
+// newExpansionNode builds a node in the state stampMacroExpansion leaves an
+// expansion node in: a MacroExpansionInfo with an ID, wrapping a context
+// shared with the rest of the expansion.
+func newExpansionNode(id int64, ctx *lisp.MacroExpansionContext) *lisp.LVal {
+	v := lisp.Symbol("expanded")
+	v.MacroExpansion = &lisp.MacroExpansionInfo{MacroExpansionContext: ctx, ID: id}
+	return v
+}
+
+// TestCopyDoesNotAliasMacroExpansionInfo is the second half of issue #466.
+// The struct is per node -- its ID is the thing that tells one expansion node
+// from another -- so a copy, which is a second node, must not write through
+// the original's.
+// CATCH: failed on 95e2e1a.
+func TestCopyDoesNotAliasMacroExpansionInfo(t *testing.T) {
+	loc := &token.Location{File: "m.lisp", Line: 3, Col: 5}
+	ctx := &lisp.MacroExpansionContext{CallSite: loc, Name: "lisp:defun"}
+	orig := newExpansionNode(7, ctx)
+
+	cp := orig.Copy()
+	require.NotNil(t, cp.MacroExpansion, "the copy lost its expansion info")
+	assert.NotSame(t, orig.MacroExpansion, cp.MacroExpansion,
+		"a copy shares the original's *MacroExpansionInfo (#466)")
+
+	cp.MacroExpansion.ID = 99
+	assert.Equal(t, int64(7), orig.MacroExpansion.ID,
+		"a write through the copy moved the original's expansion ID (#466)")
+}
+
+// TestCopyKeepsSharingTheMacroExpansionContext pins the pointer that is
+// deliberately NOT separated, and is the reason this issue is not simply
+// "copy everything".
+//
+// MacroExpansionContext describes the macro CALL, not the node.  It is
+// documented shared across every node of one expansion; #456 already made its
+// CallSite an object the expansion owns rather than one borrowed from a live
+// parse tree, so there is no third party to separate it from.  Copying it
+// would separate nothing and would make that documented sharing false for
+// copied nodes.
+//
+// GUARD: passes before the fix (everything was shared then) and pins that the
+// fix did not over-correct.
+func TestCopyKeepsSharingTheMacroExpansionContext(t *testing.T) {
+	loc := &token.Location{File: "m.lisp", Line: 3, Col: 5}
+	ctx := &lisp.MacroExpansionContext{CallSite: loc, Name: "lisp:defun"}
+	a, b := newExpansionNode(1, ctx), newExpansionNode(2, ctx)
+	require.Same(t, a.MacroExpansion.MacroExpansionContext, b.MacroExpansion.MacroExpansionContext,
+		"premise: one expansion's nodes share one context")
+
+	cp := a.Copy()
+	assert.Same(t, ctx, cp.MacroExpansion.MacroExpansionContext,
+		"copying an expansion node allocated a private MacroExpansionContext; the context"+
+			" is documented shared across an expansion and has only one owner")
+	assert.Same(t, loc, cp.MacroExpansion.CallSite,
+		"the call site moved; it belongs to the expansion (#456), not to the node")
+}
+
+// TestCopyDuplicatesTheMacroExpansionID is the half of #466 where the DOC
+// COMMENT was what was wrong rather than the code.
+//
+// ID was documented "unique per node".  LVal.Copy cannot honour that under
+// any implementation: it takes no *Runtime, so it has no counter to draw a
+// fresh value from, and drawing one from anywhere else would defeat the
+// point -- the value exists to come from the runtime that did the expanding.
+// So the behaviour stands and the comment now says what is true, and names
+// the consumer that has to know: lisp/x/debugger's stepper steps on
+// `loc.MacroID != s.start.MacroID`, so two nodes carrying one ID read to it
+// as one node.
+//
+// GUARD: passes before the fix.  It is here so that a later change which
+// starts renumbering copies fails against a stated decision instead of
+// quietly contradicting the field comment.
+func TestCopyDuplicatesTheMacroExpansionID(t *testing.T) {
+	ctx := &lisp.MacroExpansionContext{Name: "lisp:defun"}
+	orig := newExpansionNode(7, ctx)
+	cp := orig.Copy()
+	require.NotNil(t, cp.MacroExpansion)
+	assert.Equal(t, int64(7), cp.MacroExpansion.ID,
+		"a copy no longer carries the expansion ID of the node it came from;"+
+			" if that is intended, MacroExpansionInfo.ID's comment needs updating with it")
+}
+
+// TestCopyPreservesNilMacroExpansion pins the nil case, which is every node in
+// a process with no debugger attached -- i.e. the hot path.
+// GUARD: passes before the fix.
+func TestCopyPreservesNilMacroExpansion(t *testing.T) {
+	v := lisp.SExpr([]*lisp.LVal{lisp.Symbol("a")})
+	require.Nil(t, v.MacroExpansion)
+	cp := v.Copy()
+	assert.Nil(t, cp.MacroExpansion)
+	require.Len(t, cp.Cells, 1)
+	assert.Nil(t, cp.Cells[0].MacroExpansion)
+}
+
+// TestTokenCopy covers parser/token.Token.Copy directly, since SourceMeta.Copy
+// leans on it for the position separation.  A Token whose Copy shared its
+// Location would put #446 straight back through Meta.
+//
+// NEITHER a catch nor a guard: Token.Copy did not exist on 95e2e1a, so there
+// was nothing for it to fail against.  It is unit cover for new API, and it is
+// labelled so rather than left to read as a catch.
+func TestTokenCopy(t *testing.T) {
+	assert.Nil(t, (*token.Token)(nil).Copy(), "nil must stay nil")
+
+	loc := &token.Location{File: "t.lisp", Pos: 4, Line: 2, Col: 3, EndPos: 10, EndLine: 2, EndCol: 9}
+	tok := &token.Token{Type: token.COMMENT, Text: "; c", Source: loc, PrecedingNewlines: 2, PrecedingSpaces: 1}
+
+	cp := tok.Copy()
+	require.NotNil(t, cp)
+	assert.NotSame(t, tok, cp)
+	assert.Equal(t, tok.Type, cp.Type)
+	assert.Equal(t, tok.Text, cp.Text)
+	assert.Equal(t, tok.PrecedingNewlines, cp.PrecedingNewlines)
+	assert.Equal(t, tok.PrecedingSpaces, cp.PrecedingSpaces)
+
+	require.NotNil(t, cp.Source)
+	assert.NotSame(t, loc, cp.Source, "a copied Token shares the original's *token.Location")
+	assert.Equal(t, *loc, *cp.Source)
+
+	cp.Source.Line = 99
+	assert.Equal(t, 2, loc.Line, "a write through the copy moved the original's position")
+
+	// A Token with no position keeps none rather than gaining a zero one.
+	bare := (&token.Token{Type: token.COMMENT, Text: "; c"}).Copy()
+	assert.Nil(t, bare.Source)
+}

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -189,13 +189,64 @@ type MacroExpansionContext struct {
 // MacroExpansionInfo is attached to LVal nodes produced by macro expansion.
 // It is only allocated when a debugger is attached (Runtime.Debugger != nil),
 // so production code pays zero allocation cost.
+//
+// The embedded *MacroExpansionContext describes the macro CALL and is shared
+// by every node of one expansion, by design.  This struct is the per-node
+// half, so LVal.Copy gives a copy its own -- see MacroExpansionInfo.Copy.
 type MacroExpansionInfo struct {
-	*MacroExpansionContext       // shared across all nodes in one expansion
-	ID                     int64 // unique per node, monotonically increasing
+	*MacroExpansionContext // shared across all nodes in one expansion
+
+	// ID distinguishes one expansion node from another.  stampMacroExpansion
+	// assigns it from Runtime.nextMacroExpID, monotonically increasing, so no
+	// two nodes an expansion stamps share a value.
+	//
+	// It is NOT unique per *LVal* in the wider sense, and this comment used
+	// to claim it was.  LVal.Copy duplicates it, and cannot do otherwise:
+	// Copy takes no *Runtime, so it has no counter to draw a fresh value
+	// from, and there is no framing in which it could -- the value's whole
+	// purpose is to come from the runtime that did the expanding.  A copy of
+	// an expansion node therefore carries the ID of the node it came from.
+	//
+	// The consumer to know about is lisp/x/debugger: exprStepLocation reads
+	// this into StepLocation.MacroID and stepper.go steps on `loc.MacroID !=
+	// s.start.MacroID`, so two distinct nodes carrying one ID read to the
+	// stepper as one node and it does not pause between them.  Copying an
+	// expansion node under an attached debugger is what that would take; no
+	// in-tree path does it today (issue #466).
+	ID int64
+}
+
+// Copy returns a pointer to an independent copy of i, or nil if i is nil.
+//
+// The embedded *MacroExpansionContext is deliberately NOT copied.  A copy
+// separates two OWNERS, and the context has one owner -- the macro call --
+// which both nodes genuinely belong to.  It is documented shared across every
+// node of an expansion, and #456 already made CallSite an object the
+// expansion owns rather than one borrowed from a live parse tree, so there is
+// no third party to separate it from.  Copying it would separate nothing and
+// would make the "shared across all nodes in one expansion" comment above
+// false for copied nodes.
+//
+// What IS separated is this struct, which is per node.  ID rides across
+// unchanged -- see the field comment for why it cannot do otherwise.
+func (i *MacroExpansionInfo) Copy() *MacroExpansionInfo {
+	if i == nil {
+		return nil
+	}
+	cp := *i
+	return &cp
 }
 
 // SourceMeta holds formatting metadata for an LVal, populated only when
 // parsing in format-preserving mode. Nil in normal parsing — zero cost.
+//
+// It is per-node MUTABLE state rather than a shared description of one: the
+// parser writes every field below in place on nodes it has just built, and
+// rdparser.hoistOperandComments MOVES LeadingComments off one node onto
+// another with an append plus a `= nil`.  Two LVals holding one *SourceMeta
+// is consequently an anomaly the parser has to special-case -- the `outer.Meta
+// == inner.Meta` guard in that function -- which is why LVal.Copy gives a copy
+// its own; see SourceMeta.Copy.
 type SourceMeta struct {
 	TrailingComment         *token.Token   // inline comment on same line after this node
 	OriginalText            string         // original token text for literals (preserves escapes, numeric bases)
@@ -207,6 +258,50 @@ type SourceMeta struct {
 	BracketType             rune           // '(' or '[' for LSExpr nodes
 	NewlineBefore           bool           // true if at least one newline preceded this node in source
 	ClosingBracketNewline   bool           // true if closing bracket was on its own line in source
+}
+
+// Copy returns a pointer to a deep copy of m, or nil if m is nil.
+//
+// Deep, not shallow, at both levels the struct has:
+//
+//   - The two comment SLICES get their own backing arrays, because
+//     hoistOperandComments appends to LeadingComments and then nils the
+//     source out.  A shared header is the state that makes that move visible
+//     through both nodes.
+//
+//   - The comment TOKENS get their own objects, because each one holds a
+//     *token.Location.  #446 gave a copied node its own position; leaving
+//     these shared would leave that guarantee true only for the node itself
+//     and false one level down, which is exactly what issue #466 reports.
+//
+// Nil is preserved rather than materialised into a zero SourceMeta: a nil
+// Meta means "not parsed in format-preserving mode" and every reader in the
+// tree branches on it (rdparser, formatter, minifier).  Materialising one
+// would turn a copy of an ordinary parse tree into a format-preserving-
+// looking one and put an allocation on the hot path for nothing.
+func (m *SourceMeta) Copy() *SourceMeta {
+	if m == nil {
+		return nil
+	}
+	cp := *m
+	cp.TrailingComment = m.TrailingComment.Copy()
+	cp.LeadingComments = copyTokens(m.LeadingComments)
+	cp.InnerTrailingComments = copyTokens(m.InnerTrailingComments)
+	return &cp
+}
+
+// copyTokens returns a new slice holding independent copies of every token in
+// toks.  A nil slice stays nil, so a copy of a Meta with no comments allocates
+// nothing for them.
+func copyTokens(toks []*token.Token) []*token.Token {
+	if toks == nil {
+		return nil
+	}
+	cp := make([]*token.Token, len(toks))
+	for i, tok := range toks {
+		cp[i] = tok.Copy()
+	}
+	return cp
 }
 
 // LVal is a lisp value
@@ -1214,8 +1309,15 @@ func (v *LVal) equalNum(other *LVal) *LVal {
 //
 // The copy owns its positions.  Every node Copy reaches gets its own
 // *token.Location, so a write through the copy cannot move what the original
-// reports, and the reverse.  The one Location left shared is nativeSource's
-// process-wide singleton -- see the comment on the copy below.
+// reports, and the reverse.  That holds for the Locations reachable THROUGH
+// Meta's comment tokens as well as for Source on the node.  The one Location
+// left shared is nativeSource's process-wide singleton -- see the comment on
+// the copy below.
+//
+// The copy also owns its per-node metadata: Meta and MacroExpansion.  The one
+// thing deliberately still shared is MacroExpansionInfo's embedded
+// *MacroExpansionContext, which describes the macro CALL rather than the node
+// -- see MacroExpansionInfo.Copy.
 func (v *LVal) Copy() *LVal {
 	if v == nil {
 		return nil
@@ -1263,6 +1365,24 @@ func (v *LVal) Copy() *LVal {
 		// work, not here.
 		cp.Source = v.Source.Copy()
 	}
+	// Meta and MacroExpansion ride along in the struct assignment above for
+	// the same reason Source did, and issue #466 is that they still do.  Both
+	// are PER-NODE mutable state -- SourceMeta is what the parser writes and
+	// hoistOperandComments moves between nodes; MacroExpansionInfo is the
+	// per-node half of an expansion record whose shared half is the context
+	// it embeds.  Sharing them makes a "deep copy" a second writer on one
+	// object, and in Meta's case it also reopens #446 one level down: the
+	// *token.Location on every comment token is reachable from both trees.
+	//
+	// The cost argument is the opposite of Source's.  Source is present on
+	// essentially every node, which is why copying it is the measured trade
+	// recorded above.  Meta is nil outside format-preserving parsing and
+	// MacroExpansion is nil unless a debugger is attached, so on the
+	// interpreter's hot path this is two nil checks and no allocation, and it
+	// allocates only on paths already doing per-node formatting or debug
+	// work.
+	cp.Meta = v.Meta.Copy()
+	cp.MacroExpansion = v.MacroExpansion.Copy()
 	switch v.Type {
 	case LArray:
 		// Arrays are memory references but use Cells as backing storage.

--- a/parser/token/token.go
+++ b/parser/token/token.go
@@ -25,6 +25,26 @@ type Token struct {
 	PrecedingSpaces   int // spaces in whitespace before this token (same-line only)
 }
 
+// Copy returns a pointer to an independent copy of tok, or nil if tok is nil.
+//
+// Source is copied rather than carried across, for the reason Location.Copy
+// documents: a Location stored into an object that outlives -- or is mutated
+// independently of -- the object it came from is issue #362's shape, and a
+// copied Token is by definition a second owner.  Text is a string and needs
+// no copy.
+//
+// Nil is preserved because a nil *Token is meaningful where these are held:
+// SourceMeta.TrailingComment nil means "no inline comment on this node", not
+// "an empty comment".
+func (tok *Token) Copy() *Token {
+	if tok == nil {
+		return nil
+	}
+	cp := *tok
+	cp.Source = tok.Source.Copy()
+	return &cp
+}
+
 type Type uint
 
 // Type constants used for the elps lexer/parser.  These constants aren't


### PR DESCRIPTION
Fixes #466

## Reproduced

The issue's probe, run against `95e2e1a`:

```
root Meta: orig=0xc000131ab0 cp=0xc000131ab0 same=true
after cp.Meta.BlankLinesBefore=99: orig.Meta.BlankLinesBefore=99 (was 0)
LeadingComments[0] token: orig=0xc00011a1b0 cp=0xc00011a1b0 same=true
LeadingComments[0].Source: orig=0xc0001220a0 cp=0xc0001220a0 same=true
TrailingComment token: orig=0xc00011a300 cp=0xc00011a300 same=true
MacroExpansion: orig=0xc00011c330 cp=0xc00011c330 same=true; ID orig=7 cp=7
MacroExpansionContext: same=true
```

Same as the issue's, plus the two rows it did not print: the comment token's own `*token.Location` is shared, and so is `MacroExpansionContext`.

## The open question: code or doc comments

#466 leaves this open, and #467's author deliberately left these fields alone. The answer splits by pointer, and the evidence is different for each.

**`Meta` — the code.** Three things say so:

1. `SourceMeta` is not a description of a node, it is per-node **mutable** state. `parser/rdparser` writes every field of it in place, and `hoistOperandComments` *moves* `LeadingComments` from one node to another — `append` onto the outer node, `= nil` on the inner one.

2. The parser already treats two LVals sharing one `*SourceMeta` as an anomaly it has to defend against:

   ```go
   if outer.Meta == inner.Meta {
       // Shared Meta: the comments are already on the node the printer
       // writes.  Moving them would move them onto themselves.
       return
   }
   ```

   An in-tree guard against a state means the state is anomalous. `LVal.Copy` manufactured it on purpose, at every node, on every call.

3. Leaving it shared leaves the sentence #467 just added to `Copy` false one level down. "The copy owns its positions. Every node Copy reaches gets its own `*token.Location`" — except the ones on `Meta.LeadingComments[i].Source` and `Meta.TrailingComment.Source`, which both trees reached. Taking the doc option here would mean *weakening* #467's guarantee one release after landing it.

The cost argument the issue raises is confirmed: `Meta` is nil outside format-preserving parsing, so this is a nil check on the hot path. It is not the #421 trade that made `Source` a judgement call.

**`MacroExpansionInfo` — the code; its embedded `*MacroExpansionContext` — legitimately shared.** The context describes the macro **call**, is already documented "shared across all nodes in one expansion", and #456 made its `CallSite` an object the expansion owns rather than one borrowed from a live parse tree. There is no third party to separate it from, so copying it would separate nothing and would make that documented sharing false for copied nodes. The per-node wrapper around it does get separated.

**`MacroExpansionInfo.ID` — the doc comment.** This is the one place the issue's alternative reading is right. `ID` was documented "unique per node, monotonically increasing". `LVal.Copy` cannot honour that under *any* implementation: it takes no `*Runtime`, so it has no counter to draw a fresh value from, and drawing one from anywhere else would defeat the point — the value exists to come from the runtime that did the expanding. So the behaviour stands and the comment now says what is true, and names the consumer that has to know:

```go
// lisp/x/debugger/stepper.go
if loc.MacroID != s.start.MacroID {
```

The stepper steps on `MacroID` *changing*, so two distinct nodes carrying one ID read to it as one node and it will not pause between them. That is what "unique per node" was buying, and a copy does not deliver it.

## Red then green

`lisp/copy_meta_test.go`, 13 tests. Against `95e2e1a` (the fix's two assignment lines reverted, the new `Copy` methods left in so the file compiles):

```
--- FAIL: TestCopyDoesNotAliasSourceMeta
--- FAIL: TestCopyDoesNotAliasMetaCommentTokens
--- FAIL: TestCopyDoesNotAliasMetaAtDepth          18 of 18 copied nodes with metadata share the original's *SourceMeta
--- FAIL: TestCopyMetaSurvivesACommentHoist
--- FAIL: TestCopyMetaCommentSlicesArePrivate
--- FAIL: TestCopyDoesNotAliasMacroExpansionInfo
--- PASS: TestCopyPreservesMetaContent               (GUARD)
--- PASS: TestCopyPreservesNilMeta                   (GUARD)
--- PASS: TestCopyPreservesNilComments               (GUARD)
--- PASS: TestCopyKeepsSharingTheMacroExpansionContext (GUARD)
--- PASS: TestCopyDuplicatesTheMacroExpansionID      (GUARD)
--- PASS: TestCopyPreservesNilMacroExpansion         (GUARD)
--- PASS: TestTokenCopy                              (new API, neither)
```

Six catches, six guards labelled in-file, one unit test for API that did not exist on `main` and is labelled as such rather than left to read as a catch.

The most useful of the six states the consequence as **output** rather than as a pointer comparison. `hoistOperandComments`' move, performed through a copy:

```
Error: Not equal:
  expected: "; lead\n(+ 1 2) ; trail\n"
  actual  : "(+ 1 2) ; trail\n"
Messages: moving comments off the COPY changed how the ORIGINAL formats (#466)
```

A source comment silently dropped from a file `elps fmt` rewrites — not a debugging curiosity.

## Live or latent

Latent, on the same population argument #467 records and by the same method. The parser's `Meta` writes all happen on nodes it has just built, before anything can have copied them; no non-test caller of `LVal.Copy` writes through `Meta` or `MacroExpansion` afterwards; the formatter and minifier read `Meta` and never call `Copy`. So the writes the tests perform are the tests' writes — they demonstrate the mechanism. What is **observed** is the sharing, which the tests assert directly.

## Neighbourhood audit

- `parser/token.Token` gained a `Copy`, nil-preserving and separating `Source`, on the reasoning `Location.Copy` already documents (#362/#366). It is the only new exported API.
- `lisp.Quote` shallow-copies an unquoted operand including its `Meta` pointer. That is **not** this defect and is deliberate — `hoistOperandComments`' `outer.Meta == inner.Meta` guard exists precisely to handle it, and its comment says so. Left alone.
- `SingletonSnapshot.singletonLValEqual` compares `Meta` and `MacroExpansion` by pointer. Singletons carry nil for both and `Copy` preserves nil, so the snapshot is unaffected; `TestCopyPreservesNilMeta` and `TestCopyPreservesNilMacroExpansion` pin that.
- `LArray` shares its `Cells` backing and `LSortMap` its value pointers, both deliberately. Those are about the values reached *through* a node; this change is about the node's own metadata and does not touch them.
- `#382` plans to unexport both fields in the same release break, and `#362` tracks making `LVal.Source` immutable, which would settle the `Location`s reachable through `Meta` along with the rest. Neither is anticipated here.

## Gates

`go build`, `go vet`, `go test -count=1 ./...`, `go test -race ./...`, `golangci-lint run ./...`, `elps fmt -l ./...`, `elps doc -m`, `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `CI_GATES_REQUIRE_SHELLCHECK=1 ./scripts/ci-gates-test.sh`, `./scripts/confidentiality-guard.sh`, `./scripts/fuzz-budget-check.sh` — all clean.

Benchmarks: `Meta` and `MacroExpansion` are nil on every hot path, so the added work is two nil-pointer comparisons per node and no allocation. No row moves outside its own spread.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_