### PR TITLE
lisp: remove per-definition throwaway allocations from registration and import

### DIFF
--- a/lisp/env.go
+++ b/lisp/env.go
@@ -298,12 +298,25 @@ func (env *LEnv) UsePackage(name *LVal) *LVal {
 	if pkg == nil {
 		return env.Errorf("unknown package: %v", name.Str)
 	}
+	dst := env.Runtime.Package
 	for _, sym := range pkg.externals {
-		v := pkg.Get(Symbol(sym))
-		if v.Type == LError {
-			return env.Errorf("package %s: %v", name.Str, v)
+		if sym == TrueSymbol || sym == FalseSymbol {
+			// Exporting a boolean constant was always a no-op: pkg.Get
+			// resolved the constant to itself and Put refused the rebind
+			// (its error was ignored).  Skipping keeps that behavior
+			// without consulting the symbol table.
+			continue
 		}
-		env.Runtime.Package.Put(Symbol(sym), v)
+		v, ok := pkg.Symbol(sym)
+		if !ok {
+			// Cold path: reproduce pkg.Get's unbound-symbol error verbatim.
+			return env.Errorf("package %s: %v", name.Str, pkg.Get(Symbol(sym)))
+		}
+		// putName, not Put: the hot import loop binds hundreds of names per
+		// environment, and the two Symbol header allocations per name (one
+		// for the probe, one for the store) were pure key packaging.  The
+		// constant-rebind check Put performs is the guard above.
+		dst.putName(sym, v)
 	}
 	return Nil()
 }
@@ -883,6 +896,41 @@ func sealedShareableFormals(v *LVal) bool {
 	return true
 }
 
+// registrationBound reports whether name is already bound in pkg, returning
+// the bound value.  It answers the same question the Add* methods used to ask
+// with pkg.Get, at none of Get's per-miss cost: Get constructs an "unbound
+// symbol" LError — message formatting and all — for every miss, and on the
+// registration path that error was built once per definition per environment
+// only to be type-sniffed and dropped (measured at ~26% of env-construction
+// allocation objects).  The boolean constants probe as bound-to-themselves,
+// exactly as Get resolves them, so registering a definition named "true" or
+// "false" still panics as a duplicate rather than silently failing to bind.
+func registrationBound(pkg *Package, name string) (*LVal, bool) {
+	if name == TrueSymbol || name == FalseSymbol {
+		return Symbol(name), true
+	}
+	return pkg.Symbol(name)
+}
+
+// registrationFunValue builds the function value the Add* methods install: a
+// fresh LFun header over the (possibly shared, sealed) formals and the
+// documentation string.  It is FunInPackage/MacroInPackage/SpecialOpInPackage
+// with the docstring placed at construction — the public constructors
+// allocate an empty-string docstring cell the Add* methods immediately
+// replaced, one dropped allocation per definition per environment.
+func registrationFunValue(pkgName, fid string, funType LFunType, formals *LVal, fn LBuiltin, doc string) *LVal {
+	return &LVal{
+		Type:    LFun,
+		FunType: funType,
+		Native: &funData{
+			fid:     fid,
+			builtin: fn,
+			pkg:     pkgName,
+		},
+		Cells: []*LVal{formals, String(doc)},
+	}
+}
+
 // AddMacros binds the given macros to their names in env.  When called with no
 // arguments AddMacros adds the DefaultMacros to env.
 //
@@ -896,21 +944,21 @@ func (env *LEnv) AddMacros(external bool, macs ...LBuiltinDef) {
 	formals := newFormalsCopier(macs)
 	pkg := env.Runtime.Package
 	for _, mac := range macs {
-		k := Symbol(mac.Name())
-		exist := pkg.Get(k)
-		if !exist.IsNil() && exist.Type != LError { // LError is ubound symbol
+		name := mac.Name()
+		// registrationBound replicates the probe pkg.Get used to answer,
+		// without Get's per-miss error construction; see its comment.
+		if exist, bound := registrationBound(pkg, name); bound && !exist.IsNil() && exist.Type != LError { // LError is a stored error value, not a binding conflict
 			// NOT LISP-REACHABLE (#367): AddMacros is registration-time Go
 			// API.  No builtin, operator or macro calls it, so the only way to
 			// bind one name twice is an embedder registering it twice.  The
 			// embedder-facing half of that story is #351.
-			panic(fmt.Sprintf("macro already defined: %v (= %v)", k, exist))
+			panic(fmt.Sprintf("macro already defined: %v (= %v)", name, exist))
 		}
-		id := fmt.Sprintf("<builtin-macro ``%s''>", mac.Name())
-		fn := MacroInPackage(pkg.Name, id, registrationFormals(&formals, mac.Formals()), mac.Eval)
-		fn.Cells[1] = String(builtinDocstring(mac))
-		pkg.Put(k, fn)
+		fn := registrationFunValue(pkg.Name, "<builtin-macro ``"+name+"''>", LFunMacro,
+			registrationFormals(&formals, mac.Formals()), mac.Eval, builtinDocstring(mac))
+		pkg.putName(name, fn)
 		if external {
-			pkg.externals = append(pkg.externals, k.Str)
+			pkg.externals = append(pkg.externals, name)
 		}
 	}
 }
@@ -928,19 +976,17 @@ func (env *LEnv) AddSpecialOps(external bool, ops ...LBuiltinDef) {
 	formals := newFormalsCopier(ops)
 	pkg := env.Runtime.Package
 	for _, op := range ops {
-		k := Symbol(op.Name())
-		exist := pkg.Get(k)
-		if !exist.IsNil() && exist.Type != LError { // LError is ubound symbol
+		name := op.Name()
+		if exist, bound := registrationBound(pkg, name); bound && !exist.IsNil() && exist.Type != LError { // LError is a stored error value, not a binding conflict
 			// NOT LISP-REACHABLE (#367): see AddMacros above -- registration
 			// is Go API an embedder drives, never lisp source.
-			panic(fmt.Sprintf("macro already defined: %v (= %v)", k, exist))
+			panic(fmt.Sprintf("macro already defined: %v (= %v)", name, exist))
 		}
-		id := fmt.Sprintf("<special-op ``%s''>", op.Name())
-		fn := SpecialOpInPackage(pkg.Name, id, registrationFormals(&formals, op.Formals()), op.Eval)
-		fn.Cells[1] = String(builtinDocstring(op))
-		pkg.Put(k, fn)
+		fn := registrationFunValue(pkg.Name, "<special-op ``"+name+"''>", LFunSpecialOp,
+			registrationFormals(&formals, op.Formals()), op.Eval, builtinDocstring(op))
+		pkg.putName(name, fn)
 		if external {
-			pkg.externals = append(pkg.externals, k.Str)
+			pkg.externals = append(pkg.externals, name)
 		}
 	}
 }
@@ -958,19 +1004,17 @@ func (env *LEnv) AddBuiltins(external bool, funs ...LBuiltinDef) {
 	formals := newFormalsCopier(funs)
 	pkg := env.Runtime.Package
 	for _, f := range funs {
-		k := Symbol(f.Name())
-		exist := pkg.Get(k)
-		if exist.Type != LError {
+		name := f.Name()
+		if exist, bound := registrationBound(pkg, name); bound && exist.Type != LError { // a stored LError value is overwritten, as pkg.Get's probe allowed
 			// NOT LISP-REACHABLE (#367): see AddMacros above -- registration
 			// is Go API an embedder drives, never lisp source.
-			panic("symbol already defined: " + f.Name())
+			panic("symbol already defined: " + name)
 		}
-		id := fmt.Sprintf("<builtin-function ``%s''>", f.Name())
-		v := FunInPackage(pkg.Name, id, registrationFormals(&formals, f.Formals()), f.Eval)
-		v.Cells[1] = String(builtinDocstring(f))
-		pkg.Put(k, v)
+		v := registrationFunValue(pkg.Name, "<builtin-function ``"+name+"''>", LFunNone,
+			registrationFormals(&formals, f.Formals()), f.Eval, builtinDocstring(f))
+		pkg.putName(name, v)
 		if external {
-			pkg.externals = append(pkg.externals, k.Str)
+			pkg.externals = append(pkg.externals, name)
 		}
 	}
 }

--- a/lisp/package.go
+++ b/lisp/package.go
@@ -248,8 +248,19 @@ func (pkg *Package) Update(k, v *LVal) *LVal {
 }
 
 func (pkg *Package) put(k, v *LVal) {
+	pkg.putName(k.Str, v)
+}
+
+// putName binds v to name without requiring the caller to allocate a symbol
+// LVal for the key.  It is the registration fast path used by the LEnv.Add*
+// methods and by UsePackage's import loop, which bind hundreds of names per
+// environment; Put and Update funnel through it too, so the LFun name
+// bookkeeping stays in one place.  Callers are responsible for the
+// constant-rebind check Put performs — the Add* methods and UsePackage guard
+// TrueSymbol/FalseSymbol explicitly before calling.
+func (pkg *Package) putName(name string, v *LVal) {
 	if v.Type == LFun {
-		pkg.funNames[v.FID()] = k.Str
+		pkg.funNames[v.FID()] = name
 	}
-	pkg.symbols[k.Str] = v
+	pkg.symbols[name] = v
 }

--- a/lisp/registration_fastpath_test.go
+++ b/lisp/registration_fastpath_test.go
@@ -1,0 +1,138 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests pinning the observable behavior of the registration fast path
+// (registrationBound, registrationFunValue, Package.putName in env.go and
+// package.go): the same function identities, documentation, duplicate
+// detection and constant protection the pkg.Get / public-constructor /
+// pkg.Put spelling provided, without the per-definition throwaway
+// allocations.  These assertions existed nowhere else — the FID rendering
+// and the duplicate panic were previously exercised only incidentally.
+
+type regDocDef struct {
+	regFormalsDef
+	doc string
+}
+
+func (d *regDocDef) Docstring() string { return d.doc }
+
+func newRegTestEnv(t *testing.T) *LEnv {
+	t.Helper()
+	env := NewEnv(nil)
+	if rc := InitializeUserEnv(env); rc.Type == LError {
+		t.Fatalf("InitializeUserEnv: %v", rc)
+	}
+	return env
+}
+
+// TestRegistrationFunValueIdentity: registration produces the same function
+// identity surface as before — FID rendering per definition kind, package
+// attribution, FunType, docstring in Cells[1], and the funNames bookkeeping
+// pkg.Put performed.
+func TestRegistrationFunValueIdentity(t *testing.T) {
+	env := newRegTestEnv(t)
+	pkg := env.Runtime.Package
+
+	env.AddBuiltins(true, &regDocDef{regFormalsDef{name: "fastpath-fn", formals: Formals("x")}, "fn doc"})
+	env.AddMacros(true, &regDocDef{regFormalsDef{name: "fastpath-mac", formals: Formals("x")}, "mac doc"})
+	env.AddSpecialOps(true, &regDocDef{regFormalsDef{name: "fastpath-op", formals: Formals("x")}, "op doc"})
+
+	check := func(name, wantFID string, wantType LFunType, wantDoc string) {
+		t.Helper()
+		v, ok := pkg.Symbol(name)
+		if !ok || v.Type != LFun {
+			t.Fatalf("%s did not register as a function: %v", name, v)
+		}
+		if v.FID() != wantFID {
+			t.Errorf("%s FID = %q, want %q", name, v.FID(), wantFID)
+		}
+		if v.FunType != wantType {
+			t.Errorf("%s FunType = %v, want %v", name, v.FunType, wantType)
+		}
+		if v.Package() != pkg.Name {
+			t.Errorf("%s package = %q, want %q", name, v.Package(), pkg.Name)
+		}
+		if len(v.Cells) < 2 || v.Cells[1].Type != LString || v.Cells[1].Str != wantDoc {
+			t.Errorf("%s docstring cell = %v, want %q", name, v.Cells[1], wantDoc)
+		}
+		if got := pkg.GetFunName(wantFID); got != name {
+			t.Errorf("GetFunName(%q) = %q, want %q (putName must keep the funNames bookkeeping)", wantFID, got, name)
+		}
+	}
+	check("fastpath-fn", "<builtin-function ``fastpath-fn''>", LFunNone, "fn doc")
+	check("fastpath-mac", "<builtin-macro ``fastpath-mac''>", LFunMacro, "mac doc")
+	check("fastpath-op", "<special-op ``fastpath-op''>", LFunSpecialOp, "op doc")
+}
+
+// TestRegistrationDuplicatePanics: binding one name twice still panics, with
+// the same messages the pkg.Get probe produced.
+func TestRegistrationDuplicatePanics(t *testing.T) {
+	mustPanic := func(name, want string, f func()) {
+		t.Helper()
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatalf("%s: expected panic", name)
+			}
+			msg, ok := r.(string)
+			if !ok {
+				t.Fatalf("%s: panic is %T, want string: %v", name, r, r)
+			}
+			if !strings.Contains(msg, want) {
+				t.Fatalf("%s: panic %q does not contain %q", name, msg, want)
+			}
+		}()
+		f()
+	}
+
+	env := newRegTestEnv(t)
+	env.AddBuiltins(false, &regFormalsDef{name: "fastpath-dup", formals: Formals()})
+	mustPanic("builtin duplicate", "symbol already defined: fastpath-dup", func() {
+		env.AddBuiltins(false, &regFormalsDef{name: "fastpath-dup", formals: Formals()})
+	})
+
+	env2 := newRegTestEnv(t)
+	env2.AddMacros(false, &regFormalsDef{name: "fastpath-dup-mac", formals: Formals()})
+	mustPanic("macro duplicate", "macro already defined: fastpath-dup-mac", func() {
+		env2.AddMacros(false, &regFormalsDef{name: "fastpath-dup-mac", formals: Formals()})
+	})
+
+	env3 := newRegTestEnv(t)
+	env3.AddSpecialOps(false, &regFormalsDef{name: "fastpath-dup-op", formals: Formals()})
+	mustPanic("special-op duplicate", "macro already defined: fastpath-dup-op", func() {
+		env3.AddSpecialOps(false, &regFormalsDef{name: "fastpath-dup-op", formals: Formals()})
+	})
+}
+
+// TestRegistrationConstantsProbeAsBound: the boolean constants are never in
+// the package's symbol table — pkg.Get resolves them specially — so a raw
+// table probe would report them unbound and a definition named "true" would
+// silently fail to bind (Put rejects the constants, and registration does
+// not check Put's error).  registrationBound makes them probe as bound, so
+// the registration panics exactly as the pkg.Get spelling did.
+func TestRegistrationConstantsProbeAsBound(t *testing.T) {
+	for _, name := range []string{TrueSymbol, FalseSymbol} {
+		v, bound := registrationBound(NewPackage("fastpath-test"), name)
+		if !bound {
+			t.Fatalf("%s must probe as bound", name)
+		}
+		if v.Type != LSymbol || v.Str != name {
+			t.Fatalf("%s probes as %v, want the symbol itself", name, v)
+		}
+		env := newRegTestEnv(t)
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("registering a builtin named %q must panic as a duplicate", name)
+				}
+			}()
+			env.AddBuiltins(false, &regFormalsDef{name: name, formals: Formals()})
+		}()
+	}
+}


### PR DESCRIPTION
## Summary

**Stacked on #525** (sealed-formals sharing) — this PR's own change is the last commit (`ae92f8c`); the diff collapses to it once #525 merges.

An allocation profile of `BenchmarkEnvInit` *after* #525 showed the remaining env-construction cost concentrated in registration bookkeeping that exists only to be thrown away:

| waste | cost (per definition per environment) |
|---|---|
| `pkg.Get` existence probe constructs a formatted "unbound symbol" `LError` per miss, then the caller type-sniffs and drops it | ~26% of env-init allocation objects |
| FIDs rendered via `fmt.Sprintf` | fmt machinery + boxing (~14% incl. the error path's Sprintf) |
| public constructors allocate a `String("")` docstring cell the Add* methods immediately replace | 1 dropped LVal |
| `Symbol` LVals allocated purely as map-key packaging for `pkg.Get`/`pkg.Put` | 1 LVal |
| `UsePackage` import loop: two `Symbol` headers per imported name (probe + store) | 2 LVals × hundreds of imports |

The fixes: `registrationBound` (raw `Package.Symbol` lookup, with the boolean constants probing as bound-to-themselves so a definition named `true`/`false` still panics as a duplicate exactly as the `Get` probe made it), `registrationFunValue` (docstring placed at construction), FIDs by concatenation, `Package.putName` (bind by name string; `Put`/`Update` funnel through it so the `funNames` bookkeeping stays in one place), and the same treatment in `UsePackage`'s import loop with the constant-rebind guard hoisted and the cold unbound-symbol error reproducing `pkg.Get`'s message verbatim.

No value-sharing semantics change at all — every allocation removed was constructed and discarded within the same call. Refs #379, #514.

## Behavior pinned by new tests

`lisp/registration_fastpath_test.go` — none of this had direct coverage before:
- FID rendering per definition kind (`<builtin-function ``name''>` / `<builtin-macro ...>` / `<special-op ...>`), `FunType`, package attribution, docstring in `Cells[1]`, and `GetFunName` bookkeeping through `putName`;
- duplicate-registration panics with the same messages for all three Add* methods;
- the boolean-constant probe (a builtin named `true` panics as a duplicate rather than silently failing to bind — the exact edge a naive raw-table probe would regress).

## Benchmarks

Interleaved arms (base = #525's branch, PR = this change), n=12, benchtime=100ms. Allocation metrics deterministic; on this noisy sandbox the env-construction *timing* clears the noise floor anyway.

```
pkg: github.com/luthersystems/elps/lisp
          │     base      │                  new                  │
          │    sec/op     │    sec/op      vs base                │
EnvInit-4   826.3µ ± 35%   434.5µ ± 24%  -47.42% (p=0.001 n=12)

          │      B/op       │     B/op       vs base                  │
EnvInit-4    337.7Ki ± 0%      202.0Ki ± 0%  -40.18% (p=0.000 n=12)

          │   allocs/op   │  allocs/op   vs base                 │
EnvInit-4   3.859k ± 0%     1.987k ± 0%  -48.51% (p=0.000 n=12)
```

```
pkg: github.com/luthersystems/elps/lisp/lisplib
                                │     base     │                 new                  │
                                │    sec/op    │    sec/op     vs base                │
EnvConstructionCore-4             420.5µ ± 28%   213.6µ ± 34%  -49.20% (p=0.000 n=12)
EnvConstructionFull-4             715.3µ ± 23%   379.1µ ± 29%  -46.99% (p=0.000 n=12)
EnvConstruction/mode=fork-4       419.1µ ± 31%   431.5µ ± 26%        ~ (p=0.932 n=12)
EnvConstruction/mode=fullload-4   998.6µ ± 46%   755.7µ ± 29%  -24.33% (p=0.014 n=12)

                                │     B/op     │     B/op      vs base                │
EnvConstructionCore-4             199.4Ki ± 0%   118.3Ki ± 0%  -40.64% (p=0.000 n=12)
EnvConstructionFull-4             337.8Ki ± 0%   202.1Ki ± 0%  -40.17% (p=0.000 n=12)
EnvConstruction/mode=fork-4       286.0Ki ± 0%   286.0Ki ± 0%   +0.00% (p=0.028 n=12)
EnvConstruction/mode=fullload-4   530.1Ki ± 0%   394.4Ki ± 0%  -25.60% (p=0.000 n=12)

                                │  allocs/op  │  allocs/op   vs base                  │
EnvConstructionCore-4             2006.0 ± 0%    918.0 ± 0%  -54.24% (p=0.000 n=12)
EnvConstructionFull-4             3.861k ± 0%   1.989k ± 0%  -48.48% (p=0.000 n=12)
EnvConstruction/mode=fork-4       1.276k ± 0%   1.276k ± 0%        ~ (p=1.000 n=12) ¹
EnvConstruction/mode=fullload-4   5.405k ± 0%   3.532k ± 0%  -34.65% (p=0.000 n=12)
```

Every other benchmark is unchanged on B/op and allocs/op. Combined with #525, a full `LoadLibrary` environment goes from 428.1KiB / 4,082 allocs (current main) to 202.0KiB / 1,987 allocs — **−53% bytes, −51% allocations**. `scripts/benchstat-gate.sh` on the combined comparison: 25 delta rows, 0 at or above the gate.

## Test plan

- [x] `go test ./...` clean (full repo)
- [x] `go test -tags elpscheck ./lisp/...` clean
- [x] `go test -race ./lisp/...` clean
- [x] `make elpsvet` clean (both passes; no new annotations)
- [x] `make static-checks` — only the 2 pre-existing `parser/token/token.go` nolintlint findings
- [x] `make test-examples`, `./elps fmt -l ./...`, `./elps lint ./...` (pre-existing findings only), `./elps doc -m` clean
- [x] `scripts/benchstat-gate.sh` passes on the local interleaved comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq

---
_Generated by [Claude Code](https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq)_