### PR TITLE
Fresh formals per env, the ?set value contract, and waiver housekeeping

### DIFF
--- a/lisp/defformals.go
+++ b/lisp/defformals.go
@@ -1,0 +1,140 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+// formalsCopier gives every definition registered through LEnv.AddBuiltins,
+// LEnv.AddSpecialOps or LEnv.AddMacros its own formal argument list, carved
+// out of two blocks sized for the whole registration call.
+//
+// Why a copy at all:
+//
+// Almost every LBuiltinDef in the process comes out of a package-level table
+// built ONCE, at Go package initialization: lisp's own langBuiltins,
+// langSpecialOps and langMacros, a `var builtins = []*libutil.Builtin{...}` in
+// libtime, libregexp, libhelp, libschema, libmath, libbase64 and libstring, and
+// the equivalent tables embedders hand to elpsutil.  Each entry's formals were
+// constructed by lisp.Formals at that moment and never again.  Installing that
+// *LVal directly into the function value -- what the Add* methods used to do --
+// gave every LEnv in the process the SAME formals object per definition: an
+// embedder running sixty-four concurrent environments had sixty-four `lisp:map`
+// bindings whose Cells[0] was one object.  A single in-place write to a formals
+// cell, the exact shape of issue #362 where a shared-value assumption did get
+// written to, would be visible in every unrelated environment and would be a
+// data race besides.  libjson was the accidental control: it builds its table
+// from a function called per load, so its formals were already private.  See
+// issue #363.
+//
+// Why it is blocked rather than one LVal.Copy per definition:
+//
+// The copy lands once per definition per environment load -- never on the
+// evaluation path -- but environment construction is a real cost for embedders
+// that build an environment per request, and a plain formals.Copy() per
+// definition costs one allocation for the list, one per cell and one for the
+// cell slice.  Measured interleaved over BenchmarkEnvConstructionCore and
+// BenchmarkEnvConstructionFull in lisp/lisplib (n=12, 100ms), a per-definition
+// Copy() was +27.97% / +24.95% on allocs/op; carving the copies out of one
+// []LVal and one []*LVal per registration call is +0.50% / +5.88% instead, for
+// two allocations per call rather than three or more per definition.
+//
+// What blocking does NOT buy is time: +12.90% / +18.56% on sec/op against
+// +14.43% / +20.23% for the per-definition Copy(), which is within a point or
+// two of the same number.  The cost of this fix is the BYTES -- +28% on B/op
+// either way -- and those are irreducible, because a formals list private to
+// each environment is what the fix IS.  Building the tables per load instead
+// (the shape libjson already has) allocates the same bytes or more.  The block
+// is here to keep the allocation COUNT off the interpreter's ledger, not to
+// pretend the memory is free.
+//
+// A block keeps its LVals alive as a unit.  That is harmless here: every value
+// carved out of it is installed in the environment's package registry in the
+// same loop and lives exactly as long as the environment does.
+type formalsCopier struct {
+	vals []LVal
+	ptrs []*LVal
+}
+
+// newFormalsCopier sizes the blocks for defs.  It returns a value rather than a
+// pointer so that the stdlib loaders, which call the Add* methods once per
+// definition, do not pay a heap allocation for the copier itself.  Definitions
+// whose formals are not block-copyable are skipped here and fall back to
+// LVal.Copy in copy.
+func newFormalsCopier(defs []LBuiltinDef) formalsCopier {
+	var c formalsCopier
+	nval, nptr := 0, 0
+	for _, def := range defs {
+		formals := def.Formals()
+		if !blockCopyableFormals(formals) {
+			continue
+		}
+		nval += 1 + len(formals.Cells)
+		nptr += len(formals.Cells)
+	}
+	if nval > 0 {
+		c.vals = make([]LVal, nval)
+	}
+	if nptr > 0 {
+		c.ptrs = make([]*LVal, nptr)
+	}
+	return c
+}
+
+// copy returns a private copy of formals, equivalent to formals.Copy().
+//
+// The block is sized from the same defs slice copy is called for, but a
+// definition is free to build its formals afresh on every Formals() call, so
+// the sizes are re-checked rather than assumed: any shortfall, and any formals
+// shape the block path does not reproduce exactly, falls back to LVal.Copy.
+func (c *formalsCopier) copy(formals *LVal) *LVal {
+	if !blockCopyableFormals(formals) {
+		return formals.Copy()
+	}
+	n := len(formals.Cells)
+	if len(c.vals) < n+1 || len(c.ptrs) < n {
+		return formals.Copy()
+	}
+	cp := &c.vals[0]
+	*cp = *formals
+	c.vals = c.vals[1:]
+	if n == 0 {
+		// LVal.copyCells returns nil for an empty list; match it.
+		cp.Cells = nil
+		return cp
+	}
+	syms := c.vals[:n]
+	c.vals = c.vals[n:]
+	cells := c.ptrs[:n:n]
+	c.ptrs = c.ptrs[n:]
+	for i, cell := range formals.Cells {
+		syms[i] = *cell
+		cells[i] = &syms[i]
+	}
+	cp.Cells = cells
+	return cp
+}
+
+// blockCopyableFormals reports whether v is a formal argument list the block
+// path reproduces exactly: a list of leaf symbols, none of which carries the
+// per-node mutable state LVal.Copy has to duplicate separately -- a source
+// location of its own (issue #446), SourceMeta or MacroExpansionInfo (issue
+// #466).  lisp.Formals builds precisely this, so it is the path every
+// registration in this repository takes; anything else defers to LVal.Copy,
+// which handles those fields and the LArray/LSortMap cases the block path does
+// not model.
+func blockCopyableFormals(v *LVal) bool {
+	if v == nil || v.Type != LSExpr || !nativeLeafLVal(v) {
+		return false
+	}
+	for _, cell := range v.Cells {
+		if cell == nil || cell.Type != LSymbol || len(cell.Cells) != 0 || !nativeLeafLVal(cell) {
+			return false
+		}
+	}
+	return true
+}
+
+// nativeLeafLVal reports whether a shallow struct copy of v is a complete copy
+// of v's own fields -- that is, whether v carries none of the per-node mutable
+// state LVal.Copy duplicates explicitly.
+func nativeLeafLVal(v *LVal) bool {
+	return v.Source == defaultSourceLocation && v.Meta == nil && v.MacroExpansion == nil
+}

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -705,7 +705,10 @@ func (env *LEnv) Lambda(formals *LVal, body []*LVal) *LVal {
 // method doesn't produce the expected behavior and can't be exported publicly
 // because of that.
 func (env *LEnv) builtin(f LBuiltinDef) *LVal {
-	return FunInPackage(env.Runtime.Package.Name, NewEnv(env).getFID(), f.Formals(), f.Eval)
+	// The formals are copied for the same reason the Add* methods copy
+	// theirs: an LBuiltinDef's formals typically belong to a process-wide
+	// table.  See formalsCopier and issue #363.
+	return FunInPackage(env.Runtime.Package.Name, NewEnv(env).getFID(), f.Formals().Copy(), f.Eval)
 }
 
 func (env *LEnv) Terminal(expr *LVal) *LVal {
@@ -725,10 +728,15 @@ func (env *LEnv) root() *LEnv {
 
 // AddMacros binds the given macros to their names in env.  When called with no
 // arguments AddMacros adds the DefaultMacros to env.
+//
+// Each macro's formal argument list is copied into env rather than installed by
+// reference, so environments never share one formals object; see formalsCopier
+// and issue #363.
 func (env *LEnv) AddMacros(external bool, macs ...LBuiltinDef) {
 	if len(macs) == 0 {
 		macs = DefaultMacros()
 	}
+	formals := newFormalsCopier(macs)
 	pkg := env.Runtime.Package
 	for _, mac := range macs {
 		k := Symbol(mac.Name())
@@ -737,7 +745,7 @@ func (env *LEnv) AddMacros(external bool, macs ...LBuiltinDef) {
 			panic(fmt.Sprintf("macro already defined: %v (= %v)", k, exist))
 		}
 		id := fmt.Sprintf("<builtin-macro ``%s''>", mac.Name())
-		fn := MacroInPackage(pkg.Name, id, mac.Formals(), mac.Eval)
+		fn := MacroInPackage(pkg.Name, id, formals.copy(mac.Formals()), mac.Eval)
 		fn.Cells[1] = String(builtinDocstring(mac))
 		pkg.Put(k, fn)
 		if external {
@@ -748,10 +756,15 @@ func (env *LEnv) AddMacros(external bool, macs ...LBuiltinDef) {
 
 // AddSpecialOps binds the given special operators to their names in env.  When
 // called with no arguments AddSpecialOps adds the DefaultSpecialOps to env.
+//
+// Each operator's formal argument list is copied into env rather than installed
+// by reference, so environments never share one formals object; see
+// formalsCopier and issue #363.
 func (env *LEnv) AddSpecialOps(external bool, ops ...LBuiltinDef) {
 	if len(ops) == 0 {
 		ops = DefaultSpecialOps()
 	}
+	formals := newFormalsCopier(ops)
 	pkg := env.Runtime.Package
 	for _, op := range ops {
 		k := Symbol(op.Name())
@@ -760,7 +773,7 @@ func (env *LEnv) AddSpecialOps(external bool, ops ...LBuiltinDef) {
 			panic(fmt.Sprintf("macro already defined: %v (= %v)", k, exist))
 		}
 		id := fmt.Sprintf("<special-op ``%s''>", op.Name())
-		fn := SpecialOpInPackage(pkg.Name, id, op.Formals(), op.Eval)
+		fn := SpecialOpInPackage(pkg.Name, id, formals.copy(op.Formals()), op.Eval)
 		fn.Cells[1] = String(builtinDocstring(op))
 		pkg.Put(k, fn)
 		if external {
@@ -771,10 +784,15 @@ func (env *LEnv) AddSpecialOps(external bool, ops ...LBuiltinDef) {
 
 // AddBuiltins binds the given funs to their names in env.  When called with no
 // arguments AddBuiltins adds the DefaultBuiltins to env.
+//
+// Each function's formal argument list is copied into env rather than installed
+// by reference, so environments never share one formals object; see
+// formalsCopier and issue #363.
 func (env *LEnv) AddBuiltins(external bool, funs ...LBuiltinDef) {
 	if len(funs) == 0 {
 		funs = DefaultBuiltins()
 	}
+	formals := newFormalsCopier(funs)
 	pkg := env.Runtime.Package
 	for _, f := range funs {
 		k := Symbol(f.Name())
@@ -783,7 +801,7 @@ func (env *LEnv) AddBuiltins(external bool, funs ...LBuiltinDef) {
 			panic("symbol already defined: " + f.Name())
 		}
 		id := fmt.Sprintf("<builtin-function ``%s''>", f.Name())
-		v := FunInPackage(pkg.Name, id, f.Formals(), f.Eval)
+		v := FunInPackage(pkg.Name, id, formals.copy(f.Formals()), f.Eval)
 		v.Cells[1] = String(builtinDocstring(f))
 		pkg.Put(k, v)
 		if external {

--- a/lisp/lisplib/envbench_test.go
+++ b/lisp/lisplib/envbench_test.go
@@ -1,0 +1,57 @@
+// Copyright © 2026 The ELPS authors
+
+package lisplib_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+)
+
+// BenchmarkEnvConstructionCore measures lisp.NewEnv + lisp.InitializeUserEnv:
+// the lisp package's own macros, special operators and builtins, and nothing
+// else.
+//
+// BenchmarkEnvConstructionFull adds lisplib.LoadLibrary, which is where the
+// stdlib's package-level definition tables are registered.
+//
+// These two exist because issue #363's fix -- copying each definition's formal
+// argument list at registration so environments stop sharing one *LVal per
+// definition process-wide -- puts its cost exactly here: once per definition
+// per environment load, and nowhere on the evaluation path.  Environment
+// construction had no benchmark at all, so the cost of the fix could only be
+// asserted, and the issue asked for it to be measured.  Every other benchmark
+// in the repository builds its environment in a helper outside the timed loop,
+// which is correct for what those measure and blind to this.
+func BenchmarkEnvConstructionCore(b *testing.B) {
+	for b.Loop() {
+		env := newBenchEnv(b)
+		if rc := lisp.InitializeUserEnv(env); !rc.IsNil() {
+			b.Fatalf("initialize-user-env: %v", rc)
+		}
+	}
+}
+
+func BenchmarkEnvConstructionFull(b *testing.B) {
+	for b.Loop() {
+		env := newBenchEnv(b)
+		if rc := lisp.InitializeUserEnv(env); !rc.IsNil() {
+			b.Fatalf("initialize-user-env: %v", rc)
+		}
+		if rc := lisplib.LoadLibrary(env); !rc.IsNil() {
+			b.Fatalf("load-library: %v", rc)
+		}
+	}
+}
+
+func newBenchEnv(b *testing.B) *lisp.LEnv {
+	b.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	env.Runtime.Library = &lisp.RelativeFileSystemLibrary{}
+	env.Runtime.Stderr = &bytes.Buffer{}
+	return env
+}

--- a/lisp/lisplib/formals_test.go
+++ b/lisp/lisplib/formals_test.go
@@ -75,3 +75,94 @@ func TestRegisteredFunctionsHaveWellFormedFormals(t *testing.T) {
 	require.NotZero(t, nfun, "found no functions to check; the registry walk is broken")
 	t.Logf("checked the formals of %d registered functions", nfun)
 }
+
+// TestRegisteredFormalsAreNotSharedAcrossEnvs asserts that two independently
+// constructed environments do not share a single formal-argument LVal for any
+// function either of them defines.
+//
+// Nearly every builtin, special operator and macro in the process is described
+// by an LBuiltinDef held in a package-level table built once at Go package
+// initialization: lisp's own langBuiltins/langSpecialOps/langMacros, and a
+// `var builtins = []*libutil.Builtin{...}` in libtime, libregexp, libhelp,
+// libschema, libmath, libbase64 and libstring.  Each entry's formals were
+// constructed once, by lisp.Formals, at that moment.  Before this test's fix,
+// LEnv.AddBuiltins/AddSpecialOps/AddMacros installed that very *LVal into the
+// function value, so every environment in the process shared one formals
+// object per definition -- time:sleep, math:atan and lisp:map among them,
+// while json:dump-string escaped only because libjson happens to build its
+// table from a function called per load.  One in-place write to a formals cell
+// would then be a cross-environment correctness bug and, for the embedders that
+// run many environments concurrently, a data race.  See issue #363; issue #362
+// is the same class of assumption, written to.
+//
+// The sweep covers every function in both registries rather than a hand-picked
+// sample, so a new package-level table cannot reintroduce the class unnoticed.
+// It compares pointers, which is a stronger statement than "mutating one does
+// not disturb the other" and does not depend on finding a mutable field.
+func TestRegisteredFormalsAreNotSharedAcrossEnvs(t *testing.T) {
+	envA, err := lisplib.NewDocEnv()
+	require.NoError(t, err)
+	envB, err := lisplib.NewDocEnv()
+	require.NoError(t, err)
+
+	funsA := registeredFuns(envA)
+	funsB := registeredFuns(envB)
+
+	// The exact reproduction named in issue #363.  These are asserted by name
+	// so that a registry walk which stops finding them -- a renamed package, a
+	// changed loader -- fails loudly instead of sweeping zero of the functions
+	// the bug was reported against.
+	reported := []string{"time:sleep", "math:atan", "lisp:map", "json:dump-string"}
+	for _, name := range reported {
+		require.Contains(t, funsA, name, "issue #363 names %s, but the sweep did not find it", name)
+	}
+
+	names := make([]string, 0, len(funsA))
+	for name := range funsA {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	nchecked := 0
+	for _, name := range names {
+		b, ok := funsB[name]
+		if !ok {
+			continue
+		}
+		a := funsA[name]
+		fa, fb := a.Cells[0], b.Cells[0]
+		require.NotSamef(t, fa, fb,
+			"%s: both environments hold the SAME formals object %p; a write through either is visible in the other (issue #363)",
+			name, fa)
+		require.Lenf(t, fb.Cells, len(fa.Cells),
+			"%s: formals differ in length between environments", name)
+		for i := range fa.Cells {
+			require.NotSamef(t, fa.Cells[i], fb.Cells[i],
+				"%s: both environments hold the SAME formal argument %d (%v); the copy is shallow (issue #363)",
+				name, i, fa.Cells[i])
+		}
+		nchecked++
+	}
+
+	// Guard against the sweep silently finding nothing.
+	require.NotZero(t, nchecked, "found no functions to check; the registry walk is broken")
+	t.Logf("checked the formals of %d functions defined in both environments", nchecked)
+}
+
+// registeredFuns returns every function bound in env's registry, keyed by its
+// package-qualified name.
+func registeredFuns(env *lisp.LEnv) map[string]*lisp.LVal {
+	funs := make(map[string]*lisp.LVal)
+	for pkgName, pkg := range env.Runtime.Registry.Packages {
+		if pkg == nil {
+			continue
+		}
+		for sym, v := range pkg.Symbols {
+			if v == nil || v.Type != lisp.LFun || len(v.Cells) == 0 || v.Cells[0] == nil {
+				continue
+			}
+			funs[pkgName+":"+sym] = v
+		}
+	}
+	return funs
+}

--- a/lisp/lisplib/libelpspath/libelpspath.go
+++ b/lisp/lisplib/libelpspath/libelpspath.go
@@ -76,6 +76,10 @@ var builtins = []*libutil.Builtin{
 		The last argument is the new value; all preceding arguments are path
 		steps. Returns the mutated original.
 
+		The new value is stored BY REFERENCE, not copied: after the call it is
+		reachable and mutable through the result, and a later write through
+		either name is visible through the other.
+
 		(?set! obj "foo" "bar" "new")   => obj with foo.bar="new" (mutated)
 		(?set! obj "items" 0 "x")       => obj with items[0]="x" (mutated)
 		(?set! data '* "active" true)   => set active=true on all elements`),
@@ -84,6 +88,12 @@ var builtins = []*libutil.Builtin{
 
 		The last argument is the new value; all preceding arguments are path
 		steps. The original is not modified.
+
+		The copy is independent of the SOURCE document only. The new value is
+		stored BY REFERENCE, not copied: the value you supply becomes
+		reachable and mutable through the result, so a later in-place write
+		through the result (?set!, ?del!, append!) reaches the caller's
+		value, and vice versa. Pass a copy if the result must not alias it.
 
 		(?set obj "foo" "bar" "new")   => new obj with foo.bar="new"
 		(?set obj "items" 0 "x")       => new obj with items[0]="x"`),

--- a/lisp/lisplib/libelpspath/value_contract_test.go
+++ b/lisp/lisplib/libelpspath/value_contract_test.go
@@ -1,0 +1,83 @@
+// Copyright © 2026 Luther Systems, Ltd. All right reserved.
+
+package libelpspath
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The ?-family's VALUE contract, pinned so it cannot drift silently
+// (issue #399).
+//
+// The non-mutating ops return a copy that is independent of the SOURCE
+// document -- that is #395's contract, held by the alias battery in
+// path_alias_test.go.  The supplied NEW VALUE is the other side of the same
+// node, and its contract is the opposite: it is stored by reference.  Both
+// answers were defensible when #399 was filed; this is the characterization
+// test for the one that was chosen, the same treatment AddPackage's sharing
+// contract got.  Kept deliberately: copy-on-store would cost an allocation on
+// a path substrate runs per transaction, would surprise a caller who passed a
+// large structure expecting it to be shared, and would also have to change
+// ?set!'s aliasing semantics to stay coherent.  The docstrings for ?set and
+// ?set! state the contract; if a future change makes these tests fail, the
+// docstrings and the callers relying on sharing (shirocore's blend-paths)
+// must change with it.
+
+// TestSetStoresTheSuppliedValueByReference is the issue's own reproduction:
+// the value handed to a COPYING ?set is reachable and mutable through the
+// result, so a write through the result rewrites the caller's value.
+func TestSetStoresTheSuppliedValueByReference(t *testing.T) {
+	t.Parallel()
+
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = nil
+
+	doc := lisp.SortedMap()
+	doc.MapSet("tag", lisp.String("x"))
+
+	// A vector, as in the issue's reproduction: lists refuse in-place path
+	// ops (errMutateList), so a vector is the value the reach is visible on.
+	v := lisp.Array(nil, []*lisp.LVal{lisp.Int(1), lisp.Int(2), lisp.Int(3)})
+
+	result := callBuiltin(env, BuiltinQuerySet, doc, lisp.String("k"), v)
+	require.NotEqual(t, lisp.LError, result.Type, "%v", result)
+
+	stored := callBuiltin(env, BuiltinQueryGet, result, lisp.String("k"))
+	require.NotEqual(t, lisp.LError, stored.Type, "%v", stored)
+	assert.Same(t, v, stored,
+		"?set stores the supplied value by reference; a copy here is a contract change (#399)")
+
+	// The reach the pointer identity implies, spelled out: an in-place write
+	// through the result rewrites the caller's value.
+	got := callBuiltin(env, BuiltinQuerySetMutate,
+		result, lisp.String("k"), lisp.Int(0), lisp.Int(99))
+	require.NotEqual(t, lisp.LError, got.Type, "%v", got)
+	elem := callBuiltin(env, BuiltinQueryGet, v, lisp.Int(0))
+	require.NotEqual(t, lisp.LError, elem.Type, "%v", elem)
+	assert.Equal(t, 99, elem.Int,
+		"the write through the result must reach the caller's value under the by-reference contract (#399)")
+}
+
+// TestSetMutateStoresTheSuppliedValueByReference pins the same contract for
+// the mutating op, which #399 notes must stay coherent with the copying one.
+func TestSetMutateStoresTheSuppliedValueByReference(t *testing.T) {
+	t.Parallel()
+
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = nil
+
+	doc := lisp.SortedMap()
+	v := lisp.QExpr([]*lisp.LVal{lisp.Int(1)})
+
+	result := callBuiltin(env, BuiltinQuerySetMutate, doc, lisp.String("k"), v)
+	require.NotEqual(t, lisp.LError, result.Type, "%v", result)
+
+	stored, ok := doc.Map().Get(lisp.String("k"))
+	require.True(t, ok)
+	assert.Same(t, v, stored,
+		"?set! stores the supplied value by reference (#399)")
+}

--- a/scripts/benchstat-waivers.txt
+++ b/scripts/benchstat-waivers.txt
@@ -95,4 +95,17 @@
 # ---------------------------------------------------------------------------
 #
 
-# (no active waivers)
+# elps#363 -- libjson Package/$load, the env-construction allocation cost.
+#
+# Every environment now copies the formals of every builtin it registers
+# instead of aliasing one process-wide LVal (elps#363): the copy is what the
+# fix IS, so the bytes are irreducible.  The cost lands once per environment
+# construction and never on the eval path; Package/$load is the one benchmark
+# that builds a full env per iteration, so it pays the whole bill in B/op
+# (+9.45% measured, interleaved n=12) while its sec/op is unchanged and every
+# eval-path benchmark is flat.  Ceiling 12% against the measured 9.45%: a
+# second allocation regression landing on env construction still reds the
+# build.  elps#379's interning work is the plausible future reducer; when a
+# cheaper representation lands, re-measure and delete this entry.
+
+github.com/luthersystems/elps/lisp/lisplib/libjson | Package/$load | B/op | 12 | 2027-02-28 | elps#363 | env construction copies every builtin's formals per environment (elps#363); the copy is the fix, paid once per env load, eval path flat; revisit when elps#379 interning lands

--- a/scripts/benchstat-waivers.txt
+++ b/scripts/benchstat-waivers.txt
@@ -94,32 +94,5 @@
 # pkg | benchmark | metric | ceiling | expires | issue | reason
 # ---------------------------------------------------------------------------
 #
-# elps#412 / elps#410 -- libjson BenchmarkEncode, PR #411.
-#
-# TWO entries, not one, and the second one deserves saying out loud.
-#
-# The regression was described going in as a single failing row, allocs/op at
-# +7.94%. It is not. Running the gate over that run's actual benchstat output
-# (preserved as scripts/testdata/benchstat-libjson-encode-411.txt) with waivers
-# switched off reports TWO rows at or above a gate:
-#
-#     Encode-2  B/op       10.05Ki -> 11.30Ki  +12.45% (p=0.000 n=10)   gate 5%
-#     Encode-2  allocs/op    214.0 ->   231.0   +7.94% (p=0.000 n=10)   gate 5%
-#
-# B/op is an ALLOCATION metric, so it is judged against BENCH_ALLOC_THRESHOLD_PCT
-# (5), not against the 15% timing threshold. At +12.45% it is over. Waiving only
-# the count would have produced a waiver that does not work: the build would have
-# stayed red, on a row nobody had reviewed, and the natural next move would have
-# been to widen the allocation threshold -- which is precisely the outcome this
-# mechanism exists to avoid.
-#
-# They are one cost measured two ways: the same 17 extra allocations, ~1.25 KiB
-# of them. Waiving one and not the other would not be narrower, only broken. So
-# both are here, each with its own ceiling, each nameable in review.
-#
-# sec/op is NOT waived. It moves too (+11.00%, p=0.000) but its gate is 15% and
-# it is under it, so it needs nothing -- and leaving it unwaived means the timing
-# cost of this change is still watched at full strength.
 
-github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | allocs/op | 9 | 2027-02-28 | elps#412 elps#410 | Dump could emit a document Load refuses (elps#410); the fix marshals each native value and validates the bytes it produced. 3 of BenchmarkEncode's 36 stdEncodeTests rows are lisp.Value(map[string]interface{}{...}), i.e. natives, so this microbenchmark pays the check at 214->231 allocs/op (+7.94%) while documents without natives pay nothing -- every realistic JSON row (Package/dump-object, dump-array, dump-nested, dump-github) is flat on all three metrics. A hand-rolled scanner restoring allocation parity was built and measured: an end-to-end substrate benchmark (interleaved, n=12) could not distinguish it from the decode on any of that repo's 20 rows, and it cost ~130 lines of a second JSON parser required to agree with encoding/json forever. elps#412 tracks removing the redundant work instead. Ceiling 9% allows 233 allocs/op against the measured 231; a second regression landing on this benchmark still reds the build.
-github.com/luthersystems/elps/lisp/lisplib/libjson | Encode | B/op | 14 | 2027-02-28 | elps#412 elps#410 | The same 17 allocations as the allocs/op waiver above, weighed instead of counted: 10.05Ki -> 11.30Ki (+12.45%, p=0.000 n=10), ~1.25 KiB of marshalled bytes held while the native round-trip is validated. B/op is an allocation metric and so is judged against the 5% allocation gate, not the 15% timing one -- waiving the count alone would have left the build red on this row. Same fix, same tracking issue, same expiry: elps#412 removes the redundant marshal and both entries go with it. Ceiling 14% against a measured 12.45%.
+# (no active waivers)

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -299,15 +299,15 @@ assert_contains "+7.94%" "the allocs/op row is named when unwaived" \
 assert_contains "+12.45%" "the B/op row is named too — it is over the allocation gate as well" \
 	env BENCH_WAIVERS= "$GATE" "$WAIVED_FIXTURE"
 
-# The after half: the shipped waiver list is currently EMPTY.  The two #411
-# entries were deleted (#413) once elps#412's fix removed the regression they
-# accepted and the gate had reported both waiver-unused.  What the DEFAULT
-# path (no BENCH_WAIVERS override) must prove now is the deletion's other
-# side: with the entries gone, the same real comparison fires the gate again
-# -- the rows came back the moment their acceptance was withdrawn, which is
-# the property that makes deleting a stale waiver safe to do.  If a waiver is
-# ever shipped again, flip this back to the exit-0 round trip this block
-# carried before #413, asserting the shipped file covers what it claims to.
+# The after half: the shipped list no longer carries the two #411 Encode
+# entries -- they were deleted (#413) once elps#412's fix removed the
+# regression they accepted and the gate had reported both waiver-unused.
+# (The elps#363 env-construction entry it does carry names a different row
+# and cannot reach the Encode columns.)  What the DEFAULT path (no
+# BENCH_WAIVERS override) must prove now is the deletion's other side: with
+# the Encode entries gone, the same real comparison fires the gate again --
+# the rows came back the moment their acceptance was withdrawn, which is the
+# property that makes deleting a stale waiver safe to do.
 assert_exit 1 "with the shipped waiver list empty, PR #411's comparison fires again" \
 	"$GATE" "$WAIVED_FIXTURE"
 assert_contains "+7.94%" "the un-waived allocs/op row is judged again on the default path" \
@@ -361,11 +361,10 @@ assert_exit 1 "an EXPIRED waiver no longer suppresses its row" \
 	env BENCH_WAIVERS="${TESTDATA}/waivers-expired.txt" "$GATE" "$WAIVED_FIXTURE"
 assert_contains "WAIVER EXPIRED" "an expired waiver says why the row came back" \
 	env BENCH_WAIVERS="${TESTDATA}/waivers-expired.txt" "$GATE" "$WAIVED_FIXTURE"
-# No shipped-waiver expiry proof while the shipped list is empty -- with no
-# entries the fixture reds at ANY clock, so the assertion would pass without
-# reading the expiry field at all.  The expiry property is carried by the
-# waivers-expired.txt assertions above; restore the wound-clock proof against
-# the shipped file the next time it carries a real entry.
+# No shipped-waiver expiry proof against this fixture -- its over-gate rows
+# (the Encode columns) are no longer waived, so it reds at ANY clock and the
+# assertion would pass without reading the expiry field at all.  The expiry
+# property is carried by the waivers-expired.txt assertions above.
 
 # JUSTIFICATION. A waiver with no tracking reference is a threshold increase
 # with better manners; the gate must refuse to run rather than honour it. Note

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -299,27 +299,37 @@ assert_contains "+7.94%" "the allocs/op row is named when unwaived" \
 assert_contains "+12.45%" "the B/op row is named too — it is over the allocation gate as well" \
 	env BENCH_WAIVERS= "$GATE" "$WAIVED_FIXTURE"
 
-# The after half: the waivers this repository actually ships, with no env
-# override at all, make that same comparison pass. This is the assertion that
-# keeps scripts/benchstat-waivers.txt honest -- it fails if the file is deleted,
-# emptied, malformed, or edited so it no longer covers what it claims to.
-assert_exit 0 "the SHIPPED waiver file makes PR #411's real comparison pass" \
+# The after half: the shipped waiver list is currently EMPTY.  The two #411
+# entries were deleted (#413) once elps#412's fix removed the regression they
+# accepted and the gate had reported both waiver-unused.  What the DEFAULT
+# path (no BENCH_WAIVERS override) must prove now is the deletion's other
+# side: with the entries gone, the same real comparison fires the gate again
+# -- the rows came back the moment their acceptance was withdrawn, which is
+# the property that makes deleting a stale waiver safe to do.  If a waiver is
+# ever shipped again, flip this back to the exit-0 round trip this block
+# carried before #413, asserting the shipped file covers what it claims to.
+assert_exit 1 "with the shipped waiver list empty, PR #411's comparison fires again" \
+	"$GATE" "$WAIVED_FIXTURE"
+assert_contains "+7.94%" "the un-waived allocs/op row is judged again on the default path" \
+	"$GATE" "$WAIVED_FIXTURE"
+assert_contains "+12.45%" "the un-waived B/op row is judged again on the default path" \
 	"$GATE" "$WAIVED_FIXTURE"
 
-# ...and it passes because it was WAIVED, not because the gate stopped looking.
-# The row must still appear, with its delta, its ceiling and its issue.
-# Anchored on the per-ROW marker, not the bare word: the summary line already
-# says "row(s) WAIVED", so a substring check for "WAIVED" stays green even after
-# the per-row lines are deleted -- which is exactly the regression that matters.
+# A WAIVED row must still be visible: reported by name, with its delta, its
+# tracking issue, and counted in the summary.  Proven against the testdata
+# waivers now that the shipped list is empty.  Anchored on the per-ROW marker,
+# not the bare word: the summary line already says "row(s) WAIVED", so a
+# substring check for "WAIVED" stays green even after the per-row lines are
+# deleted -- which is exactly the regression that matters.
 assert_contains "WAIVED      github.com/luthersystems/elps/lisp/lisplib/libjson" \
 	"a waived row is still reported by name, not silently dropped" \
-	"$GATE" "$WAIVED_FIXTURE"
+	env BENCH_WAIVERS="${TESTDATA}/waivers-libjson-both.txt" "$GATE" "$WAIVED_FIXTURE"
 assert_contains "+7.94%" "the waived row still carries its measured delta" \
-	"$GATE" "$WAIVED_FIXTURE"
+	env BENCH_WAIVERS="${TESTDATA}/waivers-libjson-both.txt" "$GATE" "$WAIVED_FIXTURE"
 assert_contains "elps#412" "the waived row names its tracking issue in the report" \
-	"$GATE" "$WAIVED_FIXTURE"
+	env BENCH_WAIVERS="${TESTDATA}/waivers-libjson-both.txt" "$GATE" "$WAIVED_FIXTURE"
 assert_contains "row(s) WAIVED" "the summary line counts the waivers" \
-	"$GATE" "$WAIVED_FIXTURE"
+	env BENCH_WAIVERS="${TESTDATA}/waivers-libjson-both.txt" "$GATE" "$WAIVED_FIXTURE"
 
 # NARROWNESS. A waiver covers one package, one benchmark, one metric column.
 # Waiving allocs/op alone must leave B/op of the SAME benchmark failing --
@@ -351,11 +361,11 @@ assert_exit 1 "an EXPIRED waiver no longer suppresses its row" \
 	env BENCH_WAIVERS="${TESTDATA}/waivers-expired.txt" "$GATE" "$WAIVED_FIXTURE"
 assert_contains "WAIVER EXPIRED" "an expired waiver says why the row came back" \
 	env BENCH_WAIVERS="${TESTDATA}/waivers-expired.txt" "$GATE" "$WAIVED_FIXTURE"
-# The same proof against the waivers this repo actually ships: wind the clock
-# past their expiry and PR #411's comparison reds again. Without this, "expires"
-# could be a field nothing reads.
-assert_exit 1 "the SHIPPED waivers genuinely expire (clock wound past the date)" \
-	env BENCH_WAIVER_TODAY=2099-01-01 "$GATE" "$WAIVED_FIXTURE"
+# No shipped-waiver expiry proof while the shipped list is empty -- with no
+# entries the fixture reds at ANY clock, so the assertion would pass without
+# reading the expiry field at all.  The expiry property is carried by the
+# waivers-expired.txt assertions above; restore the wound-clock proof against
+# the shipped file the next time it carries a real entry.
 
 # JUSTIFICATION. A waiver with no tracking reference is a threshold increase
 # with better manners; the gate must refuse to run rather than honour it. Note


### PR DESCRIPTION
## Summary

The pre-sealing cleanup pass: three issues closed, four commits.

- **#363 — every environment gets its own builtin formals** (`e145d9e`). Nine packages registered builtins/ops/macros from package-level tables, so one formals `*LVal` was shared by every `LEnv` in the process — a cross-environment corruption and data-race trap (the class #362 fell into). Fixed at the binding chokepoint (`AddBuiltins`/`AddSpecialOps`/`AddMacros` + `LEnv.builtin`), so the one change also covers embedders' own tables — substrate's registrations get the same protection for free. `lisp/defformals.go` block-allocates the copies (one `[]LVal` + one `[]*LVal` per registration call) with an `LVal.Copy` fallback for exotic formals shapes.

  **Measured cost, owned up front**: env construction pays **+12.9% (core) / +18.6% (full stdlib) sec/op and +28% B/op** — interleaved arms, n=12, benchstat. Absolute: ~+0.1 ms and ~+0.09 MiB *per environment build*; every eval-path benchmark is flat, and block allocation keeps allocs/op nearly flat (+0.5%/+5.9%) where a naive per-def `Copy()` costs +26%. The bytes are irreducible — per-env formals is what the fix *is*. The one existing benchmark that moves is libjson `Package/$load` (it builds a full env per iteration): B/op +9.45%, over the 5% allocation gate, so it carries a reviewed waiver row (ceiling 12%, expiry 2027-02-28, revisit when #379's interning lands).

  Red-proof: `TestRegisteredFormalsAreNotSharedAcrossEnvs` sweeps **all 382 functions** defined in two independent envs, comparing every formals pointer and every formal-argument pointer; against the unfixed code it fails on the first function with the shared-pointer identity.

- **#399 — the ?set value contract, decided and pinned** (`eb64cce`). `?set`/`?set!` store the supplied value **by reference**, deliberately: copy-on-store would cost an allocation on a per-transaction path, surprise callers who pass large structures expecting sharing (shirocore's `blend-paths` does exactly this), and force `?set!`'s aliasing semantics to change coherently. The docstrings now state it, and `value_contract_test.go` pins both ops with the issue's own reproduction so it cannot drift silently.

- **#413 — the two dead Encode waivers deleted** (`e4ef4a2`, `2f52a36`). Their fix (#417) landed and the gate has reported both `waiver-unused` since. The self-test's shipped-waiver round trip now proves the deletion's other side — the #411 fixture fires the gate again on the default path — with the WAIVED-row rendering proofs moved onto testdata fixtures.

## Test Plan
- [x] `bash scripts/ci-gates-test.sh` — **309 passed, 0 failed** on the final tree (waiver entry loading and validated)
- [x] `go test ./... -count=1` — no failures
- [x] `go test -race ./lisp/ -count=1` — clean
- [x] `golangci-lint run ./lisp/...` — 0 issues
- [x] `./elps doc -m` — all documented
- [x] Red-proofs: #363 by removing the fix (sweep test fails on shared pointers); #399's contract test asserts pointer identity and write-through both directions
- [x] Env-construction benchmarks added (`BenchmarkEnvConstructionCore`/`Full`) so this cost stays measured, not remembered

Closes #363
Closes #399
Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq

---
_Generated by [Claude Code](https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq)_