### PR TITLE
lisp: give PackageRegistry.AddPackage a per-value-class admission contract

### DIFF
--- a/docs/embed.md
+++ b/docs/embed.md
@@ -244,6 +244,34 @@ ELPS ships three CLI tools (`lint`, `doc`, `fmt`). The `lint` and `doc` tools
 expose Go APIs so embedders can wire in their own runtime environment, making
 Go-provided bindings visible to static analysis and documentation.
 
+### Sharing packages and registries
+
+Several of the APIs below take a `*lisp.PackageRegistry` from a booted
+environment (`cmd.WithRegistry`, `mcpserver.WithRegistry`,
+`lsp.WithRegistry`). The doc paths merge that registry's packages into the
+environment they build, and those merges — like any embedder that installs a
+hand-built package — go through `PackageRegistry.AddPackage`, which is an
+**admission point** rather than a store (elps#524):
+
+- What gets registered is a private **snapshot** of the package. Binding into
+  your own `*Package` after `AddPackage` does not change what the runtime
+  serves — bind through the environment, or finish the package before
+  registering it.
+- A binding that is a **code-like tree** (a list, symbol, string or number
+  built at runtime rather than produced by the parser) is copied privately
+  and sealed, so the registry cannot rewrite what you still hold and you
+  cannot rewrite what it evaluates.
+- **Functions, natives, sorted-maps, arrays and byte strings are admitted by
+  reference** — no seal covers those classes. `AddPackage` transfers custody
+  of them: stop mutating them once they are registered, and remember that a
+  lisp closure carries its captured environment, so sharing one between
+  runtimes is still sharing mutable state.
+- The snapshot reads the package's maps on the calling goroutine, so no other
+  goroutine may be writing that package while `AddPackage` runs.
+
+[docs/sealed-ast.md §2.8](sealed-ast.md) states the rule per value class and
+the reasoning behind it.
+
 ### Linting
 
 The `lint` package provides `LintConfig` and `LintFiles` for running the linter

--- a/docs/sealed-ast.md
+++ b/docs/sealed-ast.md
@@ -182,7 +182,8 @@ unsealed by construction.
 
 The parse/cache boundary exposes no raw AST: `lisp.Program`
 (`lisp/program.go`) wraps parse output opaquely, and the package registry
-seals its LVal-bearing surface. Deep-copy machinery for owned expressions
+seals its LVal-bearing surface (§2.8 for what its admission promises per
+value class). Deep-copy machinery for owned expressions
 exists in-kernel (`detach()`, `lisp/detach.go` — whose walker also backs the
 lisp-level `copy` builtin in a within-env mode, elps#378) but is unexported:
 it will be re-exported
@@ -293,6 +294,73 @@ would all need a copying accessor, and the worst an exported `Frames` slice
 buys an attacker is a wrong stack trace in their own interpreter — no shared
 bytes, no other goroutine.  Deferred, with the numbers on the table rather
 than an implicit "nobody asked".
+
+### 2.8 Package registry admission (issue #524)
+
+`PackageRegistry.AddPackage` is the second exported surface with the shape
+§2.5's `Program` constructors had: a caller hands the kernel a container of
+`*LVal`s it still holds pointers to, and a `Runtime` starts serving them. A
+package built by hand in Go, or lifted out of another `Runtime`'s registry
+by the doc/LSP/MCP merges (`cmd/doc.go`, `mcpserver`'s per-request doc env —
+the path a booted downstream registry reaches the tools through), used to be
+stored as-is.
+
+`newProgram`'s rule does not transfer, because a package's contents are not
+parse output. A symbol table legitimately holds Go builtins, lisp closures,
+natives, sorted-maps, arrays and runtime data — values the seal *deliberately*
+declines to mark, because the evaluator mutates them. "Seal everything" would
+freeze storage the evaluator writes, and "reject the unsealable" would reject
+every real package. So the admission is stated per value class
+(`lisp/package_admit.go`); `AddPackage` registers a private **snapshot** of
+the package whose bindings are:
+
+| Value class | Admission |
+|---|---|
+| singletons; values **sealed throughout** | shared by reference — the sanctioned share |
+| **sealable throughout but unsealed**: runtime-built lists, symbols, strings, numbers ("code-like trees") | private `Copy()` + `SealAST()` |
+| everything else: functions, natives, sorted-maps, arrays, bytes, errors, tagged values, and trees holding one | shared by reference; **custody transferred** |
+
+The middle row is the hazard. An unsealed code-like tree is fresh mutable
+storage the caller still aliases: `stable-sort` in the registry's `Runtime`
+rewrites it under the caller and under every other registry the same package
+was added to, and a write through the caller's retained pointer rewrites what
+the `Runtime` evaluates — substrate#378's corruption class with a package for
+a vehicle. `Copy()` severs the alias, `SealAST()` freezes the registry's copy
+and (in checked builds) enrols it in the census, which is why the
+fingerprint verifier covers admitted bindings at all.
+
+The sealed fast path is load-bearing rather than an optimization note: values
+produced by evaluating literals are *already* sealed, so a package built by
+loading lisp source is admitted with its bindings shared, exactly as a
+`Program` of sealed parser output is.
+
+The last row is where this admission is knowingly weaker than
+`newProgram`'s, and the honesty is the point: a closure's captured `*LEnv`
+cannot be copied, and reference types are reference types on purpose. For
+those, `AddPackage` promises custody transfer, not isolation — the caller
+must stop writing them, and evaluating one shared closure under two
+`Runtime`s stays a bug that checked mode reports rather than one the
+admission prevents.
+
+Two consequences for callers: the registry does not hold the caller's
+`*Package`, so binding into it after `AddPackage` no longer reaches the
+`Runtime` (bind through the environment instead); and the snapshot reads the
+package's maps on the calling goroutine, so it needs the same "no concurrent
+writer" discipline every other read of a `*Package` does (#397).
+
+**Sibling mutators.** The audit behind #524 covers every exported member of
+`PackageRegistry`/`Package` that stores a caller-supplied `*LVal`.
+`Package.Put`/`Update` keep storing what they are given: they are the write
+path every `set` reaches through `LEnv.PutGlobal`, where the value belongs to
+the environment already evaluating it and `LEnv.Put`/`PutGlobal` have taken
+the ownership sighting — an admission walk there would tax the interpreter's
+hot path to guard a transfer that is not happening. `Export`/`Exports` store
+names only (`Exports` already copies its slice), and `DefinePackage` builds a
+fresh package. The read side is the residual: `PackageRegistry.Package` hands
+out the registry's live `*Package` — which is how the merges enumerate a
+booted registry — and a caller can `Put` through it. Same residual as §2.7's
+exported fields: the boundary stops accidental sharing, not a caller that
+goes looking for interpreter state.
 
 ## 3. Verification layers: what each prevents, and its blind spots
 
@@ -536,26 +604,32 @@ intends to mutate data it did not construct copies unconditionally.
    today; it will be re-exported when a real embedder consumer
    materializes.) If you build trees by hand and share them across
    environments, call `SealAST()` on each root yourself.
-2. **Never install a format-preserving reader into an evaluating runtime.**
+2. **Hand `AddPackage` a finished package.** The registry stores a snapshot
+   whose code-like bindings are privately sealed copies (§2.8, elps#524), so
+   writes through your `*Package` after registration do not reach the
+   `Runtime` — bind through the environment instead. Values the seal cannot
+   cover (functions, natives, maps, arrays) are admitted by reference: after
+   `AddPackage` they belong to the registry, so stop mutating them.
+3. **Never install a format-preserving reader into an evaluating runtime.**
    `parser.NewReader(parser.WithFormatPreserving())` produces *unsealed*
    trees for tooling (formatter/minifier/lint); it satisfies `lisp.Reader`,
    so nothing but this contract stops you on the `Load*` paths. The
    `Program` constructors are the exception: they detect the unsealed
    parse and admit a private sealed copy instead (elps#394).
-3. **In every builtin or Go helper that mutates a value in place:** check
+4. **In every builtin or Go helper that mutates a value in place:** check
    `v.IsSealed()` first; refuse with an error or operate on `v.Copy()`.
    Remember slices of `Cells` share backing — copy the cells, not just the
    header, before restructuring.
-4. **Use `copy` (lisp) / `Copy()` (Go) as the copy idioms** when you
+5. **Use `copy` (lisp) / `Copy()` (Go) as the copy idioms** when you
    need storage that no one else can write (§4.1). `copy` is deep and
    unconditional -- prefer it to the one-level `(concat 'list x)`. (The
    hermetic cross-runtime deep copy lives in-kernel as `detach()`,
    unexported until a consumer appears; `copy` is its within-env mode.)
-5. **Run the verification stack you can afford:** `go run ./cmd/elpsvet
+6. **Run the verification stack you can afford:** `go run ./cmd/elpsvet
    -test=false ./...` over code living in this module; `go test -tags
    elpscheck` (inspector) and `-race` (watchdog) in CI; call
    `lisp.VerifySealedASTs` at teardown in long-lived checked-build hosts.
-6. **When elpsvet flags you and the mutation is deliberate**, annotate the
+7. **When elpsvet flags you and the mutation is deliberate**, annotate the
    line with `//elps:mutates <justification>` and make the justification
    say *why the storage is owned* — every annotation in this repo is an
    auditable claim (50 `//elps:mutates` and 19 `//elpsvet:allow` live

--- a/lisp/package.go
+++ b/lisp/package.go
@@ -44,10 +44,37 @@ func (r *PackageRegistry) PackageNames() []string {
 	return names
 }
 
-// AddPackage registers p under p.Name if no package with that name exists
-// already.  AddPackage returns true when p was added and false when a
-// package named p.Name was already registered (in which case the registry
-// is unchanged).
+// AddPackage registers a private snapshot of p under p.Name if no package
+// with that name exists already.  AddPackage returns true when p was added
+// and false when a package named p.Name was already registered (in which
+// case the registry is unchanged).
+//
+// AddPackage is an ADMISSION point, not a store (issue #524).  A registry is
+// the interpreter state of a Runtime, so a package built outside it — by an
+// embedder, or by another Runtime whose registry is being merged into this
+// one — arrives full of values the caller still holds pointers to.  What
+// gets registered is therefore a snapshot of p rather than p itself, and
+// each bound value is admitted according to what the seal can promise about
+// it (lisp/package_admit.go states the rule per value class):
+//
+//   - a value that is sealed throughout, and a singleton, are shared by
+//     reference — the sanctioned cross-environment share;
+//   - a code-like tree that is NOT sealed (a runtime-built list, symbol,
+//     string or number: fresh mutable storage the caller still aliases) is
+//     copied privately and sealed, so neither side can write what the other
+//     evaluates;
+//   - everything else — functions, natives, sorted-maps, arrays, byte
+//     strings, and trees holding one — is shared by reference, because no
+//     seal covers those classes.  For them AddPackage transfers custody: the
+//     caller must stop mutating them, and evaluating a shared closure under
+//     two Runtimes remains the caller's problem (checked builds report it).
+//
+// Two consequences worth stating for callers.  The registry does not hold p,
+// so binding into p afterwards does not change the registered package —
+// bind through the environment (or add a finished package).  And the
+// snapshot reads p's maps on the calling goroutine, so, like every other
+// read of a *Package, it requires that no other goroutine is writing p
+// (issue #397).
 func (r *PackageRegistry) AddPackage(p *Package) bool {
 	if p == nil {
 		return false
@@ -55,7 +82,7 @@ func (r *PackageRegistry) AddPackage(p *Package) bool {
 	if _, ok := r.packages[p.Name]; ok {
 		return false
 	}
-	r.packages[p.Name] = p
+	r.packages[p.Name] = admitPackage(p)
 	return true
 }
 
@@ -219,6 +246,16 @@ func (pkg *Package) GetFunName(fid string) string {
 }
 
 // Put takes an LSymbol k and binds it to v in pkg.
+//
+// Put stores v as given: it takes no admission walk (see AddPackage and
+// lisp/package_admit.go).  It is the write path every `set` reaches through
+// LEnv.PutGlobal, where the value being bound belongs to the environment
+// that is already evaluating it and LEnv.Put/PutGlobal have already taken
+// the checked-mode ownership sighting — so a per-binding walk here would
+// tax the interpreter's hot path to guard a transfer that is not happening.
+// A Go caller that reaches around the environment to Put into a package
+// another Runtime is serving is doing the cross-Runtime sharing AddPackage's
+// snapshot exists to prevent, and owns the consequences.
 func (pkg *Package) Put(k, v *LVal) *LVal {
 	if k.Type != LSymbol && k.Type != LQSymbol {
 		return Errorf("key is not a symbol: %v", k.Type)

--- a/lisp/package_admit.go
+++ b/lisp/package_admit.go
@@ -1,0 +1,218 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+// Package admission: what a registry does with an externally built package
+// (issue #524).
+//
+// PackageRegistry.AddPackage is the second exported surface with the shape
+// issue #394 found on the Program constructors: a caller hands the kernel a
+// container of *LVals that the caller still holds pointers to, and the
+// registry — which is the interpreter state of a Runtime — starts serving
+// them.  #523 fixed the Program half with a single admission point
+// (newProgram: checkLoaderExpr, sealed-throughout fast path, private
+// Copy()+SealAST, reject the unsealable).  This file is the same idea sized
+// for a different contract.
+//
+// # Why AddPackage cannot reuse newProgram's rule
+//
+// A Program holds parse output and nothing else, so "seal it or refuse it"
+// is a complete rule: everything a Reader may legally return is either a
+// syntax node (sealable) or a mistake (rejectable).  A package's symbol
+// table is the opposite — it holds whatever an environment binds, and the
+// legitimate contents include values the seal deliberately declines to
+// cover:
+//
+//   - Go builtins (LFun over an LBuiltin), which are the entire point of an
+//     embedder's package;
+//   - lisp-defined functions, whose captured environment cannot be copied
+//     and cannot be frozen;
+//   - natives, sorted-maps, arrays and byte strings — reference types by
+//     design, which SealAST refuses to mark because the evaluator's mutating
+//     builtins write them;
+//   - runtime data of every other shape.
+//
+// "Seal everything" would freeze storage the evaluator mutates, and "reject
+// the unsealable" would reject every real package: the two in-repo consumers
+// (cmd/doc.go's `--registry` merge and mcpserver's per-request docEnv, which
+// is how substrate's `shirotester doc/lsp/mcp` shares a booted shiro
+// registry) are packages of builtins and closures, which is to say packages
+// made almost entirely of values no seal can cover.
+//
+// # The rule, per value class
+//
+// AddPackage registers a private SNAPSHOT of the package: a fresh *Package
+// carrying the same name, doc, export list, per-symbol docs and function-name
+// table, whose symbol table is built by classifying every bound value.
+//
+//	value class                                  admission
+//	-------------------------------------------  --------------------------
+//	singletons (Nil, true, false)                shared by reference
+//	sealed throughout (parse output, quoted      shared by reference
+//	  literals, values derived from them)          (the sanctioned share)
+//	sealable-throughout but NOT sealed:          private Copy() + SealAST
+//	  runtime-built lists, symbols, strings,       (the #524 hazard class)
+//	  and numbers — "code-like trees"
+//	everything else: functions, natives,         shared by reference,
+//	  maps, arrays, bytes, errors, tagged          custody transferred
+//	  values, and mixed trees holding one
+//
+// The middle row is the hazard the issue names.  A code-like tree that is not
+// sealed is fresh mutable storage the caller still aliases: `stable-sort` in
+// the registry's Runtime rewrites it under the caller (and under every other
+// registry the same package was added to), and a write through the caller's
+// retained pointer rewrites what the Runtime evaluates.  It is the
+// substrate#378 corruption class with a package for a vehicle instead of a
+// parse cache.  Copy severs the alias; SealAST makes the registry's copy
+// safe to share onward — with the environments that `use-package` it, and
+// with the checked-mode census, which from that moment holds the copy's
+// fingerprint and reports any in-place write to it (lisp/
+// seal_check_elpscheck.go).
+//
+// The sealed fast path is load-bearing, not an optimization detail: values
+// that came from evaluating literals are ALREADY sealed, so a package built
+// by loading lisp source is admitted with its bindings shared by reference,
+// exactly as a Program of already-sealed parser output is.  Copying them
+// would fork every literal in the registry for no gain.
+//
+// The last row is where this admission is deliberately weaker than
+// newProgram's, and saying so plainly is the point of writing it down.  A
+// function value, a native or a sorted-map is admitted BY REFERENCE and stays
+// aliased: nothing here makes it safe for the caller to keep mutating it, and
+// nothing here makes it safe to evaluate the same closure under two Runtimes.
+// What AddPackage promises for those values is custody transfer, not
+// isolation — the caller must stop writing them.  Rejecting them was
+// considered and would break every real consumer; copying them is either
+// impossible (a closure's captured *LEnv) or a semantic change (reference
+// types are reference types on purpose).  The compensating controls are the
+// ones that already exist: closure-free builtins are provably stateless and
+// exempt from ownership checking, and everything else is covered by the
+// checked-mode ownership table, which panics when one mutable value is used
+// by two Runtimes.
+//
+// # Sibling mutators
+//
+// The audit that came with #524 covers every exported member of
+// PackageRegistry and Package that stores a caller-supplied *LVal:
+//
+//   - AddPackage — admits, as above.
+//   - Package.Put / Package.Update — bind one value into one package.  They
+//     are the write path every `set` reaches through LEnv.PutGlobal, so an
+//     admission walk there would tax the interpreter's hot path to protect a
+//     transfer that is not happening: Put binds a value into the environment
+//     that is already evaluating it, and LEnv.Put/PutGlobal already take the
+//     checked-mode ownership sighting.  A Go caller that reaches around the
+//     environment to Put into ANOTHER Runtime's package is doing the thing
+//     AddPackage's snapshot exists to prevent, and the docs say so.
+//   - Package.Export / Exports — names only, and Exports already copies its
+//     argument slice before sorting.
+//   - PackageRegistry.DefinePackage — builds a fresh package; no caller value
+//     is stored.
+//
+// The read side is the residual: PackageRegistry.Package hands out the
+// registry's live *Package, which is how the doc/LSP/MCP merges enumerate a
+// booted registry in the first place, and a caller can Put through it.  That
+// is the same residual the seal design records for exported LVal fields
+// (docs/sealed-ast.md §2.7): the boundary stops accidental sharing, not a
+// caller that goes looking for interpreter state.
+
+// admitPackage returns the private snapshot of p that a registry stores.
+// See the file comment for the per-class rule; the traversal decisions are
+// in admitSymbolValue.
+//
+// The snapshot is taken by the calling goroutine and reads p's maps, so it
+// carries the same requirement every other read of a *Package does: no other
+// goroutine may be writing p at the time (issue #397).
+func admitPackage(p *Package) *Package {
+	adm := &Package{
+		Name:       p.Name,
+		Doc:        p.Doc,
+		symbols:    make(map[string]*LVal, len(p.symbols)),
+		symbolDocs: make(map[string]string, len(p.symbolDocs)),
+		funNames:   make(map[string]string, len(p.funNames)),
+	}
+	if len(p.externals) > 0 {
+		adm.externals = make([]string, len(p.externals))
+		copy(adm.externals, p.externals)
+	}
+	for name, v := range p.symbols {
+		adm.symbols[name] = admitSymbolValue(v)
+	}
+	for name, doc := range p.symbolDocs {
+		adm.symbolDocs[name] = doc
+	}
+	// funNames is keyed by FID and admission never copies a function value
+	// (functions are not sealable), so every recorded FID still names the
+	// value the snapshot holds.  Carrying it over keeps stack traces and
+	// error messages naming the same functions they did before the transfer.
+	for fid, name := range p.funNames {
+		adm.funNames[fid] = name
+	}
+	return adm
+}
+
+// admitSymbolValue returns the value a registry binds for one of an admitted
+// package's symbols: v itself when v is already safe to share, and a private
+// sealed copy when v is a code-like tree the caller may still be writing.
+func admitSymbolValue(v *LVal) *LVal {
+	// Cheapest question first, and the one that answers most bindings in a
+	// real package: a function, native, map, array or byte string is not a
+	// class the seal covers, so there is nothing to copy and nothing to
+	// freeze.  It is admitted by reference under the custody-transfer half
+	// of the contract.
+	if v == nil || !sealableNodeType(v.Type) {
+		return v
+	}
+	sealed, sealable := classifySymbolValue(v, cycleGuard{state: new(cycleState)})
+	if sealed || !sealable {
+		// Sealed throughout: the sanctioned share (immutability, not
+		// confinement, is what protects it).  Not sealable throughout: a
+		// list holding a function or a native, which cannot be frozen and
+		// whose interior cannot be copied faithfully — reference, as above.
+		return v
+	}
+	// The hazard class.  Copy severs every alias the caller retained (cells,
+	// locations and format metadata are all detached) and clears the sealed
+	// flag on the fresh storage; SealAST then freezes the copy and records
+	// its fingerprint with the checked-mode census.  classifySymbolValue has
+	// already established that every node of the tree is one SealAST marks,
+	// so the copy is sealed throughout when this returns.
+	cp := v.Copy()
+	cp.SealAST()
+	return cp
+}
+
+// classifySymbolValue walks v once and reports whether it is sealed
+// throughout (admit by reference) and whether it is sealable throughout
+// (eligible for the copy-and-seal treatment).  A node whose type SealAST
+// declines to mark makes the whole value unsealable, and stops the walk
+// there rather than descending into a reference type's backing.
+//
+// Unlike program.go's firstUnsealed, this walks values rather than parse
+// output, so it cannot assume a tree: a program can store a container inside
+// itself (issue #390), and Copy() on such a value would not terminate.  A
+// cycle therefore reports "neither", which lands the value in the
+// by-reference row where no copy is attempted.
+func classifySymbolValue(v *LVal, g cycleGuard) (sealed, sealable bool) {
+	if v == nil || !sealableNodeType(v.Type) {
+		return false, false
+	}
+	g, cyclic := g.descend(v)
+	if cyclic {
+		return false, false
+	}
+	if g.tracking() {
+		defer g.ascend(v)
+	}
+	sealed, sealable = v.IsSealed(), true
+	for _, c := range v.Cells {
+		cellSealed, cellSealable := classifySymbolValue(c, g)
+		sealed = sealed && cellSealed
+		sealable = sealable && cellSealable
+		if !sealed && !sealable {
+			// Neither answer can change from here: both are conjunctions.
+			return false, false
+		}
+	}
+	return sealed, sealable
+}

--- a/lisp/package_admit_elpscheck_test.go
+++ b/lisp/package_admit_elpscheck_test.go
@@ -1,0 +1,137 @@
+// Copyright © 2026 The ELPS authors
+
+//go:build elpscheck
+
+package lisp_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// Checked-mode half of the issue #524 red proof (default-build half:
+// package_admit_test.go).
+//
+// Two verifiers cover the AddPackage hazard from opposite ends, and this file
+// exercises both.
+//
+//   - The OWNERSHIP table (lisp/ownership_check_elpscheck.go) catches the
+//     hazard while it is happening.  Its allowlist admits exactly two kinds
+//     of value across a Runtime boundary: singletons and sealed nodes.  A
+//     package added to two registries used to put one UNSEALED list into two
+//     Runtimes, so the moment the second environment bound an element of it
+//     the checker panicked with "ownership violation: LVal used by two
+//     Runtimes".  With the admission in place each registry holds its own
+//     sealed copy: no sharing, and sealed even if there were.
+//
+//     The probe for that arm deliberately does NOT mutate.  A mutating probe
+//     hides the violation instead of provoking it — once the first Runtime
+//     has reordered the shared list, the second one reads a DIFFERENT node
+//     out of it, which the first never adopted, so the corruption arrives as
+//     a wrong answer and the ownership table stays quiet.  The mutating probe
+//     is the default-build proof's job (package_admit_test.go); this one
+//     shares the node.
+//
+//   - The seal CENSUS (lisp/seal_check_elpscheck.go) catches it afterwards,
+//     and its coverage is a consequence of the fix rather than a given:
+//     SealAST is the census's record point, so the admitted copy is
+//     fingerprinted precisely BECAUSE admission seals it.  An admission that
+//     did not seal would leave the registry's binding invisible to the
+//     verifier — no record, nothing to compare, silence.  The mutation test
+//     below proves the coverage is real, in the style of
+//     lisp/registration_formals_elpscheck_test.go and
+//     lisp/singleton_seal_elpscheck_test.go: mutate deliberately under the
+//     paused -race seal watchdog, prove detection, restore, prove the report
+//     clears.
+
+// addPkgSharingProbe binds an element of the admitted list into a lexical
+// scope — LEnv.Put, one of the checker's three sighting points — and returns
+// it.  It mutates nothing, so the node the second Runtime binds is the same
+// node the first one adopted.
+const addPkgSharingProbe = `(use-package 'addpkg-red)
+(let ([head (car limits)]) head)
+`
+
+// TestAddPackageCheckedCrossRuntime is the ownership half: one hand-built
+// package, two Runtimes, no violation, matching results.
+func TestAddPackageCheckedCrossRuntime(t *testing.T) {
+	pkg, _ := hostilePackage(t)
+
+	for i := range 2 {
+		// Each iteration is a fresh Runtime.  Pre-fix, iteration 2 panics in
+		// the ownership checker before producing any value.
+		env := programTestEnv(t)
+		if !env.Runtime.Registry.AddPackage(pkg) {
+			t.Fatalf("runtime %d: AddPackage refused the package", i+1)
+		}
+		got := env.LoadString("addpkg.lisp", addPkgSharingProbe)
+		if got.Type == lisp.LError {
+			t.Fatalf("runtime %d: %v", i+1, got)
+		}
+		if got.String() != addPkgWant {
+			t.Errorf("runtime %d = %v, want %s", i+1, got, addPkgWant)
+		}
+	}
+
+	if err := lisp.VerifySealedASTs(); err != nil {
+		t.Fatalf("seal census after cross-runtime package admission: %v", err)
+	}
+}
+
+// TestAddPackageCheckedCensusCatchesMutation is the census half: an in-place
+// write to the value AddPackage admitted must be reported by the fingerprint
+// verifier.  The write shape is the hazard's own — a cell of the registered
+// list edited underneath the Runtime serving it — reached here through the
+// registry rather than through a builtin, because what is being tested is the
+// verifier's coverage of the admitted copy, not any particular mutator.
+func TestAddPackageCheckedCensusCatchesMutation(t *testing.T) {
+	defer lisp.PauseSealWatchdogForTest()()
+
+	pkg, limits := hostilePackage(t)
+	env := programTestEnv(t)
+	if !env.Runtime.Registry.AddPackage(pkg) {
+		t.Fatal("AddPackage refused the package")
+	}
+	admitted, ok := env.Runtime.Registry.Package(addPkgRedName).Symbol("limits")
+	if !ok {
+		t.Fatal("the admitted package has no `limits` binding")
+	}
+
+	// Anti-vacuity.  The mutation below is only a red proof if the value it
+	// writes is (a) the registry's own copy, not the caller's node, and (b)
+	// sealed — which is what put it in the census in the first place.
+	if admitted == limits {
+		t.Fatal("the registry admitted the caller's retained node; the admission is not in effect")
+	}
+	if !admitted.IsSealed() {
+		t.Fatal("the admitted binding is unsealed; the census never recorded it and cannot see a write")
+	}
+	if len(admitted.Cells) == 0 {
+		t.Fatal("the admitted binding has no cells to mutate")
+	}
+	if err := lisp.VerifySealedASTs(); err != nil {
+		t.Fatalf("census is already dirty before the deliberate mutation: %v", err)
+	}
+
+	cell := admitted.Cells[0]
+	orig := cell.Int
+	defer func() { cell.Int = orig }()
+
+	cell.Int = 999
+
+	err := lisp.VerifySealedASTs()
+	if err == nil {
+		t.Fatal("expected VerifySealedASTs to report the mutated admitted package value")
+	}
+	if !strings.Contains(err.Error(), "mutated in place") {
+		t.Fatalf("error should use the seal-violation report; got: %v", err)
+	}
+
+	// Restore and prove the report clears — the suite continues clean.
+	cell.Int = orig
+	if err := lisp.VerifySealedASTs(); err != nil {
+		t.Fatalf("VerifySealedASTs still failing after restore: %v", err)
+	}
+}

--- a/lisp/package_admit_test.go
+++ b/lisp/package_admit_test.go
@@ -1,0 +1,313 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// This file covers issue #524: PackageRegistry.AddPackage admitting an
+// externally built package with no admission check, so a caller's mutable
+// symbol-table values became the interpreter state of one Runtime (or of
+// several) while the caller still held pointers to them.
+//
+// It is the same root shape #523 fixed for Programs, on a surface with a
+// different contract: a package legitimately holds builtins, natives,
+// sorted-maps and other runtime data, so the admission cannot be "seal it or
+// refuse it".  The rule it implements instead is stated per value class in
+// lisp/package_admit.go, and this file is that rule's test:
+//
+//	(1) TestAddPackageSealsAliasedSymbolValues — the reproduction: one
+//	    package, two registries, an unsealed list the caller keeps.  Pre-fix
+//	    the first environment's stable-sort rewrote the literal for the
+//	    second environment AND for the caller.
+//	(2) TestAddPackageDoesNotHoldCallersPackage — the container half: what
+//	    is registered is a snapshot, so a later write through the caller's
+//	    *Package does not reach the Runtime.
+//	(3) TestAddPackageSharesAdmissibleValues — the fast-path pin: sealed
+//	    values, builtins, natives and maps are admitted BY REFERENCE.  If
+//	    someone later swaps the admission for an unconditional deep copy,
+//	    this fails and they have to say so — the doc/LSP/MCP registry merges
+//	    (and substrate's booted shiro registry behind them) are made almost
+//	    entirely of these classes.
+//	(4) TestAddPackageSnapshotPreservesPackageMetadata — the snapshot is a
+//	    snapshot: docs, exports and the FID→name table survive it.
+//	(5) TestAddPackageAdmitsCyclicValueByReference — a value that contains
+//	    itself is admitted by reference rather than copied, because Copy()
+//	    on it would not terminate (issue #390).
+//
+// The checked-mode half of the red proof lives in
+// package_admit_elpscheck_test.go.
+
+// addPkgRedName is the package the red-proof fixtures build by hand, the way
+// an embedder assembling a package in Go does.
+const addPkgRedName = "addpkg-red"
+
+// addPkgProbe is the probe program, in the shape lisp/program_seal_gap_test.go
+// uses: the let materializes the list's head BEFORE the sort touches
+// anything, so the value returned is an immutable snapshot of what THIS
+// environment saw — 10 from a pristine binding, 30 from the wreckage another
+// environment left behind.
+//
+// The sort sits under ignore-errors because on a properly admitted (sealed)
+// binding it is refused with modify-literal-error.  That refusal is not what
+// this file tests; swallowing it keeps the probe alive for what it does test.
+const addPkgProbe = `(use-package 'addpkg-red)
+(let ([pre (car limits)]) (ignore-errors (stable-sort > limits)) pre)
+`
+
+// addPkgWant is what every environment must read: the pristine head.
+const addPkgWant = "10"
+
+// hostilePackage builds the fixture: a package bound to a runtime-built list
+// — fresh mutable storage, sealed by nothing — which the caller retains and
+// hands to as many registries as it likes.  Returns the package and the list
+// the caller keeps aliasing.
+func hostilePackage(t *testing.T) (*lisp.Package, *lisp.LVal) {
+	t.Helper()
+	limits := lisp.QExpr([]*lisp.LVal{lisp.Int(10), lisp.Int(20), lisp.Int(30)})
+	// Anti-vacuity: a fixture that arrived sealed would exercise the fast
+	// path and prove nothing about the hazard class.
+	if limits.IsSealed() {
+		t.Fatal("anti-vacuity: the hand-built list is sealed; the fixture no longer models unsealed runtime storage")
+	}
+	pkg := lisp.NewPackage(addPkgRedName)
+	if lerr := pkg.Put(lisp.Symbol("limits"), limits); lerr.Type == lisp.LError {
+		t.Fatalf("put limits: %v", lerr)
+	}
+	pkg.Export("limits")
+	return pkg, limits
+}
+
+// TestAddPackageSealsAliasedSymbolValues is issue #524's reproduction.
+//
+// One hand-built package is added to two independent environments — the
+// topology of every registry merge, and of an embedder that installs its
+// package into every environment it creates.  Each environment snapshots the
+// binding's head before sorting it in place; every snapshot must be the
+// pristine one, and the caller's own list must be untouched afterwards.
+//
+// On the unfixed tree environment 1's stable-sort rewrote the one shared
+// list, so environment 2 read 30 before evaluating anything of its own, and
+// the caller's `limits` came back reordered from a call it never made.
+func TestAddPackageSealsAliasedSymbolValues(t *testing.T) {
+	pkg, limits := hostilePackage(t)
+
+	envs := []*lisp.LEnv{programTestEnv(t), programTestEnv(t)}
+	for i, env := range envs {
+		if !env.Runtime.Registry.AddPackage(pkg) {
+			t.Fatalf("environment %d: AddPackage refused the package", i+1)
+		}
+	}
+
+	// The admitted binding must be a private, sealed copy in each registry:
+	// not the caller's node, and not the other registry's node either.
+	admitted := make([]*lisp.LVal, len(envs))
+	for i, env := range envs {
+		v, ok := env.Runtime.Registry.Package(addPkgRedName).Symbol("limits")
+		if !ok {
+			t.Fatalf("environment %d: admitted package has no `limits` binding", i+1)
+		}
+		if v == limits {
+			t.Errorf("environment %d: the registry admitted the caller's retained node by reference", i+1)
+		}
+		if !v.IsSealed() {
+			t.Errorf("environment %d: the admitted binding is unsealed; the admission did not seal the copy", i+1)
+		}
+		admitted[i] = v
+	}
+	if admitted[0] == admitted[1] {
+		t.Error("two registries share one admitted node; the admission copied per registry, or should have")
+	}
+
+	for i, env := range envs {
+		got := env.LoadString("addpkg.lisp", addPkgProbe)
+		if got.Type == lisp.LError {
+			t.Fatalf("environment %d: %v", i+1, got)
+		}
+		if got.String() != addPkgWant {
+			t.Errorf("environment %d read a write through the shared package: got %v, want %s (the pristine binding)",
+				i+1, got, addPkgWant)
+		}
+	}
+
+	// The caller's list is the other direction of the same guarantee: a
+	// Runtime evaluating an admitted package must not rewrite what the
+	// caller still holds.
+	if got := limits.Cells[0].Int; got != 10 {
+		t.Errorf("the caller's retained list was reordered by an environment: head = %d, want 10", got)
+	}
+}
+
+// TestAddPackageDoesNotHoldCallersPackage covers the container half of the
+// contract.  The registry stores a snapshot, so a caller that keeps writing
+// its own *Package after registering it — the widest write channel into
+// another Runtime's interpreter state — no longer reaches the registry.
+func TestAddPackageDoesNotHoldCallersPackage(t *testing.T) {
+	pkg, _ := hostilePackage(t)
+	env := programTestEnv(t)
+	if !env.Runtime.Registry.AddPackage(pkg) {
+		t.Fatal("AddPackage refused the package")
+	}
+	registered := env.Runtime.Registry.Package(addPkgRedName)
+	if registered == pkg {
+		t.Fatal("the registry stored the caller's *Package; a later write through it lands in the Runtime")
+	}
+
+	// Every write an embedder has: a new binding, a rebound one, a new
+	// export.
+	if lerr := pkg.Put(lisp.Symbol("injected"), lisp.String("surprise")); lerr.Type == lisp.LError {
+		t.Fatalf("put injected: %v", lerr)
+	}
+	if lerr := pkg.Put(lisp.Symbol("limits"), lisp.String("replaced")); lerr.Type == lisp.LError {
+		t.Fatalf("rebind limits: %v", lerr)
+	}
+	pkg.Export("injected")
+
+	if _, ok := registered.Symbol("injected"); ok {
+		t.Error("a binding created after AddPackage reached the registry")
+	}
+	v, ok := registered.Symbol("limits")
+	if !ok {
+		t.Fatal("the registered package lost its `limits` binding")
+	}
+	if v.Type != lisp.LSExpr {
+		t.Errorf("a rebind after AddPackage reached the registry: limits is now %v", v.Type)
+	}
+	for _, name := range registered.Externals() {
+		if name == "injected" {
+			t.Error("an export declared after AddPackage reached the registry")
+		}
+	}
+}
+
+// TestAddPackageSharesAdmissibleValues pins the by-reference rows of the
+// admission table.  Sealed values are the sanctioned cross-environment share
+// and must not be forked; functions, natives, sorted-maps and mixed trees
+// are classes no seal covers, and copying them would be either impossible or
+// a semantic change.  The registry merges in cmd/doc.go and mcpserver (which
+// is how a booted embedder registry reaches the doc/LSP/MCP tools) are made
+// almost entirely of these values.
+func TestAddPackageSharesAdmissibleValues(t *testing.T) {
+	// A sealed value, obtained the way real bindings get one: by evaluating
+	// a literal.
+	src := programTestEnv(t)
+	sealedVal := src.LoadString("sealed.lisp", `'(1 2 3)`)
+	if sealedVal.Type == lisp.LError {
+		t.Fatalf("evaluate literal: %v", sealedVal)
+	}
+	if !sealedVal.IsSealed() {
+		t.Fatal("anti-vacuity: a quoted literal evaluated to an unsealed value; the fast-path fixture is broken")
+	}
+
+	fn := lisp.Fun("addpkg-share-fun", lisp.Formals(),
+		func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal { return lisp.Nil() })
+	native := lisp.Native(t)
+	vector := lisp.Vector([]*lisp.LVal{lisp.Int(1)})
+	sortmap := lisp.SortedMap()
+	// A mixed tree: a list holding a value the seal cannot mark.  Copying it
+	// would deep-copy around a node that must keep reference semantics, so
+	// it is admitted whole, by reference.
+	mixed := lisp.QExpr([]*lisp.LVal{lisp.Int(1), native})
+
+	pkg := lisp.NewPackage("addpkg-share")
+	shared := map[string]*lisp.LVal{
+		"sealed": sealedVal,
+		"fn":     fn,
+		"native": native,
+		"vector": vector,
+		"map":    sortmap,
+		"mixed":  mixed,
+	}
+	for name, v := range shared {
+		if lerr := pkg.Put(lisp.Symbol(name), v); lerr.Type == lisp.LError {
+			t.Fatalf("put %s: %v", name, lerr)
+		}
+	}
+
+	env := programTestEnv(t)
+	if !env.Runtime.Registry.AddPackage(pkg) {
+		t.Fatal("AddPackage refused the package")
+	}
+	registered := env.Runtime.Registry.Package("addpkg-share")
+	for name, want := range shared {
+		got, ok := registered.Symbol(name)
+		if !ok {
+			t.Errorf("%s: binding lost by admission", name)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s: admission copied a value it must share by reference (%v)", name, want.Type)
+		}
+	}
+}
+
+// TestAddPackageSnapshotPreservesPackageMetadata proves the snapshot carries
+// everything the registry serves besides the values: the package doc, the
+// export list (so use-package still imports), per-symbol docs, and the
+// FID→name table that names functions in stack traces and error messages.
+func TestAddPackageSnapshotPreservesPackageMetadata(t *testing.T) {
+	pkg, _ := hostilePackage(t)
+	pkg.Doc = "red-proof package"
+	fn := lisp.FunInPackage(addPkgRedName, "addpkg-red-fid", lisp.Formals(),
+		func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal { return lisp.Nil() })
+	if lerr := pkg.Put(lisp.Symbol("noop"), fn); lerr.Type == lisp.LError {
+		t.Fatalf("put noop: %v", lerr)
+	}
+	pkg.Export("noop")
+
+	env := programTestEnv(t)
+	if !env.Runtime.Registry.AddPackage(pkg) {
+		t.Fatal("AddPackage refused the package")
+	}
+	registered := env.Runtime.Registry.Package(addPkgRedName)
+
+	if registered.Doc != pkg.Doc {
+		t.Errorf("package doc lost by admission: %q", registered.Doc)
+	}
+	if got, want := strings.Join(registered.Externals(), ","), strings.Join(pkg.Externals(), ","); got != want {
+		t.Errorf("export list = %q, want %q", got, want)
+	}
+	if got := registered.GetFunName(fn.FID()); got != "noop" {
+		t.Errorf("GetFunName(%s) = %q, want \"noop\"; the FID→name table did not survive admission", fn.FID(), got)
+	}
+
+	// use-package must still import the exports out of the snapshot.
+	res := env.LoadString("meta.lisp", `(use-package 'addpkg-red) (car limits)`)
+	if res.Type == lisp.LError {
+		t.Fatalf("use-package the admitted package: %v", res)
+	}
+	if res.String() != addPkgWant {
+		t.Errorf("(car limits) = %v, want %s", res, addPkgWant)
+	}
+}
+
+// TestAddPackageAdmitsCyclicValueByReference covers the walk's termination
+// guarantee.  A value can contain itself (issue #390), and Copy() on such a
+// value does not terminate — so the classification reports "neither sealed
+// nor sealable" for a cycle and the value takes the by-reference row.  The
+// assertion that matters is that AddPackage returns at all.
+func TestAddPackageAdmitsCyclicValueByReference(t *testing.T) {
+	cyclic := lisp.QExpr([]*lisp.LVal{lisp.Int(1)})
+	cyclic.Cells = append(cyclic.Cells, cyclic)
+
+	pkg := lisp.NewPackage("addpkg-cyclic")
+	if lerr := pkg.Put(lisp.Symbol("loop"), cyclic); lerr.Type == lisp.LError {
+		t.Fatalf("put loop: %v", lerr)
+	}
+
+	env := programTestEnv(t)
+	if !env.Runtime.Registry.AddPackage(pkg) {
+		t.Fatal("AddPackage refused the package")
+	}
+	got, ok := env.Runtime.Registry.Package("addpkg-cyclic").Symbol("loop")
+	if !ok {
+		t.Fatal("cyclic binding lost by admission")
+	}
+	if got != cyclic {
+		t.Error("admission copied a cyclic value; the copy cannot terminate and the walk must have refused it")
+	}
+}

--- a/lisp/seal.go
+++ b/lisp/seal.go
@@ -120,13 +120,28 @@ func (v *LVal) SealAST() {
 	recordSealedRoot(v)
 }
 
-func (v *LVal) sealAST() {
-	if v == nil || v.sealed || isSingleton(v) {
-		return
-	}
-	switch v.Type {
+// sealableNodeType reports whether SealAST marks a node of type t.  The set
+// is exactly the types elps literal syntax can produce; every other type was
+// necessarily constructed at runtime, and sealing it would freeze storage the
+// evaluator legitimately mutates (see SealAST's comment).
+//
+// It is stated once, here, because three places have to agree on it: sealAST,
+// InheritSeal, and the package registry's admission check (lisp/
+// package_admit.go), which decides per value class what AddPackage may do
+// with a caller's binding.  A new parser-producible type that is added to
+// one switch and forgotten in another is a silent hole in whichever check
+// was missed.
+func sealableNodeType(t LType) bool {
+	switch t {
 	case LSExpr, LQuote, LSymbol, LQSymbol, LString, LInt, LFloat:
+		return true
 	default:
+		return false
+	}
+}
+
+func (v *LVal) sealAST() {
+	if v == nil || v.sealed || isSingleton(v) || !sealableNodeType(v.Type) {
 		return
 	}
 	// The write below is the one sanctioned non-fresh LVal write in the
@@ -189,12 +204,7 @@ func errModifyLiteral(env *LEnv) *LVal {
 // Sealing is monotone, so this is idempotent and safe to call on a value
 // that is already sealed.
 func (v *LVal) InheritSeal(src *LVal) {
-	if v == nil || v.sealed || !src.IsSealed() || isSingleton(v) {
-		return
-	}
-	switch v.Type {
-	case LSExpr, LQuote, LSymbol, LQSymbol, LString, LInt, LFloat:
-	default:
+	if v == nil || v.sealed || !src.IsSealed() || isSingleton(v) || !sealableNodeType(v.Type) {
 		return
 	}
 	// Same sanctioned write as sealAST's: v is a header the caller minted a


### PR DESCRIPTION
## Summary

`PackageRegistry.AddPackage` was the second exported surface with the shape #394 found on the `Program` constructors: a caller hands the kernel a container of `*LVal`s it still holds pointers to, and a `Runtime` starts serving them. #523 fixed the `Program` half with one admission point (`newProgram`). `AddPackage` had none — it stored the caller's `*Package` verbatim — so an externally built package carried the caller's mutable symbol-table values straight into interpreter state, and into every other registry the same package was added to.

`AddPackage` is now an admission point. It registers a private **snapshot** of the package, whose bindings are admitted per value class.

## Design rationale

`newProgram`'s rule does not transfer. A `Program` holds parse output, so "seal it or refuse it" is a complete rule. A package's symbol table legitimately holds Go builtins, lisp closures, natives, sorted-maps, arrays and other runtime data — values the seal *deliberately* declines to mark, because the evaluator mutates them. "Seal everything" would freeze storage the evaluator writes; "reject the unsealable" would reject every real package, since the in-repo consumers (`cmd/doc.go`'s registry merge and `mcpserver`'s per-request doc env — the path a booted downstream registry reaches the doc/LSP/MCP tools through) are packages of builtins and closures.

So the rule is stated per value class (`lisp/package_admit.go`, `docs/sealed-ast.md` §2.8):

| Value class | Admission |
|---|---|
| singletons; values **sealed throughout** | shared by reference — the sanctioned share |
| **sealable throughout but unsealed**: runtime-built lists, symbols, strings, numbers | private `Copy()` + `SealAST()` |
| everything else: functions, natives, sorted-maps, arrays, bytes, errors, tagged values, and trees holding one | shared by reference, **custody transferred** |

- The **middle row is the hazard** the issue names: fresh mutable storage the caller still aliases. A `stable-sort` in the registry's `Runtime` rewrites it under the caller (and under every other registry holding the package); a write through the caller's retained pointer rewrites what the `Runtime` evaluates. `Copy()` severs the alias, `SealAST()` freezes the copy and (in checked builds) enrols it in the census.
- The **sealed fast path is load-bearing**, not an optimization note: values produced by evaluating literals are already sealed, so a package built by loading lisp source is admitted with its bindings shared, exactly as a `Program` of sealed parser output is.
- The **last row is knowingly weaker** than `newProgram`'s rule, and the docs say so rather than implying a guarantee that is not there: a closure's captured `*LEnv` cannot be copied and reference types are reference types on purpose, so `AddPackage` promises custody transfer for them, not isolation. The compensating controls are the existing ones (closure-free builtins are provably stateless and ownership-exempt; everything else is covered by the checked-mode ownership table).
- The classification walk is **cycle-guarded** (a value can contain itself, #390, and `Copy()` on such a value would not terminate): a cycle lands in the by-reference row rather than being copied.
- **Container half:** the registry no longer holds the caller's `*Package`, so a `Put` through it after registration does not reach the `Runtime`.

### Sibling mutators (the audit #524 asks for)

- `Package.Put`/`Update` keep storing what they are given. They are the write path every `set` reaches through `LEnv.PutGlobal`, where the value belongs to the environment already evaluating it and `LEnv.Put`/`PutGlobal` have already taken the checked-mode ownership sighting — an admission walk there would tax the interpreter's hot path to guard a transfer that is not happening. Documented on the method.
- `Export`/`Exports` store names only (`Exports` already copies its slice); `DefinePackage` builds a fresh package.
- Residual, recorded in the docs: `PackageRegistry.Package` hands out the registry's live `*Package` (that is how the merges enumerate a booted registry), and a caller can `Put` through it. Same residual as §2.7's exported fields.

### Incidental

`seal.go`'s parser-producible type list is extracted into `sealableNodeType`, so `sealAST`, `InheritSeal` and the new admission cannot drift apart. It inlines into all three call sites.

## Red proofs

Both were run against the pre-fix tree (guard disabled) and are red there:

**Default build — `lisp/package_admit_test.go`.** One hand-built package added to two environments. Pre-fix:

```
package_admit_test.go:132: environment 2 read a write through the shared package: got 30, want 10 (the pristine binding)
package_admit_test.go:141: the caller's retained list was reordered by an environment: head = 30, want 10
package_admit_test.go:157: the registry stored the caller's *Package; a later write through it lands in the Runtime
```

The file also pins the by-reference rows (sealed values, builtins, natives, maps and mixed trees are *not* copied — swapping the admission for an unconditional deep copy has to be a deliberate, argued change), the snapshot's metadata fidelity (doc, exports, per-symbol docs, the FID→name table, `use-package`), and the cyclic-value case.

**`-tags elpscheck` — `lisp/package_admit_elpscheck_test.go`.** Two verifiers, from opposite ends:

- *Ownership table.* Pre-fix the cross-runtime arm panics with `ownership violation: LVal used by two Runtimes` (an `int` node bound in two Runtimes). Its probe deliberately does **not** mutate: a mutating probe hides the violation, because once the first Runtime reorders the shared list the second reads a node the first never adopted, so the corruption arrives as a wrong answer and the table stays quiet. (That subtlety is written into the file.)
- *Seal census.* The admitted copy is mutated in place under the paused `-race` seal watchdog (the `registration_formals_elpscheck_test.go` pattern), `VerifySealedASTs` must report it, then the bytes are restored and the report must clear. That coverage exists *only because* admission seals the copy: an admission that did not seal would leave the binding unrecorded and the verifier silent — asserted by anti-vacuity checks on identity and `IsSealed()`.

## Test plan

| Gate | Result |
|---|---|
| `go build ./...` | pass |
| `go test ./...` | pass |
| `go test -tags elpscheck ./lisp/...` | pass |
| `go test -race ./lisp/...` | pass |
| `make elpsvet` (both passes) | clean |
| `make static-checks` | only the 2 pre-existing `nolintlint` findings in `parser/token/token.go` |
| `./elps doc -m` | "All functions and exports are documented." |
| `./elps fmt -l ./...` | clean |
| `./elps lint ./...` | no new findings (pre-existing `editors/vscode/test/grammar/*` fixtures only) |
| benchstat, interleaved n=10 | `BenchmarkParser` (the `sealAST` path): every row `~`, geomean sec/op −0.46%, B/op and allocs/op bit-identical ("all samples are equal"). `BenchmarkPackage*`: every row `~`, zero allocs unchanged. |

## Downstream (substrate)

Checked `/home/user/substrate` (read-only). No direct `AddPackage` call sites: substrate reaches it only by handing a booted shiro registry to elps tooling (`bootShiroRegistry` → `lsp.WithRegistry`, `mcpserver.WithRegistry`, `lint.LintConfig.Registry`), and of those only `mcpserver`'s doc env merges packages — after the registry is fully booted, so nothing is bound into those packages afterwards and the served contents are unchanged. **No downstream changes are required by this PR.** Two notes for whoever does the next elps bump:

- Per-request doc envs now hold private `*Package` snapshots instead of the shared objects, which incidentally removes the cross-goroutine `*Package` sharing on exactly the path #397 was reported against; the cost is one map copy per package per doc env at construction.
- Substrate still uses the pre-#382 exported surface (`Registry.Packages[...]`, `Package.Externals`) in `internal/substrate/shiro/libcc/libcc.go` and a few tests. That migration is owed to #382, not to this change, and the new contract is compatible with it (`Registry.Package(name)` / `Externals()` / `Export(...)`).

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq

---
_Generated by [Claude Code](https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq)_