### PR TITLE
ci: build benchstat with its own toolchain, not the pinned one

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -239,6 +239,16 @@ jobs:
           cache-dependency-path: pr/go.sum
 
       - name: Install benchstat
+        # setup-go pins GOTOOLCHAIN=local, which is what keeps the benchmarks
+        # themselves on GO_VERSION rather than silently switching toolchains
+        # mid-run. benchstat is not the code under measurement -- it only
+        # post-processes the text output -- so it does not need that pin, and
+        # honouring it here breaks the job outright whenever x/perf@latest
+        # starts requiring a newer Go than GO_VERSION (x/perf began requiring
+        # go >= 1.26.0 on 2026-08-19). Build the tool with whatever toolchain
+        # it asks for; every benchmark-running step below keeps the pin.
+        env:
+          GOTOOLCHAIN: auto
         run: go install golang.org/x/perf/cmd/benchstat@latest
 
       # Interleaved, alternating arms every round rather than running all of


### PR DESCRIPTION
## Summary

The required benchmark check currently fails on **every** pull request, before a single benchmark runs:

```
go install golang.org/x/perf/cmd/benchstat@latest
go: golang.org/x/perf@v0.0.0-20260819171926-ebcb4798430d requires
    go >= 1.26.0 (running go 1.25.13; GOTOOLCHAIN=local)
```

`actions/setup-go` pins `GOTOOLCHAIN=local`, so the `go install` is forbidden from fetching the newer toolchain that `x/perf` began requiring on 2026-08-19. This sets `GOTOOLCHAIN: auto` on that one step.

The failure is time-based rather than change-based, which is worth stating plainly: the last green benchmark run was 2026-08-17, and the first run after the upstream release — [#510](https://github.com/luthersystems/elps/pull/510) — failed. Nothing in any PR caused it, and no PR can go green until this lands.

## Why this is the right pin to relax

The pin exists so benchmarks are *measured* on `GO_VERSION` instead of whatever toolchain a module happens to request — that matters, and it stays exactly as it is. benchstat is not the code under measurement; it only post-processes the text the runs emit. Building the tool with its own required toolchain cannot move a number. Every benchmark-running step below keeps the pin, and `GO_VERSION` is untouched, so cached baselines stay comparable.

Deliberately **not** pinning a pseudo-version instead: `x/perf` publishes no tagged versions, so a pin means freezing the tool at a commit hash that nothing would ever revisit. Given the gate reads benchstat's output, a silently stale tool is the worse failure mode.

## Test Plan

- [x] `GOTOOLCHAIN=auto go install golang.org/x/perf/cmd/benchstat@latest` succeeds (fetches go1.26.7, installs); the same command with `GOTOOLCHAIN=local` under go1.25.13 is what CI hit
- [x] `benchmark.yml` parses, and the `Install benchstat` step carries `env: {GOTOOLCHAIN: auto}`
- [ ] This PR's own `Required: benchmark` check goes green — the real verification, since this PR exercises the fixed workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xd6BnWC1e9MP4EBK3oh6DN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd6BnWC1e9MP4EBK3oh6DN)_