### PR TITLE
docs: record v1.51.0 and v1.52.0 in the vscode changelog

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -4,6 +4,28 @@ Published extension versions track the `elps` release tag they ship with -- the
 publish workflow sets `package.json` from the tag name -- so the numbering
 jumps from 0.2.0 to 1.50.0.
 
+## 1.52.0
+
+- Language: writing through a program literal -- `stable-sort`, `(slice
+  'vector ...)` and `(append 'vector ...)` on a quoted literal or a view over
+  one -- now raises the catchable `modify-literal-error` condition
+  (`cannot modify a program literal; take a (copy ...) first`) instead of
+  silently sorting or appending to a fresh copy. Runtime-constructed lists and
+  vectors keep their in-place semantics, and empty sealed inputs are exempt, so
+  only code that mutated program text is affected. `handler-bind` and
+  `ignore-errors` catch it like any other condition.
+- Startup: the binary no longer builds a 2.2MB character-width table at init,
+  and interpreter environment construction allocates about half of what it did
+  (-53% bytes, -51% allocations), so the language server, linter and formatter
+  start faster and analysis of large workspaces costs less memory.
+
+## 1.51.0
+
+- Stability: an array with unset elements no longer takes the host process down
+  when the language server evaluates `aref` or `equal?` over it -- every panic
+  site in the interpreter is now classified by reachability from lisp and
+  enforced by a sweep test.
+
 ## 1.50.0
 
 - LSP: negotiate `positionEncoding` with the client and convert columns at the


### PR DESCRIPTION
## Summary

`editors/vscode/CHANGELOG.md` still ends at 1.50.0, so the Marketplace listing describes a two-releases-old extension. v1.51.0 and v1.52.0 both shipped extension-facing changes and neither added an entry.

The publish workflow sets `package.json` from the tag, so this entry ships with the **next** release rather than retroactively appearing on the already-published 1.52.0 listing — it's the record catching up, and it keeps the next publish from compounding the gap.

## What the entry covers

**1.52.0** — the two things a user of the extension actually notices:
- `modify-literal-error` (#527): writing through a program literal now raises a catchable condition instead of silently copying. Worth a changelog line because it is a language semantics change visible while running or debugging code in the editor — with the scope stated precisely (runtime-constructed values unaffected, empty sealed inputs exempt) so nobody reads it as broader than it is.
- Startup and analysis cost: dropping the runewidth table (#522) plus halving environment construction (#525, #526) makes the bundled language server, linter and formatter start faster and hold less memory on large workspaces.

**1.51.0** — the array-with-unset-elements panic (#515), which could take the language server's host process down.

Deliberately omitted: the accessor migration, sealing verification tooling, benchmark/waiver housekeeping. They are substantial changes but they do not alter what the extension does, and the file's convention is user-facing notes only.

## Test plan

- [x] Documentation only — no code, no build inputs touched
- [x] `git diff --stat` confirms the single file
- [x] Markdown structure matches the existing entries (version heading, hyphen bullets, wrapped prose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq

---
_Generated by [Claude Code](https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq)_