### PR TITLE
chore: add a SessionStart hook so web sessions can run tests and lint

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# SessionStart hook for Claude Code on the web.
+#
+# This repairs two pieces of version skew between the web container image and
+# what this repository targets.  Neither is a defect in this repository, and
+# neither reproduces on a developer laptop, so the whole script is a no-op
+# outside a remote session.
+#
+# 1. `make test` (`go test -cover ./...`) dies with:
+#
+#        go: no such tool "covdata"
+#
+#    Go 1.25 changed cmd/distpack to ship only the tools a build action needs
+#    (asm cgo compile cover link preprofile vet).  covdata is no longer
+#    prebuilt; Go >= 1.25's `go tool` builds it on demand from GOROOT/src, and
+#    Go 1.24's `go tool` has no such fallback -- it only stats
+#    $GOROOT/pkg/tool/$GOOS_$GOARCH.
+#
+#    The container's PATH `go` has been older than this module's `go`
+#    directive (go1.24.7 vs go 1.25.0), so GOTOOLCHAIN=auto makes it exec the
+#    newer toolchain *and* export GOROOT pointing at that toolchain's tree.
+#    `go test -cover` then shells out to `go tool covdata percent` for every
+#    package that has no test files, and that child resolves `go` from PATH --
+#    finding the OLD binary again, now aimed at a GOROOT whose pkg/tool has no
+#    covdata.  Hence the error, and hence `go test ./...` (no -cover) working
+#    fine, which is what makes this look like a phantom.
+#
+#    Pinning GOTOOLCHAIN makes parent and child select the same toolchain, so
+#    the skew cannot arise.  It also makes the session use exactly the Go that
+#    CI uses, rather than whatever the image happens to ship.
+#
+# 2. golangci-lint findings are not stable across its minor versions, and an
+#    unpinned binary silently disagrees with CI.  Measured on this tree: the
+#    version below reports 0 issues, v2.11.4 reports 27.  A golangci-lint
+#    built with a Go older than the module's `go` directive additionally
+#    refuses to start at all ("the Go language version ... is lower than the
+#    targeted Go version"), which is how this bites a repository that has
+#    moved its `go` directive forward.
+#
+# Both pins below must be kept in sync with .github/workflows/elps.yml.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+	exit 0
+fi
+
+# Keep in sync with `go-version:` in .github/workflows/elps.yml.
+GO_TOOLCHAIN="go1.25.13"
+# Keep in sync with the golangci-lint-action `version:` in the same file.
+GOLANGCI_VERSION="2.6.2"
+
+# Version-scoped so a container reused across repositories does not have two
+# pins fighting over one path.
+TOOLS_BIN="${HOME}/.cache/claude-code-tools/golangci-lint-${GOLANGCI_VERSION}"
+ENV_FILE="${CLAUDE_ENV_FILE:-/dev/null}"
+
+mkdir -p "$TOOLS_BIN"
+
+# --- Go toolchain ---------------------------------------------------------
+# Fetching it here means the first build of the session is not also a
+# download, and the export makes every `go` invocation agree with CI.
+if GOTOOLCHAIN="$GO_TOOLCHAIN" go version >/dev/null 2>&1; then
+	printf 'export GOTOOLCHAIN=%s\n' "$GO_TOOLCHAIN" >>"$ENV_FILE"
+	echo "session-start: GOTOOLCHAIN pinned to ${GO_TOOLCHAIN}"
+else
+	echo "session-start: WARNING could not fetch ${GO_TOOLCHAIN}; GOTOOLCHAIN left alone" >&2
+fi
+
+# --- golangci-lint --------------------------------------------------------
+install_golangci() {
+	arch="$(uname -m)"
+	case "$arch" in
+	x86_64) arch=amd64 ;;
+	aarch64 | arm64) arch=arm64 ;;
+	*)
+		echo "session-start: WARNING unsupported arch ${arch}" >&2
+		return 1
+		;;
+	esac
+
+	url="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/golangci-lint-${GOLANGCI_VERSION}-linux-${arch}.tar.gz"
+	tmp="$(mktemp -d)"
+	rc=0
+	if curl -fsSL --retry 3 --max-time 300 "$url" | tar -xz -C "$tmp" --strip-components=1; then
+		install -m 0755 "${tmp}/golangci-lint" "${TOOLS_BIN}/golangci-lint" || rc=1
+	else
+		rc=1
+	fi
+	rm -rf "$tmp"
+	return "$rc"
+}
+
+if "${TOOLS_BIN}/golangci-lint" version 2>/dev/null | grep -q "version ${GOLANGCI_VERSION} "; then
+	echo "session-start: golangci-lint ${GOLANGCI_VERSION} already cached"
+elif install_golangci; then
+	echo "session-start: golangci-lint ${GOLANGCI_VERSION} installed"
+else
+	echo "session-start: WARNING golangci-lint ${GOLANGCI_VERSION} install failed" >&2
+fi
+
+if [ -x "${TOOLS_BIN}/golangci-lint" ]; then
+	printf 'export PATH=%s:$PATH\n' "$TOOLS_BIN" >>"$ENV_FILE"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,5 +20,17 @@
       "Bash(mkdir *)",
       "mcp__elps__*"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Problem

In a remote web-session container, `make test` (`go test -cover ./...`) fails on every package that has no test files:

```
# github.com/luthersystems/elps
go: no such tool "covdata"
```

Plain `go test ./...` succeeds. That asymmetry is why this has been worked around rather than fixed — it looks like a corrupt toolchain, and it is not.

## Root cause

It is version skew between the container's `go` and the toolchain this module selects, in a place that is easy to miss.

1. **Go 1.25 stopped shipping most prebuilt tools.** `cmd/distpack` now keeps only the tools a build action needs — `asm cgo compile cover link preprofile vet`. Confirmed by diffing `src/cmd/distpack/pack.go` between 1.24 and 1.25: the comment changes from *"discard helper tools"* to *"keep only tools needed for build actions"*. `covdata`, `buildid`, `nm`, `pprof`, `test2json` and friends are gone from `pkg/tool/`; Go ≥ 1.25's `go tool` builds them on demand from `GOROOT/src` (`loadBuiltinTool` / `buildAndRunBuiltinTool` in `cmd/go/internal/tool/tool.go`). Go 1.24 has no such fallback — `base.Tool` only stats `$GOROOT/pkg/tool/$GOOS_$GOARCH` and dies with exactly this message.

2. **The container's PATH `go` is 1.24.7; this module's `go` directive is 1.25.0.** `GOTOOLCHAIN=auto` therefore makes the 1.24.7 binary exec the 1.25.0 toolchain *and* export `GOROOT` pointing at it (`execGoToolchain` in `cmd/go/internal/toolchain/exec.go` does `os.Setenv("GOROOT", dir)`).

3. **`go test -cover` shells back out to `go`.** `work.CovData` runs `go tool covdata percent -i …`, and `shell.runOut` resolves that `go` with `pathcache.LookPath` — i.e. from `PATH`, finding the **1.24.7** binary again, now with `GOROOT` aimed at the **1.25.0** tree that has no prebuilt `covdata` and a `go` command too old to build one.

Isolated the trigger down to a single variable: `GOROOT=<1.25 toolchain> go tool covdata percent -i .` fails, the same command without `GOROOT` set succeeds.

## Fix

A `SessionStart` hook, gated on `CLAUDE_CODE_REMOTE` so a developer checkout is untouched, that:

- **pins `GOTOOLCHAIN=go1.25.13`** via `$CLAUDE_ENV_FILE`, so the parent `go` and the `go tool covdata` child select the same toolchain and the skew cannot arise. `go1.25.13` is exactly what every workflow here asks `setup-go` for, so a web session and CI now run the same Go.
- **installs golangci-lint 2.6.2**, the version `elps.yml` pins, into a version-scoped cache on `PATH`. The container ships v2.5.0. Findings are not stable across golangci-lint minors — measured on this tree, **v2.6.2 reports 0 issues and v2.11.4 reports 27** — so an unpinned host binary silently disagrees with CI.

Both steps are idempotent and the golangci-lint download is non-fatal.

## Test plan

Validated with the original `go1.24.7` first on `PATH`, i.e. against the actual broken configuration:

| | before hook | after hook |
|---|---|---|
| `go test -cover ./...` | `go: no such tool "covdata"` on 7 packages | passes |
| `golangci-lint run ./...` | 0 issues (v2.5.0) | 0 issues (v2.6.2, matching CI) |
| `make test` (full, incl. `_examples`) | fails | passes |

Also checked: re-running the hook is a no-op (`already cached`), and with `CLAUDE_CODE_REMOTE` unset it exits 0 silently.

## Note

No CI behaviour changes — this touches only `.claude/`. `.github/workflows/govulncheck.yml` still carries the note that "the 1.25 line is a golangci-lint constraint"; that remains true for the *released* binaries, and this PR does not attempt to move elps to Go 1.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq

---
_Generated by [Claude Code](https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq)_