### PR TITLE
lisp: seal Program trees at construction, closing the #394 leak

### DIFF
--- a/docs/embed.md
+++ b/docs/embed.md
@@ -80,11 +80,15 @@ genuinely needs the AST (tooling, serialization, transfer between runtimes)
 exists in-kernel (`detach`, returning hermetic deep copies) but is
 unexported until a real embedder consumer materializes.
 
-Note the scope of the guarantee: `Program` seals the parse/cache boundary so
-AST nodes cannot *escape* to the embedder.  Full hermetic sealing is the
-composition of this boundary type with seals on evaluation's own AST leak
-points (quote and macro paths inside eval) — see the `Program` godoc for
-details.
+The guarantee runs in both directions.  Outward, `Program` seals the
+parse/cache boundary so AST nodes cannot *escape* to the embedder.  Inward,
+the constructors establish the hermetic seal (`docs/sealed-ast.md`) on the
+expressions they admit: reader output that is not already sealed throughout
+— a format-preserving parser, a caller-written `Reader` — is privately
+copied and sealed, and output the seal cannot protect (reference types,
+function values) is rejected with an error (elps#394).  A cached `Program`
+is therefore always safe to load from many environments — see the `Program`
+godoc for details.
 
 ## Writing Functions
 

--- a/docs/sealed-ast.md
+++ b/docs/sealed-ast.md
@@ -511,14 +511,20 @@ intends to mutate data it did not construct copies unconditionally.
 
 1. **Parse through a sealing path.** `Reader.Read`, `LoadString`,
    `ParseProgram`/`ReadProgram` all seal. Prefer `lisp.Program` at your
-   cache boundary. (Owned expressions need the in-kernel `detach()`
-   machinery, which is unexported today; it will be re-exported when a real
-   embedder consumer materializes.) If you build trees by hand and share
-   them across environments, call `SealAST()` on each root yourself.
+   cache boundary: its constructors *establish* the seal at admission
+   (elps#394) — reader output that is not already sealed throughout is
+   privately copied and sealed, and output the seal cannot protect
+   (reference types, function values) is rejected with an error. (Owned
+   expressions need the in-kernel `detach()` machinery, which is unexported
+   today; it will be re-exported when a real embedder consumer
+   materializes.) If you build trees by hand and share them across
+   environments, call `SealAST()` on each root yourself.
 2. **Never install a format-preserving reader into an evaluating runtime.**
    `parser.NewReader(parser.WithFormatPreserving())` produces *unsealed*
    trees for tooling (formatter/minifier/lint); it satisfies `lisp.Reader`,
-   so nothing but this contract stops you.
+   so nothing but this contract stops you on the `Load*` paths. The
+   `Program` constructors are the exception: they detect the unsealed
+   parse and admit a private sealed copy instead (elps#394).
 3. **In every builtin or Go helper that mutates a value in place:** check
    `v.IsSealed()` first; refuse with an error or operate on `v.Copy()`.
    Remember slices of `Cells` share backing — copy the cells, not just the

--- a/lisp/program.go
+++ b/lisp/program.go
@@ -31,17 +31,18 @@ import (
 // (program_seal_test.go) guards the surface: no exported method may expose
 // *LVal.
 //
-// Scope of the guarantee: Program seals the parse/cache boundary — it stops
-// raw AST nodes from ESCAPING to embedders.  It does not, by itself, make one
-// Program safe to evaluate in multiple runtimes concurrently: evaluation can
-// still alias parts of the AST into runtime values through quote and macro
-// paths inside eval.  Sealing those eval-side leak points is separate work
-// (the exp-ast-leakpoints line); full hermetic sealing is the composition of
-// the two — Program at the boundary, leak seals inside eval.  Until then,
-// treat a shared Program like any shared AST: reuse within one runtime is
-// fine, cross-runtime reuse has the aliasing caveats of issues #288/#362,
-// and the in-kernel detach machinery is what a sanctioned hand-off of a
-// private copy would use (unexported until a consumer appears).
+// Scope of the guarantee: Program seals the parse/cache boundary in both
+// directions.  Outward, it stops raw AST nodes from ESCAPING to embedders
+// (the compile-time seal above).  Inward, every constructor establishes the
+// hermetic seal (lisp/seal.go) on the expressions it admits — reader output
+// that is not already sealed throughout is privately copied and sealed, and
+// output the seal cannot cover is rejected (see newProgram, issue #394) —
+// so the sharing a parse cache does is always the sanctioned kind: sealed
+// nodes are frozen storage under copy-on-write protection, and evaluating
+// one Program from many environments cannot corrupt it for the others.
+// Concurrency is unchanged by any of this: a Runtime serves one goroutine,
+// so concurrent evaluation still means one environment per goroutine, all
+// of them free to share the sealed Program.
 //
 // The zero Program is valid, empty, and evaluates to nil.
 type Program struct {
@@ -88,7 +89,11 @@ func (p Program) detach() ([]*LVal, error) {
 
 // ReadProgram parses the contents of r using reader and seals the result as
 // a Program.  The parsed expression slice never leaves this package: it goes
-// directly from the reader's return value into the sealed Program.
+// from the reader's return value through newProgram's seal admission into
+// the sealed Program.  Reader output that is not already hermetically sealed
+// (a format-preserving parser, a caller-written Reader) is privately copied
+// and sealed; output the seal cannot protect — reference types, function
+// values — is rejected with an error.  See newProgram.
 func ReadProgram(reader Reader, name string, r io.Reader) (Program, error) {
 	if reader == nil {
 		return Program{}, errors.New("nil reader")
@@ -97,7 +102,7 @@ func ReadProgram(reader Reader, name string, r io.Reader) (Program, error) {
 	if err != nil {
 		return Program{}, err
 	}
-	return Program{exprs: exprs}, nil
+	return newProgram(exprs)
 }
 
 // ReadLocationProgram is ReadProgram for a LocationReader, assigning physical
@@ -110,7 +115,7 @@ func ReadLocationProgram(reader LocationReader, name, loc string, r io.Reader) (
 	if err != nil {
 		return Program{}, err
 	}
-	return Program{exprs: exprs}, nil
+	return newProgram(exprs)
 }
 
 // ParseProgram parses the contents of r using env.Runtime.Reader and seals
@@ -126,6 +131,113 @@ func (env *LEnv) ParseProgram(name, loc string, r io.Reader) (Program, error) {
 		return ReadLocationProgram(reader, name, loc, r)
 	}
 	return ReadProgram(env.Runtime.Reader, loc, r)
+}
+
+// newProgram is the single admission point for every Program constructor:
+// reader output becomes a Program only after the hermetic seal that makes
+// Program's boundary guarantee true is actually established (issue #394).
+//
+// Program's premise is that a cached parse "cannot leak *LVal pointers
+// between environments by construction", and before this check the premise
+// held only when the Reader happened to seal.  The standard parser does
+// (rdparser.ParseExpression calls SealAST on each completed top-level
+// expression); a format-preserving parser deliberately does not (its Meta
+// construction continues past the parser's seal point); and a
+// caller-supplied Reader may do anything at all, including handing the same
+// tree to every Read call.  Wrapping such output unchecked shared one
+// unsealed, mutable tree among every environment that loaded the Program —
+// the substrate#378 corruption class, with no diagnostic in a production
+// build.
+//
+// The admission asks TextLoader's questions, in TextLoader's order, adapted
+// to the different mechanism (TextLoader hands each load a private copy;
+// Program hands every load the same sealed tree):
+//
+//   - checkLoaderExpr runs first, verbatim.  Reference types (bytes, map,
+//     array, native) share mutable state through every copy AND every
+//     evaluation — SealAST declines to mark them and Copy preserves their
+//     reference semantics — so no admission can make them safe to share and
+//     they are rejected with TextLoader's error.
+//   - Output that is already sealed throughout is admitted as-is.  This is
+//     the standard-parser fast path, and the sharing it takes is the
+//     sanctioned kind: sealed nodes are frozen storage under copy-on-write
+//     protection, shared across runtimes by design (lisp/seal.go;
+//     elpstest.RunBenchmark takes the same share).  The check is a deep
+//     walk, not a root check: SealAST stops without descending at anything
+//     it declines to mark, so a Reader can hand back a sealed root over
+//     unsealed storage.  (RunBenchmark's root-only check is sound only
+//     because it constructed the parser itself; a Program's Reader belongs
+//     to the caller.)
+//   - Anything else gets the private-copy-and-seal treatment: Copy severs
+//     every alias the Reader may have retained (cells, locations, and
+//     format metadata are all detached), and SealAST freezes the copy.
+//     Sealing here is safe even for a format-preserving parse — the parser
+//     skips SealAST because Meta construction continues past its per-
+//     expression seal point, but Read has returned by now, so construction
+//     is complete.
+//   - A node that even the fresh copy cannot seal (a function value, say —
+//     no parser produces one, but the Reader interface cannot promise
+//     that) would reopen the same hole one Reader further out, so it is
+//     rejected.  This is the one place the admission is deliberately
+//     stricter than TextLoader: TextLoader's per-load copies mean its
+//     cached tree is never itself shared between environments, but for
+//     Program the seal is the only thing standing between environments, so
+//     "cannot seal" has to mean "cannot admit".
+func newProgram(exprs []*LVal) (Program, error) {
+	for _, expr := range exprs {
+		if err := checkLoaderExpr(expr); err != nil {
+			lerr := Error(err)
+			// Copied, not aliased: the error escapes to the caller through
+			// GoError while expr remains the Reader's property, so the two
+			// must not share a *token.Location (TextLoader's rule; cold
+			// path, the copy is free in practice).
+			lerr.source = copyLocation(expr.source)
+			return Program{}, GoError(lerr)
+		}
+	}
+	allSealed := true
+	for _, expr := range exprs {
+		if firstUnsealed(expr) != nil {
+			allSealed = false
+			break
+		}
+	}
+	if allSealed {
+		return Program{exprs: exprs}, nil
+	}
+	sealed := make([]*LVal, len(exprs))
+	for i, expr := range exprs {
+		cp := expr.Copy()
+		cp.SealAST()
+		if u := firstUnsealed(cp); u != nil {
+			lerr := Error(fmt.Errorf("cannot seal expression of type %v into a program", u.Type))
+			// Copied, not aliased, as above — u's location was already
+			// privately copied from the Reader's tree, but the program copy
+			// is discarded on this path while the error escapes, and the
+			// rule is cheaper to follow than to prove unnecessary.
+			lerr.source = copyLocation(u.source)
+			return Program{}, GoError(lerr)
+		}
+		sealed[i] = cp
+	}
+	return Program{exprs: sealed}, nil
+}
+
+// firstUnsealed returns the first node reachable through v's Cells that is
+// not sealed, or nil when the tree is sealed throughout.  The trees it
+// walks were admitted by checkLoaderExpr, whose recursion already assumes
+// finite, non-nil parser-shaped nodes; the same custody assumption applies
+// here.
+func firstUnsealed(v *LVal) *LVal {
+	if !v.IsSealed() {
+		return v
+	}
+	for _, c := range v.Cells {
+		if u := firstUnsealed(c); u != nil {
+			return u
+		}
+	}
+	return nil
 }
 
 // LoadProgram evaluates the program's expressions as if in a progn, exactly

--- a/lisp/program_seal_gap_elpscheck_test.go
+++ b/lisp/program_seal_gap_elpscheck_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2026 The ELPS authors
+
+//go:build elpscheck
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// Checked-mode half of the issue #394 red proof (default-build half:
+// program_seal_gap_test.go).
+//
+// The ownership checker's allowlist admits exactly two kinds of value to
+// cross a runtime boundary: singletons and SEALED nodes (see the Allowlist
+// section of lisp/ownership_check_elpscheck.go).  On the unfixed tree a
+// Program built through the format-preserving reader carried UNSEALED
+// nodes, so this test's second LoadProgram was a cross-runtime sighting
+// and the checker panicked with "ownership violation: LVal used by two
+// Runtimes" — the detection the issue documents.  With the constructors
+// establishing the seal, the same evaluation is the sanctioned sealed
+// share: no panic, identical results, and the seal census that SealAST
+// recorded at admission verifies clean afterwards.
+func TestProgramSealGapCheckedCrossRuntime(t *testing.T) {
+	p := formatPreservingProgram(t, sealGapSrc)
+
+	for i := range 2 {
+		// Each iteration is a fresh Runtime.  Pre-fix, iteration 2 panics
+		// in the ownership checker before producing any value.
+		got := programTestEnv(t).LoadProgram(p)
+		if got.Type == lisp.LError {
+			t.Fatalf("runtime %d: %v", i+1, got)
+		}
+		if got.String() != sealGapWant {
+			t.Errorf("runtime %d = %v, want %s", i+1, got, sealGapWant)
+		}
+	}
+
+	// The admission sealed (and therefore recorded) the Program's tree;
+	// the census must agree nothing wrote it in place.
+	if err := lisp.VerifySealedASTs(); err != nil {
+		t.Fatalf("seal census after cross-runtime Program loads: %v", err)
+	}
+}

--- a/lisp/program_seal_gap_test.go
+++ b/lisp/program_seal_gap_test.go
@@ -1,0 +1,303 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/internal/astraw"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+)
+
+// This file covers issue #394: the Program constructors accepting reader
+// output WITHOUT the seal admission, so a Program could hand one unsealed
+// tree to every environment that loaded it.
+//
+// Program's doc comment promises that an embedder's parse cache "cannot
+// leak *LVal pointers between environments by construction".  Before the
+// fix that held only when the Reader happened to seal: the standard parser
+// does, but parser.NewReader(parser.WithFormatPreserving()) deliberately
+// does not (a supported public option), and a caller-written Reader may
+// return anything, including the same tree on every Read.  One environment
+// evaluating (stable-sort > literal) then rewrote the program literal for
+// every other environment sharing the Program — the substrate#378 class,
+// silent in a production build.
+//
+// Layers of coverage, mirroring libelpspath/path_seal_test.go:
+//
+//	(1) TestProgramFormatPreservingParseIsSealed — issue reproduction A:
+//	    the one-line public-API misuse, one Program, three environments,
+//	    each reporting the literal BEFORE it mutates anything.
+//	(2) TestProgramCopiesAliasedReaderOutput — issue reproduction B: a
+//	    Reader that retains (and re-serves) its output; the Program must
+//	    own a private sealed copy.
+//	(3) TestProgramSharesSealedParserOutput — the fast path pin: already-
+//	    sealed parser output is admitted as-is, not copied, so the fix
+//	    cannot silently change the parse cache's cost model.
+//	(4) Rejection tests for output the seal cannot protect, mirroring
+//	    (and one step past) TextLoader's checkLoaderExpr.
+//
+// The checked-mode half of the red proof lives in
+// program_seal_gap_elpscheck_test.go: pre-fix, the cross-runtime evaluation
+// below panicked a -tags elpscheck binary with "ownership violation: LVal
+// used by two Runtimes".
+
+// sealGapSrc is the reproduction program.  The let materializes the
+// literal's head BEFORE the sort touches anything, so the returned value is
+// an immutable snapshot of what this environment saw: 10 from a pristine
+// literal, 30 from the wreckage a previous environment left behind.
+const sealGapSrc = `(defun limits () '(10 20 30))
+(let ([pre (car (limits))]) (stable-sort > (limits)) pre)
+`
+
+// sealGapWant is what every load must return: the pristine literal's head.
+const sealGapWant = "10"
+
+// programSealedThroughout walks every node of the program's expressions and
+// returns the first unsealed one, or nil.  A root-only check would pass a
+// sealed header over unsealed storage, which is one of the shapes the
+// admission must catch.
+func programSealedThroughout(p lisp.Program) *lisp.LVal {
+	var walk func(v *lisp.LVal) *lisp.LVal
+	walk = func(v *lisp.LVal) *lisp.LVal {
+		if !v.IsSealed() {
+			return v
+		}
+		for _, c := range v.Cells {
+			if u := walk(c); u != nil {
+				return u
+			}
+		}
+		return nil
+	}
+	for _, expr := range astraw.Exprs(p) {
+		if u := walk(expr); u != nil {
+			return u
+		}
+	}
+	return nil
+}
+
+// formatPreservingProgram parses src through the format-preserving reader —
+// the supported public option whose documented behaviour is to skip the
+// parser's seal — via ParseProgram, the constructor an embedder wiring
+// that reader into a runtime actually hits.
+func formatPreservingProgram(t *testing.T, src string) lisp.Program {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader(parser.WithFormatPreserving())
+	p, err := env.ParseProgram("gap.lisp", "gap.lisp", strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("ParseProgram: %v", err)
+	}
+	return p
+}
+
+// TestProgramFormatPreservingParseIsSealed is issue #394's reproduction A.
+//
+// One Program built through the format-preserving reader, three fresh
+// environments.  Each environment snapshots the literal's head before
+// sorting it; every snapshot must be the pristine one, and must agree with
+// a freshly-parsed baseline.  On the unfixed tree env2 and env3 read env1's
+// write before running anything of their own.
+func TestProgramFormatPreservingParseIsSealed(t *testing.T) {
+	p := formatPreservingProgram(t, sealGapSrc)
+
+	if u := programSealedThroughout(p); u != nil {
+		t.Errorf("a Program built from format-preserving reader output holds an unsealed %v node;"+
+			" the constructors did not establish the seal", u.Type)
+	}
+
+	want := programTestEnv(t).LoadString("gap.lisp", sealGapSrc)
+	if want.Type == lisp.LError {
+		t.Fatalf("baseline load: %v", want)
+	}
+	if want.String() != sealGapWant {
+		t.Fatalf("baseline = %v, want %s; the reproduction program no longer probes the literal", want, sealGapWant)
+	}
+
+	for i := range 3 {
+		got := programTestEnv(t).LoadProgram(p)
+		if got.Type == lisp.LError {
+			t.Fatalf("environment %d: %v", i+1, got)
+		}
+		if got.String() != want.String() {
+			t.Errorf("environment %d read another environment's write out of the shared Program:"+
+				" got %v, want %v (the pristine literal)", i+1, got, want)
+		}
+	}
+}
+
+// aliasingReader is reproduction B's Reader: it retains its expression
+// slice and hands the SAME slice to every Read call, the way a caller-side
+// cache would.  Program must not admit those nodes by reference.
+type aliasingReader struct {
+	exprs []*lisp.LVal
+	err   error
+}
+
+func (r *aliasingReader) Read(name string, _ io.Reader) ([]*lisp.LVal, error) {
+	return r.exprs, r.err
+}
+
+// unsealedExprs parses src into an UNSEALED tree (via the format-preserving
+// parser) for use as hostile reader output, with an anti-vacuity check that
+// it really is unsealed — otherwise every assertion downstream is about the
+// parser, not about the admission.
+func unsealedExprs(t *testing.T, src string) []*lisp.LVal {
+	t.Helper()
+	exprs, err := parser.NewReader(parser.WithFormatPreserving()).Read("gap.lisp", strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for i, expr := range exprs {
+		if expr.IsSealed() {
+			t.Fatalf("anti-vacuity: format-preserving expr %d is sealed; the hostile-reader fixture is broken", i)
+		}
+	}
+	return exprs
+}
+
+// TestProgramCopiesAliasedReaderOutput is issue #394's reproduction B, plus
+// the ownership assertions that make "copied" checkable: two Programs built
+// from one retained slice must not share nodes with the reader or with each
+// other, and vandalizing the reader's tree after construction must not
+// change what either Program evaluates to.
+func TestProgramCopiesAliasedReaderOutput(t *testing.T) {
+	reader := &aliasingReader{exprs: unsealedExprs(t, sealGapSrc)}
+
+	p1, err := lisp.ReadProgram(reader, "gap.lisp", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("ReadProgram 1: %v", err)
+	}
+	p2, err := lisp.ReadProgram(reader, "gap.lisp", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("ReadProgram 2: %v", err)
+	}
+
+	for _, p := range []lisp.Program{p1, p2} {
+		if u := programSealedThroughout(p); u != nil {
+			t.Errorf("a Program built from unsealed reader output holds an unsealed %v node", u.Type)
+		}
+	}
+	raw1, raw2 := astraw.Exprs(p1), astraw.Exprs(p2)
+	for i := range reader.exprs {
+		if raw1[i] == reader.exprs[i] || raw2[i] == reader.exprs[i] {
+			t.Errorf("expr %d: the Program admitted the reader's retained node by reference", i)
+		}
+		if raw1[i] == raw2[i] {
+			t.Errorf("expr %d: two Programs built from one retained slice share a node", i)
+		}
+	}
+
+	// Vandalize every node the reader still holds.  A Program that copied
+	// is unaffected; a Program that aliased now evaluates garbage.
+	var vandalize func(v *lisp.LVal)
+	vandalize = func(v *lisp.LVal) {
+		v.Int = 999
+		v.Str = "vandalized"
+		for _, c := range v.Cells {
+			vandalize(c)
+		}
+	}
+	for _, expr := range reader.exprs {
+		vandalize(expr)
+	}
+
+	for i, p := range []lisp.Program{p1, p2} {
+		got := programTestEnv(t).LoadProgram(p)
+		if got.Type == lisp.LError {
+			t.Fatalf("program %d: %v", i+1, got)
+		}
+		if got.String() != sealGapWant {
+			t.Errorf("program %d = %v, want %s: writes through the reader's retained tree reached the Program",
+				i+1, got, sealGapWant)
+		}
+	}
+}
+
+// recordingReader wraps the standard sealing parser and records the slice
+// it returned, so the test can compare the Program's nodes against the
+// parser's by pointer.
+type recordingReader struct {
+	inner lisp.Reader
+	last  []*lisp.LVal
+}
+
+func (r *recordingReader) Read(name string, stream io.Reader) ([]*lisp.LVal, error) {
+	exprs, err := r.inner.Read(name, stream)
+	r.last = exprs
+	return exprs, err
+}
+
+// TestProgramSharesSealedParserOutput pins the fast path against the
+// alternative fix that was considered and rejected (copying always).
+// Already-sealed parser output is the sanctioned cross-environment share —
+// sealed nodes are frozen storage under copy-on-write — and substrate's
+// parse cache builds a Program per phylum on the transaction path.  If
+// someone later swaps the admission for an unconditional copy, this fails
+// and they have to say so.
+func TestProgramSharesSealedParserOutput(t *testing.T) {
+	reader := &recordingReader{inner: parser.NewReader()}
+	p, err := lisp.ReadProgram(reader, "fast.lisp", strings.NewReader(sealGapSrc))
+	if err != nil {
+		t.Fatalf("ReadProgram: %v", err)
+	}
+	if len(reader.last) != p.Len() {
+		t.Fatalf("recorded %d exprs, Program has %d", len(reader.last), p.Len())
+	}
+	for i, raw := range astraw.Exprs(p) {
+		if raw != reader.last[i] {
+			t.Errorf("expr %d: sealed parser output was copied on admission;"+
+				" that is a deliberate change to the parse-cache cost model, not a refactor", i)
+		}
+	}
+}
+
+// TestProgramRejectsReferenceTypes mirrors TextLoader's checkLoaderExpr at
+// the Program boundary: reference types share mutable state through every
+// copy and every evaluation, the seal cannot mark them, so a Reader that
+// emits one cannot be cached.  The nested case pins that the check walks
+// the tree rather than glancing at roots.
+func TestProgramRejectsReferenceTypes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		expr *lisp.LVal
+	}{
+		{"vector-root", lisp.Vector([]*lisp.LVal{lisp.Int(1)})},
+		{"native-nested", lisp.SExpr([]*lisp.LVal{lisp.Symbol("quote"), lisp.Native(t)})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := &aliasingReader{exprs: []*lisp.LVal{tc.expr}}
+			_, err := lisp.ReadProgram(reader, "ref.lisp", strings.NewReader(""))
+			if err == nil {
+				t.Fatal("a reference type was admitted into a Program")
+			}
+			if !strings.Contains(err.Error(), "cannot cache reference type") {
+				t.Errorf("error should use TextLoader's reference-type report; got: %v", err)
+			}
+		})
+	}
+}
+
+// TestProgramRejectsUnsealableTypes covers the residue past TextLoader's
+// denylist: a value type that SealAST declines to mark (a function value —
+// no parser emits one, but the Reader interface cannot promise that) would
+// ride into every environment unsealed, reopening exactly the hole this
+// admission closes.  Program rejects it rather than admitting a tree its
+// seal does not cover.
+func TestProgramRejectsUnsealableTypes(t *testing.T) {
+	fn := lisp.Fun("gap-test-fun", lisp.Formals(),
+		func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal { return lisp.Nil() })
+	reader := &aliasingReader{exprs: []*lisp.LVal{fn}}
+	_, err := lisp.ReadProgram(reader, "fun.lisp", strings.NewReader(""))
+	if err == nil {
+		t.Fatal("an unsealable function value was admitted into a Program")
+	}
+	if !strings.Contains(err.Error(), "cannot seal expression") {
+		t.Errorf("error should report the unsealable expression; got: %v", err)
+	}
+}


### PR DESCRIPTION
# Summary

`Program`'s stated purpose is that an embedder's parse cache **cannot leak `*LVal` pointers between environments by construction** — but `ReadProgram` / `ReadLocationProgram` / `ParseProgram` wrapped any `Reader`'s output unchecked, so the guarantee held only when the reader happened to seal. A format-preserving reader (`parser.NewReader(parser.WithFormatPreserving())`, a supported public option whose documented behaviour is to skip the parser's seal) or any caller-written `Reader` handed **one unsealed, mutable tree** to every environment that loaded the `Program` — the substrate#378 corruption class, silent in a production build (issue #394, reproductions A and B).

All three constructors now funnel through a single admission point, `newProgram` (`lisp/program.go`), so the seal that makes `Program`'s premise true is *established at construction* instead of assumed.

# The contract decision (mirrored from TextLoader)

`TextLoader` is the other public entry point that caches a `Reader`'s output for repeated evaluation, and the admission asks its questions in its order, adapted only where the mechanisms differ (TextLoader hands each load a private copy; `Program` hands every load the same sealed tree):

1. **`checkLoaderExpr` runs first, verbatim, with TextLoader's error.** Reference types (bytes, map, array, native) share mutable state through every copy *and* every evaluation — `SealAST` declines to mark them and `Copy` preserves their reference semantics — so no admission can make them safe to share. Rejected, exactly as TextLoader rejects them.
2. **Output already sealed throughout is admitted as-is.** This is the standard-parser fast path and the sanctioned cross-runtime share (sealed nodes are frozen storage under copy-on-write; `elpstest.RunBenchmark` takes the same share). The check is a **deep walk, not a root check**: `SealAST` stops without descending at anything it declines to mark, so a caller's `Reader` can hand back a sealed root over unsealed storage — `RunBenchmark`'s root-only check is sound only because it constructed the parser itself, which a `Program`'s caller-owned `Reader` cannot promise.
3. **Anything else gets the private-copy-and-seal treatment** — the same answer TextLoader gives to a tree it cannot trust, expressed with `Program`'s mechanism: `Copy()` severs every alias the reader may have retained (cells, locations, and format metadata are all detached), then `SealAST` freezes the copy. Sealing here is safe even for a format-preserving parse: the parser skips `SealAST` only because its `Meta` construction continues past the per-expression seal point, and `Read` has returned by now, so construction is complete.
4. **The one deliberately conservative step past TextLoader's precedent** (noted per the ambiguity rule): a node even the fresh copy cannot seal — a function value, say; no parser emits one, but the `Reader` interface cannot promise that — is *rejected* (`cannot seal expression of type %v into a program`). TextLoader admits an `LFun` because its per-load copies mean the cached tree itself is never shared between environments; for `Program` the seal is the only thing standing between environments, so an unsealable node would reopen exactly the hole this closes. Rejection is the option that cannot corrupt, and it is the direction the issue itself names for a type whose premise is "by construction". It affects no tree any parser can produce.

The fast path is pinned by test (`TestProgramSharesSealedParserOutput`): already-sealed parser output is admitted by reference, not copied, so the fix cannot silently change the parse-cache cost model substrate's transaction path relies on.

# Red proof

Both halves were run against the unfixed tree (fix stashed) before being run against the fix:

- **Default build** (`lisp/program_seal_gap_test.go`): the issue's reproduction A — one `ParseProgram` through the format-preserving reader, three fresh environments, each snapshotting `(car (limits))` *before* `stable-sort` touches the literal. Unfixed: env 2 and env 3 read env 1's write (`got 30, want 10 (the pristine literal)`), and the deep-seal walk finds unsealed nodes. Reproduction B (an aliasing `Reader` that retains and re-serves its slice) failed on every assertion: nodes admitted by reference, two Programs sharing nodes, and vandalizing the reader's retained tree broke the Program's evaluation. The rejection tests also failed (reference types and function values were admitted).
- **Checked build** (`lisp/program_seal_gap_elpscheck_test.go`): the same shared `Program` evaluated in two fresh Runtimes panicked the unfixed `-tags elpscheck` binary with `ownership violation: LVal used by two Runtimes` — the detection the issue documents. With the fix, the evaluation is the sanctioned sealed share: no panic, identical results, and `VerifySealedASTs()` (the census `SealAST` records at admission) verifies clean.

All tests pass with the fix in place. No new `//elpsvet:allow` annotations and no checker allowlist entries were needed.

# Test plan

- `go test ./...` — pass
- `go test -tags elpscheck ./lisp/...` — pass
- `go test -race ./lisp/...` — pass
- `make elpsvet` (both passes, default and `-tags elpscheck`) — clean
- `make static-checks` — only the 2 pre-existing nolintlint findings in `parser/token/token.go`
- `scripts/confidentiality-guard.sh` — clean (733 files scanned)

Benchmark note: nothing modified is benchmark-covered (`parser/rdparser/bench_test.go` exercises rdparser's own `ParseProgramFaultTolerant`, not these constructors). The constructors gain one deep walk per parse on the standard path — parse/cache-boundary cost, not eval-loop cost.

Also updated `docs/sealed-ast.md` (embedder checklist items 1–2) and `docs/embed.md` to state the now-true contract, and the `Program` godoc's stale "scope of the guarantee" paragraph to match the merged seal design.

Closes #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq

---
_Generated by [Claude Code](https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq)_