### PR TITLE
fix(ci): stop the benchmark gate reading an integer count as a measurement

### DIFF
--- a/lisp/lisplib/libjson/own_message_bench_test.go
+++ b/lisp/lisplib/libjson/own_message_bench_test.go
@@ -93,4 +93,24 @@ func BenchmarkEncodeOwnMessageMedium(b *testing.B) { benchOwnMessage(b, 172, 146
 // BenchmarkEncodeOwnMessageLarge is roughly 295 KB, the top row: a phylum that
 // has started returning large opaque blobs.  The point of keeping it is that
 // the saving must be shown to SCALE, not merely to exist.
+//
+// Its allocs/op column does not reproduce, and that is a property of the size
+// class rather than a defect to fix here.  The true cost is 9.985 allocations
+// per operation at the default GOGC -- a fifth of a percent below an integer --
+// so the value `go test` prints, int64(mallocs)/int64(b.N), is 9 on one sample
+// and 10 on the next.  The fraction is sync.Pool: encoding ~295 KB per
+// operation forces a collection every few iterations, runtime poolCleanup drops
+// every pool at every GC, and the next Get reallocates the per-P array via
+// pin -> pinSlow.  It is charged to whichever operation runs after the
+// collection, so it tracks GC cadence.  An alloc-profile diff over 2000 encodes
+// puts the whole difference on sync.(*Pool).pinSlow and none of it on a pool
+// MISS -- the encoder comes back from the pool essentially every time (0.001
+// misses/op) -- so warming the pool before b.ResetTimer does not touch it, and
+// nothing survives poolCleanup that could.
+//
+// The consequence is for the CI gate, not for this file: a 9-count row can only
+// express a move of 11.11% or nothing, so scripts/benchstat-gate.sh reports a
+// one-allocation step here as QUANTISED rather than as a regression.  See the
+// quantisation-check note in that script.  The Small and Medium rows above
+// reproduce exactly and stay gateable at one allocation.
 func BenchmarkEncodeOwnMessageLarge(b *testing.B) { benchOwnMessage(b, 3410, 295000) }

--- a/scripts/benchstat-gate.sh
+++ b/scripts/benchstat-gate.sh
@@ -129,9 +129,10 @@
 # --------------------------------------------------------------
 # Both thresholds above are single numbers applied to every row of their metric
 # class, which is exactly as good as the assumption behind it: that the rows in
-# a class have comparable noise.  For the allocation metrics it holds --
-# identical code reproduces them EXACTLY, benchstat prints "± 0%" and routinely
-# annotates the row "all samples are equal".  For timing it does not.
+# a class have comparable noise.  For most allocation rows it holds -- identical
+# code reproduces them EXACTLY, benchstat prints "± 0%" and routinely annotates
+# the row "all samples are equal".  For timing it does not, and for one shape of
+# allocation row it does not either; see the quantisation check below.
 #
 # Issue #443 is the worked example.  BenchmarkPackageGetFunParallel failed the
 # gate on PR #442 -- a parser-only change with no path to a map lookup in the
@@ -169,11 +170,14 @@
 # chose once.  Note what it does NOT do:
 #
 #   * It never applies to B/op or allocs/op.  Those are the metrics that have
-#     caught every real regression this gate has caught; they are exact rather
-#     than sampled, and their spread is "± 0%", so a rule keyed on spread would
-#     be a no-op there anyway.  It is skipped explicitly regardless, so that
-#     stays true even if some future benchmark makes an allocation column
-#     jitter.
+#     caught every real regression this gate has caught, and on the rows where
+#     they are exact their spread is "± 0%", so a rule keyed on spread would be
+#     a no-op there anyway.  It is skipped explicitly regardless -- an
+#     allocation column that DOES jitter must not be able to buy itself the
+#     timing metrics' leniency, because a jittery allocation column is a
+#     benchmark defect and not a noise floor.  Rows where an allocation column
+#     jitters are handled by the quantisation check below instead, which is a
+#     far narrower rule: it can only ever discard a ONE-COUNT move.
 #   * It cannot suppress a large move.  On the row above it would take a >24%
 #     regression to fire -- which is what "this row cannot resolve less than
 #     that" means.  A row whose noise is genuinely that large is not being
@@ -192,6 +196,86 @@
 # longer -benchtime for that benchmark, or keeping a sub-100ns RunParallel body
 # out of the comparison set), and the NOISE-FLOOR line is what tells you which
 # rows need it.
+#
+# A count is not a measurement: the quantisation check
+# ----------------------------------------------------
+# `go test` reports allocs/op as
+#
+#     int64(memstats.Mallocs - before) / int64(b.N)
+#
+# INTEGER DIVISION.  The numerator is not a multiple of b.N, so the printed
+# column is a TRUNCATION of a continuous cost, and a row whose true cost sits
+# near an integer prints either side of it from run to run with no code change
+# at all.
+#
+# libjson's BenchmarkEncodeOwnMessageLarge is the worked example.  Measured
+# directly, by reading MemStats around 2000 encodes of the same ~295 KB document
+# at the DEFAULT GOGC:
+#
+#     true allocs/op = 9.985          reported allocs/op = 9  or  10
+#
+# a fifth of a percent below the boundary.  Ten consecutive samples of that row
+# from ONE binary, at CI's -benchtime=100ms, come back as a mix of 9s and 10s,
+# and benchstat -- correctly -- summarises the arm as "9.000 ± 11%" on a column
+# this file used to describe as exact.  When the mix falls the wrong way across
+# two arms the table reads
+#
+#     EncodeOwnMessageLarge-2   9.000 ± 11%   10.00 ± 10%   +11.11% (p=0.023 n=10)
+#
+# on code that did not change -- which is what reddened a PR touching only the
+# nested tree-sitter module.  Note the delta cannot be small: the SMALLEST move
+# this row can express is one allocation out of nine, and 1/9 is 11.11%.  A 5%
+# gate on a 9-count row has exactly two reachable verdicts, "no change" and
+# "+11.11%".
+#
+# Where the fractional part comes from, on this row, is sync.Pool: runtime
+# poolCleanup drops every pool at every GC, so the next Get goes through
+# pin -> pinSlow and reallocates the per-P array.  An alloc-profile diff over
+# 2000 encodes attributes the difference to sync.(*Pool).pinSlow, NOT to a pool
+# miss -- the encoder itself comes back from the pool essentially every time
+# (0.001 misses/op).  That cost is per-GC, so dividing it by the handful of
+# operations between two collections lands it at "about one allocation per op",
+# and which side of 10.0 it lands on is GC cadence rather than code.  Warming
+# the pool before b.ResetTimer does not touch it: nothing survives poolCleanup.
+#
+# The rule:
+#
+#   A move of ONE COUNT on an integer-count metric (allocs/op) is called a
+#   REGRESSION only when the row reproduces its own count -- that is, only when
+#   benchstat measured NO spread on either arm.  A one-count move on a row that
+#   disagrees with itself is reported as QUANTISED and excluded from the
+#   verdict.
+#
+# It is deliberately the tightest rule that fixes the class:
+#
+#   * It can only ever discard a ONE-COUNT move.  Two counts is not reachable by
+#     truncation -- that needs the true values to differ by more than a whole
+#     allocation -- so it is adjudicated normally.
+#   * One count clears the 5% allocation gate only at 20 allocs/op and below
+#     (1/20 = 5.00%, 1/21 = 4.76%).  From 21 up a single-count move is already
+#     under the gate, so this rule changes no verdict that was not already
+#     "below-gate".
+#   * It does NOT fire on a stable row.  A genuine one-allocation regression on
+#     a 9-count row that reproduces exactly still reds the build at +11.11%,
+#     with "± 0%" on both arms.  That is measured rather than assumed: adding
+#     one escaping allocation to the encode path moves
+#     BenchmarkEncodeOwnMessageSmall from 9.000 ± 0% to 10.000 ± 0%, and the
+#     gate calls it a REGRESSION.  The check keys on a row disagreeing WITH
+#     ITSELF, which a real regression does not do.
+#   * It does nothing when benchstat could not compute an interval ("± ∞ ¹",
+#     below 6 samples) or when the base cell cannot be parsed.  Those rows fall
+#     back to the threshold alone and SAY SO on the regression line, so a check
+#     that did not run is never mistaken for one that ran and passed.
+#
+# The honest cost: on a row that does not reproduce its own allocation count, a
+# real ONE-allocation regression is now reported rather than gated.  It was
+# never distinguishable there -- the same one-count step is what the row
+# produces on identical code -- and the QUANTISED line is what says which rows
+# need fixing.  The fix for such a row is to make the count reproduce: stop the
+# benchmark forcing a collection every few operations, or keep it out of the
+# comparison set.  Raising the allocation threshold is NOT the fix -- 5% is
+# already far below the 11.11% quantum of a 9-count row, so no reachable
+# threshold separates the two cases.
 #
 # Reviewed waivers
 # ---------------
@@ -418,6 +502,37 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 		return s
 	}
 
+	# 1 for a metric that counts WHOLE THINGS, which today means allocs/op
+	# alone.  B/op is an allocation metric too, but it is not a count: its
+	# quantum is one byte out of thousands, so the quantisation rule below is a
+	# no-op there and is not applied to it.
+	function is_count_metric(m) {
+		return (m ~ /^allocs?\/op$/)
+	}
+
+	# The numeric magnitude of a benchstat value cell, or -1 when it is not one
+	# this gate can read.  benchstat SCALES large values and prints the scale as
+	# a suffix -- "128.0k" is 128000 allocations, not 128 -- so the printed
+	# token is not the number, and the quantisation rule below needs the number.
+	# Unreadable is -1 rather than 0 so a cell this gate cannot parse can never
+	# be mistaken for a row with no allocations, which would suppress it.
+	function parse_magnitude(s,   mant, suf, mult) {
+		if (s !~ /^[0-9]+(\.[0-9]+)?[A-Za-z]*$/) return -1
+		if (!match(s, /^[0-9]+(\.[0-9]+)?/)) return -1
+		mant = substr(s, RSTART, RLENGTH) + 0
+		suf = substr(s, RSTART + RLENGTH)
+		if (suf == "") return mant
+		mult = 0
+		if (suf == "k" || suf == "K") mult = 1000
+		else if (suf == "M") mult = 1000000
+		else if (suf == "G") mult = 1000000000
+		else if (suf == "Ki") mult = 1024
+		else if (suf == "Mi") mult = 1048576
+		else if (suf == "Gi") mult = 1073741824
+		if (mult == 0) return -1
+		return mant * mult
+	}
+
 	# `go test` appends -<GOMAXPROCS> to every benchmark name (and omits it
 	# entirely at GOMAXPROCS=1), so the suffix follows the RUNNER, not the code.
 	# Waivers are written without it and rows are stripped down to match; that is
@@ -559,6 +674,11 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 		if (index(line, "│") > 0) next
 
 		name = $1
+		# The median of the base arm, as benchstat printed it.  Both table formats
+		# put it in the first column after the name ("9.000", "128.0k"), and
+		# the quantisation rule below needs its magnitude to know how many
+		# WHOLE allocations a percentage delta stands for.
+		basev = parse_magnitude($2)
 
 		# Bound the delta search: stop before "(p=" so the p-value is never
 		# scanned, and start after the last "±" so an old-format "± 2%" spread
@@ -673,6 +793,40 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 				pkg, metric, name, delta_tok, pval_str, gate, spread, dir
 			next
 		}
+		# QUANTISATION.  `go test` reports allocs/op as
+		# int64(memstats.Mallocs)/int64(b.N) -- INTEGER DIVISION of a quantity
+		# that is not an integer.  A row whose true cost is 9.99 allocations
+		# per operation prints 9 on one sample and 10 on the next, from GC
+		# cadence alone, and benchstat reads that as an 11.11% move.  See the
+		# quantisation-check note in the header for the measurement.
+		#
+		# So a move of ONE COUNT on an integer-count metric is only adjudicated
+		# when the row is reproducing that count exactly.  When either arm
+		# disagrees with itself -- a nonzero spread on a metric that is
+		# supposed to be exact -- one count is the smallest thing it can say
+		# and the change is indistinguishable from the reported integer landing
+		# on the other side of the boundary.
+		#
+		# The bound is deliberately the tightest one that fixes the class: it
+		# can only ever discard a ONE-COUNT move, and one count clears the 5%
+		# allocation gate only on a row under 20 allocs/op.  Above that a
+		# single-count move is already below the gate and this rule changes
+		# nothing.
+		if (is_count_metric(metric) && basev > 0 && spread > 0 &&
+		    basev * regr / 100.0 < 1.5) {
+			quantised++
+			printf "  QUANTISED   %-46s %-9s %-40s delta=%s p=%s (gate %s%%) base %s allocs/op, so this is a ONE-ALLOCATION step -- and the row does not reproduce its own count (spread ±%s%% on a metric that should be exact), so a one-step move cannot be told from `go test` truncating a fractional allocs/op to the other integer; not a regression, and not suppressed either: pin the count (drop the per-op allocation below the GC-cadence noise, or cut b.N variance) if this row needs to be gateable at one allocation %s\n",
+				pkg, metric, name, delta_tok, pval_str, gate, basev, spread, dir
+			next
+		}
+		noquant = ""
+		if (is_count_metric(metric) && regr > 0) {
+			if (basev <= 0) {
+				noquant = " [base cell unreadable, so the quantisation check did not run]"
+			} else if (spread < 0) {
+				noquant = " [no interval: benchstat needs >= 6 samples, so the quantisation check did not run]"
+			}
+		}
 		nospread = (!is_alloc_metric(metric) && spread < 0) ? " [no interval: benchstat needs >= 6 samples, so the resolution check did not run]" : ""
 
 		# At or above the gate. A waiver can turn this into a PASS, but only
@@ -683,14 +837,14 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 			regressions++
 			wexpiredhit[wi] = 1
 			printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) WAIVER EXPIRED %s (%s), no longer suppressing %s%s\n",
-				pkg, metric, name, delta_tok, pval_str, gate, wexp[wi], wissue[wi], dir, nospread
+				pkg, metric, name, delta_tok, pval_str, gate, wexp[wi], wissue[wi], dir, nospread noquant
 			next
 		}
 		if (wi && regr > wceil[wi]) {
 			regressions++
 			wexceeded[wi] = 1
 			printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) EXCEEDS its waiver ceiling %s%% (%s) %s%s\n",
-				pkg, metric, name, delta_tok, pval_str, gate, wceilstr[wi], wissue[wi], dir, nospread
+				pkg, metric, name, delta_tok, pval_str, gate, wceilstr[wi], wissue[wi], dir, nospread noquant
 			next
 		}
 		if (wi) {
@@ -703,7 +857,7 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 
 		regressions++
 		printf "  REGRESSION  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) %s%s\n",
-			pkg, metric, name, delta_tok, pval_str, gate, dir, nospread
+			pkg, metric, name, delta_tok, pval_str, gate, dir, nospread noquant
 	}
 
 	END {
@@ -735,10 +889,10 @@ awk -v alpha="$ALPHA" -v threshold="$THRESHOLD" -v alloc_threshold="$ALLOC_THRES
 					wsource, wline[i], wpkg[i], wbench[i], wmetric[i], wexp[i], wissue[i]
 			}
 		}
-		printf "VERDICT %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
+		printf "VERDICT %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
 			regressions + 0, significant + 0, compared + 0, tilde + 0, badp + 0,
 			waived + 0, wbad + 0, wstale + 0, wunused + 0, wexp_n + 0, nw + 0,
-			woutscope + 0, unresolved + 0
+			woutscope + 0, unresolved + 0, quantised + 0
 	}
 ' "$waiver_input" "$input" >"$report"
 
@@ -747,7 +901,7 @@ sed '$d' "$report"
 
 read -r _ n_regressions n_significant n_compared n_tilde n_badp \
 	n_waived n_waiver_bad n_waiver_stale n_waiver_unused n_waiver_expired n_waivers \
-	n_waiver_outscope n_unresolved <<<"$verdict_line"
+	n_waiver_outscope n_unresolved n_quantised <<<"$verdict_line"
 
 if [ "$n_waiver_bad" -gt 0 ]; then
 	cat >&2 <<-EOF
@@ -791,6 +945,14 @@ echo "benchstat-gate: interpreted ${n_compared} delta row(s) + ${n_tilde} no-cha
 # exists to fix.
 if [ "$n_unresolved" -gt 0 ]; then
 	echo "benchstat-gate: ${n_unresolved} timing row(s) moved past the gate but by LESS than their own measured spread, so this comparison cannot resolve them (reported as NOISE-FLOOR above, excluded from the verdict). They are not gateable as sampled; make them quieter or keep them out of the comparison set."
+fi
+
+# Same doctrine as NOISE-FLOOR above, for the integer-count metrics: printed
+# whenever it is nonzero, never folded into the regression count. A QUANTISED
+# row is a benchmark whose allocs/op does not reproduce, which is a standing
+# problem with the benchmark rather than a clean result.
+if [ "$n_quantised" -gt 0 ]; then
+	echo "benchstat-gate: ${n_quantised} allocation-count row(s) moved past the gate by exactly ONE allocation on a row that does not reproduce its own count, so the move cannot be told from \`go test\` truncating a fractional allocs/op (reported as QUANTISED above, excluded from the verdict). They are not gateable at one allocation as sampled."
 fi
 
 # Printed on EVERY run, including clean ones. A waiver is a standing decision,

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -550,6 +550,111 @@ assert_exit 1 "the shipped waivers do NOT rescue the true regression" \
 	"$GATE" "$TRUE_FIXTURE"
 
 echo
+echo "== benchstat-gate: the quantisation check on allocs/op ==================="
+
+# allocs/op is not a measurement, it is a COUNT -- and `go test` prints it as
+# int64(mallocs)/int64(b.N), integer division of a quantity that is not a
+# multiple of b.N. A row whose true cost is 9.985 allocations per operation (the
+# measured figure for libjson's BenchmarkEncodeOwnMessageLarge at the default
+# GOGC) prints 9 on one sample and 10 on the next, from GC cadence alone. On a
+# 9-count row the smallest expressible move is 1/9 = 11.11%, so a 5% gate has
+# only two reachable verdicts there: the gate is finer than the metric.
+#
+# As with the resolution check above, the pair below is what has to hold
+# together: the fix must silence the truncation flip AND still fire on a real
+# one-allocation regression, or it is just the allocation gate switched off.
+QUANT_NULL="${TESTDATA}/benchstat-allocs-quantised-null.txt"
+QUANT_REAL="${TESTDATA}/benchstat-allocs-one-step-real.txt"
+
+# The noise-only half: a measured NULL comparison (one binary, two runs) that
+# the pre-check gate called a regression.
+assert_exit 0 "a one-allocation step on a row that does not reproduce its count is not a regression" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_NULL"
+assert_contains "QUANTISED" "the unresolvable count row is REPORTED, not dropped" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_NULL"
+assert_contains "+5.56%" "the quantised row still carries its measured delta" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_NULL"
+assert_contains "base 9 allocs/op" "the report names the base count the step was measured against" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_NULL"
+assert_contains "allocation-count row(s) moved past the gate" \
+	"the summary line counts quantised rows" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_NULL"
+
+# The real half. SAME base count (9), SAME one-allocation move, SAME machine and
+# sampling parameters -- one escaping allocation really added to the encode
+# path. It differs only in that the rows reproduce their count, which is what
+# the check keys on. If this ever stops failing, the quantisation check has
+# become an off switch for the allocation gate.
+assert_exit 1 "a one-allocation move on a row that DOES reproduce its count is still a regression" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_REAL"
+assert_contains "REGRESSION  github.com/luthersystems/elps/lisp/lisplib/libjson allocs/op EncodeOwnMessageSmall-2" \
+	"the deterministic +11.11% one-allocation row is a regression" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_REAL"
+assert_contains "REGRESSION  github.com/luthersystems/elps/lisp/lisplib/libjson allocs/op EncodeOwnMessageMedium-2" \
+	"...on both rows that reproduce, not just one" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_REAL"
+# The jittery row, carrying the SAME real regression: two whole counts is not
+# reachable by truncation, so it is adjudicated normally despite the spread.
+assert_contains "REGRESSION  github.com/luthersystems/elps/lisp/lisplib/libjson allocs/op EncodeOwnMessageLarge-2" \
+	"a TWO-count move is a regression even on a row that does not reproduce" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_REAL"
+assert_not_contains "QUANTISED" "nothing in the real regression is written off as quantisation" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_REAL"
+
+# The check is about the METRIC BEING A COUNT, not about size. Lowering the
+# allocation gate to 1% must not make the truncation flip gateable -- one
+# allocation is still the smallest thing a 9-count row can say.
+assert_exit 0 "the quantised row stays unresolvable with the allocation gate at 1%" \
+	env BENCH_WAIVERS= BENCH_ALLOC_THRESHOLD_PCT=1 "$GATE" "$QUANT_NULL"
+assert_contains "QUANTISED" "...and says so, rather than passing silently" \
+	env BENCH_WAIVERS= BENCH_ALLOC_THRESHOLD_PCT=1 "$GATE" "$QUANT_NULL"
+
+# CLASS BOUNDARY, the other way. The check applies to COUNTS only. B/op is an
+# allocation metric whose quantum is one byte, so a large B/op regression must
+# not be able to buy itself this exemption -- the existing alloc fixtures are
+# the guard, re-asserted here against the new code path.
+assert_exit 1 "a large B/op + allocs/op regression is untouched by the quantisation check" \
+	env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-alloc-regression.txt"
+assert_not_contains "QUANTISED" "...and no row in it is written off as quantisation" \
+	env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-alloc-regression.txt"
+# 128.0k allocs/op moving +8.00% is 10240 allocations, not one. That the gate
+# reads the SCALE ("k") rather than the printed mantissa is what keeps it from
+# treating that as a 10-allocation step and suppressing it.
+assert_contains "REGRESSION" "a scaled count cell (128.0k) is read at its true magnitude" \
+	env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-alloc-regression.txt"
+
+# NO INTERVAL. benchstat prints "± ∞ ¹" below 6 samples, so there is no evidence
+# either way about whether the row reproduces. Those rows fall back to the
+# threshold alone and must SAY SO, exactly as the timing resolution check does.
+assert_contains "quantisation check did not run" \
+	"a count row judged without an interval says the check did not run" \
+	env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-alloc-regression.txt"
+
+# THE ARITHMETIC, at every edge at once. One synthetic table, five allocs/op
+# rows differing only in base count, spread, and how many counts the move is
+# worth. The last two rows are the containment argument: one allocation clears
+# the 5% gate at 20 counts and below, so from 21 up the check cannot change a
+# verdict that was not already "below-gate".
+QUANT_EDGE="${TESTDATA}/benchstat-allocs-quantisation-boundary.txt"
+assert_exit 1 "the boundary table still fails: two of its five rows are real" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_EDGE"
+assert_contains "REGRESSION  github.com/luthersystems/elps/lisp             allocs/op ReproducingNine-2" \
+	"9 -> 10 with no spread is a REGRESSION" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_EDGE"
+assert_contains "QUANTISED   github.com/luthersystems/elps/lisp             allocs/op JitteryNine-2" \
+	"...and the SAME delta on a row that does not reproduce is QUANTISED" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_EDGE"
+assert_contains "REGRESSION  github.com/luthersystems/elps/lisp             allocs/op JitteryNineTwoStep-2" \
+	"a TWO-count move on that same jittery row is still a REGRESSION" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_EDGE"
+assert_contains "QUANTISED   github.com/luthersystems/elps/lisp             allocs/op JitteryTwenty-2" \
+	"20 allocs/op is the largest base the check can reach" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_EDGE"
+assert_contains "below-gate  github.com/luthersystems/elps/lisp             allocs/op JitteryTwentyOne-2" \
+	"...and at 21 a one-count move was already below the gate, untouched" \
+	env BENCH_WAIVERS= "$GATE" "$QUANT_EDGE"
+
+echo
 echo "== benchstat-gate: the threshold is the only thing holding it back ======="
 
 # Proves the parser genuinely SEES the real comparison's significant deltas and

--- a/scripts/testdata/benchstat-allocs-one-step-real.txt
+++ b/scripts/testdata/benchstat-allocs-one-step-real.txt
@@ -1,0 +1,49 @@
+# A REAL one-allocation regression. The counterpart of
+# benchstat-allocs-quantised-null.txt, and the half that has to keep failing.
+#
+# Same benchmarks, same machine, same sampling parameters, same 9 allocs/op
+# base. The only difference is that the "pr" arm was built from a tree carrying
+# one extra escaping allocation per encode, added to Serializer.dump for exactly
+# this purpose. So the +11.11% on the Small and Medium rows is ONE ALLOCATION,
+# genuinely added, on a row whose base count is nine -- numerically identical to
+# the false positive in the null fixture.
+#
+# What separates them is not the size of the move. It is that these rows
+# REPRODUCE: every sample of Small and Medium reads 9 on one arm and 10 on the
+# other, so benchstat prints "± 0%" on both, and the quantisation check does not
+# apply. The null fixture's row disagrees with itself.
+#
+# The Large row is the same regression seen through a row that does NOT
+# reproduce (9.000 ± 11% -> 11.000 ± 9%): the extra allocation still moves it
+# two whole counts, which truncation cannot manufacture, so it is adjudicated
+# normally too.
+#
+# Read the B/op table before concluding that allocs/op is redundant: the added
+# allocation is 16 bytes, so B/op moves +0.89% and +0.06% -- an order of
+# magnitude under the 5% allocation gate, and not significant at all on Large.
+# allocs/op is the ONLY column that sees this regression, which is the reason
+# the quantisation check keys on the row reproducing rather than simply
+# discarding every one-count move.
+goos: linux
+goarch: amd64
+pkg: github.com/luthersystems/elps/lisp/lisplib/libjson
+                         │  base.txt   │               pr.txt                │
+                         │   sec/op    │    sec/op     vs base               │
+EncodeOwnMessageSmall-2    5.897µ ± 6%   5.714µ ± 14%       ~ (p=0.529 n=10)
+EncodeOwnMessageMedium-2   94.91µ ± 8%   97.64µ ±  5%       ~ (p=0.684 n=10)
+EncodeOwnMessageLarge-2    1.992m ± 4%   2.053m ±  9%       ~ (p=0.063 n=10)
+geomean                    103.7µ        104.6µ        +0.91%
+
+                         │   base.txt   │               pr.txt                │
+                         │     B/op     │     B/op      vs base               │
+EncodeOwnMessageSmall-2    1.750Ki ± 0%   1.766Ki ± 0%  +0.89% (p=0.000 n=10)
+EncodeOwnMessageMedium-2   17.07Ki ± 0%   17.08Ki ± 0%  +0.06% (p=0.000 n=10)
+EncodeOwnMessageLarge-2    302.4Ki ± 0%   302.6Ki ± 2%       ~ (p=0.138 n=10)
+geomean                    20.83Ki        20.90Ki       +0.34%
+
+                         │  base.txt   │               pr.txt                │
+                         │  allocs/op  │  allocs/op   vs base                │
+EncodeOwnMessageSmall-2    9.000 ±  0%   10.000 ± 0%  +11.11% (p=0.000 n=10)
+EncodeOwnMessageMedium-2   9.000 ±  0%   10.000 ± 0%  +11.11% (p=0.000 n=10)
+EncodeOwnMessageLarge-2    9.000 ± 11%   11.000 ± 9%  +22.22% (p=0.000 n=10)
+geomean                    9.000          10.32       +14.70%

--- a/scripts/testdata/benchstat-allocs-quantisation-boundary.txt
+++ b/scripts/testdata/benchstat-allocs-quantisation-boundary.txt
@@ -1,0 +1,30 @@
+# The class boundary of the quantisation check, in one table.
+#
+# Synthetic, unlike its two companion fixtures -- the measured evidence lives in
+# benchstat-allocs-quantised-null.txt (the false positive) and
+# benchstat-allocs-one-step-real.txt (the regression that must still fire). This
+# one exists to pin the ARITHMETIC, which no real comparison happens to exercise
+# at every edge at once. Five allocs/op rows, differing only in base count, in
+# spread, and in how many counts the move is worth:
+#
+#   ReproducingNine-2     9 -> 10, ± 0%   +11.11%  REGRESSION  reproduces, so it is real
+#   JitteryNine-2         9 -> 10, ±11%   +11.11%  QUANTISED   one count, does not reproduce
+#   JitteryNineTwoStep-2  9 -> 11, ±11%   +22.22%  REGRESSION  two counts; truncation cannot do that
+#   JitteryTwenty-2      20 -> 21, ± 5%    +5.00%  QUANTISED   the largest base the check can reach
+#   JitteryTwentyOne-2   21 -> 22, ± 5%    +4.76%  below-gate  one count is already under 5% here
+#
+# The last two are the containment argument: one allocation clears the 5%
+# allocation gate only at 20 counts and below, so above that the check cannot
+# change a verdict that was not already "below-gate". It is not a general
+# licence for allocation rows to move.
+goos: linux
+goarch: arm64
+pkg: github.com/luthersystems/elps/lisp
+cpu: Neoverse-N1
+                        │     base     │                 pr                  │
+                        │  allocs/op   │  allocs/op    vs base               │
+ReproducingNine-2         9.000 ±  0%    10.00 ±  0%  +11.11% (p=0.000 n=10)
+JitteryNine-2             9.000 ± 11%    10.00 ± 10%  +11.11% (p=0.023 n=10)
+JitteryNineTwoStep-2      9.000 ± 11%    11.00 ±  9%  +22.22% (p=0.000 n=10)
+JitteryTwenty-2           20.00 ±  5%    21.00 ±  5%   +5.00% (p=0.008 n=10)
+JitteryTwentyOne-2        21.00 ±  5%    22.00 ±  5%   +4.76% (p=0.008 n=10)

--- a/scripts/testdata/benchstat-allocs-quantised-null.txt
+++ b/scripts/testdata/benchstat-allocs-quantised-null.txt
@@ -1,0 +1,50 @@
+# A SPURIOUS allocs/op firing, caught live on a NULL comparison.
+#
+# Not synthetic and not a transcription. Both arms are the SAME BINARY --
+# `go test -c` once, then measured repeatedly -- at the sampling parameters CI
+# uses (GOMAXPROCS=2, -benchtime=100ms, 10 rounds per arm). Nothing whatsoever
+# differs between "base" and "pr": they are two independent measurement runs of
+# one binary on one machine. Every number here is noise by construction, so
+# every REGRESSION verdict on this table is a false one.
+#
+# BenchmarkEncodeOwnMessageLarge encodes a ~295 KB document. Its TRUE cost,
+# measured by reading MemStats around 2000 encodes, is 9.985 allocations per
+# operation -- a fifth of a percent below an integer. `go test` reports
+# allocs/op as int64(mallocs)/int64(b.N), so each SAMPLE prints 9 or 10
+# depending on where GC cadence puts the fraction, and an arm of ten samples is
+# a mix of both. benchstat then summarises the arm as "9.000 ± 5%" -- a spread,
+# on a column this gate used to treat as exact. See the quantisation-check note
+# in scripts/benchstat-gate.sh for where the fraction comes from (sync.Pool's
+# per-P array, reallocated after every GC).
+#
+# 182 arm measurements were taken this way and 800 random pairs of them
+# adjudicated. The gate as it stood before the quantisation check reported a
+# REGRESSION on 3 of the 800 -- a 0.375% false-positive rate per comparison, on
+# ONE row, on code that did not change. With the check: 0 of 800, and those same
+# 3 rows reported as QUANTISED rather than silenced.
+#
+# This file is one of the three, verbatim. Note what the delta cannot be: the
+# smallest move a 9-count row can express is one allocation out of nine, and
+# 1/9 is 11.11%. A 5% gate on such a row has two reachable verdicts, "no change"
+# and a double-digit percentage; the gate is finer than the metric it is
+# reading. (This particular draw lands on a HALF step -- benchstat's median of a
+# five-nines/five-tens arm is 9.500 -- which is smaller still than one
+# allocation and could not possibly be a real change.)
+#
+# The B/op and sec/op tables of the same run are kept for contrast. B/op is an
+# allocation metric too, but its quantum is one byte out of 300000, so it is
+# unmoved -- which is why the quantisation check is applied to counts alone.
+goos: linux
+goarch: amd64
+pkg: github.com/luthersystems/elps/lisp/lisplib/libjson
+                        │  base.txt   │            pr.txt             │
+                        │   sec/op    │   sec/op     vs base          │
+EncodeOwnMessageLarge-2   1.939m ± 3%   1.917m ± 2%  ~ (p=0.353 n=10)
+
+                        │   base.txt   │             pr.txt             │
+                        │     B/op     │     B/op      vs base          │
+EncodeOwnMessageLarge-2   302.0Ki ± 1%   302.6Ki ± 2%  ~ (p=0.061 n=10)
+
+                        │  base.txt  │              pr.txt               │
+                        │ allocs/op  │ allocs/op   vs base               │
+EncodeOwnMessageLarge-2   9.000 ± 0%   9.500 ± 5%  +5.56% (p=0.033 n=10)


### PR DESCRIPTION
## The problem

`BenchmarkEncodeOwnMessageLarge` reports **9 allocs/op**. A 9-count row cannot express a move smaller than 1/9 = **11.11%**. Under the 5% allocation gate it therefore has exactly two reachable verdicts — "no change" and "+11.11%" — and it produced the second on a PR that touched only the nested tree-sitter module:

```
allocs/op EncodeOwnMessageLarge-2 delta=+11.11% p=0.023 (gate 5%)
```

The gate is finer than the metric it is reading.

## Root cause — and a correction

The standing diagnosis was a `sync.Pool` **miss** on the encoder (PR #530). That is not what is happening.

`go test` reports allocs/op as `int64(mallocs)/int64(b.N)` — **integer division of a quantity that is not a multiple of `b.N`**. Reading `MemStats` around 2000 encodes of the same ~295 KB document, at the **default** GOGC:

```
true allocs/op = 9.985        reported allocs/op = 9  or  10
```

A fifth of a percent below an integer. Each sample lands on either side of the boundary from GC cadence alone.

Where the fraction comes from is `sync.Pool`, but not a miss. An alloc-profile diff over 2000 encodes (`-base`, `MemProfileRate=1`) attributes the whole difference to `sync.(*Pool).pinSlow`: `poolCleanup` drops every pool at every GC, so the next `Get` reallocates the per-P array. The encoder itself comes back from the pool **0.999 times per op** (0.001 misses/op). Encoding 295 KB per operation forces a collection every few iterations, so a per-GC cost divided by a handful of ops lands at "about one allocation per op".

| GOGC | true allocs/op | reported |
|---|---|---|
| off | 9.007 | 9 |
| 120 | 9.739 | 9 |
| **100 (default)** | **9.985** | **9 or 10** |
| 90 | 10.027 | 10 |
| 60 | 11.007 | 11 |

## Why the two harness options were rejected

- **Warm the pool before `ResetTimer`** — measured, and it cannot work. Nothing survives `poolCleanup`; the allocation being counted is `pinSlow`, which recurs after *every* GC no matter how warm the pool is. The encoder pool is already hitting 99.9% of the time.
- **Pin GOGC in the harness** — there is no GOGC at which this value is integral and stable (see the table), pinning it changes what the row measures (GC pressure is part of the cost of a 295 KB encode), and it does not generalize: any row whose true allocs/op sits near an integer is vulnerable at whatever GOGC you choose. CI already runs the default, which is the value that sits *on* the boundary.

## The fix

`scripts/benchstat-gate.sh` gains a **quantisation check**, the count-metric analogue of the existing `NOISE-FLOOR` resolution rule:

> A move of **one count** on an integer-count metric (`allocs/op`) is called a REGRESSION only when the row reproduces its own count — benchstat spread `± 0%` on both arms. A one-count move on a row that disagrees with itself is reported as **QUANTISED** and excluded from the verdict.

Deliberately the tightest rule that fixes the class:

- It can only ever discard a **one**-count move. Two counts is unreachable by truncation.
- One count clears the 5% gate only at **20 allocs/op and below** (1/20 = 5.00%, 1/21 = 4.76%). From 21 up it changes no verdict that was not already `below-gate`.
- It does **not** fire on a stable row — that is what the red-proof below shows.
- With no computable interval (`± ∞`, n<6) or an unreadable base cell, it does not run and **says so** on the regression line, exactly as the timing check does.

Rows are reported, never silenced, and counted in the summary line.

## Before / after — measured, not argued

182 arm measurements of **one `go test -c` binary**, at CI's sampling parameters (GOMAXPROCS=2, `-benchtime=100ms`, 10 rounds/arm), 800 random null pairings adjudicated:

| gate | null comparisons failed |
|---|---|
| before | **3 / 800** (0.375%, on code that did not change) |
| after | **0 / 800**, the same 3 rows reported as QUANTISED |

One of the three is kept verbatim as `scripts/testdata/benchstat-allocs-quantised-null.txt`.

## Red-proof — the half that must keep failing

One escaping allocation added to `Serializer.dump`, measured the same way:

```
                          │  base.txt   │               pr.txt                │
                          │  allocs/op  │  allocs/op   vs base                │
EncodeOwnMessageSmall-2     9.000 ±  0%   10.000 ± 0%  +11.11% (p=0.000 n=10)   REGRESSION
EncodeOwnMessageMedium-2    9.000 ±  0%   10.000 ± 0%  +11.11% (p=0.000 n=10)   REGRESSION
EncodeOwnMessageLarge-2     9.000 ± 11%   11.000 ± 9%  +22.22% (p=0.000 n=10)   REGRESSION
```

Same base count (9), same one-allocation move, same machine — the gate still fails the build on all three. Small and Medium reproduce (`± 0%`), so the check does not apply; Large is the same regression through the jittery row, where the added allocation moves it two whole counts.

Read the `B/op` column of that run before concluding `allocs/op` is redundant: **+0.89% and +0.06%**, an order of magnitude under the 5% gate and not significant at all on Large. `allocs/op` is the only column that sees a small added allocation — which is why the rule keys on *reproducing* rather than discarding every one-count move.

Kept as `benchstat-allocs-one-step-real.txt`. The scaffolding allocation was reverted; it is not in this branch.

## Honest cost and residual

On a row that does not reproduce its allocation count, a real **one**-allocation regression is now reported rather than gated. It was never distinguishable there — the same one-count step is what the row produces on identical code — and the QUANTISED line names which rows need fixing. Raising the allocation threshold is not an alternative: 5% is already far below the 11.11% quantum of a 9-count row, so no reachable threshold separates the two cases.

Residual hole, stated plainly: a false positive whose bimodal draw is extreme enough that *both* arms report `± 0%` would still fire. It needs roughly a 9:1 / 1:9 separation of a 50/50 process (~1e-5 per pairing against the 3.75e-3 measured here) and did not occur in 800.

## Verification

- `bash scripts/ci-gates-test.sh` — **304 passed, 0 failed** (281 before; +23 assertions), with `CI_GATES_REQUIRE_SHELLCHECK=1` and shellcheck clean on all 14 scripts.
- Every one of the 24 pre-existing fixtures returns an **identical verdict**; only the new false-positive fixture changes (1 → 0).
- `go build ./...`, `go test ./lisp/lisplib/libjson/ ./lisp`, `make test`, `golangci-lint run ./...` (0 issues), `scripts/confidentiality-guard.sh`, `make fuzz-budget-check` — all clean. No fuzz target added.

## Note on substrate

`substrate/scripts/benchstat-gate.sh` is an earlier ancestor of this file (556 lines vs 806, single 10% threshold, no per-metric-class split, no resolution check). It carries the same latent defect — a one-count flip on a low-count row is +11.11% there too — but the two copies have diverged far enough that porting is separate work. Not touched here.

## Files

- `scripts/benchstat-gate.sh` — the check, plus a header section documenting it; corrects two header claims this row falsifies (allocation columns are not exact on every row).
- `scripts/ci-gates-test.sh` — 23 assertions covering both halves and every arithmetic edge.
- `scripts/testdata/benchstat-allocs-quantised-null.txt` — measured false positive.
- `scripts/testdata/benchstat-allocs-one-step-real.txt` — measured real regression.
- `scripts/testdata/benchstat-allocs-quantisation-boundary.txt` — synthetic, pins the arithmetic at every edge.
- `lisp/lisplib/libjson/own_message_bench_test.go` — comment only, recording why this row does not reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq

---
_Generated by [Claude Code](https://claude.ai/code/session_013WFdAfZ8LNMmGBockuMuJq)_