### PR TITLE
diagnostic: measure the caret underline in terminal cells, not bytes

### DIFF
--- a/diagnostic/diagnostic.go
+++ b/diagnostic/diagnostic.go
@@ -28,11 +28,31 @@ func (s Severity) String() string {
 }
 
 // Span identifies a region of source code to highlight in the diagnostic.
+//
+// UNITS AND CONVENTION.  Col and EndCol are 1-based BYTE columns, and EndCol
+// is INCLUSIVE -- it names the column of the span's last byte, not the one
+// after it.  A span covering "false" at columns 7 through 11 is Col: 7,
+// EndCol: 11.
+//
+// That is the OPPOSITE of parser/token.Location.EndCol, which is documented
+// (as of the #463 fix) as an EXCLUSIVE byte column.  The two types have
+// same-named fields with opposite conventions, and nothing in the tree bridges
+// one into the other today: cmd/diagnostic.go and repl/diagnostic.go both set
+// Col and leave EndCol zero for auto-detection.  The first caller to wire an
+// analyser's end position straight into a Span would get an underline one
+// caret too long, which is why the convention is written down here rather than
+// left to be inferred (issue #469).  Converting is `EndCol: loc.EndCol - 1`.
+//
+// The RENDERER measures the underline in terminal CELLS rather than in bytes,
+// so the carets line up with what a terminal draws even when the span holds
+// multi-byte, East Asian wide, or combining characters -- see displayWidth in
+// renderer.go.  The byte convention here is about how a caller ADDRESSES the
+// source; it is not the unit the carets are counted in.
 type Span struct {
 	File   string // path for reading source; display name if unreadable
 	Line   int    // 1-based line number
-	Col    int    // 1-based start column
-	EndCol int    // 1-based end column (0 = auto-detect from source)
+	Col    int    // 1-based start byte column
+	EndCol int    // 1-based end byte column, INCLUSIVE (0 = auto-detect from source)
 	Label  string // text shown under the underline
 }
 

--- a/diagnostic/renderer.go
+++ b/diagnostic/renderer.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/mattn/go-runewidth"
 )
 
 // Renderer formats diagnostics as Rust-style annotated source snippets.
@@ -129,10 +131,26 @@ func (r *Renderer) writeSpan(ew *errWriter, span Span, p palette) {
 
 	// Source line with line number
 	// Replace tabs with spaces for consistent alignment
-	displaySource := strings.ReplaceAll(source, "\t", "    ")
+	displaySource := strings.ReplaceAll(source, "\t", tabExpansion)
 	ew.printf(" %s%s |%s  %s\n", p.boldBlue, lineStr, p.reset, displaySource)
 
-	// Underline
+	// Underline.
+	//
+	// Both halves of it -- how far in the carets start, and how many there
+	// are -- have to be measured in the SAME unit, and that unit has to be
+	// TERMINAL CELLS, because a terminal is what lays the two lines out on
+	// top of each other.  Issue #469 was that they were not: the indent was
+	// computed with displayWidth (cells) and the length with `endCol - col +
+	// 1` (bytes), so any span containing a multi-byte rune got more carets
+	// than the text it pointed at and they ran on over what followed.  On
+	// "(f 加算 1)" the two-rune token got six carets.
+	//
+	// Bytes are not the unit and neither are runes.  A rune count is right
+	// for the common case only because most runes happen to occupy one cell;
+	// an East Asian wide character occupies two and a combining mark
+	// occupies none, so 加算 needs FOUR carets rather than two or six.  Both
+	// measurements below therefore go through displayWidth, which is the one
+	// place that decides what a cell is.
 	col := span.Col
 	endCol := span.EndCol
 	if col <= 0 {
@@ -144,14 +162,32 @@ func (r *Renderer) writeSpan(ew *errWriter, span Span, p palette) {
 	if endCol < col {
 		endCol = col
 	}
-	underLen := endCol - col + 1
 
-	// Account for tab expansion in positioning
-	prefix := ""
-	if col > 1 && col-1 <= len(source) {
-		prefix = source[:col-1]
+	// Byte indices into source: start inclusive, end exclusive.  Span.EndCol
+	// is an INCLUSIVE 1-based byte column (see its doc comment), so the
+	// exclusive end index is endCol itself.  Both are clamped because Col and
+	// EndCol arrive from a caller and nothing upstream promises they are
+	// inside this line.
+	start, end := col-1, endCol
+	if start > len(source) {
+		start = len(source)
 	}
-	displayCol := displayWidth(prefix)
+	if end > len(source) {
+		end = len(source)
+	}
+	if end < start {
+		end = start
+	}
+
+	displayCol := displayWidth(source[:start])
+	underLen := displayWidth(source[start:end])
+	if underLen < 1 {
+		// A zero-width span still has to point somewhere: a caret under the
+		// start column is more use than a blank line.  Reachable when the
+		// span names a position past the end of the line, and when the
+		// spanned text is nothing but zero-width marks.
+		underLen = 1
+	}
 
 	underPad := strings.Repeat(" ", displayCol)
 	underline := strings.Repeat("^", underLen)
@@ -208,15 +244,60 @@ func (r *Renderer) detectEndCol(source string, col int) int {
 	return end // convert back to 1-based end column
 }
 
-// displayWidth returns the display width of a string, expanding tabs to 4 spaces.
+const (
+	// tabWidth is how many terminal cells a tab is rendered as.  It is a
+	// choice, not a fact -- a real terminal advances to the next tab stop --
+	// but the renderer rewrites tabs into spaces before printing the source
+	// line, so within this package it becomes a fact.
+	tabWidth = 4
+
+	// tabExpansion is what writeSpan substitutes for a tab in the printed
+	// source line.  It MUST be tabWidth spaces: the source line and the caret
+	// line are laid out by two different pieces of code and only agree
+	// because these two constants do.
+	tabExpansion = "    "
+)
+
+// cells measures runes in terminal cells.
+//
+// It is an explicit Condition rather than runewidth's package-level default
+// because that default is configured from the environment: go-runewidth's
+// init reads LC_ALL/LC_CTYPE/LANG and sets EastAsianWidth, under which the
+// ~1000 codepoints in the Unicode "Ambiguous" width class (→, ①, Greek and
+// Cyrillic letters, box drawing) become two cells wide instead of one.  Left
+// on the default, the same diagnostic would be underlined differently
+// depending on the locale of the shell that ran it, and the package's own
+// golden tests would pass or fail on the same grounds.  Ambiguous-as-narrow
+// is the choice essentially every modern terminal makes.
+var cells = func() *runewidth.Condition {
+	c := runewidth.NewCondition()
+	c.EastAsianWidth = false
+	return c
+}()
+
+// displayWidth returns how many terminal cells s occupies, with tabs counted
+// as tabWidth.
+//
+// This is the single definition of "how wide is this text" for the renderer,
+// and both halves of the caret underline go through it -- that is the whole
+// of the fix for issue #469, which sized the underline in bytes while
+// indenting it in cells.
+//
+// It counts CELLS and not runes.  The two agree for the Latin text that most
+// diagnostics are about, which is why counting runes survived here as long as
+// it did, but they part company in both directions: an East Asian wide
+// character or an emoji occupies two cells, and a combining mark occupies
+// none.  Under a rune count "加算" indents following text by two columns when
+// the terminal has moved four, and "é" written as e + U+0301 indents by two
+// when the terminal has moved one.
 func displayWidth(s string) int {
 	w := 0
 	for _, ch := range s {
 		if ch == '\t' {
-			w += 4
-		} else {
-			w++
+			w += tabWidth
+			continue
 		}
+		w += cells.RuneWidth(ch)
 	}
 	return w
 }

--- a/diagnostic/underline_width_test.go
+++ b/diagnostic/underline_width_test.go
@@ -1,0 +1,322 @@
+// Copyright © 2026 The ELPS authors
+
+package diagnostic
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// This file is the pin for elps#469: writeSpan sized the caret underline in
+// BYTES while indenting it in display columns, so on any span containing a
+// multi-byte rune the caret run was longer than the text it pointed at and
+// spilled over whatever followed.
+//
+// It is deliberately not a test about an integer.  #469 is two numbers that
+// have to agree with each other, and the only place they are observably
+// wrong is the rendered two-line block a user reads, so that is what these
+// tests compare.  A failure prints the source line and the caret line one
+// above the other, which is the form in which the defect is obvious.
+//
+// BYTES, RUNES, OR CELLS.  Bytes were the bug.  Runes would have fixed the
+// reported spillover and still been wrong, because the underline has to line
+// up with what a TERMINAL draws and a terminal does not advance one cell per
+// rune: an East Asian wide character advances two and a combining mark
+// advances none.  Both halves now go through displayWidth, which counts
+// cells, so they agree by construction rather than by coincidence -- and the
+// CJK rows below are what separates the two candidate fixes.  Under a rune
+// count "加算" gets two carets under a four-cell token; under bytes it got
+// six.  Four is right.
+//
+// Rows and tests marked GUARD pass on 95e2e1a as well as here.  They pin
+// behaviour the fix must not break; they are not catches.
+
+// renderOneSpan renders a single-span diagnostic over src and returns the
+// printed source line and the caret line beneath it, both with the gutter
+// stripped.  Colour is off, so the lines contain no escape sequences.
+func renderOneSpan(t *testing.T, src string, span Span) (srcLine, caretLine string) {
+	t.Helper()
+	r := testRenderer(map[string]string{span.File: src})
+	var buf bytes.Buffer
+	if err := r.Render(&buf, Diagnostic{
+		Severity: SeverityError,
+		Message:  "probe",
+		Spans:    []Span{span},
+	}); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	// Layout is: header, "  --> loc", gutter, source line, caret line,
+	// gutter.  Both lines carry the same "%s |  " gutter, so splitting on the
+	// first "|" and dropping the two spaces after it leaves the payload.
+	var payload []string
+	for _, line := range strings.Split(buf.String(), "\n") {
+		i := strings.Index(line, "|")
+		if i < 0 {
+			continue
+		}
+		payload = append(payload, strings.TrimPrefix(line[i+1:], "  "))
+	}
+	if len(payload) < 3 {
+		t.Fatalf("expected three gutter lines, got %d:\n%s", len(payload), buf.String())
+	}
+	return payload[1], payload[2]
+}
+
+// TestUnderlineCoversExactlyTheSpannedText is the reproduction from #469.
+//
+// The wanted caret line is written out in full rather than derived, so that
+// what the test asserts is a picture of the output and not a restatement of
+// the implementation.
+func TestUnderlineCoversExactlyTheSpannedText(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		src   string
+		col   int
+		want  string // the caret line, verbatim
+		guard bool
+	}{{
+		// GUARD: ASCII, where a byte, a rune and a cell are all the same
+		// thing.  This is why the defect survived: every in-tree diagnostic
+		// is about a name like this one.
+		name: "ascii", src: "(set! abc 1)", col: 7,
+		want: "      ^^^", guard: true,
+	}, {
+		// 2 bytes, 1 rune, 1 cell.  Was "^^".
+		name: "two-byte-rune", src: "(set! é 1)", col: 7,
+		want: "      ^",
+	}, {
+		// 6 bytes, 2 runes, 4 cells -- the row that tells cells from runes.
+		// Was "^^^^^^", running four columns past the token and underlining
+		// " 1)" as well.
+		name: "cjk-wide", src: "(f 加算 1)", col: 4,
+		want: "   ^^^^",
+	}, {
+		// 8 bytes, 2 runes, 2 cells (mathematical italic, outside the BMP and
+		// NOT wide).  Was "^^^^^^^^".
+		name: "astral-narrow", src: "(f 𝛼𝛽 1)", col: 4,
+		want: "   ^^",
+	}, {
+		// e + U+0301 COMBINING ACUTE: 3 bytes, 2 runes, 1 cell.  Was "^^^^";
+		// a rune count would say two.
+		name: "combining-mark", src: "(f é\u0301 1)", col: 4,
+		want: "   ^",
+	}, {
+		// An emoji is two cells.  Was six carets for six bytes.
+		name: "emoji", src: "(f 😀x 1)", col: 4,
+		want: "   ^^^",
+	}, {
+		// GUARD: tabs.  The source line has its tabs rewritten to four
+		// spaces before printing, and displayWidth counts them as four, so
+		// the indent was already right; this pins that the change did not
+		// disturb it.
+		name: "tab-indent", src: "\t(set! abc 1)", col: 8,
+		want: "          ^^^", guard: true,
+	}, {
+		// The two together: a CJK name AFTER a tab.  The indent comes from
+		// the tab rule and the length from the width rule, which is the
+		// combination that has to hold for either to be useful.
+		name: "tab-then-cjk", src: "\t(f 加算 1)", col: 5,
+		want: "       ^^^^",
+	}, {
+		// A wide character BEFORE the span: the indent has to skip four
+		// cells, not two runes and not six bytes.  Also a catch -- on
+		// 95e2e1a displayWidth counted 加算 as two, so the carets started two
+		// columns left of the token.
+		name: "wide-before-the-span", src: "(加算 abc 1)", col: 9,
+		want: "      ^^^",
+	}} {
+		name := tc.name
+		if tc.guard {
+			name += "-GUARD"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			srcLine, caretLine := renderOneSpan(t, tc.src, Span{File: "t.lisp", Line: 1, Col: tc.col})
+			if caretLine != tc.want {
+				t.Errorf("caret line does not cover the spanned text (#469):\n"+
+					"  source: %s\n  got:    %s\n  want:   %s\n"+
+					"  (%d carets, wanted %d)",
+					srcLine, caretLine, tc.want,
+					strings.Count(caretLine, "^"), strings.Count(tc.want, "^"))
+			}
+		})
+	}
+}
+
+// TestUnderlineIsMeasuredInTheSameUnitAsTheIndent states the same defect as a
+// property rather than as expected text, over every span position in each
+// source line: whatever writeSpan chose to underline, the carets must start
+// at the spanned text's first cell and run for exactly as many cells as that
+// text occupies.
+//
+// The point of having it as well as the table above is that it cannot be
+// satisfied by writing the wrong string into a `want`, and it covers span
+// positions nobody thought to tabulate.
+func TestUnderlineIsMeasuredInTheSameUnitAsTheIndent(t *testing.T) {
+	t.Parallel()
+	for _, src := range []string{
+		"(set! abc 1)",
+		"(f 加算 1)",
+		"(set! é 1)",
+		"(f 𝛼𝛽 1)",
+		"(f é\u0301 1)",
+		"\t(f 加算 xyz)",
+		"(加算 é 1)",
+		"(f 😀 1)",
+	} {
+		t.Run(src, func(t *testing.T) {
+			t.Parallel()
+			for col := 1; col <= len(src); col++ {
+				// Only start a span on a rune boundary; a byte column inside
+				// a rune is not a position any producer emits.
+				if src[col-1]&0xC0 == 0x80 {
+					continue
+				}
+				span := Span{File: "t.lisp", Line: 1, Col: col}
+				srcLine, caretLine := renderOneSpan(t, src, span)
+
+				// The renderer's own auto-detection decides where the span
+				// ends; recompute it the same way so the property is about
+				// the two MEASUREMENTS agreeing, not about token detection.
+				r := &Renderer{}
+				endCol := r.detectEndCol(src, col)
+				if endCol < col {
+					endCol = col
+				}
+				if endCol > len(src) {
+					endCol = len(src)
+				}
+				wantPad := displayWidth(src[:col-1])
+				wantCarets := displayWidth(src[col-1 : endCol])
+				if wantCarets < 1 {
+					wantCarets = 1
+				}
+
+				gotPad := len(caretLine) - len(strings.TrimLeft(caretLine, " "))
+				gotCarets := strings.Count(caretLine, "^")
+				if gotPad != wantPad || gotCarets != wantCarets {
+					t.Errorf("col %d: carets start at cell %d for %d cells, want %d for %d (#469):\n"+
+						"  source: %s\n  carets: %s",
+						col, gotPad, gotCarets, wantPad, wantCarets, srcLine, caretLine)
+				}
+				// The consequence, stated directly: the carets must not run
+				// past the text they point at.
+				if gotPad+gotCarets > displayWidth(src) {
+					t.Errorf("col %d: the caret run ends at cell %d, past the end of a %d-cell line (#469):\n"+
+						"  source: %s\n  carets: %s",
+						col, gotPad+gotCarets, displayWidth(src), srcLine, caretLine)
+				}
+			}
+		})
+	}
+}
+
+// TestDisplayWidthCountsCells is the unit underneath both tests above.
+//
+// The wide and combining rows are the ones a rune count gets wrong, and they
+// are the reason the fix is "measure both halves in cells" rather than the
+// smaller "measure both halves in runes" that would also have stopped the
+// reported spillover.
+func TestDisplayWidthCountsCells(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		s    string
+		want int
+	}{
+		{"empty", "", 0},
+		{"ascii", "abc", 3},
+		{"tab", "\t", tabWidth},
+		{"tab and ascii", "\tab", tabWidth + 2},
+		{"latin-1 accent", "é", 1},
+		{"decomposed accent", "e\u0301", 1},
+		{"cjk", "加算", 4},
+		{"hangul", "한글", 4},
+		{"fullwidth latin", "ＡＢ", 4},
+		{"halfwidth katakana", "ｱｲ", 2},
+		{"astral non-wide", "𝛼𝛽", 2},
+		{"emoji", "😀", 2},
+		{"ambiguous stays narrow", "→①", 2},
+		{"greek stays narrow", "λαβ", 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := displayWidth(tc.s); got != tc.want {
+				t.Errorf("displayWidth(%q) = %d, want %d", tc.s, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTabExpansionMatchesTabWidth pins the pair of constants the source line
+// and the caret line each read separately.  If they drift, every tab-indented
+// diagnostic misaligns and nothing else says so.
+func TestTabExpansionMatchesTabWidth(t *testing.T) {
+	t.Parallel()
+	if len(tabExpansion) != tabWidth || strings.Trim(tabExpansion, " ") != "" {
+		t.Errorf("tabExpansion %q is not %d spaces; the source line and the caret line"+
+			" are laid out by different code and only agree because these match",
+			tabExpansion, tabWidth)
+	}
+}
+
+// TestSpanEndColIsInclusive pins the convention #469 flags as a latent trap:
+// diagnostic.Span.EndCol is INCLUSIVE, while parser/token.Location.EndCol is
+// documented (since #463) EXCLUSIVE, and the two fields have the same name.
+//
+// Nothing bridges them today -- cmd/diagnostic.go and repl/diagnostic.go both
+// leave Span.EndCol zero -- so this is not a defect, it is the thing the next
+// person to wire an analyser's end position into a Span needs to know.  The
+// convention is now written on the field; this makes it executable, so a
+// silent switch to exclusive fails here rather than in someone's terminal.
+//
+// GUARD: passes on 95e2e1a.
+func TestSpanEndColIsInclusive(t *testing.T) {
+	t.Parallel()
+	// "false" occupies byte columns 7..11 of "(set! false 42)".
+	const src = "(set! false 42)"
+	_, caretLine := renderOneSpan(t, src, Span{File: "t.lisp", Line: 1, Col: 7, EndCol: 11})
+	if got := strings.Count(caretLine, "^"); got != len("false") {
+		t.Errorf("Col 7 / EndCol 11 underlined %d columns of a %d-column name;"+
+			" Span.EndCol is inclusive, and if that changed the doc comment on"+
+			" Span needs to change with it\n  source: %s\n  carets: %s",
+			got, len("false"), src, caretLine)
+	}
+}
+
+// TestUnderlineSurvivesOutOfRangeSpans covers positions no in-tree producer
+// emits but the exported type permits, since Span is filled in by callers and
+// nothing validates it.
+//
+// On 95e2e1a an EndCol past the end of the line produced a caret run as long
+// as the number said -- 500 carets across the terminal for a 15-column line.
+// Not a crash, so it is a robustness improvement rather than the defect #469
+// is about; it is here because the fix computes a slice from these numbers
+// and a slice is the kind of thing that panics.
+func TestUnderlineSurvivesOutOfRangeSpans(t *testing.T) {
+	t.Parallel()
+	const src = "(set! abc 1)"
+	for _, span := range []Span{
+		{File: "t.lisp", Line: 1, Col: 7, EndCol: 500},
+		{File: "t.lisp", Line: 1, Col: 500},
+		{File: "t.lisp", Line: 1, Col: 500, EndCol: 900},
+		{File: "t.lisp", Line: 1, Col: 900, EndCol: 500},
+		{File: "t.lisp", Line: 1, Col: -3, EndCol: -9},
+		{File: "t.lisp", Line: 1, Col: len(src), EndCol: len(src)},
+	} {
+		_, caretLine := renderOneSpan(t, src, span)
+		carets := strings.Count(caretLine, "^")
+		if carets < 1 {
+			t.Errorf("span %+v produced no carets at all", span)
+		}
+		// One cell past the last is allowed: a position at end-of-line
+		// legitimately points just after the final character.  Anything
+		// beyond that is the runaway run 95e2e1a produced.
+		if pad := len(caretLine) - len(strings.TrimLeft(caretLine, " ")); pad+carets > displayWidth(src)+1 {
+			t.Errorf("span %+v underlined %d cells starting at %d, past the end of a %d-cell line:\n  %s",
+				span, carets, pad, displayWidth(src), caretLine)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/ergochat/readline v0.1.3
 	github.com/google/go-dap v0.12.0
+	github.com/mattn/go-runewidth v0.0.14
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/muesli/reflow v0.3.0
 	github.com/spf13/cobra v1.10.2
@@ -34,7 +35,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7 // indirect


### PR DESCRIPTION
Fixes #469

## Reproduced

On `95e2e1a`, rendering spans with `EndCol` unset so `detectEndCol` supplies it:

```
SRC "(set! é 1)"     1 |  (set! é 1)
                       |        ^^          2 carets under a 1-cell token

SRC "(f 加算 1)"      1 |  (f 加算 1)
                       |     ^^^^^^        6 carets under a 4-cell token, spilling over " 1)"

SRC "(f 𝛼𝛽 1)"       1 |  (f 𝛼𝛽 1)
                       |     ^^^^^^^^      8 carets under a 2-cell token

SRC "(f é́ 1)"        1 |  (f é́ 1)
                       |     ^^^^          4 carets under a 1-cell token (e + U+0301)

SRC "(set! abc 1)"   1 |  (set! abc 1)
                       |        ^^^        ASCII: correct
```

## Bytes, runes, or cells

The issue asks the question and this is the answer: **cells**, and it matters.

`underLen` was bytes and `displayCol` was a rune count. Fixing only the mismatch — measuring both halves in runes — would have stopped the reported spillover and still been wrong, because the underline has to line up with what a **terminal** draws and a terminal does not advance one cell per rune. An East Asian wide character advances two; a combining mark advances none. Under a rune count `加算` gets two carets under a four-cell token, and `é` written as `e` + U+0301 gets two under one cell.

So both halves now go through `displayWidth`, which is the one place that decides what a cell is, and they agree by construction rather than by coincidence. The CJK rows in the tests are what separates the two candidate fixes: six is the byte answer, two is the rune answer, **four** is right.

**What the repo already had:** `displayWidth` in this file, counting one per rune with tabs expanded to four — no width classes anywhere in the tree. `github.com/mattn/go-runewidth` was already in the module graph as an indirect dependency via the direct `muesli/reflow`, so this only moves it from indirect to direct; `go.sum` is unchanged and no module is added.

It is used through an **explicit `Condition`** rather than the package-level default, which matters: go-runewidth's `init` reads `LC_ALL`/`LC_CTYPE`/`LANG` and sets `EastAsianWidth` from it, under which the ~1000 codepoints in Unicode's Ambiguous width class (`→`, `①`, Greek, Cyrillic, box drawing) become two cells wide. Left on the default, the same diagnostic would be underlined differently depending on the locale of the shell that ran `elps`, and this package's own golden tests would pass or fail on the same grounds. Ambiguous-as-narrow is what essentially every modern terminal does.

`tabWidth` and `tabExpansion` are now named constants. The source line and the caret line are laid out by two separate pieces of code and only line up because these agree; `TestTabExpansionMatchesTabWidth` pins that.

The out-of-range clamping is new. `Span` is an exported type filled in by callers and nothing validates it; the fix computes a slice from `Col`/`EndCol`, and a slice is the kind of thing that panics.

## The latent trap next to it

`diagnostic.Span.EndCol` is used **inclusively**; `token.Location.EndCol` is documented (since #463) **exclusive**. Nothing bridges them today — `cmd/diagnostic.go` and `repl/diagnostic.go` both set `Col` only. So this is not a defect and nothing is renamed: an exported field is not worth breaking for a convention that can be written down. The convention is now on the type, with the conversion (`EndCol: loc.EndCol - 1`) and a pointer at #463, and `TestSpanEndColIsInclusive` makes it executable so a silent switch fails here rather than in someone's terminal.

**This is deliberately not #464.** That is the LSP server emitting byte columns where LSP 3.16 specifies UTF-16 code units, it is another agent's, and it is in `lsp/` — untouched here. `diagnostic` is a standalone package with no LSP consumer, and "the two ends of one underline are counted in the same unit" is a property under any answer #464 gets.

## Red then green

`diagnostic/underline_width_test.go`. Against `95e2e1a` (`renderer.go` restored, the two new constants stubbed so the file compiles):

```
--- FAIL: TestUnderlineCoversExactlyTheSpannedText
    --- FAIL: /two-byte-rune          --- FAIL: /cjk-wide
    --- FAIL: /astral-narrow          --- FAIL: /combining-mark
    --- FAIL: /emoji                  --- FAIL: /tab-then-cjk
    --- FAIL: /wide-before-the-span
    --- PASS: /ascii-GUARD            --- PASS: /tab-indent-GUARD
--- FAIL: TestUnderlineIsMeasuredInTheSameUnitAsTheIndent   (7 of 8 source lines)
--- FAIL: TestDisplayWidthCountsCells                       (cjk, hangul, fullwidth, emoji, decomposed accent)
--- FAIL: TestUnderlineSurvivesOutOfRangeSpans
--- PASS: TestSpanEndColIsInclusive                         (GUARD)
--- PASS: TestTabExpansionMatchesTabWidth                    (GUARD)
```

A failure prints the two lines one above the other, which is the form the defect is obvious in:

```
  source: (f 加算 1)
  got:       ^^^^^^
  want:      ^^^^
  (6 carets, wanted 4)
```

`wide-before-the-span` is worth noting: on `main` it fails on the **indent**, not the length — `displayWidth` counted `加算` as two, so the carets started two columns left of the token. Fixing only `underLen` would have left that.

`TestUnderlineIsMeasuredInTheSameUnitAsTheIndent` states the same defect as a property over every rune-boundary start column of eight source lines, so it cannot be satisfied by writing the wrong string into a `want`.

All nine existing tests in `renderer_test.go` still pass unchanged, including `TestRenderErrorGolden`.

## Neighbourhood audit

- `detectEndCol` already advances by `utf8.DecodeRuneInString`, so it returns a valid rune boundary and the new slice is safe. Unchanged.
- `displaySource`'s tab replacement and `displayWidth`'s tab handling are the only other place two measurements have to agree in this file; they now share a constant.
- `lsp/`, `lint/`, `analysis/`, `mcpserver/` all carry their own position types and none constructs a `diagnostic.Span`. `lsp/position.go`'s byte-vs-UTF-16 question is #464 and is untouched.
- No other caller of `displayWidth` exists.

## Gates

`go build`, `go vet`, `go test -count=1 ./...`, `go test -race ./...`, `golangci-lint run ./...`, `elps fmt -l ./...`, `elps doc -m`, `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `CI_GATES_REQUIRE_SHELLCHECK=1 ./scripts/ci-gates-test.sh`, `./scripts/confidentiality-guard.sh`, `./scripts/fuzz-budget-check.sh` — all clean.

No benchmark touches `diagnostic`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdyHypXM1ybiPrgGbddaNA)_