### PR TITLE
elpstest: stop the benchmark timer at the body; drop three load-dependent bounds

### DIFF
--- a/elpstest/lisptest.go
+++ b/elpstest/lisptest.go
@@ -229,9 +229,11 @@ func (r *Runner) RunTestFile(t *testing.T, path string) {
 // successfully.
 //
 // Only the benchmark body is timed.  Building the environment, running SetupFn
-// and loading the benchmark file all happen with the timer stopped, so what a
-// Runner configures cannot change what its numbers mean: a Runner with a
-// SetupFn and a Runner without one measure the same region.
+// and loading the benchmark file all happen before it with the timer stopped;
+// TeardownFn and the log flush happen after it with the timer stopped again.
+// So what a Runner configures cannot change what its numbers mean: a Runner
+// with a SetupFn or a TeardownFn and a Runner with neither measure the same
+// region, and RunBenchmark returns with the timer in the state it found it.
 func (r *Runner) RunBenchmark(b *testing.B, i int, path string, source io.Reader) {
 	b.StopTimer()
 	env, err := r.NewEnv(b)
@@ -256,13 +258,20 @@ func (r *Runner) RunBenchmark(b *testing.B, i int, path string, source io.Reader
 		r.LispError(b, err)
 		return
 	}
-	if r.TeardownFn != nil {
-		defer func() {
-			b.StopTimer()
-			r.TeardownFn(env)
-			b.StartTimer()
-		}()
-	}
+	// Teardown runs after the body, with the timer already stopped by the
+	// body's own StopTimer below, and does NOT restart it.  The measured
+	// region ends at the body, so there is nothing left for a running timer
+	// to measure except the deferred work itself -- which was issue #474:
+	// this branch ended in StartTimer, and the `defer ...Flush()` registered
+	// above runs after it, so the flush was charged to the benchmark.
+	//
+	// Written through the nil-safe wrapper rather than guarded on
+	// r.TeardownFn, matching RunTest and the SetupFn call above (#476).  The
+	// guard existed only to avoid the timer dance that is now gone.
+	defer func() {
+		_ = r.Teardown(env)
+	}()
+
 	suite := libtesting.EnvTestSuite(env)
 	if suite == nil {
 		b.Errorf("unable to locate test suite")
@@ -271,6 +280,13 @@ func (r *Runner) RunBenchmark(b *testing.B, i int, path string, source io.Reader
 	ltest := suite.Benchmark(i)
 	b.StartTimer()
 	err = lisp.GoError(env.Eval(lisp.SExpr([]*lisp.LVal{ltest.Fun, lisp.Int(b.N)})))
+	// The measured region ends HERE, before any deferred work.  Unstopped,
+	// the timer ran on through the teardown defer's restart and through the
+	// log flush, adding a fixed charge to every RunBenchmark call that grows
+	// with whatever the benchmark wrote to stderr (issue #474).  Stopped
+	// before the error check so that a failing benchmark takes the same path
+	// as a passing one.
+	b.StopTimer()
 	if err != nil {
 		r.LispError(b, err)
 		return

--- a/elpstest/runnerbenchmark_teardown_test.go
+++ b/elpstest/runnerbenchmark_teardown_test.go
@@ -1,0 +1,228 @@
+// Copyright © 2026 The ELPS authors
+
+package elpstest
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/elpsutil"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+)
+
+// This file covers issue #474: (*Runner).RunBenchmark started the timer
+// before the benchmark body and never stopped it, so everything that ran
+// afterwards inside the same *testing.B function was charged to the
+// measurement.  Two things were:
+//
+//  1. the `defer env.Runtime.Stderr.(*Logger).Flush()`, on every path,
+//     costing whatever the benchmark left buffered on stderr; and
+//
+//  2. with a TeardownFn configured, the b.StartTimer() at the end of the
+//     teardown defer -- which is what re-exposed (1) after teardown itself
+//     had correctly run untimed.
+//
+// The issue measured 650ns on a 15.6us benchmark.  That number is not what
+// these tests assert, and deliberately so.  A threshold on a duration is the
+// #443/#452 shape: it sits near its own noise floor and it turns machine load
+// into a test failure.
+//
+// THE ASSERTION IS THE TIMER ITSELF, following the standard #476 set for the
+// SetupFn half of this same function.  A *testing.B whose timer is stopped
+// has a frozen B.Elapsed(), so sleeping and differencing B.Elapsed() across
+// the sleep yields EXACTLY zero when the region is untimed and at least the
+// sleep when it is not.  There is no threshold to tune and no arithmetic on a
+// measured duration.
+//
+// TestBenchmarkElapsedFreezesWhenTimerStopped in the sibling file is the
+// guard for that premise, and is not restated here.
+
+// teardownProbeDelay is how long a probe blocks while watching the timer.  It
+// only has to be long enough that a RUNNING timer's B.Elapsed() advances
+// measurably; a stopped one does not advance at all.
+const teardownProbeDelay = 20 * time.Millisecond
+
+// teardownProbeSource is a benchmark file with nothing in it but the
+// benchmark, so the measured region is as close to empty as it can be and
+// anything charged after the body stands out.
+const teardownProbeSource = `
+(use-package 'testing)
+
+(benchmark-simple "probe"
+  (+ 1 1))
+`
+
+// TestRunBenchmarkReturnsWithTheTimerStopped is the catch for #474.
+//
+// It observes the timer at the moment RunBenchmark returns -- after every one
+// of its defers, including the teardown defer and the log flush, has run.  A
+// RunBenchmark that has stopped timing leaves B.Elapsed() frozen there; the
+// one on 95e2e1a left it running, on BOTH arms:
+//
+//   - without a TeardownFn, because nothing ever stopped the timer after the
+//     body, so the deferred Flush was inside the measurement; and
+//
+//   - with one, because the teardown defer ended in b.StartTimer().
+//
+// This is the strongest form the property has.  "Is the flush timed?" is
+// awkward to observe directly -- the flush is a defer inside a function the
+// test does not control -- whereas "does the timer end up stopped?" is
+// observable from the caller and implies it, because nothing stops the timer
+// after the flush.
+func TestRunBenchmarkReturnsWithTheTimerStopped(t *testing.T) {
+	benchtime1x(t)
+	for _, test := range []struct {
+		name     string
+		teardown func(*lisp.LEnv) *lisp.LVal
+	}{
+		{"no-teardown", nil},
+		{"with-teardown", func(*lisp.LEnv) *lisp.LVal { return lisp.Nil() }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var delta time.Duration
+			r := &Runner{TeardownFn: test.teardown}
+			res := testing.Benchmark(func(b *testing.B) {
+				r.RunBenchmark(b, 0, "probe_test.lisp", strings.NewReader(teardownProbeSource))
+				// Every defer RunBenchmark registered has now run.
+				before := b.Elapsed()
+				time.Sleep(teardownProbeDelay)
+				delta = b.Elapsed() - before
+			})
+			if res.N == 0 {
+				t.Fatalf("benchmark failed; RunBenchmark reported an error")
+			}
+			if delta != 0 {
+				t.Errorf("RunBenchmark returned with the benchmark timer RUNNING:"+
+					" B.Elapsed() advanced %v across a %v sleep after it returned."+
+					" Everything the deferred work does -- the teardown defer's"+
+					" StartTimer and the Logger.Flush after it -- is charged to the"+
+					" measurement (issue #474); a stopped timer advances by exactly 0.",
+					delta, teardownProbeDelay)
+			}
+		})
+	}
+}
+
+// TestRunBenchmarkDoesNotTimeTeardown pins the half of #474 that is about
+// TeardownFn specifically, from inside the teardown itself.
+//
+// It is not redundant with the test above.  That one says the timer is
+// stopped when RunBenchmark RETURNS; this one says it is stopped while
+// TeardownFn is RUNNING, which is a separate claim -- an implementation that
+// timed the teardown and then stopped the timer on the way out would satisfy
+// the first and not this.
+//
+// GUARD on 95e2e1a: the teardown defer already began with b.StopTimer(), so
+// the teardown body itself was untimed there too.  It is here because the
+// fix DELETES that StopTimer/StartTimer pair, and this is what says the
+// deletion did not cost the property the pair was providing.
+func TestRunBenchmarkDoesNotTimeTeardown(t *testing.T) {
+	benchtime1x(t)
+	var delta time.Duration
+	var reached bool
+	var b0 *testing.B
+
+	r := &Runner{TeardownFn: func(*lisp.LEnv) *lisp.LVal {
+		reached = true
+		before := b0.Elapsed()
+		time.Sleep(teardownProbeDelay)
+		delta = b0.Elapsed() - before
+		return lisp.Nil()
+	}}
+	res := testing.Benchmark(func(b *testing.B) {
+		b0 = b
+		r.RunBenchmark(b, 0, "probe_test.lisp", strings.NewReader(teardownProbeSource))
+	})
+	if res.N == 0 {
+		t.Fatalf("benchmark failed; RunBenchmark reported an error")
+	}
+	if !reached {
+		t.Fatal("TeardownFn was never called: this test observed nothing")
+	}
+	if delta != 0 {
+		t.Errorf("TeardownFn ran with the benchmark timer RUNNING:"+
+			" B.Elapsed() advanced %v across a %v sleep inside it (issue #474);"+
+			" a stopped timer advances by exactly 0.",
+			delta, teardownProbeDelay)
+	}
+}
+
+// TestRunBenchmarkStillTimesTheBody is the negative control for both tests
+// above.  Without it, a RunBenchmark that stopped the timer too EARLY -- or
+// never started it -- would satisfy every "the timer is stopped" assertion in
+// this file and measure nothing at all.
+//
+// It reads the timer from inside the benchmark body, so it says the body is
+// inside the measured region without comparing two durations to each other.
+// GUARD: passes on 95e2e1a.
+func TestRunBenchmarkStillTimesTheBody(t *testing.T) {
+	benchtime1x(t)
+	var delta time.Duration
+	var reached bool
+	var b0 *testing.B
+
+	probe := &bodyTimerProbe{
+		observe: func() {
+			reached = true
+			before := b0.Elapsed()
+			time.Sleep(teardownProbeDelay)
+			delta = b0.Elapsed() - before
+		},
+	}
+	r := &Runner{
+		LoaderFn:   probe.loader(),
+		TeardownFn: func(*lisp.LEnv) *lisp.LVal { return lisp.Nil() },
+	}
+	res := testing.Benchmark(func(b *testing.B) {
+		b0 = b
+		r.RunBenchmark(b, 0, "probe_test.lisp", strings.NewReader(bodyProbeSource))
+	})
+	if res.N == 0 {
+		t.Fatalf("benchmark failed; RunBenchmark reported an error")
+	}
+	if !reached {
+		t.Fatal("the probe builtin was never evaluated in the benchmark body")
+	}
+	if delta < teardownProbeDelay/2 {
+		t.Errorf("the benchmark BODY ran with the timer stopped:"+
+			" B.Elapsed() advanced only %v across a %v sleep inside it."+
+			" RunBenchmark is measuring nothing.",
+			delta, teardownProbeDelay)
+	}
+}
+
+// bodyProbeSource calls the probe from inside the benchmark body rather than
+// at top level, so what it observes is the measured region.
+const bodyProbeSource = `
+(use-package 'testing)
+
+(benchmark-simple "probe"
+  (probe-body-timer))
+`
+
+// bodyTimerProbe registers a builtin the benchmark body calls.  The loader
+// mirrors loadTimerProbe.loader in the sibling file (#476); the two are left
+// separate rather than unified so this change stays confined to the defect it
+// is about.
+type bodyTimerProbe struct {
+	observe func()
+}
+
+func (p *bodyTimerProbe) loader() func(*lisp.LEnv) *lisp.LVal {
+	return func(env *lisp.LEnv) *lisp.LVal {
+		if rc := lisplib.LoadLibrary(env); rc.Type == lisp.LError {
+			return rc
+		}
+		if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+			return rc
+		}
+		env.AddBuiltins(true, elpsutil.Function("probe-body-timer", lisp.Formals(),
+			func(*lisp.LEnv, *lisp.LVal) *lisp.LVal {
+				p.observe()
+				return lisp.Nil()
+			}))
+		return lisp.Nil()
+	}
+}

--- a/lisp/lisplib/libtime/sleep_test.go
+++ b/lisp/lisplib/libtime/sleep_test.go
@@ -406,22 +406,50 @@ func TestSleepRejectsNonDuration(t *testing.T) {
 	}
 }
 
+// The three tests below -- this one, TestSleepMaxCannotExceedHostCeiling and
+// TestSleepMaxThroughEval -- each used to follow their condition check with an
+// `elapsed > time.Second` assertion.  Those are gone, and this is why (#475).
+//
+// THEY WERE REDUNDANT.  Each enforced "the sleep was refused on entry rather
+// than performed", and each was already inside a runBounded(t, slack, ...)
+// that fails the test after 30s.  The durations being refused are 1h+1s, 1h
+// and 2h, and BuiltinSleep has no partial-sleep path: it either refuses
+// before reaching sleepContext, or sleeps the caller's full duration bounded
+// by the context -- and all three environments run on context.Background(),
+// so nothing can cut a sleep short.  elapsed is therefore either microseconds
+// or at least an hour.  There is no implementation that lands in the gap
+// between 1s and 30s by SLEEPING; the only way to land there is scheduling
+// delay, which is machine load.  That is the #435 shape -- a correctness
+// property enforced by a wall clock, where a correct implementation fails the
+// test for being slow -- and it is not fixed by widening the bound (#443/#452,
+// #435/#447).
+//
+// CHECKED BY MUTATION rather than by argument alone.  With the three checks
+// removed, a build in which the length cap refuses only AFTER sleeping (the
+// exact failure the old comment here said the elapsed assertion was
+// load-bearing for) still fails all three, through runBounded:
+//
+//	--- FAIL: TestSleepMaxThroughEval (30.03s)   sleep did not return within 30s
+//	--- FAIL: TestSleepLengthCapRefusesImmediately (30.03s)
+//	--- FAIL: TestSleepMaxCannotExceedHostCeiling (30.03s)
+//
+// So runBounded catches everything the deleted checks could, and nothing is
+// lost by letting it be the only clock.  It is a hang detector: no assertion
+// in these three tests succeeds on the strength of a wall-clock reading.
+//
+// Where a tighter statement IS wanted, TestSleepPastDeadlineFailsFast's
+// `elapsed > remaining/2` is the pattern -- relative to a duration the test
+// controls rather than to an absolute second.
+//
 // TestSleepLengthCapRefusesImmediately covers the length cap itself, with no
 // context involved: a duration over DefaultMaxSleep is refused on entry.
-//
-// The elapsed assertion is the load-bearing one. A cap that errored only
-// AFTER sleeping would satisfy a condition-only check while leaving the
-// unbounded-block defect entirely in place.
 func TestSleepLengthCapRefusesImmediately(t *testing.T) {
 	t.Parallel()
 	env := sleepEnv(t, nil)
-	v, elapsed := runBounded(t, slack, func() *lisp.LVal {
+	v, _ := runBounded(t, slack, func() *lisp.LVal {
 		return callSleep(env, lisp.DefaultMaxSleep+time.Second)
 	})
 	requireSleepLimit(t, v)
-	if elapsed > time.Second {
-		t.Fatalf("took %v to refuse an over-cap sleep, expected immediate", elapsed)
-	}
 }
 
 // TestSleepUnderCapStillSleeps is the negative control for the test above.
@@ -466,6 +494,12 @@ func TestSleepMaxRaisesTheCap(t *testing.T) {
 // source may raise the default cap, but not past a ceiling the host set --
 // otherwise untrusted source could grant itself an unbounded sleep and the
 // bound would be decorative.
+//
+// The first call's `elapsed > time.Second` check is gone; see the block above
+// TestSleepLengthCapRefusesImmediately (#475).  It is refused inside sleepCap,
+// before a sleep is reachable at all, and the only way past that is for
+// sleepCap to accept the 1h :max -- at which point the call sleeps an hour and
+// runBounded fails the test.
 func TestSleepMaxCannotExceedHostCeiling(t *testing.T) {
 	t.Parallel()
 	env := lisp.NewEnv(nil)
@@ -477,13 +511,10 @@ func TestSleepMaxCannotExceedHostCeiling(t *testing.T) {
 		t.Fatalf("load time package: %v", rc)
 	}
 
-	v, elapsed := runBounded(t, slack, func() *lisp.LVal {
+	v, _ := runBounded(t, slack, func() *lisp.LVal {
 		return callSleepMax(env, time.Hour, libtime.Duration(time.Hour))
 	})
 	requireSleepLimit(t, v)
-	if elapsed > time.Second {
-		t.Fatalf("took %v to refuse, expected immediate", elapsed)
-	}
 
 	// And the ceiling lowers the no-:max default too, so the default cannot
 	// quietly exceed it.
@@ -530,10 +561,16 @@ func TestSleepRejectsNonDurationMax(t *testing.T) {
 // TestSleepMaxThroughEval proves the keyword reaches the builtin through the
 // formals machinery, not just through a hand-built args list. The direct
 // callers above would all still pass if the formal were misdeclared.
+//
+// Its `elapsed > time.Second` check is gone; see the block above
+// TestSleepLengthCapRefusesImmediately (#475).  This was the most exposed of
+// the three, because it goes through LoadString -- read, parse, evaluate two
+// calls -- which is the same work the 2.29s LoadStringContext measurement on
+// #455 covers.
 func TestSleepMaxThroughEval(t *testing.T) {
 	t.Parallel()
 	env := sleepEnv(t, nil)
-	v, elapsed := runBounded(t, slack, func() *lisp.LVal {
+	v, _ := runBounded(t, slack, func() *lisp.LVal {
 		return env.LoadString("sleep_max_test.lisp",
 			`(time:sleep (time:parse-duration "2h") :max (time:parse-duration "1s"))`)
 	})
@@ -544,9 +581,6 @@ func TestSleepMaxThroughEval(t *testing.T) {
 	requireSleepLimit(t, v)
 	if !strings.Contains(v.String(), "maximum 1s") {
 		t.Fatalf("error = %v, want the 1s :max to be the reported maximum", v)
-	}
-	if elapsed > time.Second {
-		t.Fatalf("took %v to refuse, expected immediate", elapsed)
 	}
 }
 


### PR DESCRIPTION
Fixes #474
Fixes #475

Two defects in the benchmark/test harness, paired because both are "a wall clock measuring something it should not".

---

## #474 — `RunBenchmark` never stops the timer

### Reproduced

The issue's probe, on `95e2e1a`:

```
withTeardown=false N=1 reported=40.45µs atTeardownEnd=0s      charged-after-teardown=40.45µs
withTeardown=true  N=1 reported=15.111µs atTeardownEnd=14.933µs charged-after-teardown=178ns
```

Same mechanism as the issue's 650ns figure; the absolute number is machine-dependent and is not what anything here asserts. After the fix, `charged-after-teardown=0s` on both arms.

### The fix

`b.StopTimer()` when the body returns, before any deferred work, and the teardown defer no longer restarts the timer. The measured region ends at the body either way, so restoring a running timer served nothing but charging the deferred `Logger.Flush` to the benchmark.

The teardown call now goes through `r.Teardown(env)`, the nil-safe wrapper, matching `RunTest` and the `_ = r.Setup(env)` #476 landed a few lines above. The `if r.TeardownFn != nil` guard existed only to avoid the timer dance that is now gone.

`StopTimer` is placed before the error check so a failing benchmark takes the same path as a passing one. The framework's own `b.StopTimer()` after `benchFunc` returns is a no-op on an already-stopped timer.

### The tests have no threshold

Matching the standard #476 set for the `SetupFn` half of this same function, and deliberately: a threshold on a duration is the #443/#452 shape. A `*testing.B` whose timer is stopped has a **frozen** `B.Elapsed()`, so sleeping and differencing `B.Elapsed()` across the sleep yields *exactly* zero when the region is untimed and at least the sleep when it is not. Nothing compares two measured durations.

Against `95e2e1a`:

```
--- FAIL: TestRunBenchmarkReturnsWithTheTimerStopped
    --- FAIL: /no-teardown     B.Elapsed() advanced 20.210307ms across a 20ms sleep after it returned
    --- FAIL: /with-teardown   B.Elapsed() advanced 22.23721ms  across a 20ms sleep after it returned
--- PASS: TestRunBenchmarkDoesNotTimeTeardown   (GUARD)
--- PASS: TestRunBenchmarkStillTimesTheBody     (GUARD, negative control)
```

Two catches, both arms. The two guards are labelled in-file:

- **`DoesNotTimeTeardown`** passed on `main` because the teardown defer already began with `StopTimer`. It is here because the fix *deletes* that `StopTimer`/`StartTimer` pair, and it says the deletion did not cost the property the pair provided. It is a separate claim from the catch — an implementation that timed the teardown and then stopped the timer on the way out would satisfy the catch and fail this.
- **`StillTimesTheBody`** is the negative control. Without it, a `RunBenchmark` that stopped the timer too early — or never started it — would satisfy every "the timer is stopped" assertion in the file and measure nothing at all.

`TestBenchmarkElapsedFreezesWhenTimerStopped` from #476 already guards the premise both rely on; it is not restated.

### What moved in the benchmark gate, and what did not

**Correcting a prediction.** I expected lisp-level rows to shift down, since this changes what is measured. **They did not, and the reason is worth writing down**: `elpstest` has *two* things called `RunBenchmark`, and only one of them is this defect.

- The **package-level** `elpstest.RunBenchmark(b, source)` is what all 43 gated lisp-level benchmarks use (`lisp/alias_bench_test.go` and friends). It already had a matching `b.StopTimer()` at the end of each iteration and is not touched here.
- The **method** `(*Runner).RunBenchmark`, which is the defect, has exactly one in-tree caller reaching a gated benchmark: `libjson_test.go`'s `RunBenchmarkFile`.

So the whole measurable effect is confined to `libjson`, and CI's interleaved n=10 comparison bears that out:

```
info  .../lisp/lisplib/libjson  sec/op    geomean  delta=-0.37%
info  .../lisp/lisplib/libjson  B/op      geomean  delta=-0.02%
info  .../lisp/lisplib/libjson  allocs/op geomean  delta=-0.00%
info  .../lisp                  sec/op    geomean  delta=+0.10%
```

A small *improvement* in the only package that goes through the changed function, no significant row anywhere, and:

```
benchstat-gate: interpreted 27 delta row(s) + 451 no-change row(s);
6 significant move(s) in the bad direction; 0 at or above the gate
(timing 15%, allocation 5%).
```

The six below-gate moves (`AliasCDR` +0.86%, `AliasSliceThenAppendMutate` +1.95%, `BuiltinSetCopyDeep/depth4` +4.00%, `Parser/sicp.lisp` +1.61%, `BuildWorkspaceState` B/op +0.04%) are all in packages that do not reach the changed code at all, so they are the runs' own spread, not this change — which is the #452 rule applied.

To be explicit about what this does *not* do: no threshold is weakened, no waiver is added, `B/op` and `allocs/op` are untouched by the change, and no benchmark body changes. A row that gets faster here is the gate working — the removed time was never the code under benchmark.

No `Runner` in this repository sets `TeardownFn`, so the teardown half moves nothing in-tree at all. `elpstest` is an exported package and `TeardownFn` an exported field, which is the same downstream-Runner argument #434 makes.

---

## #475 — three `elapsed > time.Second` bounds in `sleep_test.go`

**Verdict: reproduce-or-close resolves to *remove them*.** They carry no signal.

### They cannot fail for a reason other than load

The three refuse durations of **1h+1s, 1h and 2h**, each already inside a `runBounded(t, slack, ...)` that fails after 30s. `BuiltinSleep` has no partial-sleep path — it either refuses before reaching `sleepContext`, or sleeps the caller's full duration bounded by the context — and all three environments run on `context.Background()`, so nothing can cut a sleep short. `elapsed` is therefore either microseconds or **at least an hour**.

There is no implementation that lands between 1s and 30s by *sleeping*. The only way to land there is scheduling delay, i.e. machine load. That is exactly the #435 shape: a correct implementation fails the test for being slow.

### Checked by mutation, not by argument alone

The comment being deleted claimed "a cap that errored only AFTER sleeping would satisfy a condition-only check while leaving the unbounded-block defect entirely in place." That is the claim to test. With the three bounds **removed**, in a build where the cap refuses only after sleeping:

```
--- FAIL: TestSleepMaxThroughEval (30.03s)              sleep did not return within 30s
--- FAIL: TestSleepLengthCapRefusesImmediately (30.03s) sleep did not return within 30s
--- FAIL: TestSleepMaxCannotExceedHostCeiling (30.03s)  sleep did not return within 30s
```

(Two mutants were needed: `TestSleepMaxCannotExceedHostCeiling`'s guarded call is refused inside `sleepCap`, before the length check, so it took a second mutant putting the sleep before the ceiling refusal.)

`runBounded` catches everything the deleted checks could. Nothing is lost.

### The flake itself did not reproduce

Stated plainly, because the issue was honest that it had inferred rather than seen one. Under 24 busy-loop spinners on 4 cores with `-race`, and again with six `go test -race` suites of the same package running concurrently — 108+ samples of each call shape — the largest wall time observed for any of the three was **65ms**, well inside the 1s bound. The `2.29s` figure in the issue is from #455's adjacent measurement, not from these tests.

That does not change the verdict: the bounds add no coverage, so their only possible contribution is a failure mode, and the argument above does not depend on having seen one. This is not the same as widening the bound, which is the move #443/#452 and #435/#447 established is wrong.

The reasoning is written into the file above `TestSleepLengthCapRefusesImmediately`, including the mutation output, so the next person to reach for a wall clock here reads why the last three were removed. Where a tighter statement genuinely is wanted, `TestSleepPastDeadlineFailsFast`'s `elapsed > remaining/2` is the pattern — relative to a duration the test controls.

---

## Found while doing this, filed as #499, not fixed here

`TestSleepMaxCannotExceedHostCeiling`'s **second** call (`callSleep(env, 2*time.Second)` against a 1s host ceiling) has no timing assertion at all, and 2s is short enough that a sleep-then-refuse implementation returns comfortably inside `runBounded`'s 30s. Under the first mutant that call slept its full 2 seconds and the test still passed, in 2.03s. Found by **running**. That is a real gap in the "refused on entry" property for that one call — and unlike the three bounds this PR removes, a *relative* bound there would carry signal. Filed rather than folded in: it is a missing assertion on a different call, not one of the three #475 is about.

## Neighbourhood audit

- The two `RunBenchmark`s are unrelated code paths with the same name (see the benchmark section above). Only the method is changed; the package-level function already stopped its timer per iteration.
- `RunBenchmarkFile`'s `$load` sub-benchmark calls `LoadBenchmarks`, which does not touch the timer. Unaffected.
- `RunTest` has no timer and already used the `Teardown` wrapper; `RunBenchmark` now matches it.
- #441's `iterExprs[i] = expr.Copy()` (fresh AST per iteration) lives in the package-level function and is untouched.
- #476's `_ = r.Setup(env)` and its `TestRunnerRunBenchmarkDoesNotTimeLoad` still pass unchanged; the two test files are left separate rather than unified so this change stays confined to its defect.
- The other seven `runBounded` callers in `sleep_test.go` were checked. Their `elapsed` assertions are of the kind this issue *keeps*: `TestSleepUnderCapStillSleeps` asserts a lower bound (the sleep happened), `TestSleepPastDeadlineFailsFast` uses `remaining/2` relative to a duration it controls, and #477 already removed the deadline racing the work in `TestSleepInterruptedThroughEval`. None is an absolute second bounding a refusal.

## Gates

`go build`, `go vet`, `go test -count=1 ./...`, `go test -race ./...`, `golangci-lint run ./...` (0 issues), `elps fmt -l ./...`, `elps doc -m`, `make go-test`, `make race`, `make test-elpscheck`, `make test-examples`, `CI_GATES_REQUIRE_SHELLCHECK=1 ./scripts/ci-gates-test.sh`, `./scripts/confidentiality-guard.sh`, `./scripts/fuzz-budget-check.sh` (10 min headroom, unchanged) — all clean. CI green on all 22 checks including `Required: benchmark` and `Required: fuzz`.