### PR TITLE
Classify every panic site by lisp-reachability, and enforce it

### DIFF
--- a/internal/fuzzseed/evalseed.go
+++ b/internal/fuzzseed/evalseed.go
@@ -167,6 +167,26 @@ func EvalTerminating() map[string]string {
 		// configured Stderr, which the harness captures. ---
 		"debug-print-empty": `(debug-print)`,
 		"debug-print-args":  `(debug-print 1 2 3)`,
+
+		// --- the sequence constructors that build their result through
+		// lisp.Array, whose unsupplied cells used to be Go nils (#367).  The
+		// empty forms are the interesting ones: they are the shapes that ask
+		// for storage and then fill none of it.
+		//
+		// concat is here for a second reason.  Its vector branch no longer
+		// allocates the container first and writes through it; it fills a
+		// slice and wraps the finished slice, so these rows are what pin that
+		// the rewrite still produces the same sequences.
+		"concat-vector-empty":  `(concat 'vector)`,
+		"concat-vector":        `(concat 'vector (vector 1 2) (vector 3))`,
+		"concat-list-empty":    `(concat 'list)`,
+		"concat-list":          `(concat 'list '(1 2) '(3))`,
+		"concat-vector-mixed":  `(concat 'vector '(1 2) (vector 3))`,
+		"map-vector":           `(map 'vector to-string (make-sequence 0 4))`,
+		"map-vector-empty":     `(map 'vector to-string ())`,
+		"zip-vector":           `(zip 'vector '(1 2) '(3 4))`,
+		"reverse-vector-empty": `(reverse 'vector (vector))`,
+		"sequence-vector-read": `(let ([v (concat 'vector (vector 1))]) (list (nth v 0) (aref v 0) (equal? v v)))`,
 	}
 }
 
@@ -240,5 +260,37 @@ func EvalAdversarial() []string {
 		// --- debug output.  A4's minimised input is the zero-argument form,
 		// which wrote to os.Stdout instead of the runtime's Stderr. ---
 		"(debug-print)", "(debug-print 1)", "(debug-stack)",
+
+		// --- type confusion at the interpreter's PANICKING accessors
+		// (issue #367).  LVal.Bytes, LVal.Map, LVal.FunData and seqCells all
+		// panic on a wrong-typed receiver, and each is unreachable from lisp
+		// only because every caller checks the type first.  Each line below
+		// offers a builtin the wrong type for the accessor it is about to
+		// reach, so a caller that drops its check turns one of these into an
+		// internal-panic instead of an error.
+		//
+		// `(append 'bytes 0)` above is the shape that actually shipped: the
+		// type SPECIFIER was validated and the sequence was not.  These
+		// generalise it across the accessors and give the mutator a starting
+		// point inside each one.
+		//
+		// LVal.Bytes:
+		"(concat 'bytes 0)", "(reverse 'bytes 0)", "(to-string 0)",
+		"(base64:std-encode 0)", "(json:dump-string (to-bytes \"a\"))",
+		// LVal.Map:
+		"(get 0 'a)", "(assoc 0 'a 1)", "(assoc! 0 'a 1)", "(keys 0)",
+		"(dissoc 0 'a)", "(key? 0 'a)", "(sorted-map 0 1)",
+		"(elpspath:? 0 \"a\")", "(elpspath:?set 0 \"a\" 1)",
+		// LVal.FunData, reached by anything that takes a function argument:
+		"(map 'list 0 '(1))", "(foldl 0 0 '(1))", "(sort 0 '(1))",
+		"(apply 0 '())", "(funcall 0)", "(select 'list 0 '(1))",
+		// seqCells, whose contract is "the caller guarded with isSeq":
+		"(nth 0 0)", "(first 0)", "(rest 0)", "(slice 'list 0 0 1)",
+		"(zip 'list 0 0)", "(insert-index 'list 0 0 1)",
+		// toFloat, reached once both operands are believed numeric:
+		"(< 1 'a)", "(max 1 \"a\")", "(min 'a 1)", "(pow 1 'a)",
+		"(make-sequence 0 1 'a)", "(equal? 1 'a)",
+		// LVal.CallStack, which panics on a non-error receiver:
+		"(ignore-errors (get 0 'a))", "(handler-bind ([condition (lambda (c &rest r) c)]) (get 0 'a))",
 	}
 }

--- a/lisp/array_test.go
+++ b/lisp/array_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"github.com/luthersystems/elps/elpstest"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/require"
 )
 
 func TestArray(t *testing.T) {
@@ -75,4 +78,64 @@ func TestArray(t *testing.T) {
 		}},
 	}
 	elpstest.RunTestSuite(t, tests)
+}
+
+// TestArrayWithoutBackingStorageIsReadable pins the fix for issue #367.
+//
+// lisp.Array documents that cells may be nil, and every internal caller uses
+// that form and then fills the storage itself.  An embedder following the
+// documentation does not fill it, and before this fix the array it got held
+// the slice's zero value -- a Go nil *LVal -- in every element.  A nil *LVal
+// is not a value the interpreter can hold, so the first lisp expression to
+// read one dereferenced it and took the host process down.  The evaluator
+// reported that as `internal-panic`, which handler-bind is documented NOT to
+// catch, so the embedder had no way to contain it either.
+//
+// The unit here is deliberately the CONSTRUCTOR, not any one reader: `aref`
+// was merely the first expression to touch the element.  `equal?`, `nth` and
+// printing reached the same nil by other routes, and a per-reader nil check
+// would have been one guard per reader against a value that should never have
+// existed.
+func TestArrayWithoutBackingStorageIsReadable(t *testing.T) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	rc := lisp.InitializeUserEnv(env)
+	require.NotEqual(t, lisp.LError, rc.Type, "initialize-user-env: %v", rc)
+	rc = env.InPackage(lisp.String(lisp.DefaultUserPackage))
+	require.NotEqual(t, lisp.LError, rc.Type, "in-package: %v", rc)
+
+	for _, test := range []struct {
+		name string
+		arr  *lisp.LVal
+	}{
+		{"vector", lisp.Array(lisp.QExpr([]*lisp.LVal{lisp.Int(3)}), nil)},
+		{"empty", lisp.Array(lisp.QExpr([]*lisp.LVal{lisp.Int(0)}), nil)},
+		// Zero dimensions is one element, not zero: the product of an empty
+		// list of sizes is 1.  It is the smallest array that has an element
+		// nobody supplied.
+		{"zero-dimensional", lisp.Array(lisp.QExpr(nil), nil)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.NotEqual(t, lisp.LError, test.arr.Type, "constructing the array: %v", test.arr)
+			for _, cell := range test.arr.Cells[1].Cells {
+				require.NotNil(t, cell,
+					"Array left an element as a Go nil; every unset element must be Nil()")
+				require.True(t, cell.IsNil(), "an unset array element must be nil, got %v", cell)
+			}
+			env.PutGlobal(lisp.Symbol("a"), test.arr)
+			// Reading the array must produce values, not an internal-panic --
+			// and it must not produce an error either: an unset element is
+			// nil, which is an answer.
+			for _, expr := range []string{`(equal? a a)`, `(to-string (nth a 0))`} {
+				res := env.LoadString(test.name, expr)
+				require.False(t, lisp.IsInternalPanic(res),
+					"%s over an array with no backing storage panicked the host: %v", expr, res)
+			}
+			if test.name == "vector" {
+				res := env.LoadString(test.name, `(aref a 0)`)
+				require.False(t, lisp.IsInternalPanic(res), "(aref a 0) panicked the host: %v", res)
+				require.True(t, res.IsNil(), "an unset element must read as nil, got %v", res)
+			}
+		})
+	}
 }

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -1408,23 +1408,29 @@ func builtinConcatSeq(env *LEnv, args *LVal) *LVal {
 			return Nil()
 		}
 	}
-	var ret *LVal
-	var cells []*LVal
-	switch typespec.Str {
-	case "vector":
-		ret = Array(QExpr([]*LVal{Int(size)}), nil)
-		cells = seqCells(ret)
-		cells = cells[0:0:size]
-	case "list":
-		ret = QExpr(make([]*LVal, size))
-		cells = ret.Cells[0:0:size]
-	default:
+	if typespec.Str != "vector" && typespec.Str != "list" {
 		return env.Errorf("type specifier is not valid: %v", typespec)
 	}
+	// The result's storage is filled BEFORE it is wrapped in an LVal, rather
+	// than allocating the container first and writing through it.  Both orders
+	// cost one allocation, but this one never observes the container in a
+	// half-built state -- the previous order left the cells holding the slice's
+	// zero value, a Go nil *LVal, until the appends below overwrote them, and a
+	// Go nil is not a value the interpreter can hold (issue #367).  It also
+	// avoids paying for Array's nil-initialization of storage this function is
+	// about to overwrite in full (measured: ~8% of BenchmarkAliasConcatCopy).
+	//
+	// Capacity is exactly size, so the appends cannot outgrow the slice and the
+	// result is clamped in the sense clampCap means: appending to the returned
+	// value allocates rather than writing into a neighbour (issue #373).
+	cells := make([]*LVal, 0, size)
 	for _, v := range rest {
 		cells = append(cells, seqCells(v)...)
 	}
-	return ret
+	if typespec.Str == "vector" {
+		return Array(QExpr([]*LVal{Int(size)}), cells)
+	}
+	return QExpr(cells)
 }
 
 func builtinSortStable(env *LEnv, args *LVal) *LVal {
@@ -2883,6 +2889,11 @@ func numericListType(cells []*LVal) LType {
 
 func toFloat(x *LVal) float64 {
 	if !x.IsNumeric() {
+		// NOT LISP-REACHABLE (#367): toFloat is unexported and every caller --
+		// builtinLEq/LT/GEq/GT/Pow, builtinAdd/Sub, addNumeric/lessNumeric and
+		// equalNum -- rejects a non-numeric operand with an error before
+		// reaching here, so a program cannot present one.  The panic marks a
+		// hole in one of those guards, not bad input.
 		panic("toFloat called with non-numeric argument: " + x.String())
 	}
 	if x.Type == LInt {

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -742,6 +742,10 @@ func (env *LEnv) AddMacros(external bool, macs ...LBuiltinDef) {
 		k := Symbol(mac.Name())
 		exist := pkg.Get(k)
 		if !exist.IsNil() && exist.Type != LError { // LError is ubound symbol
+			// NOT LISP-REACHABLE (#367): AddMacros is registration-time Go
+			// API.  No builtin, operator or macro calls it, so the only way to
+			// bind one name twice is an embedder registering it twice.  The
+			// embedder-facing half of that story is #351.
 			panic(fmt.Sprintf("macro already defined: %v (= %v)", k, exist))
 		}
 		id := fmt.Sprintf("<builtin-macro ``%s''>", mac.Name())
@@ -770,6 +774,8 @@ func (env *LEnv) AddSpecialOps(external bool, ops ...LBuiltinDef) {
 		k := Symbol(op.Name())
 		exist := pkg.Get(k)
 		if !exist.IsNil() && exist.Type != LError { // LError is ubound symbol
+			// NOT LISP-REACHABLE (#367): see AddMacros above -- registration
+			// is Go API an embedder drives, never lisp source.
 			panic(fmt.Sprintf("macro already defined: %v (= %v)", k, exist))
 		}
 		id := fmt.Sprintf("<special-op ``%s''>", op.Name())
@@ -798,6 +804,8 @@ func (env *LEnv) AddBuiltins(external bool, funs ...LBuiltinDef) {
 		k := Symbol(f.Name())
 		exist := pkg.Get(k)
 		if exist.Type != LError {
+			// NOT LISP-REACHABLE (#367): see AddMacros above -- registration
+			// is Go API an embedder drives, never lisp source.
 			panic("symbol already defined: " + f.Name())
 		}
 		id := fmt.Sprintf("<builtin-function ``%s''>", f.Name())
@@ -1467,6 +1475,11 @@ func extractMarkTailRec(mark *LVal) (fun, args *LVal) {
 // mark must be LMarkTailRec
 func decrementMarkTailRec(mark *LVal) (done bool) {
 	if len(mark.Cells) != 4 {
+		// NOT LISP-REACHABLE (#367): markTailRec is the only producer of an
+		// LMarkTailRec and it always builds exactly four cells; the mark is
+		// consumed by funCall's own `r.Type == LMarkTailRec` branch and never
+		// reaches a lisp binding, a reader syntax or a builtin's arguments.  A
+		// wrong shape here is an evaluator bug, not program input.
 		panic("invalid mark")
 	}
 	mark.Cells[0].Int--

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -540,6 +540,23 @@ func MakeVector(n int) *LVal {
 // nil, in which case a vector (one dimensional array) is returned.  If dims is
 // non-nil then cells must either be nil or have one element for every array
 // element, in row-major order.
+//
+// When no backing storage is supplied every element is initialized to Nil,
+// the same value MakeVector gives an unset element.  It used to be left as
+// the zero value of the slice, a Go nil *LVal, which is not a value the rest
+// of the interpreter can hold: reading one dereferences it.  In-tree that was
+// latent -- every caller here fills the cells it asked for before the array
+// escapes -- but Array is exported and its documentation says cells may be
+// nil, so an embedder following it built a value that panicked the host the
+// first time lisp touched it:
+//
+//	env.PutGlobal(Symbol("a"), Array(QExpr([]*LVal{Int(3)}), nil))
+//	(aref a 0)    ; internal-panic: nil pointer dereference
+//
+// A panic is the wrong answer twice over: the read is not an error at all
+// (an unset element is nil, which is what the array now holds), and an
+// internal-panic is deliberately not catchable by handler-bind, so the host
+// had no way to contain it.  See issue #367.
 func Array(dims *LVal, cells []*LVal) *LVal {
 	if dims == nil {
 		dims = QExpr([]*LVal{Int(len(cells))})
@@ -563,6 +580,9 @@ func Array(dims *LVal, cells []*LVal) *LVal {
 		return Errorf("array contents do not match size")
 	} else if len(cells) == 0 {
 		cells = make([]*LVal, totalSize)
+		for i := range cells {
+			cells[i] = Nil()
+		}
 	}
 
 	return &LVal{
@@ -808,6 +828,14 @@ func markTailRec(npop int, fun *LVal, args *LVal) *LVal {
 	}
 }
 
+// tailRecElided, tailRecFun and tailRecArgs read a tail-recursion mark.
+//
+// NOT LISP-REACHABLE (#367): the marks are produced only by markTailRec and
+// consumed only inside funCall, which reaches these three accessors from
+// behind its own `r.Type == LMarkTailRec` test.  LMarkTailRec has no reader
+// syntax, no constructor a builtin can call and no path into a lisp binding,
+// so no program can present a value of any other type here.  A panic marks a
+// missing type test in the evaluator.
 func (v *LVal) tailRecElided() int {
 	if v.Type != LMarkTailRec {
 		panic("not marker-tail-recursion")
@@ -858,6 +886,19 @@ func IsInternalPanic(v *LVal) bool {
 	return ok && stack != nil && len(stack.GoStack) > 0
 }
 
+// CallStack returns the call stack attached to the error v.  CallStack panics
+// if v.Type is not LError.
+//
+// NOT LISP-REACHABLE (#367): the panic guards a Go type assertion, not a
+// program's data.  Every in-tree caller -- builtinLoad*/builtinIsKey,
+// env.Error*, macroDefun/macroDefmacro, opLambda, libjson's attachStack, and
+// the two diagnostic renderers -- tests v.Type == LError first, so lisp source
+// has no way to route a non-error here.  Reaching it means embedder Go code
+// called the accessor on a value it had not classified, and that is the
+// #351/#355 shape rather than this one.  A caller that cannot classify the
+// value should test v.Type == LError itself: the type IS the check, so an
+// accessor that answered nil would be reporting "no stack recorded" for a
+// value that can never have one.
 func (v *LVal) CallStack() *CallStack {
 	if v.Type != LError {
 		panic("not an error: " + v.Type.String())
@@ -869,6 +910,11 @@ func (v *LVal) CallStack() *CallStack {
 	return stack
 }
 
+// SetCallStack attaches a copy of stack to the error v.  SetCallStack panics
+// if v.Type is not LError.
+//
+// NOT LISP-REACHABLE (#367): same argument as CallStack above -- every
+// in-tree caller guards on v.Type == LError.
 func (v *LVal) SetCallStack(stack *CallStack) {
 	if v.Type != LError {
 		panic("not an error: " + v.Type.String())
@@ -876,6 +922,17 @@ func (v *LVal) SetCallStack(stack *CallStack) {
 	v.Native = stack.Copy()
 }
 
+// FunData returns the function metadata of v.  FunData panics if v.Type is
+// not LFun.  Package, Builtin, FID and Env are thin readers over it and
+// inherit the same requirement.
+//
+// NOT LISP-REACHABLE (#367): calling a non-function is rejected before any of
+// these are consulted -- evalSExpr answers "unbound symbol"/"not a function",
+// and the builtins that take a function argument (map, foldl/foldr, sort,
+// apply, funcall) run it through GetFunGlobal and return an error for anything
+// that is not an LFun.  The remaining callers reach it from inside a
+// `Type == LFun` branch: Docstring, str, Package.put, funCall/MacroCall,
+// libschema's isValidator, and the debugger and profiler annotators.
 func (v *LVal) FunData() *LFunData {
 	if v.Type != LFun {
 		panic("not a function: " + v.Type.String())
@@ -978,6 +1035,19 @@ func (v *LVal) UserData() *LVal {
 }
 
 // Bytes returns the []byte stored in v.  Bytes panics if v.Type is not LBytes.
+//
+// NOT LISP-REACHABLE (#367), and the guard belongs to the CALLER: every
+// in-tree caller tests v.Type == LBytes (or reaches this from inside a
+// `case LBytes`) before calling.  `(append 'bytes 0)` was the counterexample
+// -- the type SPECIFIER was validated and the sequence was not -- and it is
+// now a seed in the eval fuzz corpus, replayed on every run.
+//
+// Deliberately not softened to "return nil for a non-LBytes": nil is a
+// perfectly good empty byte string, so a caller that skipped its type check
+// would get a silent wrong answer instead of a loud one.  That is the trade
+// KeyArg's doc comment rejects.  A caller that cannot vouch for the type must
+// test it and raise its own error; TestBuiltinRegistryNeverPanics
+// (lisp/lisplib) is what finds the caller that forgot.
 func (v *LVal) Bytes() []byte {
 	if v.Type != LBytes {
 		panic("not bytes: " + v.Type.String())
@@ -987,6 +1057,14 @@ func (v *LVal) Bytes() []byte {
 	return *v.Native.(*[]byte)
 }
 
+// Map returns the map data stored in v.  Map panics if v.Type is not
+// LSortMap.
+//
+// NOT LISP-REACHABLE (#367), on the same terms as Bytes above: every in-tree
+// caller -- the sorted-map builtins, Copy's LSortMap case, equal, libschema
+// and libelpspath's path walkers -- tests LSortMap first.  Returning nil for
+// a non-map would only move the crash to the caller's next method call on the
+// nil *MapData, so the type test stays the caller's job.
 func (v *LVal) Map() *MapData {
 	if v.Type != LSortMap {
 		panic("not sorted-map: " + v.Type.String())
@@ -1712,6 +1790,16 @@ func seqCells(v *LVal) []*LVal {
 	// Callers must guard with isSeq.  The panic is the assertion for that
 	// contract -- it is in a default clause so that reaching seqCells with a
 	// type nobody thought about is loud rather than silent.
+	//
+	// NOT LISP-REACHABLE (#367): every caller either tests isSeq(v) and
+	// returns "argument is not a proper sequence" first, or passes a
+	// one-dimensional array this function just built.  isSeq is what makes
+	// the multi-dimensional case unreachable too: it requires
+	// v.Cells[0].Len() == 1, so an array with more than one dimension is
+	// rejected as a sequence before it gets here.  A caller that forgets the
+	// guard is caught by TestBuiltinRegistryNeverPanics (lisp/lisplib), which
+	// offers a multi-dimensional array to every registered builtin in every
+	// argument position.
 	switch v.Type {
 	case LSExpr:
 		return v.Cells

--- a/lisp/lisplib/panicsweep_test.go
+++ b/lisp/lisplib/panicsweep_test.go
@@ -1,0 +1,313 @@
+// Copyright © 2026 The ELPS authors
+
+package lisplib_test
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuiltinRegistryNeverPanics asserts the invariant of issue #367 over the
+// whole registered surface: no evaluated program, over any data, may take the
+// host process down with a Go panic.
+//
+// # What it does
+//
+// It walks every builtin, special operator and macro reachable from the loaded
+// standard library and calls each one THROUGH THE EVALUATOR, with a matrix of
+// adversarial argument values in every position: values of the wrong type for
+// what the function reads, empty and multi-dimensional containers, extreme
+// integers, NaN and Inf, an error value, a native value, a tagged value and a
+// function value.  Roughly 800k calls.
+//
+// # Why through the evaluator, and not by calling the LBuiltin directly
+//
+// Because "lisp-reachable" is the criterion.  Calling the Go function directly
+// bypasses arity checking, so it manufactures argument lists the evaluator
+// never produces, and it answers a DIFFERENT question -- the one
+// TestOptionalArgBuiltinsTolerateShortArgLists already answers for short
+// argument lists.  Here the arity is what a program could actually write and
+// only the argument VALUES are hostile, so a failure is a reproduction rather
+// than a hypothetical.
+//
+// # The load-bearing assertion
+//
+// env.eval recovers every Go panic into an ordinary-looking *LVal, so "the
+// test process survived" proves nothing at all.  The assertion with teeth is
+// lisp.IsInternalPanic(result) == false, exactly as in lisp/eval_fuzz_test.go:
+// it keys off the Go-stack snapshot the recover handler attaches to the error,
+// which nothing reachable from lisp can forge.
+//
+// # What it is for
+//
+// The panic sites left in the interpreter -- the type-asserting accessors
+// (LVal.Bytes, LVal.Map, LVal.FunData, LVal.CallStack), seqCells, toFloat --
+// are unreachable from lisp only because every CALLER guards.  Each one now
+// carries that argument in a comment.  A comment does not stay true on its
+// own: this test is what re-checks the arguments on every run, so the next
+// builtin that validates its type specifier but not its sequence -- which is
+// what `(append 'bytes 0)` was -- is found mechanically instead of in an
+// embedder's production process.  That is the shape #355 established for
+// CondMissingArgument, applied to type confusion instead of arity.
+//
+// # What it does not cover
+//
+// One call, at the arity a program would write, over a fixed value matrix.  It
+// does not compose calls, mutate a value between them, or drive the special
+// operators' control structure.  FuzzEval covers those, over program TEXT; the
+// two are complementary and neither subsumes the other.
+func TestBuiltinRegistryNeverPanics(t *testing.T) {
+	names := registeredCallables(t)
+	require.NotEmpty(t, names, "found no builtins to check; the registry walk is broken")
+	t.Logf("sweeping %d registered functions", len(names))
+
+	// The skip list must not rot. A name that leaves the registry, or is
+	// renamed, would otherwise sit here looking like coverage while excluding
+	// nothing -- and the reverse mistake, a skip that silently stopped
+	// applying, would let the sweep call something it must not.
+	registered := make(map[string]bool, len(names))
+	for _, name := range names {
+		registered[name] = true
+	}
+	for name := range panicSweepSkips {
+		require.Truef(t, registered[name],
+			"the skip list names %s, which is not registered; drop the entry or fix the name", name)
+	}
+
+	var evaluated, answered int
+	for _, name := range names {
+		if reason, skip := panicSweepSkips[name]; skip {
+			t.Logf("skipping %s: %s", name, reason)
+			continue
+		}
+		// A fresh environment per function. Evaluation mutates global state
+		// (set, defun, in-package, deftype), so a shared one would make a
+		// failure depend on every call that ran before it, and a reproduction
+		// that needs 800k predecessors is not a reproduction.
+		env := panicSweepEnv(t)
+		vals := panicSweepValues(env)
+		n := namedFormalCount(lookupFormals(t, env, name))
+		if n == 0 {
+			continue
+		}
+		// Only the first three positions are varied exhaustively; beyond that
+		// the cross product stops being affordable and the remaining cells
+		// rotate through the same choices. Three is enough for every shape
+		// this is aimed at: a type specifier, the value it mistypes, and an
+		// index or count that indexes it.
+		vary := min(n, 3)
+		idx := make([]int, vary)
+		for {
+			cells := make([]*lisp.LVal, 0, n+1)
+			cells = append(cells, lisp.Symbol(name))
+			for i := range n {
+				// Quote every argument: these are VALUES, and an unquoted
+				// symbol or list would be evaluated into something else
+				// before the function ever saw it.
+				cells = append(cells, lisp.Quote(vals[idx[i%vary]].Copy()))
+			}
+			res := env.Eval(lisp.SExpr(cells))
+			evaluated++
+			if res.Type != lisp.LError {
+				answered++
+			}
+			if lisp.IsInternalPanic(res) {
+				args := make([]string, 0, n)
+				for i := range n {
+					args = append(args, safeString(vals[idx[i%vary]]))
+				}
+				t.Fatalf("(%s %s) panicked the host: %v"+
+					"\na lisp program must not be able to do this (#367): the failure must be"+
+					"\nan ordinary condition the caller can handler-bind, so the builtin needs a"+
+					"\ntype check where it currently trusts its argument",
+					name, strings.Join(args, " "), res)
+			}
+			k := vary - 1
+			for k >= 0 {
+				idx[k]++
+				if idx[k] < len(vals) {
+					break
+				}
+				idx[k] = 0
+				k--
+			}
+			if k < 0 {
+				break
+			}
+		}
+	}
+
+	// Guard against a vacuous pass. Every call above could be rejected on
+	// arity or on the first argument's type without ever reaching the code
+	// this is aimed at, and the test would report success having exercised
+	// nothing. The floor is well under the measured count (~837k evaluated,
+	// ~34k answered) so ordinary growth does not have to retune it, but a
+	// registry walk that silently stops matching, or a change that makes
+	// every call fail early, fails here instead of passing.
+	t.Logf("evaluated %d calls, %d of which produced a value rather than an error", evaluated, answered)
+	require.Greater(t, evaluated, 100_000, "the sweep evaluated too few calls to be meaningful")
+	require.Greater(t, answered, 5_000,
+		"almost every call in the sweep errored; the arguments are being rejected before"+
+			" reaching the code paths this is aimed at")
+}
+
+// safeString renders a value for a failure message without trusting it to be
+// renderable.  Rendering is itself interpreter code reachable from lisp, so a
+// value that panics a builtin may well panic String too -- and a report that
+// dies while describing the defect it found reports nothing.  The recovered
+// case still names the type, which is the part that identifies the input.
+func safeString(v *lisp.LVal) (s string) {
+	defer func() {
+		if r := recover(); r != nil {
+			s = fmt.Sprintf("<unrenderable %v: %v>", v.Type, r)
+		}
+	}()
+	return v.String()
+}
+
+// panicSweepSkips names the registered functions the sweep must not call, and
+// why. Each is a function whose EFFECT, not whose failure mode, makes it
+// unsuitable -- none is excluded for being suspected of panicking.
+var panicSweepSkips = map[string]string{
+	// The loaders evaluate their argument as a program. That is FuzzEval's
+	// job, done there under a step and time budget this test does not set up;
+	// running it here would make the sweep's cost depend on what the matrix
+	// happens to spell.
+	"lisp:load-file":   "evaluates its argument as a program",
+	"lisp:load-string": "evaluates its argument as a program",
+	"lisp:load-bytes":  "evaluates its argument as a program",
+	"time:sleep":       "blocks for the duration in its argument",
+	// The testing package runs its body as a subtest against the ambient
+	// *testing.T, so calling it from inside one reports failures for programs
+	// this test made up.
+	"testing:test":      "runs its body as a test",
+	"testing:test-let":  "runs its body as a test",
+	"testing:benchmark": "runs its body as a benchmark",
+}
+
+// panicSweepEnv builds a fully loaded environment under a bounded evaluation
+// budget, with debug output captured rather than written to the test's
+// streams.
+//
+// Runtime.Library is left nil on purpose, as in newFuzzEnv: that is what makes
+// load-file return an error instead of reading the filesystem, so a call this
+// test generates cannot escape onto the test machine's disk.
+func panicSweepEnv(t *testing.T) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	rc := lisp.InitializeUserEnv(env,
+		lisp.WithStderr(&bytes.Buffer{}),
+		lisp.WithMaxSteps(200_000),
+		lisp.WithMaxTailIterations(10_000),
+		lisp.WithMaximumPhysicalStackHeight(500),
+		lisp.WithMaxAlloc(100_000),
+	)
+	require.NotEqual(t, lisp.LError, rc.Type, "initialize-user-env: %v", rc)
+	rc = lisplib.LoadLibrary(env)
+	require.NotEqual(t, lisp.LError, rc.Type, "load-library: %v", rc)
+	rc = env.InPackage(lisp.String(lisp.DefaultUserPackage))
+	require.NotEqual(t, lisp.LError, rc.Type, "in-package: %v", rc)
+	return env
+}
+
+// panicSweepValues is the adversarial matrix. Every entry is a value a lisp
+// program can hold, and every entry is the wrong type for most of the places
+// it will be offered.
+func panicSweepValues(env *lisp.LEnv) []*lisp.LVal {
+	m := lisp.SortedMap()
+	m.MapSet("a", lisp.Int(1))
+	nested := lisp.SortedMap()
+	nested.MapSet("a", lisp.QExpr([]*lisp.LVal{lisp.Int(1), lisp.SortedMap()}))
+	nested.MapSet("b", lisp.Bytes([]byte("z")))
+	return []*lisp.LVal{
+		lisp.Nil(),
+		lisp.Bool(true),
+		lisp.Int(0),
+		lisp.Int(2),
+		lisp.Int(-1),
+		lisp.Int(math.MaxInt),
+		lisp.Int(math.MinInt),
+		lisp.Float(1.5),
+		lisp.Float(math.NaN()),
+		lisp.Float(math.Inf(1)),
+		lisp.String(""),
+		lisp.String("x"),
+		lisp.Symbol("x"),
+		// The type specifiers the sequence and byte builtins dispatch on.
+		// Offering them is what gets past the FIRST argument's validation and
+		// into the code that reads the second one -- the shape
+		// `(append 'bytes 0)` had.
+		lisp.Symbol("bytes"),
+		lisp.Symbol("list"),
+		lisp.Symbol("vector"),
+		lisp.Symbol("string"),
+		lisp.Bytes([]byte("ab")),
+		lisp.Bytes(nil),
+		m,
+		nested,
+		// A MULTI-dimensional array: not a sequence, and the value that
+		// reaches seqCells' first panic if a caller forgets isSeq.
+		lisp.Array(lisp.QExpr([]*lisp.LVal{lisp.Int(2), lisp.Int(2)}),
+			[]*lisp.LVal{lisp.Int(1), lisp.Int(2), lisp.Int(3), lisp.Int(4)}),
+		lisp.Vector([]*lisp.LVal{lisp.Int(1), lisp.Int(2)}),
+		lisp.Vector(nil),
+		// An array built the way an embedder builds one, with no backing
+		// storage supplied. Every element is Nil; it was a Go nil *LVal
+		// before #367, and reading one panicked the host.
+		lisp.Array(lisp.QExpr([]*lisp.LVal{lisp.Int(3)}), nil),
+		lisp.QExpr([]*lisp.LVal{lisp.Int(1), lisp.Int(2)}),
+		lisp.QExpr([]*lisp.LVal{lisp.QExpr([]*lisp.LVal{lisp.String("a"), lisp.Int(1)})}),
+		lisp.Errorf("boom"),
+		lisp.Native(struct{}{}),
+		env.GetGlobal(lisp.Symbol("car")),
+		env.TaggedValue(lisp.Symbol("sweep-type"), lisp.Int(1)),
+	}
+}
+
+// registeredCallables returns the qualified name of every builtin, special
+// operator and macro in the registry, in a stable order.
+//
+// The `user` package is skipped: it re-exports `lisp` rather than registering
+// anything of its own, so including it would double the run for no new code.
+func registeredCallables(t *testing.T) []string {
+	t.Helper()
+	env, err := lisplib.NewDocEnv()
+	require.NoError(t, err)
+	var names []string
+	for pkgName, pkg := range env.Runtime.Registry.Packages {
+		if pkgName == lisp.DefaultUserPackage {
+			continue
+		}
+		for sym, v := range pkg.Symbols {
+			if v == nil || v.Type != lisp.LFun || v.Builtin() == nil || len(v.Cells) == 0 {
+				continue
+			}
+			names = append(names, pkgName+":"+sym)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// lookupFormals returns the formal argument list bound to a qualified name.
+func lookupFormals(t *testing.T, env *lisp.LEnv, qualified string) *lisp.LVal {
+	t.Helper()
+	pkgName, sym, ok := strings.Cut(qualified, ":")
+	require.True(t, ok, "not a qualified symbol: %s", qualified)
+	pkg := env.Runtime.Registry.Packages[pkgName]
+	require.NotNil(t, pkg, "package not in registry: %s", pkgName)
+	v := pkg.Symbols[sym]
+	require.NotNil(t, v, "symbol not in package: %s", qualified)
+	require.NotEmpty(t, v.Cells, "function has no formals: %s", qualified)
+	return v.Cells[0]
+}

--- a/lisp/loader.go
+++ b/lisp/loader.go
@@ -28,6 +28,12 @@ type LocationReader interface {
 
 // LoaderMust returns its first argument when err is nil.  If err is nil
 // LoaderMust panics.
+//
+// NOT LISP-REACHABLE (#367): this is the Go `Must` idiom, for an embedder
+// building a Loader from a source it controls (a //go:embed constant, a
+// literal) at start-up.  Nothing in the interpreter calls it, so no evaluated
+// program can reach it; an embedder wrapping a source a program supplies
+// should handle the error instead.
 func LoaderMust(fn Loader, err error) Loader {
 	if err != nil {
 		panic(err)

--- a/lisp/singleton.go
+++ b/lisp/singleton.go
@@ -50,6 +50,12 @@ func isSingleton(v *LVal) bool {
 // a guard at the entry of any function that walks an LVal tree and
 // writes to LVal fields. Cheap (one pointer compare against each of
 // three constants), documents intent, and surfaces regressions loudly.
+//
+// NOT LISP-REACHABLE (#367): it is a deliberate detector for a Go-side
+// defect -- host code writing through a pointer to shared memory (#274,
+// #333) -- and the condition it detects is a property of elps's own code,
+// not of any program's data. It has no callers today; a caller that adds
+// it is asserting its own correctness, so the panic stays a panic.
 func assertNotSingleton(v *LVal) {
 	if isSingleton(v) {
 		panic(fmt.Sprintf("internal error: attempt to mutate singleton LVal (%s)", v.Type))

--- a/lisp/singleton_check_elpscheck.go
+++ b/lisp/singleton_check_elpscheck.go
@@ -67,6 +67,11 @@ func init() {
 // If you are adding a mutation guard, prefer removing the mutation. The
 // codebase's copy-on-write helpers (Quote, Splice, shallowUnquote) exist
 // so that no caller has to reason about whether a value is shared.
+//
+// NOT LISP-REACHABLE (#367): a deliberate corruption detector, compiled only
+// under the `elpscheck` build tag, whose trigger is elps's own code having
+// written to shared memory. It stays a panic on purpose -- turning it into a
+// condition would let the corrupted process keep running.
 func checkSingleton(_ *LVal) {
 	if drift := initSnapshot.Verify(); drift != "" {
 		panic(fmt.Sprintf("singleton corruption detected: %s mutated\n  current Nil=%+v\n  current True=%+v\n  current False=%+v",

--- a/lisp/stack.go
+++ b/lisp/stack.go
@@ -291,6 +291,13 @@ func (s *CallStack) CheckTailCall() error {
 // is empty Pop returns nil.
 func (s *CallStack) Pop() CallFrame {
 	if len(s.Frames) < 1 {
+		// NOT LISP-REACHABLE (#367): all three callers (funCall, MacroCall,
+		// SpecialOpCall) install the Pop as a `defer` on the line after a
+		// PushFID that returned no error, so pushes and pops are balanced by
+		// construction along every exit path, panics included.  Tail-call
+		// elision does not pop frames -- it decrements a counter on the mark
+		// and reuses the frame already pushed -- so it cannot unbalance them
+		// either.  An empty stack here means a push/pop pair was separated.
 		panic("pop called on an empty stack")
 	}
 	f := s.Frames[len(s.Frames)-1]

--- a/lisp/x/profiler/callgrind.go
+++ b/lisp/x/profiler/callgrind.go
@@ -195,6 +195,13 @@ func (p *callgrindProfiler) incrementCallRef(name string, loc *token.Location) *
 }
 
 // Finds a call ref for the current scope
+//
+// NOT LISP-REACHABLE (#367): the refs are pushed by Start and popped by the
+// closure Start returns, which the evaluator installs as a `defer`, so a
+// program's calls and returns are balanced no matter what the program does.
+// The one unbalanced pop is Complete() -- embedder lifecycle API -- called
+// before Enable() or called twice, which is Go API misuse at integration time
+// and stays a panic.
 func (p *callgrindProfiler) getCallRefAndDecrement() *callRef {
 	//C.GetGoId(thread)
 	thread := &([]int32{1}[0])


### PR DESCRIPTION
## Summary

Completes #367: no program text the interpreter evaluates, over any data, may take the host down with a Go panic. The criterion is lisp-**reachability**, not the count of `panic(` sites — panics only embedder Go code can trigger stay panics, but each now carries a recorded one-line argument for why lisp cannot reach it, rather than an assumption.

All 20 sites in `lisp/`, `lisp/lisplib/`, and `lisp/x/` were classified. **One was reproducibly lisp-reachable and is fixed; the other nineteen carry reachability arguments at the panic itself.**

### The reproduction (fixed)

`lisp.Array` documents that `cells` may be nil, but an embedder following that documentation got an array holding Go-nil `*LVal`s in every element — a value the interpreter cannot hold:

```
env.PutGlobal(lisp.Symbol("a"), lisp.Array(lisp.QExpr([]*lisp.LVal{lisp.Int(3)}), nil))
(aref a 0)      ; internal-panic: nil pointer dereference
(equal? a a)    ; internal-panic: nil pointer dereference
```

Wrong twice over: reading an unset element is not an error at all, and `internal-panic` is deliberately uncatchable by `handler-bind`, so the host had no way to contain it. Unset elements are now `Nil()` — fixed in the **constructor** (the value should never exist) rather than in `aref`, `equal?`, and every other reader. `builtinConcatSeq`'s vector branch is restructured off the half-built-container pattern, recovering the ~8% the constructor's nil-initialization would otherwise have cost `BenchmarkAliasConcatCopy` (measured; other vector benchmarks within noise).

### The other nineteen

Hazard-only conversions to documented arguments: accessors whose callers all guard (`Bytes`, `Map`, `FunData`, `CallStack`, `seqCells`, `toFloat`), internal evaluator invariants (tail-recursion markers, mark decrements), embedder-registration panics (#351's contract), the deliberate elpscheck detector, and the callgrind profiler's lifecycle API. The accessors deliberately keep the panic: softening `LVal.Bytes` to return nil turns a loud failure into a silent wrong answer, and softening `LVal.Map` just moves the crash to the caller's next method call.

### Enforcement

- `lisp/lisplib/panicsweep_test.go` — a registry-walking sweep (the #355 `TestOptionalArgBuiltinsTolerateShortArgLists` pattern) that finds the next instance mechanically, including a multi-dimensional-array row in its matrix.
- `internal/fuzzseed/evalseed.go` — new eval seeds targeting the guarded accessors and the array shapes.
- `lisp/array_test.go` — the reproduction pinned red-to-green.

## Test plan

- `make test` — all packages pass (a few `go: no such tool "covdata"` lines on this host are a local toolchain gap on no-test packages; proven passing without `-cover`)
- `go test -race` on `lisp/`, `lisp/lisplib/`, `lisp/x/profiler/` — green
- `./elps doc -m` — all documented
- `make static-checks` — only two pre-existing `nolintlint` findings in `parser/token/token.go` (byte-identical to main; local golangci-lint 2.5.0 version skew), nothing from this diff
- Fuzz corpora replay as part of `go test` — green

Fixes #367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq

---
_Generated by [Claude Code](https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq)_