### PR TITLE
Close three verification gaps: fail-open assert, sleep bound, stall lag

### DIFF
--- a/internal/fuzzwatch/fuzzwatch.go
+++ b/internal/fuzzwatch/fuzzwatch.go
@@ -95,6 +95,34 @@
 // all: with no stall recorded, Starved() is false and Hung fires at exactly
 // the configured budget, as before.
 //
+// # A stall is charged when it is READ, not when its tick lands
+//
+// The monitor only learns about a stall from a tick, and a tick cannot be
+// delivered while the process is frozen. So at the instant a freeze ends the
+// accumulated total has not grown yet: [Budget.Report] read at that moment
+// used to count the whole freeze as scheduled time, and [Budget.Check] read at
+// that moment returned Hung with Starved() false -- the evidence exonerating
+// the input existed but had not landed. Observed with SIGSTOP (#501): a 1.5s
+// budget over a 3s freeze, read at resume, gave "wall=3.306s lost=0s
+// scheduled=3.306s starved=false", and the same freeze read two heartbeats
+// later gave "wall=4.704s lost=3s scheduled=1.704s starved=true". Same window,
+// opposite verdict, decided by whether the ticker goroutine happened to run
+// first.
+//
+// That instant is reachable and not merely a harness artefact: a caller arms
+// its timer for [Budget.Total] and calls Check when it fires, so any freeze
+// LONGER than the budget straddles the deadline and the first Check after it
+// necessarily runs at resume, with both timers overdue and no ordering between
+// them.
+//
+// Report therefore charges the unexplained interval since the last heartbeat
+// itself, by the same rule the ticker applies (see [monitor.pending]). The
+// charge is transient -- computed for that one Report, never written back --
+// so the ticker's accounting is untouched and the delayed tick, when it
+// arrives, charges the same stall exactly once. The fix is in the READING; the
+// resolution floor is unchanged, and no budget or threshold was widened
+// (#443/#452, #435/#447).
+//
 // # What this does NOT measure: CPU share
 //
 // This instrument resolves scheduler STALL -- intervals during which the
@@ -201,16 +229,42 @@ const (
 // existing watchdog clears it by 50x or more because it is sized against
 // sub-millisecond work, which is the property that actually makes it sound.
 //
+// One more floor sits underneath, and it is a property of the accounting
+// rather than of the load: the instrument resolves stall no finer than one
+// heartbeat. Report now charges a stall as soon as it is READ rather than
+// waiting for the tick that would explain it (#501, see the package doc), so a
+// Check landing exactly at the instant a freeze ends no longer charges the
+// freeze to the code under test. But the charge is still measured from the
+// last heartbeat OBSERVED, so it is quantised to within a tick and it still
+// only appears at all once the gap passes tolerance*tick. A budget sized close
+// enough to its work for a 400ms quantum to matter cannot be adjudicated by
+// this instrument, and no amount of verdict logic can lift that; it is the
+// same argument as the floor above, arriving from the accounting side.
+//
 // TestEveryBudgetIsAboveTheHonestFloor enforces this across the repository.
 const MinHonestBudget = 10 * time.Second
 
 // monitor accumulates scheduler stall observed by a heartbeat goroutine.
 //
-// Both fields are cumulative and monotonic, so a caller records a snapshot at
-// the start of a window and subtracts: no history, no lock, O(1).
+// The two charged fields are cumulative and monotonic, so a caller records a
+// snapshot at the start of a window and subtracts: no history, no lock, O(1).
+// beatNanos is not cumulative: it is when the heartbeat was last known to have
+// run, which is what lets a reader see a stall the ticker has not been able to
+// charge yet.
 type monitor struct {
 	lostNanos    atomic.Int64
 	longestNanos atomic.Int64
+
+	// beatNanos is the last observed heartbeat, as nanoseconds since origin.
+	// Zero means no tick has been received yet, in which case origin itself is
+	// the last instant the process was demonstrably running.
+	beatNanos atomic.Int64
+
+	// origin is set once, before the heartbeat goroutine starts, and read-only
+	// afterwards. Offsets from it are monotonic-clock differences, so the
+	// read-time accounting cannot be confused by a wall-clock step the way a
+	// stored Unix timestamp could.
+	origin time.Time
 }
 
 var (
@@ -222,6 +276,11 @@ var (
 // calls it, so a target never has to remember to.
 func start() {
 	startOnce.Do(func() {
+		// Set before the goroutine starts, so every reader that reached here
+		// through New -- which is all of them -- sees it. Until the first tick
+		// lands this is also the last instant the process is known to have been
+		// running, which is exactly what pending needs.
+		defaultMonitor.origin = time.Now()
 		go defaultMonitor.run(tick)
 	})
 }
@@ -229,8 +288,18 @@ func start() {
 func (m *monitor) run(d time.Duration) {
 	t := time.NewTicker(d)
 	defer t.Stop()
-	last := time.Now()
+	last := m.origin
 	for now := range t.C {
+		// Publish the heartbeat BEFORE charging the interval it closes, and
+		// note that pending's reader does the opposite: it reads the charged
+		// total first and this timestamp second. Those two orders together are
+		// what make double-counting impossible. If a reader's total already
+		// includes this Add, then this Store -- which precedes it -- had
+		// already happened when the reader looked, so the reader sees an
+		// up-to-date beat and computes no pending charge. The reverse
+		// interleaving costs one read that misses a stall still in flight,
+		// which is the direction this package already errs in.
+		m.beatNanos.Store(int64(now.Sub(m.origin)))
 		m.observe(now.Sub(last), d)
 		last = now
 	}
@@ -251,6 +320,33 @@ func (m *monitor) observe(gap, nominal time.Duration) {
 			return
 		}
 	}
+}
+
+// pending returns the interval since the last observed heartbeat, and the part
+// of it that is already scheduler stall by the same rule observe applies. It is
+// the answer to "what has this monitor not been able to tell me yet": a tick
+// cannot be delivered while the process is frozen, so a stall in progress, or
+// one that ended within the last heartbeat, is invisible in lostNanos and
+// visible only here (#501).
+//
+// It computes; it does not accumulate. Nothing here writes to the charged
+// totals, so the tick that eventually arrives charges the same stall exactly
+// once and a caller folding this into a Report cannot double-count it.
+func (m *monitor) pending(now time.Time, nominal time.Duration) (gap, lost time.Duration) {
+	if m.origin.IsZero() {
+		// Never started -- no heartbeat, and no instant at which the process
+		// was known to be running. Nothing may be claimed.
+		return 0, 0
+	}
+	gap = now.Sub(m.origin) - time.Duration(m.beatNanos.Load())
+	if gap <= nominal*tolerance {
+		return gap, 0
+	}
+	// Charge the same quantity observe would when the tick finally lands: the
+	// EXCESS over the nominal interval. Matching it is what makes the read at
+	// resume agree with the read two heartbeats later, which is the whole
+	// point.
+	return gap, gap - nominal
 }
 
 func (m *monitor) lost() time.Duration {
@@ -299,7 +395,8 @@ type Report struct {
 	// Wall is the total wall-clock time since the budget was created.
 	Wall time.Duration
 	// Lost is the part of Wall during which this process was demonstrably not
-	// being scheduled.
+	// being scheduled. It includes a gap since the last heartbeat that the
+	// ticker has not been able to charge yet; see Budget.Report.
 	Lost time.Duration
 	// LongestStall is the longest single heartbeat gap in the window.
 	LongestStall time.Duration
@@ -355,19 +452,51 @@ func New(d time.Duration) *Budget {
 func (b *Budget) Total() time.Duration { return b.total }
 
 // Report snapshots the window so far.
+//
+// The snapshot includes stall the heartbeat has not charged yet. A tick cannot
+// be delivered while the process is frozen, so at the instant a freeze ends the
+// accumulated total still reads zero and the window looks perfectly healthy --
+// which is #501: a Check landing there charged the whole freeze to the code
+// under test and called it Hung. Report therefore asks the monitor what it has
+// not been able to account for and folds it in.
+//
+// The fold is transient: monitor.pending only computes, so the ticker's
+// accounting is untouched and the delayed tick charges the stall exactly once
+// whenever it does arrive. The one interleaving that could count it twice --
+// reading a total that already includes the tick's charge alongside a beat
+// timestamp from before it -- is excluded by the store order in monitor.run
+// together with the read order below.
 func (b *Budget) Report() Report {
 	longest := defaultMonitor.longest()
 	if longest < b.longestAt {
 		longest = b.longestAt
 	}
+	now := time.Now()
 	r := Report{
-		Wall: time.Since(b.startedAt),
+		Wall: now.Sub(b.startedAt),
+		// Read the charged total FIRST, the beat timestamp second: see
+		// monitor.run.
 		Lost: defaultMonitor.lost() - b.lostAt,
 	}
 	// longestNanos is a process-wide maximum, so it is only meaningful for this
 	// window when it grew during it.
 	if longest > b.longestAt {
 		r.LongestStall = longest
+	}
+	if gap, unaccounted := defaultMonitor.pending(now, tick); unaccounted > 0 {
+		// A window cannot have lost more time than it has existed, and a gap
+		// that began before this budget did is not this window's to charge, so
+		// cap the read-time charge at whatever part of the window is not
+		// accounted for already.
+		if room := r.Wall - r.Lost; unaccounted > room {
+			unaccounted = room
+		}
+		if unaccounted > 0 {
+			r.Lost += unaccounted
+			if stall := min(gap, r.Wall); stall > r.LongestStall {
+				r.LongestStall = stall
+			}
+		}
 	}
 	return r
 }

--- a/internal/fuzzwatch/fuzzwatch_test.go
+++ b/internal/fuzzwatch/fuzzwatch_test.go
@@ -48,6 +48,76 @@ func TestMonitorLongestIsAMaximum(t *testing.T) {
 	}
 }
 
+// #501: the ticker cannot charge a stall while the process is frozen, because
+// the tick that would charge it cannot be delivered. pending is what a reader
+// asks instead, and these pin its arithmetic without a clock.
+
+func TestMonitorPendingSeesAStallTheTickerHasNotCharged(t *testing.T) {
+	var m monitor
+	m.origin = time.Now().Add(-3 * time.Second)
+	// beatNanos still 0: the heartbeat has not run since origin, which is what
+	// a three-second freeze starting at origin looks like from a reader.
+	gap, lost := m.pending(time.Now(), tick)
+	if gap < 3*time.Second {
+		t.Fatalf("gap = %s, want at least the 3s since the last known heartbeat", gap)
+	}
+	if want := gap - tick; lost != want {
+		t.Fatalf("pending lost = %s, want %s (the excess over the nominal interval)", lost, want)
+	}
+	// Nothing was written: the ticker's accounting is the ticker's, and the
+	// delayed tick must charge this stall exactly once when it arrives.
+	if got := m.lost(); got != 0 {
+		t.Fatalf("pending charged %s to the accumulated total; it must only compute", got)
+	}
+	if got := m.longest(); got != 0 {
+		t.Fatalf("pending recorded a longest stall (%s); it must only compute", got)
+	}
+}
+
+func TestMonitorPendingIgnoresOrdinaryJitter(t *testing.T) {
+	var m monitor
+	m.origin = time.Now()
+	// A read landing between heartbeats is the normal case, not a stall.
+	if _, lost := m.pending(m.origin.Add(tick*tolerance), tick); lost != 0 {
+		t.Fatalf("a gap of exactly tolerance*tick was charged %s; the floor is unchanged (#501 "+
+			"fixes when a stall is READ, not how small a stall is visible)", lost)
+	}
+	if _, lost := m.pending(m.origin.Add(tick*tolerance+time.Millisecond), tick); lost == 0 {
+		t.Fatal("a gap just past tolerance*tick was not charged at all")
+	}
+}
+
+func TestMonitorPendingIsSilentBeforeTheHeartbeatStarts(t *testing.T) {
+	var m monitor
+	// No origin: there is no instant at which this monitor knows the process
+	// was running, so it may not claim a stall of the whole epoch.
+	gap, lost := m.pending(time.Now(), tick)
+	if gap != 0 || lost != 0 {
+		t.Fatalf("an unstarted monitor reported gap=%s lost=%s, want 0/0", gap, lost)
+	}
+}
+
+// The property that makes the read-time charge safe to fold in: it is the SAME
+// quantity the tick would charge for the same gap. A read at the instant a
+// freeze ends and a read two heartbeats later therefore agree, and neither is
+// the sum of both.
+func TestPendingChargesWhatTheTickWouldCharge(t *testing.T) {
+	for _, gap := range []time.Duration{
+		tick, tick * tolerance, tick*tolerance + time.Millisecond,
+		time.Second, 3 * time.Second, 30 * time.Second,
+	} {
+		var ticked, read monitor
+		ticked.observe(gap, tick)
+		read.origin = time.Now()
+		_, pending := read.pending(read.origin.Add(gap), tick)
+		if pending != ticked.lost() {
+			t.Errorf("gap %s: read-time charge %s, tick charge %s -- the two must agree or a "+
+				"window's verdict depends on which one happened to run first (#501)",
+				gap, pending, ticked.lost())
+		}
+	}
+}
+
 func TestReportScheduled(t *testing.T) {
 	r := Report{Wall: 10 * time.Second, Lost: 7 * time.Second}
 	if want, got := 3*time.Second, r.Scheduled(); got != want {

--- a/internal/fuzzwatch/stall_probe_unix_test.go
+++ b/internal/fuzzwatch/stall_probe_unix_test.go
@@ -26,6 +26,13 @@ import (
 // actually line up end to end on a live process. A synthetic Report cannot go
 // wrong in the way a real one can.
 //
+// Two probes share the rig, differing only in WHEN the child reads its budget.
+// TestCheckUnderARealSchedulerStall reads once the freeze has been accounted
+// for, and asks what a window containing a real freeze is called (#488). The
+// #501 probe reads at the instant the freeze ends, before any tick could have
+// been delivered, and asks what Check is told about the freeze at the one
+// moment the accounting has not caught up.
+//
 // The stall is manufactured with SIGSTOP/SIGCONT rather than with CPU load.
 // That is deliberate and is the only honest way to do it here: PR #483
 // measured that contention does NOT produce stalls this instrument can see
@@ -49,6 +56,11 @@ const (
 	// Let the child accumulate a little scheduled time before freezing it, so
 	// the budget is provably not spent at the moment the stall begins.
 	stallRunBefore = 300 * time.Millisecond
+	// How often a child looks at its budget. Short enough that the #501 child
+	// wakes essentially at the instant SIGCONT lands, and far below
+	// stallFreeze/2, which is how that child tells the sleep the freeze
+	// swallowed from an ordinary one.
+	stallPoll = 25 * time.Millisecond
 )
 
 // TestStallProbeChildProcess is not a test. It is the body of the child
@@ -65,13 +77,12 @@ func TestStallProbeChildProcess(t *testing.T) {
 	// budget of SCHEDULED time is spent. Whatever stall happens in between is
 	// the parent's doing, not ours.
 	//
-	// The settle is not cosmetic and is not there to steer the verdict. The
-	// monitor is sampled asynchronously, so at the instant a freeze ends the
-	// heartbeat that will charge it has not run yet and Report still counts
-	// the whole freeze as scheduled time. Re-reading after a couple of
-	// heartbeats is what a budget of any realistic size (the smallest live one
-	// is 15s) gets for free. Reported separately; it is not what #488 is
-	// about, and this test must not depend on it either way.
+	// This loop used to settle for two heartbeats before trusting a read that
+	// said the budget was spent, because at the instant a freeze ended the
+	// monitor had not charged it yet and Report counted the whole freeze as
+	// scheduled time. That was #501, and Report now charges an unexplained gap
+	// at read time, so a single read is enough and the settle is gone. The
+	// #488 assertions below are unchanged and never depended on it.
 	deadline := time.Now().Add(60 * time.Second)
 	for {
 		if time.Now().After(deadline) {
@@ -79,17 +90,57 @@ func TestStallProbeChildProcess(t *testing.T) {
 			return
 		}
 		if b.Report().Scheduled() >= b.Total() {
-			time.Sleep(2 * tick)
-			if b.Report().Scheduled() >= b.Total() {
-				break
-			}
-			continue
+			break
 		}
-		time.Sleep(25 * time.Millisecond)
+		time.Sleep(stallPoll)
 	}
 	v, _, r := b.Check()
 	fmt.Printf("FUZZWATCH-CHILD RESULT verdict=%s wall=%d lost=%d scheduled=%d starved=%t hardwall=%d\n",
 		v, r.Wall, r.Lost, r.Scheduled(), r.Starved(), b.hardWall)
+}
+
+// TestStallResumeProbeChildProcess is not a test either. It is the body of the
+// child TestReportAtTheInstantAStallEnds spawns.
+//
+// It differs from the child above in one respect, which is the entire point:
+// it reads at the WORST possible instant rather than the most convenient one.
+// It polls in short sleeps and calls Check as the very first thing after a
+// sleep that took far longer than it asked for -- i.e. the sleep the freeze
+// swallowed. That is not a contrived moment: a caller arms its timer for the
+// budget, so a freeze longer than the budget always straddles the deadline and
+// the first Check after it always lands here, with the caller's timer and the
+// heartbeat ticker both overdue and no ordering between them.
+//
+// Before #501 the answer at that instant was "lost=0s, starved=false, hung":
+// the freeze was real, the monitor was about to charge it, and the verdict was
+// taken a moment too early and blamed the code under test.
+func TestStallResumeProbeChildProcess(t *testing.T) {
+	if os.Getenv(stallChildEnv) != "1" {
+		t.Skip("helper process for TestReportAtTheInstantAStallEnds; not run directly")
+	}
+	b := New(stallChildBudget)
+	fmt.Println("FUZZWATCH-CHILD READY")
+
+	deadline := time.Now().Add(60 * time.Second)
+	for {
+		before := time.Now()
+		time.Sleep(stallPoll)
+		// FIRST, before anything else gets a chance to let the heartbeat catch
+		// up: this read is the measurement. Whether the sleep was the ordinary
+		// one or the one the freeze swallowed is decided afterwards, from the
+		// same instant.
+		v, _, r := b.Check()
+		if time.Since(before) < stallFreeze/2 {
+			if time.Now().After(deadline) {
+				fmt.Println("FUZZWATCH-CHILD ABORT never observed a freeze")
+				return
+			}
+			continue
+		}
+		fmt.Printf("FUZZWATCH-CHILD RESUME verdict=%s wall=%d lost=%d scheduled=%d starved=%t hardwall=%d\n",
+			v, r.Wall, r.Lost, r.Scheduled(), r.Starved(), b.hardWall)
+		return
+	}
 }
 
 // stallResult is one parsed RESULT line from the child.
@@ -126,7 +177,7 @@ func TestCheckUnderARealSchedulerStall(t *testing.T) {
 	var last stallResult
 	var got bool
 	for i := range attempts {
-		res, err := runStallProbe(t)
+		res, err := runStallProbe(t, "TestStallProbeChildProcess", "FUZZWATCH-CHILD RESULT ")
 		if err != nil {
 			t.Fatalf("attempt %d: %v", i+1, err)
 		}
@@ -157,13 +208,69 @@ func TestCheckUnderARealSchedulerStall(t *testing.T) {
 	}
 }
 
-// runStallProbe spawns this test binary as a child, freezes it mid-window with
-// SIGSTOP, resumes it, and returns what the child's Check() said.
-func runStallProbe(t *testing.T) (stallResult, error) {
+// #501, end to end: a Report taken at the INSTANT a freeze ends must already
+// show the freeze.
+//
+// The mechanism is accounting lag, not arm ordering, so #488's fix cannot
+// reach it: at that instant Starved() is honestly false, because the evidence
+// has not landed. The monitor learns of a stall from a tick and a tick cannot
+// be delivered while the process is frozen, so the whole freeze read as
+// scheduled time and Check called it a hang -- observed 3/3 on the unfixed
+// accounting as "verdict=hung wall=3.306s lost=0s scheduled=3.306s
+// starved=false", against a 1.5s budget and a 3s freeze.
+//
+// Every attempt is asserted rather than searched: unlike the #488 probe there
+// is no window shape to hunt for, so a single attempt that comes back healthy
+// is a regression, not a miss. Repeating simply gives the race more chances to
+// land the read before the heartbeat catches up.
+func TestReportAtTheInstantAStallEnds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns a child process and freezes it for several seconds")
+	}
+
+	const attempts = 3
+	for i := range attempts {
+		res, err := runStallProbe(t, "TestStallResumeProbeChildProcess", "FUZZWATCH-CHILD RESUME ")
+		if err != nil {
+			t.Fatalf("attempt %d: %v", i+1, err)
+		}
+		t.Logf("attempt %d: %s", i+1, res)
+
+		// The rig, first: the read has to have happened at the end of a real
+		// freeze, or the assertions below are vacuous.
+		if res.wall < stallFreeze {
+			t.Fatalf("attempt %d: %s -- the window is shorter than the %s freeze, so the child "+
+				"did not read at the end of it and this attempt asserts nothing", i+1, res, stallFreeze)
+		}
+
+		// The floor is deliberately generous: what is being distinguished is
+		// zero from three seconds, not one measurement from another. The
+		// charge is quantised to the last heartbeat OBSERVED, so a fraction of
+		// a tick either way is expected and uninteresting.
+		if res.lost < stallFreeze/2 {
+			t.Fatalf("attempt %d: %s -- a %s freeze was still unaccounted at the instant it "+
+				"ended, so the window reads as scheduled time and the freeze is charged to the "+
+				"code under test (#501)", i+1, res, stallFreeze)
+		}
+		if !res.starved {
+			t.Fatalf("attempt %d: %s -- a window that was frozen for most of its wall clock "+
+				"must be starved at the instant it resumes, not two heartbeats later (#501)", i+1, res)
+		}
+		if res.verdict == Hung.String() {
+			t.Fatalf("attempt %d: %s -- Check read at the end of a real freeze called it a hang "+
+				"(#501)", i+1, res)
+		}
+	}
+}
+
+// runStallProbe spawns this test binary as a child running childTest, freezes
+// it mid-window with SIGSTOP, resumes it, and returns the result line the child
+// emitted under prefix.
+func runStallProbe(t *testing.T, childTest, prefix string) (stallResult, error) {
 	t.Helper()
 
 	//nolint:gosec // os.Args[0] is this test binary, re-executed as its own child; no external input reaches it
-	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestStallProbeChildProcess$", "-test.count=1", "-test.v")
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^"+childTest+"$", "-test.count=1", "-test.v")
 	cmd.Env = append(os.Environ(), stallChildEnv+"=1")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -205,11 +312,11 @@ func runStallProbe(t *testing.T) (stallResult, error) {
 		return stallResult{}, fmt.Errorf("SIGCONT: %w", err)
 	}
 
-	line, err := awaitLine(lines, "FUZZWATCH-CHILD RESULT ", 60*time.Second)
+	line, err := awaitLine(lines, prefix, 60*time.Second)
 	if err != nil {
 		return stallResult{}, fmt.Errorf("waiting for the child's verdict: %w", err)
 	}
-	return parseStallResult(strings.TrimPrefix(line, "FUZZWATCH-CHILD RESULT "))
+	return parseStallResult(strings.TrimPrefix(line, prefix))
 }
 
 func awaitLine(lines <-chan string, prefix string, timeout time.Duration) (string, error) {

--- a/lisp/lisplib/libtime/sleep_test.go
+++ b/lisp/lisplib/libtime/sleep_test.go
@@ -500,11 +500,42 @@ func TestSleepMaxRaisesTheCap(t *testing.T) {
 // before a sleep is reachable at all, and the only way past that is for
 // sleepCap to accept the 1h :max -- at which point the call sleeps an hour and
 // runBounded fails the test.
+//
+// The SECOND call is the exception in that family, and it does need a timing
+// assertion (#499).  The argument that lets runBounded be the only clock rests
+// on the refused duration dwarfing runBounded's 30s: 1h, 1h+1s and 2h all
+// either return in microseconds or not at all.  This call's duration is
+// ceilingProbe, which must exceed the 1s host ceiling but is otherwise as
+// small as the test likes -- and at 2s it is an order of magnitude SMALLER
+// than slack, so a build that slept it out and only then refused returns
+// comfortably inside runBounded's bound and looks identical to a refusal on
+// entry.  runBounded cannot separate the two here, so the elapsed time has to.
+//
+// The bound is relative to ceilingProbe, a duration this test picks, not to an
+// absolute second: it says "returned in well under the sleep it refused",
+// which is a statement about the implementation rather than about how fast the
+// machine is.  Pinning it to a wall-clock constant is the #435 shape that
+// #443/#452 and #435/#447 were about.  TestSleepPastDeadlineFailsFast's
+// `elapsed > remaining/2` is the same pattern.
 func TestSleepMaxCannotExceedHostCeiling(t *testing.T) {
 	t.Parallel()
+	// ceiling is the host's limit; ceilingProbe is the duration the second
+	// call asks for.  They are named together because the property being
+	// tested is entirely the relation between them: ceilingProbe > ceiling is
+	// what makes the sleep refusable at all.
+	const (
+		ceiling      = time.Second
+		ceilingProbe = 2 * time.Second
+	)
+	if ceilingProbe <= ceiling {
+		t.Fatalf("ceilingProbe %v does not exceed the %v ceiling: the default cap"+
+			" has nothing to refuse and the test would pass on the wrong evidence",
+			ceilingProbe, ceiling)
+	}
+
 	env := lisp.NewEnv(nil)
 	env.Runtime.Reader = parser.NewReader()
-	if rc := lisp.InitializeUserEnv(env, lisp.WithMaxSleep(time.Second)); rc.Type == lisp.LError {
+	if rc := lisp.InitializeUserEnv(env, lisp.WithMaxSleep(ceiling)); rc.Type == lisp.LError {
 		t.Fatalf("initialize-user-env: %v", rc)
 	}
 	if rc := libtime.LoadPackage(env); rc.Type == lisp.LError {
@@ -518,10 +549,14 @@ func TestSleepMaxCannotExceedHostCeiling(t *testing.T) {
 
 	// And the ceiling lowers the no-:max default too, so the default cannot
 	// quietly exceed it.
-	v2, _ := runBounded(t, slack, func() *lisp.LVal {
-		return callSleep(env, 2*time.Second)
+	v2, elapsed := runBounded(t, slack, func() *lisp.LVal {
+		return callSleep(env, ceilingProbe)
 	})
 	requireSleepLimit(t, v2)
+	if elapsed >= ceilingProbe/2 {
+		t.Fatalf("took %v to refuse a %v sleep, expected a refusal on entry",
+			elapsed, ceilingProbe)
+	}
 }
 
 // TestSleepRejectsNonPositiveMax: a negative :max is a bug in the caller's

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -70,12 +70,26 @@ assert_contains() {
 }
 
 # assert_not_contains <needle> <description> <command...>
+#
+# IMPORTANT: this consults the exit status before reading the output, because
+# an absent needle is only evidence when the command actually ran.  A command
+# that could not execute produces no output, so the needle is trivially absent
+# and the assertion would otherwise report PASS having checked nothing (#502).
+#
+# The test is `> 125` rather than `-ne 0` because several commands under test
+# are EXPECTED to exit non-zero -- a gate that fires, a script that refuses --
+# and those are legitimate verdicts.  126 (not executable), 127 (not found) and
+# 128+ (killed by a signal) are not verdicts any script in scripts/ can return.
 assert_not_contains() {
 	local needle="$1" desc="$2"
 	shift 2
-	local out
+	local out rc
 	out=$("$@" 2>&1)
-	if echo "$out" | grep -qF -- "$needle"; then
+	rc=$?
+	if [ "$rc" -gt 125 ]; then
+		bad "$desc — the command could not run (exit $rc), so nothing was asserted"
+		echo "$out" | sed 's/^/        | /'
+	elif echo "$out" | grep -qF -- "$needle"; then
 		bad "$desc — output unexpectedly contained '$needle'"
 		echo "$out" | sed 's/^/        | /'
 	else
@@ -83,8 +97,62 @@ assert_not_contains() {
 	fi
 }
 
+# assert_helper_verdict <PASS|FAIL> <description> <helper> <helper-args...>
+#
+# Runs one of the assertion helpers above and checks the verdict it reported.
+# Nothing else in this suite asserts that its own assertions can fail, which is
+# the same blind spot the file exists to close everywhere else (#502).
+#
+# The helper runs inside a command substitution, so the pass/fail counters it
+# increments belong to that subshell and never reach the totals below.
+assert_helper_verdict() {
+	local want="$1" desc="$2"
+	shift 2
+	local out verdict
+	out=$("$@" 2>&1)
+	verdict=$(printf '%s\n' "$out" | head -n 1 | awk '{print $1}')
+	if [ "$verdict" = "$want" ]; then
+		ok "$desc"
+	else
+		bad "$desc — helper reported '${verdict:-no verdict}', want '$want'"
+		printf '%s\n' "$out" | sed 's/^/        | /'
+	fi
+}
+
 GATE="${SCRIPT_DIR}/benchstat-gate.sh"
 
+echo "== the assertion helpers themselves must be able to FAIL =================="
+
+# A path that cannot execute, to stand in for the real thing this suite hit:
+# a copy of the file with a wrong SCRIPT_DIR, where every assertion in a block
+# failed loudly and the one assert_not_contains sat there reporting PASS.
+NOT_A_SCRIPT="${SCRIPT_DIR}/testdata/definitely-not-an-executable-script.sh"
+
+assert_helper_verdict FAIL "assert_not_contains FAILS when the command does not exist (#502)" \
+	assert_not_contains "REGRESSION" "inner: missing command" "$NOT_A_SCRIPT"
+assert_helper_verdict FAIL "assert_not_contains FAILS when the needle is present" \
+	assert_not_contains "REGRESSION" "inner: needle present" printf 'REGRESSION\n'
+assert_helper_verdict PASS "assert_not_contains passes when the command ran and the needle is absent" \
+	assert_not_contains "REGRESSION" "inner: needle absent" printf 'all clean\n'
+# The legitimate non-zero verdicts the `> 125` test exists to preserve: a gate
+# that fires exits 1, and must still be readable as "it ran and said nothing".
+assert_helper_verdict PASS "assert_not_contains passes on a clean exit-1 verdict" \
+	assert_not_contains "REGRESSION" "inner: exit 1, no needle" false
+
+# The other two helpers already fail closed on a command that cannot run. Pin
+# that, so the property this section asserts is a property of all three.
+assert_helper_verdict FAIL "assert_contains FAILS when the command does not exist" \
+	assert_contains "REGRESSION" "inner: missing command" "$NOT_A_SCRIPT"
+assert_helper_verdict FAIL "assert_exit FAILS when the command does not exist" \
+	assert_exit 0 "inner: missing command" "$NOT_A_SCRIPT"
+
+if [ -e "$NOT_A_SCRIPT" ]; then
+	bad "the missing-command fixture exists, so the three assertions above proved nothing"
+else
+	ok "the missing-command fixture is genuinely absent"
+fi
+
+echo
 echo "== benchstat-gate: fires on regressions =================================="
 
 assert_exit 1 "new-format table with a +83.31% significant timing regression" \


### PR DESCRIPTION
## Summary

Three independent one-package fixes, one commit each, all in test/CI machinery — none touches the interpreter:

- **#502 — `ci-gates-test.sh`: `assert_not_contains` fails closed.** The helper never consulted the exit status of the command it ran, so a command that could not execute (missing file, exit 127) produced no output, the needle was absent, and the assertion reported PASS having checked nothing. It now fails on exit >125 (126/127/128+ are "could not execute", never a legitimate gate verdict), while a gate that fires with exit 1 still reads as a clean run. A new section drives all three assertion helpers through an `assert_helper_verdict` harness and proves each can FAIL — the suite previously never asserted its own assertions work.

- **#499 — `TestSleepMaxCannotExceedHostCeiling` asserts refusal on entry.** The second call refused a 2s sleep under `runBounded`'s 30s slack, so an implementation that slept the full 2s and *then* refused passed. The refusal is now bounded relative to a duration the test controls (`elapsed < ceilingProbe/2`, the shape #475 pointed at), with `ceiling`/`ceilingProbe` named together and a guard that the probe actually exceeds the ceiling. Mutation-verified: the sleep-then-refuse mutant passed the old test in 2.00s and fails the new one.

- **#501 — fuzzwatch charges a stall at read time.** The monitor only charged a stall when its next heartbeat tick was delivered — which cannot happen while the process is frozen — so a `Check` at the instant a freeze ended saw `lost=0s`, `starved=false`, and returned `Hung`, charging the whole freeze to the code under test. `Report()` now folds in the unexplained gap since the last observed heartbeat via a write-nothing `monitor.pending()`, charging the same excess-over-nominal the tick would, ordered against the ticker (beat stored before the charge; total read before the beat) so the stall counts exactly once. The `tolerance*tick` visibility floor is unchanged — no budget or threshold widened. Red/green via a SIGSTOP subprocess probe reproducing the issue's exact numbers (`hung / lost=0s / starved=false`, 3/3 without the fix; `lost=2.9s / starved=true` at the instant of resume with it), plus clock-free unit tests pinning read-time charge == tick charge.

## Test Plan
- [x] `make test` passes (full suite, serial re-run clean)
- [x] `make static-checks` — changed packages 0 issues; the 2 `nolintlint` findings in `parser/token/token.go` are byte-identical to `main` and are local-version skew (container has golangci-lint 2.5.0, CI pins v2.6 where those `//nolint:gosec` directives are used)
- [x] `go test -race ./internal/fuzzwatch/` passes; probe gives `starved=true` 3/3 under race
- [x] `bash scripts/ci-gates-test.sh` — 308 passed, 0 failed
- [x] `./elps doc -m` reports no missing docs
- [x] Red-proofs: #499 by mutant (sleep-then-refuse), #501 by disabling the fold, #502 by the new helper self-tests against a missing command

Closes #502
Closes #499
Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq

---
_Generated by [Claude Code](https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq)_