### PR TITLE
scripts: delete the unused libjson Package/$load B/op benchstat waiver

### DIFF
--- a/scripts/benchstat-waivers.txt
+++ b/scripts/benchstat-waivers.txt
@@ -94,18 +94,8 @@
 # pkg | benchmark | metric | ceiling | expires | issue | reason
 # ---------------------------------------------------------------------------
 #
-
-# elps#363 -- libjson Package/$load, the env-construction allocation cost.
-#
-# Every environment now copies the formals of every builtin it registers
-# instead of aliasing one process-wide LVal (elps#363): the copy is what the
-# fix IS, so the bytes are irreducible.  The cost lands once per environment
-# construction and never on the eval path; Package/$load is the one benchmark
-# that builds a full env per iteration, so it pays the whole bill in B/op
-# (+9.45% measured, interleaved n=12) while its sec/op is unchanged and every
-# eval-path benchmark is flat.  Ceiling 12% against the measured 9.45%: a
-# second allocation regression landing on env construction still reds the
-# build.  elps#379's interning work is the plausible future reducer; when a
-# cheaper representation lands, re-measure and delete this entry.
-
-github.com/luthersystems/elps/lisp/lisplib/libjson | Package/$load | B/op | 12 | 2027-02-28 | elps#363 | env construction copies every builtin's formals per environment (elps#363); the copy is the fix, paid once per env load, eval path flat; revisit when elps#379 interning lands
+# (No active waivers.  The last entry -- the elps#363 libjson Package/$load
+# B/op waiver for the fresh-formals-per-env copy -- was deleted once the
+# seal-enabled env-construction work landed (elps#519) and the gate reported
+# the row `waiver-unused` on every run; see elps#514 for the remaining
+# eval-path reclaim.)

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -302,8 +302,9 @@ assert_contains "+12.45%" "the B/op row is named too — it is over the allocati
 # The after half: the shipped list no longer carries the two #411 Encode
 # entries -- they were deleted (#413) once elps#412's fix removed the
 # regression they accepted and the gate had reported both waiver-unused.
-# (The elps#363 env-construction entry it does carry names a different row
-# and cannot reach the Encode columns.)  What the DEFAULT path (no
+# (The elps#363 env-construction entry that later joined the list was
+# deleted the same way once the gate reported it waiver-unused; the shipped
+# list is now empty.)  What the DEFAULT path (no
 # BENCH_WAIVERS override) must prove now is the deletion's other side: with
 # the Encode entries gone, the same real comparison fires the gate again --
 # the rows came back the moment their acceptance was withdrawn, which is the


### PR DESCRIPTION
## Summary

Deletes the last remaining benchstat waiver — the elps#363 libjson `Package/$load` B/op entry (ceiling 12%, expiry 2027-02-28) — from `scripts/benchstat-waivers.txt`.

The waiver covered the env-construction allocation cost of the fresh-formals-per-env fix (#513). Since the seal-enabled env-construction optimizations landed (#519), the row no longer regresses and the gate has reported the entry `waiver-unused` on every recent CI run — which is, per the waiver file's own header, "the signal to delete the entry". The row's protection does not weaken: with the entry gone, any future `Package/$load` B/op regression is judged against the ordinary 5% allocation gate again.

Also updates the now-stale parenthetical in `scripts/ci-gates-test.sh` that described the shipped list as still carrying this entry; the assertions themselves are unchanged (they already prove the "shipped list empty ⇒ rows come back" property this deletion relies on).

Refs #514 (its item 3 records this deletion as the follow-through; the eval-path characterize/reclaim items remain open there). #363 itself is already closed.

## Test plan

- [x] `bash scripts/ci-gates-test.sh` — 322 passed, 0 failed against the emptied shipped list
- [x] `scripts/benchstat-gate.sh` run directly against the real #411 fixture with the edited waiver file: exits 1 with the un-waived rows judged again (no exit-2 parse error, no `WAIVER-STALE`)
- [x] `go test ./...` — all packages pass
- [x] `make static-checks` — only the 2 pre-existing nolintlint findings in `parser/token/token.go`, unrelated to this change
- [x] `scripts/confidentiality-guard.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq

---
_Generated by [Claude Code](https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq)_