### PR TITLE
test(libjson): pin the encoder's field set against getEncoder's resets

### DIFF
--- a/lisp/lisplib/libjson/encode_test.go
+++ b/lisp/lisplib/libjson/encode_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	mathrand "math/rand"
+	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -411,6 +413,62 @@ func TestPooledEncoderCarriesNoStateBetweenDocuments(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "1", string(b), "the previous document's bytes leaked")
 	})
+}
+
+// TestEncoderFieldsAreAccountedForInGetEncoder pins the encoder's field set,
+// so that adding a field to it cannot be a silent decision.
+//
+// getEncoder is the whole of what stands between a recycled encoder and the
+// document it is about to write: every field that says something about ONE
+// document has to be put back to its start-of-document value there, or the
+// previous document's state carries into the next one.
+// TestPooledEncoderCarriesNoStateBetweenDocuments asserts that property for
+// the fields that exist today, and it is structurally unable to assert it for
+// a field that does not exist yet -- a field added to the struct and forgotten
+// in getEncoder leaks across documents with every test in this package still
+// green.
+//
+// So this test does the one thing a test can do about a field nobody has
+// written yet: it makes the struct's shape something the author has to come
+// here and change, with the reset rule in front of them when they do.
+//
+// "Reset it in getEncoder" is not the only acceptable answer.  scratch is not
+// reset and does not need to be, because every use site writes the bytes it
+// reads before it reads them.  That is an argument rather than an invariant
+// the compiler checks, and the point of this test is that it gets made for a
+// new field instead of assumed.
+func TestEncoderFieldsAreAccountedForInGetEncoder(t *testing.T) {
+	// Every field of encoder, in declaration order, as of the last time
+	// someone checked the struct against getEncoder.  The trailing note on
+	// each is how that field is accounted for.
+	known := []string{
+		"buf",         // Reset() in getEncoder
+		"scratch",     // not reset: written before read at every use site
+		"stringNums",  // reset in getEncoder
+		"nestedDeep",  // reset in getEncoder
+		"wroteNative", // reset in getEncoder
+	}
+
+	typ := reflect.TypeOf(encoder{})
+	got := make([]string, typ.NumField())
+	for i := range got {
+		got[i] = typ.Field(i).Name
+	}
+	if !slices.Equal(got, known) {
+		t.Fatalf("the encoder's fields changed:\n"+
+			"  was: %v\n"+
+			"  now: %v\n"+
+			"Do not just update the list above to match. First check the new field "+
+			"set against getEncoder: every field that means something about a single "+
+			"document must be reset there, or a pooled encoder carries the previous "+
+			"document's state into the next one -- silently, because a stale flag "+
+			"changes a verdict rather than crashing anything. A field left out of "+
+			"getEncoder needs the argument scratch has, that every use site writes "+
+			"what it reads before reading it; buffer-like fields are exactly where "+
+			"that argument is easiest to get wrong. Then extend the list, with a "+
+			"note saying which of the two applies.",
+			known, got)
+	}
 }
 
 // TestDumpDoesNotAliasAPooledBuffer pins the property that makes pooling safe

--- a/lisp/lisplib/libjson/json.go
+++ b/lisp/lisplib/libjson/json.go
@@ -473,6 +473,14 @@ func (s *Serializer) dump(v *lisp.LVal, stringNums bool) (b []byte, loadable boo
 	// than recycling it: the encoder goes back to the pool with an empty one
 	// and the caller keeps the array, exactly as it did before the pool
 	// existed.  Copying instead was measured and is worse -- see donateBuffer.
+	//
+	// The two calls below are order-dependent and the order is the safe one
+	// only by a property of loadableBytes: donateBuffer EMPTIES the buffer, so
+	// anything reading it afterwards reads nothing, and loadableBytes gets
+	// away with running second because it reads the nestedDeep and
+	// wroteNative flags and never the bytes.  Keep it that way -- if
+	// loadableBytes ever needs the document, it has to run BEFORE the buffer
+	// is donated.
 	b, loadable = enc.donateBuffer(), enc.loadableBytes()
 	putEncoder(enc)
 	return b, loadable, nil


### PR DESCRIPTION
## Summary

Follow-up hardening on #530, which pooled the libjson `encoder` via `sync.Pool`. A security review of `lisp/lisplib/libjson/encode.go` found the design sound and identified one maintenance hazard.

Pooling turned every field of `encoder` into something `getEncoder` must put back to a start-of-document value, or the previous document's state carries into the next one. All five fields are accounted for today:

| field | how |
|---|---|
| `buf` | `Reset()` in `getEncoder` |
| `scratch` | not reset — provably write-before-read at every use site |
| `stringNums` | reset in `getEncoder` |
| `nestedDeep` | reset in `getEncoder` |
| `wroteNative` | reset in `getEncoder` |

`TestPooledEncoderCarriesNoStateBetweenDocuments` covers exactly those five. What nothing covered is the *next* field: one added to the struct and forgotten in `getEncoder` is a cross-use data leak that leaves the entire package green — and a stale flag changes a loadability verdict rather than crashing anything, so it is silent.

**`TestEncoderFieldsAreAccountedForInGetEncoder`** closes that. It reads the struct's field names with `reflect.TypeOf(encoder{})`, compares them against a literal list, and on any add/remove/rename fails with a message that tells the author to re-verify `getEncoder`'s reset coverage — and, for a field left out of it, to make the write-before-read argument `scratch` has, flagging buffer-like fields as where that argument is easiest to get wrong — *before* extending the list.

Also: a short comment at `Serializer.dump` (`json.go`) recording that `enc.donateBuffer(), enc.loadableBytes()` is order-dependent. `donateBuffer()` empties the buffer before `loadableBytes()` runs, which is only correct because `loadableBytes` reads the `nestedDeep`/`wroteNative` flags and never the bytes. Stated so nobody "fixes" it into a bug. No behavior change.

`encode.go` itself is untouched — this PR is a test plus a comment.

## Red-proof

House discipline: the guard was shown failing before being trusted. A dummy field was temporarily added to `encoder`:

```go
	nestedDeep  bool
	wroteNative bool

	dummyLeak []byte
}
```

`go test -run TestEncoderFieldsAreAccountedForInGetEncoder ./lisp/lisplib/libjson/`:

```
--- FAIL: TestEncoderFieldsAreAccountedForInGetEncoder (0.00s)
    encode_test.go:458: the encoder's fields changed:
          was: [buf scratch stringNums nestedDeep wroteNative]
          now: [buf scratch stringNums nestedDeep wroteNative dummyLeak]
        Do not just update the list above to match. First check the new field set against getEncoder: every field that means something about a single document must be reset there, or a pooled encoder carries the previous document's state into the next one -- silently, because a stale flag changes a verdict rather than crashing anything. A field left out of getEncoder needs the argument scratch has, that every use site writes what it reads before reading it; buffer-like fields are exactly where that argument is easiest to get wrong. Then extend the list, with a note saying which of the two applies.
FAIL
FAIL	github.com/luthersystems/elps/lisp/lisplib/libjson	0.004s
```

The dummy field was then reverted; `encode.go` is byte-identical to `main`.

## Test plan

- [x] `go test ./lisp/lisplib/libjson/` — `ok ... 0.621s`
- [x] `go test ./lisp` — `ok ... 17.266s`
- [x] `golangci-lint run ./...` — `0 issues.`
- [x] `gofmt -l` clean on both touched files
- [x] Red-proof above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq

---
_Generated by [Claude Code](https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq)_