### PR TITLE
profiler: let embedders inject the tracer instead of resolving the global one

### DIFF
--- a/lisp/x/profiler/opentelemetry_annotator.go
+++ b/lisp/x/profiler/opentelemetry_annotator.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/luthersystems/elps/lisp"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
@@ -17,7 +16,6 @@ type otelAnnotator struct {
 	profiler
 	currentContext context.Context
 	currentSpan    trace.Span
-	tracer         trace.Tracer
 }
 
 func NewOpenTelemetryAnnotator(runtime *lisp.Runtime, parentContext context.Context, opts ...Option) *otelAnnotator {
@@ -26,9 +24,13 @@ func NewOpenTelemetryAnnotator(runtime *lisp.Runtime, parentContext context.Cont
 			runtime: runtime,
 		},
 		currentContext: parentContext,
-		tracer:         otel.GetTracerProvider().Tracer("elps"),
 	}
+	// The tracer is resolved after the options are applied: reading the
+	// global TracerProvider before them would capture whichever provider
+	// happened to be installed at construction, which is exactly what
+	// WithTracer and WithTracerProvider exist to avoid.
 	p.applyConfigs(opts...)
+	p.otelTracer = p.resolveOtelTracer()
 	return p
 }
 
@@ -53,7 +55,7 @@ func (p *otelAnnotator) Start(fun *lisp.LVal) func() {
 	}
 	oldContext := p.currentContext
 	prettyLabel, funName := p.prettyFunName(fun)
-	p.currentContext, p.currentSpan = p.tracer.Start(p.currentContext, prettyLabel)
+	p.currentContext, p.currentSpan = p.otelTracer.Start(p.currentContext, prettyLabel)
 	p.addCodeAttributes(fun, funName)
 	return func() {
 		p.currentSpan.End()

--- a/lisp/x/profiler/profiler.go
+++ b/lisp/x/profiler/profiler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/parser/token"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // profiler is a minimal lisp.Profiler
@@ -14,6 +15,11 @@ type profiler struct {
 	enabled    bool
 	skipFilter SkipFilter
 	funLabeler FunLabeler
+	// otelTracer is consumed only by the OpenTelemetry annotator. It lives
+	// here because Option is func(*profiler), so it is the only place a
+	// shared option can write to. Set via WithTracer or WithTracerProvider;
+	// nil means fall back to the global TracerProvider.
+	otelTracer trace.Tracer
 }
 
 var _ lisp.Profiler = &profiler{}

--- a/lisp/x/profiler/tracer.go
+++ b/lisp/x/profiler/tracer.go
@@ -1,0 +1,49 @@
+package profiler
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// tracerName is the instrumentation name reported for spans created by the
+// OpenTelemetry annotator.
+const tracerName = "elps"
+
+// WithTracer sets the tracer used to create spans, instead of resolving one
+// from the global TracerProvider.
+//
+// Embedders that run more than one runtime in a single process should set
+// this or WithTracerProvider. otel.SetTracerProvider installs a *process
+// global*, so annotators left to resolve it all emit into whichever provider
+// was installed most recently -- spans from one runtime surface under another
+// runtime's provider, attached to the wrong trace.
+//
+// A nil tracer is ignored, leaving the global fallback in place.
+func WithTracer(tracer trace.Tracer) Option {
+	return func(p *profiler) {
+		if tracer != nil {
+			p.otelTracer = tracer
+		}
+	}
+}
+
+// WithTracerProvider sets the TracerProvider used to create spans, instead of
+// the global one. See WithTracer for why an embedder would want this.
+//
+// A nil provider is ignored, leaving the global fallback in place.
+func WithTracerProvider(tp trace.TracerProvider) Option {
+	return func(p *profiler) {
+		if tp != nil {
+			p.otelTracer = tp.Tracer(tracerName)
+		}
+	}
+}
+
+// resolveOtelTracer returns the configured tracer, falling back to the global
+// TracerProvider for embedders that set neither option.
+func (p *profiler) resolveOtelTracer() trace.Tracer {
+	if p.otelTracer != nil {
+		return p.otelTracer
+	}
+	return otel.GetTracerProvider().Tracer(tracerName)
+}

--- a/lisp/x/profiler/tracer_test.go
+++ b/lisp/x/profiler/tracer_test.go
@@ -1,0 +1,179 @@
+package profiler_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/x/profiler"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// newExportingProvider returns a provider that samples everything and syncs
+// spans into the returned exporter.
+func newExportingProvider(t *testing.T) (*trace.TracerProvider, *tracetest.InMemoryExporter) {
+	t.Helper()
+	exporter := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(
+		trace.WithSyncer(exporter),
+		trace.WithSampler(trace.AlwaysSample()),
+	)
+	t.Cleanup(func() {
+		assert.NoError(t, tp.Shutdown(context.Background()), "TracerProvider shutdown")
+	})
+	return tp, exporter
+}
+
+// setGlobalProvider installs tp as the process-global provider and restores
+// the previous one afterwards.
+//
+// These tests are deliberately not parallel: otel.SetTracerProvider is
+// process-global, which is the very hazard the options under test exist to
+// let embedders avoid.
+func setGlobalProvider(t *testing.T, tp oteltrace.TracerProvider) {
+	t.Helper()
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+}
+
+// runTraced evaluates the shared test lisp source under an annotator built
+// with opts, and returns once the profile is complete.
+func runTraced(t *testing.T, opts ...profiler.Option) {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	ppa := profiler.NewOpenTelemetryAnnotator(env.Runtime, context.Background(), opts...)
+	require.NoError(t, ppa.Enable())
+	require.NoError(t, lisp.GoError(lisp.InitializeUserEnv(env)))
+	lerr := env.Eval(env.LoadString("test.lisp", testLisp))
+	require.NotEqual(t, lisp.LError, lerr.Type, lerr.Str)
+	require.NoError(t, ppa.Complete())
+}
+
+// TestWithTracerProviderBypassesGlobal asserts that an annotator configured
+// with an explicit provider emits into that provider and not into the global
+// one, even when the global is installed and exporting.
+func TestWithTracerProviderBypassesGlobal(t *testing.T) {
+	globalTP, globalExporter := newExportingProvider(t)
+	setGlobalProvider(t, globalTP)
+	injectedTP, injectedExporter := newExportingProvider(t)
+
+	runTraced(t, profiler.WithELPSDocFilter(), profiler.WithTracerProvider(injectedTP))
+
+	assert.NotEmpty(t, injectedExporter.GetSpans(),
+		"spans must be emitted into the injected provider")
+	assert.Empty(t, globalExporter.GetSpans(),
+		"an injected provider must not leak spans into the global one")
+}
+
+// TestWithTracerBypassesGlobal covers the same guarantee for a directly
+// supplied tracer.
+func TestWithTracerBypassesGlobal(t *testing.T) {
+	globalTP, globalExporter := newExportingProvider(t)
+	setGlobalProvider(t, globalTP)
+	injectedTP, injectedExporter := newExportingProvider(t)
+
+	runTraced(t, profiler.WithELPSDocFilter(),
+		profiler.WithTracer(injectedTP.Tracer("embedder")))
+
+	assert.NotEmpty(t, injectedExporter.GetSpans(),
+		"spans must be emitted into the injected tracer")
+	assert.Empty(t, globalExporter.GetSpans(),
+		"an injected tracer must not leak spans into the global provider")
+}
+
+// TestAnnotatorsAreIsolated is the multi-runtime case this option exists for.
+//
+// Two runtimes in one process, each with its own provider, must keep their
+// spans separate. Without injection both resolve the global provider, so the
+// one installed most recently captures both runtimes' spans -- and those
+// spans land under the wrong trace root, not merely in the wrong exporter.
+func TestAnnotatorsAreIsolated(t *testing.T) {
+	// A third provider is installed globally and must stay empty: it
+	// stands in for a provider some other component set up.
+	globalTP, globalExporter := newExportingProvider(t)
+	setGlobalProvider(t, globalTP)
+
+	firstTP, firstExporter := newExportingProvider(t)
+	secondTP, secondExporter := newExportingProvider(t)
+
+	// Construct and run interleaved, so that a construction-time read of
+	// the global provider cannot accidentally produce the right answer.
+	runTraced(t, profiler.WithELPSDocFilter(), profiler.WithTracerProvider(firstTP))
+	runTraced(t, profiler.WithELPSDocFilter(), profiler.WithTracerProvider(secondTP))
+
+	first, second := firstExporter.GetSpans(), secondExporter.GetSpans()
+	require.NotEmpty(t, first, "first runtime emitted no spans")
+	require.NotEmpty(t, second, "second runtime emitted no spans")
+	assert.Len(t, second, len(first),
+		"identical sources must produce the same number of spans in each provider")
+	assert.Empty(t, globalExporter.GetSpans(),
+		"neither runtime may emit into the global provider")
+
+	// Every span in each provider must belong to a single trace, and the
+	// two providers must not share it: a shared trace ID is the signature
+	// of one runtime's spans being rooted in the other's trace.
+	firstTraces, secondTraces := traceIDs(first), traceIDs(second)
+	for id := range firstTraces {
+		assert.NotContains(t, secondTraces, id,
+			"the two runtimes must not share a trace")
+	}
+}
+
+// traceIDs returns the set of trace IDs present in spans.
+func traceIDs(spans tracetest.SpanStubs) map[oteltrace.TraceID]struct{} {
+	out := make(map[oteltrace.TraceID]struct{}, len(spans))
+	for _, s := range spans {
+		out[s.SpanContext.TraceID()] = struct{}{}
+	}
+	return out
+}
+
+// TestDefaultsToGlobalTracerProvider pins the pre-existing behaviour for
+// embedders that pass neither option: the global provider is still used, and
+// is read at construction.
+func TestDefaultsToGlobalTracerProvider(t *testing.T) {
+	globalTP, globalExporter := newExportingProvider(t)
+	setGlobalProvider(t, globalTP)
+
+	runTraced(t, profiler.WithELPSDocFilter())
+
+	assert.NotEmpty(t, globalExporter.GetSpans(),
+		"without an injected tracer the global provider must still be used")
+}
+
+// TestNilTracerOptionsFallBackToGlobal asserts the options ignore nil rather
+// than installing a nil tracer, which would panic on the first span.
+func TestNilTracerOptionsFallBackToGlobal(t *testing.T) {
+	globalTP, globalExporter := newExportingProvider(t)
+	setGlobalProvider(t, globalTP)
+
+	require.NotPanics(t, func() {
+		runTraced(t, profiler.WithELPSDocFilter(),
+			profiler.WithTracer(nil), profiler.WithTracerProvider(nil))
+	})
+	assert.NotEmpty(t, globalExporter.GetSpans(),
+		"nil options must leave the global fallback in place")
+}
+
+// TestLastTracerOptionWins pins the ordering semantics shared by every option
+// in this package: later options overwrite earlier ones.
+func TestLastTracerOptionWins(t *testing.T) {
+	firstTP, firstExporter := newExportingProvider(t)
+	secondTP, secondExporter := newExportingProvider(t)
+	setGlobalProvider(t, noop.NewTracerProvider())
+
+	runTraced(t, profiler.WithELPSDocFilter(),
+		profiler.WithTracerProvider(firstTP), profiler.WithTracerProvider(secondTP))
+
+	assert.Empty(t, firstExporter.GetSpans(), "the overridden provider must be unused")
+	assert.NotEmpty(t, secondExporter.GetSpans(), "the last option must win")
+}


### PR DESCRIPTION
## Summary

- `NewOpenTelemetryAnnotator` resolved its tracer from `otel.GetTracerProvider()`, a **process global**. An embedder running more than one `lisp.Runtime` in one process cannot give each runtime its own traces: every annotator emits into whichever provider was installed most recently, so one runtime's spans surface under another's provider — and attached to another trace's root, which is the part that makes it expensive to debug.
- Adds `WithTracer` and `WithTracerProvider`. The global stays as the fallback, so embedders that set neither option see no change.
- The tracer is now resolved **after** `applyConfigs` rather than in the struct literal. Reading the global before the options were applied would capture a provider the caller was in the middle of overriding — the same construction-order trap the options exist to remove.

Found while instrumenting substrate, where two `Server`s in one process capture each other's phylum spans. Analysis and reproduction: [luthersystems/substrate#390](https://github.com/luthersystems/substrate/issues/390).

## Verified against a real embedder

Built as a standalone module against the real `opttrace` and this annotator — two `opttrace.Tracer`s over separate in-memory exporters, both calling `SetGlobalTracer()` as substrate's `NewServer` does, then a phylum evaluated under each:

| Scenario | Server A exporter | Server B exporter |
|---|---|---|
| No injection (before) | **0 spans** | 1 span — *A's* |
| `WithTracer` injected | 1 span | 1 span, no shared trace root |

The first row is the bug; the second is this change. `TestAnnotatorsAreIsolated` covers the same shape in-repo, asserting both that neither runtime leaks into a globally-installed third provider and that the two runtimes never share a trace ID.

## Notes for reviewers

- The tracer field moves from `otelAnnotator` onto the embedded `profiler` struct. It is only meaningful to the OpenTelemetry annotator, but `Option` is `func(*profiler)`, so that is the only place a shared option can write; keeping a copy in both would invite the two to drift. It is commented as such.
- Both options ignore `nil` rather than installing a nil tracer that would panic on the first span (`TestNilTracerOptionsFallBackToGlobal`).
- The new tests are deliberately not parallel — they manipulate `otel.SetTracerProvider`, which is the very global the options exist to let embedders avoid — and each restores the previous provider on cleanup.
- Consumers using `WithTracer` may need an adapter: `trace.Tracer` embeds `embedded.Tracer`, whose method is unexported, so it cannot be implemented outside otel without embedding that marker. substrate#390 carries the adapter substrate will use.

## Test Plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./lisp/x/profiler/...` reports no issues
- [x] `./elps fmt -l ./...` reports no changes
- [x] `./elps doc -m` reports no missing docs
- [ ] `make test` — fails locally at `go test -cover` with `no such tool "covdata"`, an incomplete downloaded Go toolchain in my sandbox; reproducible on packages this PR does not touch, and plain `go test ./...` is green. Needs a CI run to confirm.
- [ ] `golangci-lint run ./...` — 2 pre-existing `nolintlint` findings in `parser/token/token.go`, untouched by this PR and likely a local linter version difference from CI. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xd6BnWC1e9MP4EBK3oh6DN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd6BnWC1e9MP4EBK3oh6DN)_