### PR TITLE
benchgate: disqualify runners that cannot measure, instead of adjudicating them

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -126,6 +126,37 @@ BENCH_WAIVERS= go run ./cmd/benchgate /tmp/benchstat.txt      # with waivers off
 benchgate can also adjudicate the two raw `go test -bench` arms directly, with no
 `benchstat` binary in the loop (`make bench-gate-arms BENCH_BASE=… BENCH_HEAD=…`).
 
+### Before you measure: is the machine fit? (`make bench-burnin`)
+
+```bash
+make bench-burnin      # ~half a second; exit 0 fit, exit 3 re-measure elsewhere
+```
+
+A fixed, code-independent loop run seven times, requiring the samples to agree
+to within ±10%. A machine that cannot reproduce a fixed loop cannot resolve a
+10% gate on anything else either, and half an hour of benchmarking on one
+produces numbers that read like findings. Run it first — on a laptop with a
+browser open as much as on CI.
+
+### `UNMEASURABLE` and exit 3
+
+The gate has a fourth verdict (issue #542). A **timing** row whose own
+confidence interval is at or above the fitness ceiling (`-variance-ceiling`,
+default ±30%) is `UNMEASURABLE`: its delta is printed and adjudicated in
+neither direction. If such a row moved at or above the gate, the run exits **3
+(RUNNER-UNFIT)** — it found no regression *and* certified nothing, so the answer
+is to re-run, not to read the diff. An unmeasurable row *below* its gate is a
+warning only and changes no exit code.
+
+Exit 1 still wins over exit 3: a regression measured on a row that could be
+measured is a finding regardless of what else in the table was unmeasurable. And
+the ceiling can only ever withhold a finding — it never turns a passing run into
+a failing one.
+
+The shape it exists for: an arm measuring itself at ±71% against the other arm's
+±3%, on code that did not change, adjudicated as `+83% REGRESSION`. Preserved as
+`cmd/benchgate/testdata/elps/benchstat-runner-unfit-542.txt`.
+
 ## Checklist
 
 - [ ] Baseline benchmarks captured before changes

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,6 +49,23 @@ env:
   # comparison (identical code on both arms) on this pool.
   BENCH_REGRESSION_THRESHOLD_PCT: "15"
   BENCH_ALLOC_THRESHOLD_PCT: "5"
+  # Runner fitness, not a gate (issue #542). A TIMING row whose own confidence
+  # interval is at or above this cannot size its own move, so benchgate refuses
+  # to adjudicate it in EITHER direction: the row is reported as UNMEASURABLE
+  # and the job exits 3 (RUNNER-UNFIT, "re-measure") rather than 1 or 0.
+  #
+  # It is restated here rather than left to the binary's default because it is
+  # policy, and policy belongs next to the prose explaining it. The number is
+  # derived from measurements, not chosen: elps' noisiest LEGITIMATE row
+  # measures itself at +/-24-25% on IDENTICAL code (#443,
+  # cmd/benchgate/testdata/elps/benchstat-parallel-noise-443.txt), so a tighter
+  # ceiling would call this repository's own +48% true-regression control
+  # unmeasurable; the substrate#424 incident this exists for measured +/-71% on
+  # one arm and +/-30% on the re-run. 30, tested at-or-above, is the only round
+  # number that clears both. LOWER it only after re-measuring the noise floor
+  # on this pool -- and note that lowering it cannot hide a regression, it can
+  # only convert one into "re-measure".
+  BENCH_VARIANCE_CEILING_PCT: "30"
   # Pinned, not inherited from the runner's core count. `go test` appends
   # GOMAXPROCS to every benchmark name (EnvGet-2, EnvGet-4), and benchstat
   # pairs rows by that full name -- so two arms measured at different core

--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,18 @@ bench-gate-arms:
 	go run ./cmd/benchgate -waivers-default scripts/benchstat-waivers.txt \
 		-base $(BENCH_BASE) -head $(BENCH_HEAD)
 
+# Is THIS MACHINE fit to measure anything? A fixed, code-independent loop, run
+# seven times, with the samples required to agree to within ±10% (issue #542).
+#
+# Run it BEFORE a local before/after comparison. A laptop with a browser open,
+# or a CI runner with a noisy co-tenant, cannot resolve a 10% gate on anything,
+# and half an hour of benchmarking on one produces numbers that read like
+# findings. Exit 0 = fit, exit 3 = re-measure somewhere else. Takes ~half a
+# second.
+.PHONY: bench-burnin
+bench-burnin:
+	go run ./cmd/benchgate burnin
+
 # --- Release targets ---
 
 LATEST_TAG := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "none")

--- a/cmd/benchgate/adjudicate.go
+++ b/cmd/benchgate/adjudicate.go
@@ -281,7 +281,7 @@ func adjudicate(c *comparison, p *policy) *verdict {
 				waiverNote = fmt.Sprintf(" [its waiver (%s, ceiling %s%%, expires %s) neither applied nor was outgrown here: both are claims about a size this comparison could not measure]",
 					w.issue, w.ceilStr, w.expires)
 			}
-			v.lines = append(v.lines, fmt.Sprintf("  UNMEASURABLE %-45s %-9s %-40s delta=%s p=%s (gate %s%%) spread ±%s%% is at or above the ±%s%% fitness ceiling -- an arm this dispersed carries no information about the size of the move, so this delta is NOT adjudicated in either direction: not a regression, and not a pass. Re-measure on a fit runner (`benchgate burnin` before the run says whether it is one) %s%s",
+			v.lines = append(v.lines, fmt.Sprintf("  UNMEASURABLE %-45s %-9s %-40s delta=%s p=%s (gate %s%%) spread ±%s%% is at or above the ±%s%% fitness ceiling -- an arm this dispersed carries no information about the size of the move, so this delta is NOT adjudicated in either direction: not a regression, and not a pass. Re-measure on a fit runner (`benchgate burnin` before the run says whether it is one); if the row comes back this dispersed on a machine that passes burn-in, the BENCHMARK is what needs fixing -- a longer -benchtime, or keeping it out of the comparison set -- because re-running it will not converge %s%s",
 				r.pkg, r.metric, r.name, r.deltaTok, r.pvalStr, gateStr, awkNum(r.spread), p.ceilingStr, dir, waiverNote))
 			continue
 		}
@@ -399,7 +399,7 @@ format has genuinely changed.
 	// Same doctrine again, for the rows the MACHINE could not measure. This one
 	// carries the exit code with it, so it says which way it went.
 	if v.unmeasurable > 0 {
-		pf(stdout, "benchgate: %d timing row(s) moved at or above the gate on an interval at or above the ±%s%% fitness ceiling, so the comparison cannot size the move at all (reported as UNMEASURABLE above). They are NOT counted as regressions and NOT counted as passes: this run certified nothing about them. Re-measure -- `benchgate burnin` on the runner first will say whether it can measure anything.\n", v.unmeasurable, p.ceilingStr)
+		pf(stdout, "benchgate: %d timing row(s) moved at or above the gate on an interval at or above the ±%s%% fitness ceiling, so the comparison cannot size the move at all (reported as UNMEASURABLE above). They are NOT counted as regressions and NOT counted as passes: this run certified nothing about them. Re-measure -- `benchgate burnin` on the runner first will say whether it can measure anything, and a row that stays this dispersed on a machine that passes burn-in is a benchmark to fix rather than a job to re-run.\n", v.unmeasurable, p.ceilingStr)
 	}
 	if v.unmeasurableInfo > 0 {
 		pf(stdout, "benchgate: %d further row(s) were equally unfit to measure but moved LESS than their gate, so they change no verdict and are reported as warnings only. A noisy row can hide a real regression; whole-machine fitness is what `benchgate burnin` is for.\n", v.unmeasurableInfo)

--- a/cmd/benchgate/adjudicate.go
+++ b/cmd/benchgate/adjudicate.go
@@ -5,16 +5,59 @@ import (
 	"io"
 )
 
-// policy is the whole adjudication policy: five numbers and a waiver list.
+// defaultVarianceCeiling is the per-row fitness ceiling: a timing row whose own
+// confidence interval is at or above this cannot be adjudicated at all.
+//
+// The number is derived from this repository's own measurements rather than
+// picked, and the two constraints on it are both empirical:
+//
+//	the floor   elps' noisiest LEGITIMATE row, BenchmarkPackageGetFunParallel,
+//	            measures itself at ±24%/±25% on IDENTICAL code (#443, and
+//	            preserved as testdata/elps/benchstat-parallel-noise-443.txt).
+//	            A ceiling at or below that would call this repository's own
+//	            true-regression control (+48.00% on that same ±25% row)
+//	            unmeasurable and turn a real finding into a re-measure loop.
+//	the target  the substrate#424 incident measured ±71% on one arm, and ±30%
+//	            on the re-run. A ceiling above 30 misses half the incident it
+//	            was written for.
+//
+// 30, tested at-or-above, is the only round number that satisfies both. It is a
+// flag because the right number is a property of the runner and the benchmark
+// set: a repository whose rows are quieter than elps' parallel map lookup
+// should tighten it, and BENCH_VARIANCE_CEILING_PCT is how.
+const defaultVarianceCeiling = 30.0
+
+// policy is the whole adjudication policy: six numbers and a waiver list.
 // See the "Why there is no config file" note in the package doc.
 type policy struct {
 	alpha             float64
 	threshold         float64
 	allocThreshold    float64
+	varianceCeiling   float64
 	thresholdStr      string
 	allocThresholdStr string
+	ceilingStr        string
 	waivers           *waiverSet
 	waiverSource      string
+}
+
+// unmeasurable reports whether this row's own confidence interval is too wide
+// for the comparison to say anything about its delta.
+//
+// TIMING ROWS ONLY, and that is the same class boundary the resolution check
+// draws, for the same reason: a jittery ALLOCATION column is a benchmark defect
+// rather than a sick machine, and this repository's doctrine is that it must
+// not be able to buy itself the timing metrics' treatment (see the
+// resolution-check note in the package doc). The one benign way an allocation
+// count jitters -- `go test` truncating a fractional allocs/op -- is handled by
+// the quantisation check, which can only ever discard a ONE-COUNT move.
+//
+// A row with no computable interval (unknownSpread, benchstat's "± ∞ ¹" below 6
+// samples) is NOT unmeasurable by this rule: nothing was measured to compare
+// against the ceiling. Those rows fall back to the threshold alone and the
+// report says so, exactly as they already did for the resolution check.
+func (p *policy) unmeasurable(metric string, spread float64) bool {
+	return !isAllocMetric(metric) && spread >= 0 && spread >= p.varianceCeiling
 }
 
 // verdict is what an adjudication produced: the report lines, the counters,
@@ -30,6 +73,18 @@ type verdict struct {
 	waived      int
 	unresolved  int
 	quantised   int
+
+	// unmeasurable counts rows at or above their gate whose own interval was
+	// too wide to adjudicate. Those are what exit 3 is drawn from: a delta big
+	// enough to matter, measured on a row that could not measure it.
+	unmeasurable int
+	// unmeasurableInfo counts rows whose interval was equally unfit but whose
+	// delta was BELOW the gate. Reported as a warning and deliberately NOT
+	// folded into the exit code: a noisy row can hide a real regression, but
+	// failing every slightly-noisy minor row makes the gate brittle, and a
+	// brittle gate gets switched off. Whole-machine fitness is burn-in's job
+	// (benchgate burnin), which is where that gap is closed.
+	unmeasurableInfo int
 
 	waiverBad        int
 	waiverStale      int
@@ -115,8 +170,18 @@ func adjudicate(c *comparison, p *policy) *verdict {
 
 		v.significant++
 		if regr < gate {
-			v.lines = append(v.lines, fmt.Sprintf("  below-gate  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) %s",
-				r.pkg, r.metric, r.name, r.deltaTok, r.pvalStr, gateStr, dir))
+			// A row below its gate is not adjudicated, so an unfit interval
+			// changes nothing about the verdict -- but it is still worth
+			// saying, because "small move" and "move too noisy to size" are
+			// different statements and only one of them is reassuring.
+			unfit := ""
+			if p.unmeasurable(r.metric, r.spread) {
+				v.unmeasurableInfo++
+				unfit = fmt.Sprintf(" [spread ±%s%% is at or above the ±%s%% fitness ceiling, so this row could not have been sized either way -- below-gate here means UNMEASURED, not small]",
+					awkNum(r.spread), p.ceilingStr)
+			}
+			v.lines = append(v.lines, fmt.Sprintf("  below-gate  %-46s %-9s %-40s delta=%s p=%s (gate %s%%) %s%s",
+				r.pkg, r.metric, r.name, r.deltaTok, r.pvalStr, gateStr, dir, unfit))
 			continue
 		}
 
@@ -169,7 +234,56 @@ func adjudicate(c *comparison, p *policy) *verdict {
 		}
 		noSpread := ""
 		if !isAllocMetric(r.metric) && r.spread < 0 {
-			noSpread = " [no interval: benchstat needs >= 6 samples, so the resolution check did not run]"
+			noSpread = fmt.Sprintf(" [no interval: benchstat needs >= 6 samples, so the resolution check did not run, and neither did the ±%s%% fitness ceiling]", p.ceilingStr)
+		}
+
+		// FITNESS (#542). Everything above asks whether the CODE moved. This
+		// asks whether the MACHINE was in a state to tell -- the question that
+		// went unasked when a runner mid-job produced a base arm at ±71% and a
+		// pr arm at ±3% on a tree with no Go-code delta, and this gate compared
+		// the two medians and called the +83% difference a REGRESSION.
+		//
+		// The order of the three row-level checks is load-bearing:
+		//
+		//	NOISE-FLOOR first  it is the STRONGER statement -- not merely "this
+		//	                   row is noisy" but "this row cannot resolve THIS
+		//	                   move" -- and it is already the verdict on those
+		//	                   rows. Re-labelling them would change no exit code
+		//	                   and lose the more specific reason.
+		//	QUANTISED next     an integer-count row is exempt from this check by
+		//	                   class anyway; the ordering just keeps the reason
+		//	                   printed on such a row the specific one.
+		//	a live WAIVER      a waiver is a standing decision that this row's
+		//	  before this      regression, up to a recorded ceiling, is already
+		//	                   accepted. There is nothing left to certify, so
+		//	                   there is nothing for an unfit measurement to
+		//	                   invalidate -- and this way the fitness check can
+		//	                   only ever WITHHOLD a regression finding (exit 1
+		//	                   -> exit 3). It can never turn a run that would
+		//	                   have passed into one that fails, which is what
+		//	                   makes it safe to switch on everywhere.
+		//
+		// Note what a waiver does NOT buy: an expired one, or a move past the
+		// recorded ceiling, is a NEW finding drawn from this measurement, and a
+		// new finding needs a measurement worth drawing from. Those fall
+		// through to UNMEASURABLE like any other row.
+		waivedNow := w != nil && !w.expired && regr <= w.ceiling
+		if !waivedNow && p.unmeasurable(r.metric, r.spread) {
+			v.unmeasurable++
+			waiverNote := ""
+			if w != nil {
+				// The row HAS a waiver that did not apply -- expired, or the
+				// move is past its ceiling. Recorded so the waiver-reporting
+				// loop below does not go on to advise deleting it, which would
+				// be advice drawn from the measurement this line has just
+				// declared worthless.
+				w.unmeasured = true
+				waiverNote = fmt.Sprintf(" [its waiver (%s, ceiling %s%%, expires %s) neither applied nor was outgrown here: both are claims about a size this comparison could not measure]",
+					w.issue, w.ceilStr, w.expires)
+			}
+			v.lines = append(v.lines, fmt.Sprintf("  UNMEASURABLE %-45s %-9s %-40s delta=%s p=%s (gate %s%%) spread ±%s%% is at or above the ±%s%% fitness ceiling -- an arm this dispersed carries no information about the size of the move, so this delta is NOT adjudicated in either direction: not a regression, and not a pass. Re-measure on a fit runner (`benchgate burnin` before the run says whether it is one) %s%s",
+				r.pkg, r.metric, r.name, r.deltaTok, r.pvalStr, gateStr, awkNum(r.spread), p.ceilingStr, dir, waiverNote))
+			continue
 		}
 
 		// At or above the gate. A waiver can turn this into a PASS, but only a
@@ -216,7 +330,7 @@ func adjudicate(c *comparison, p *policy) *verdict {
 			v.waiverStale++
 			v.lines = append(v.lines, fmt.Sprintf("  WAIVER-STALE  %s:%d waives %s / %s / %s -- that package IS in this comparison and that row is not, so the benchmark was renamed or removed and the waiver is protecting nothing. %s",
 				ws.source, w.line, w.pkg, w.bench, w.metric, w.issue))
-		case !w.used && !w.exceeded && !w.expiredHit:
+		case !w.used && !w.exceeded && !w.expiredHit && !w.unmeasured:
 			v.waiverUnused++
 			v.lines = append(v.lines, fmt.Sprintf("  waiver-unused %s:%d waives %s / %s / %s, and that row is not regressing above its gate -- the waiver can be deleted. %s",
 				ws.source, w.line, w.pkg, w.bench, w.metric, w.issue))
@@ -282,6 +396,15 @@ format has genuinely changed.
 		pf(stdout, "benchgate: %d timing row(s) moved past the gate but by LESS than their own measured spread, so this comparison cannot resolve them (reported as NOISE-FLOOR above, excluded from the verdict). They are not gateable as sampled; make them quieter or keep them out of the comparison set.\n", v.unresolved)
 	}
 
+	// Same doctrine again, for the rows the MACHINE could not measure. This one
+	// carries the exit code with it, so it says which way it went.
+	if v.unmeasurable > 0 {
+		pf(stdout, "benchgate: %d timing row(s) moved at or above the gate on an interval at or above the ±%s%% fitness ceiling, so the comparison cannot size the move at all (reported as UNMEASURABLE above). They are NOT counted as regressions and NOT counted as passes: this run certified nothing about them. Re-measure -- `benchgate burnin` on the runner first will say whether it can measure anything.\n", v.unmeasurable, p.ceilingStr)
+	}
+	if v.unmeasurableInfo > 0 {
+		pf(stdout, "benchgate: %d further row(s) were equally unfit to measure but moved LESS than their gate, so they change no verdict and are reported as warnings only. A noisy row can hide a real regression; whole-machine fitness is what `benchgate burnin` is for.\n", v.unmeasurableInfo)
+	}
+
 	// Same doctrine as NOISE-FLOOR above, for the integer-count metrics.
 	if v.quantised > 0 {
 		pf(stdout, "benchgate: %d allocation-count row(s) moved past the gate by exactly ONE allocation on a row that does not reproduce its own count, so the move cannot be told from `go test` truncating a fractional allocs/op (reported as QUANTISED above, excluded from the verdict). They are not gateable at one allocation as sampled.\n", v.quantised)
@@ -295,8 +418,16 @@ format has genuinely changed.
 			v.waiverCount, p.waiverSource, v.waived, v.waiverStale, v.waiverUnused, v.waiverExpired, v.waiverOutOfScope)
 	}
 
+	// Exit-code precedence, and it only goes this way round: a regression found
+	// on a row that COULD be measured is a finding, and an unmeasurable row
+	// elsewhere in the same table does not make it less of one. Reporting
+	// "re-measure" over the top of it would postpone a real result and invite a
+	// re-run that finds it again.
 	if v.regressions > 0 {
 		return 1
+	}
+	if v.unmeasurable > 0 {
+		return 3
 	}
 	return 0
 }

--- a/cmd/benchgate/burnin.go
+++ b/cmd/benchgate/burnin.go
@@ -1,0 +1,382 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"runtime"
+	"sort"
+	"time"
+)
+
+// This file is the FIRST of the two runner-fitness checks (issue #542): a
+// self-check the machine runs BEFORE it is trusted to adjudicate anything.
+//
+// The gate in adjudicate.go judges the CODE. It has no way to ask whether the
+// machine underneath it was in a fit state to measure code at all, and on a
+// shared CI runner that is not a theoretical concern:
+//
+//	substrate#424, head 850f118ef, two consecutive jobs
+//	  run 1   base arm ±71% (samples ~30-130ms), pr arm ±3%  -> +83% "REGRESSION"
+//	  run 2   base arm ±30%,                     pr arm ±2%  -> +34% "REGRESSION"
+//
+// on a tree with ZERO Go-code delta from one the same gate had measured at
+// parity ±3% an hour earlier. Every package on that runner ran 1.5-2x slower in
+// absolute terms; three independent measurements (a fresh runner, a local
+// interleaved n=12, a GOMAXPROCS=2 starvation A/B) all read parity-to-better.
+//
+// The two checks are complementary, and the split is the point:
+//
+//	burnin (this file)      a machine that is ALREADY sick when the job starts.
+//	                        Code-independent, so it cannot be confounded by the
+//	                        change under test, and it runs before any benchmark
+//	                        has been sampled -- the only point at which "do not
+//	                        measure on this machine" is still cheap.
+//	variance ceiling        a machine that goes sick PARTWAY THROUGH, which is
+//	(adjudicate.go)         what happened above: the base arm's samples were
+//	                        disrupted and the pr arm's were not.
+//
+// Neither subsumes the other. A machine can pass burn-in and then acquire a
+// noisy co-tenant; a machine can be born sick and still produce rows whose
+// intervals happen to look tight. Both are cheap.
+//
+// # Why a fixed loop rather than a benchmark
+//
+// The workload below is deliberately NOT one of the repository's benchmarks.
+// It is a fixed number of iterations of a loop that does not read the clock,
+// does not depend on the code under test, and computes a value that is checked
+// against a pinned constant. So:
+//
+//   - It cannot be confounded by the change under test. A burn-in that ran the
+//     PR's own code would report "unfit" for a PR that made something slower,
+//     which is the opposite of the question being asked.
+//   - Its ITERATION COUNT is fixed and its DURATION is measured -- never the
+//     other way round. A workload that runs "for 100ms" adapts to the machine
+//     and reports the same duration on a sick one; only a fixed amount of work
+//     can show that the machine took longer to do it.
+//   - It asserts its own checksum, so a compiler that optimises half of it
+//     away, or an edit that changes what it costs, is caught rather than
+//     silently turning the check into a no-op.
+//
+// # What it asserts
+//
+// K runs, the first W discarded as warmup (cold caches, CPU frequency ramp,
+// cgroup CPU credit), and the remaining samples must agree with each other to
+// within a spread ceiling. The claim is narrow and mechanical:
+//
+//	A machine that cannot reproduce a FIXED loop to within ±10% cannot
+//	resolve a 10% gate on anything else either.
+//
+// It is not a claim that the machine is fast, or that it matches some absolute
+// reference: an arm64 runner and an amd64 runner disagree wildly on the
+// absolute duration and both are perfectly fit. Only self-consistency is
+// asserted, because only self-consistency is what a percentage gate needs.
+//
+// The heap is collected before each run so the samples differ by what the
+// MACHINE did rather than by where a GC cycle happened to land.
+
+const (
+	// defaultBurninRuns and defaultBurninWarmup: 7 runs, 2 discarded, 5 kept --
+	// the same order of magnitude as the n=5..10 the benchmark workflows
+	// themselves sample at, so the check has roughly the sampling power of the
+	// measurement it is vouching for. Two warmup runs rather than one: the
+	// first pays for cold caches AND the first GC cycle, and the second is
+	// where CPU frequency scaling settles on the runners measured.
+	defaultBurninRuns   = 7
+	defaultBurninWarmup = 2
+
+	// defaultBurninSpread is the ceiling the kept samples must agree within.
+	// ±10% is the tightest of the gates this tool adjudicates (substrate's
+	// timing gate is 10%, elps' allocation gate is 5%), so a machine that
+	// passes can at least resolve the loosest question it will be asked. It is
+	// deliberately not tighter: a healthy shared runner does show a few percent
+	// of jitter, and a burn-in that reds healthy machines would be turned off.
+	defaultBurninSpread = 10.0
+
+	// minKept is the smallest number of kept samples a spread can be computed
+	// from and still mean something. With one kept sample the spread is
+	// identically zero -- a check that cannot fail, which is precisely the
+	// defect this tool exists to prevent -- and with two it is one arithmetic
+	// step away from that.
+	minKept = 3
+)
+
+// referenceRounds is the size of the reference workload: fixed, so the
+// DURATION is the measurement. Sized so one run takes long enough to span
+// several scheduler quanta (tens of milliseconds on the runners measured) and
+// short enough that the default 7 runs are under a second.
+const referenceRounds = 48000
+
+// referenceChecksum is what referenceWork(referenceRounds) must return. It is
+// pinned so that a compiler that elides the loop, or an edit that changes what
+// the loop costs, fails loudly instead of quietly turning the burn-in into a
+// measurement of nothing. The arithmetic is integer-only and so is identical on
+// every architecture.
+const referenceChecksum uint64 = 0xe5784d860f36dc7b
+
+const (
+	fnvOffset uint64 = 14695981039346656037
+	fnvPrime  uint64 = 1099511628211
+)
+
+// referenceWork runs the reference workload: rounds iterations of a
+// fixed-length FNV-1a mixing loop over a freshly allocated buffer. Each round
+// does both halves of what a benchmark run does -- arithmetic the CPU must
+// retire in order, and an allocation the collector must eventually deal with --
+// so a machine that is starved of either shows up.
+//
+// The returned checksum is what keeps the work alive: it is consumed by the
+// caller and compared against referenceChecksum, so nothing here is dead code
+// the compiler may delete.
+func referenceWork(rounds int) uint64 {
+	h := fnvOffset
+	// A uint64 counter rather than the loop indices: it is the same
+	// position-dependent mixing without an int -> uint64 conversion on a value
+	// that came from a flag, and it keeps the arithmetic identical on a 32-bit
+	// platform.
+	var n uint64
+	for range rounds {
+		// Allocated inside the loop on purpose: the collector is part of what
+		// is being measured, and a buffer hoisted out of the loop would make
+		// this a pure-CPU check.
+		buf := make([]byte, 512)
+		for i := range buf {
+			n++
+			h ^= n
+			h *= fnvPrime
+			buf[i] = byte(h >> 56)
+		}
+		for _, b := range buf {
+			h ^= uint64(b)
+			h *= fnvPrime
+		}
+	}
+	return h
+}
+
+// sample is one timed run of the reference workload, plus the checksum it
+// computed. Tests inject a substitute so the spread arithmetic and the
+// warmup discard are exercised with no dependence on real timing.
+type sample struct {
+	d   time.Duration
+	sum uint64
+}
+
+// realSampler times referenceWork. The heap is collected first so a GC cycle
+// left over from the previous run is not charged to this one.
+func realSampler(rounds int) sample {
+	runtime.GC()
+	start := time.Now()
+	sum := referenceWork(rounds)
+	return sample{d: time.Since(start), sum: sum}
+}
+
+// burninConfig is the whole burn-in policy.
+type burninConfig struct {
+	ceilingStr string
+	ceiling    float64
+	runs       int
+	warmup     int
+	rounds     int
+}
+
+// burninStats is the arithmetic over the KEPT samples, separated from the
+// timing and the I/O so it can be tested with injected durations.
+type burninStats struct {
+	kept   []time.Duration
+	median float64 // nanoseconds
+	spread float64 // percent
+}
+
+// computeStats discards the first warmup samples and summarises the rest.
+//
+// spread is the furthest any kept sample lands from their median, as a percent
+// of that median. It is deliberately a RANGE statistic rather than a standard
+// deviation: one disrupted sample out of five is exactly the shape this check
+// is looking for, and an SD over five samples dilutes it into the average
+// instead of reporting it.
+func computeStats(samples []time.Duration, warmup int) burninStats {
+	kept := append([]time.Duration(nil), samples[warmup:]...)
+	sorted := append([]time.Duration(nil), kept...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	n := len(sorted)
+	var median float64
+	if n%2 == 1 {
+		median = float64(sorted[n/2])
+	} else {
+		median = (float64(sorted[n/2-1]) + float64(sorted[n/2])) / 2
+	}
+
+	st := burninStats{kept: kept, median: median}
+	if median <= 0 {
+		// A zero or negative median means the clock reported nothing for the
+		// workload, which is not a spread of 0% -- it is an unusable sample.
+		// Reported as an impossible spread so it can never read as "fit".
+		st.spread = math.Inf(1)
+		return st
+	}
+	for _, d := range kept {
+		if dev := math.Abs(float64(d)-median) / median * 100; dev > st.spread {
+			st.spread = dev
+		}
+	}
+	return st
+}
+
+// dur renders a duration the way the report prints it: three significant
+// figures in the unit that suits its magnitude, so 84.2ms and 1.21s both read
+// cleanly. time.Duration.String() prints 84.231847ms, which invites the reader
+// to compare digits the measurement does not have.
+func dur(ns float64) string {
+	d := math.Round(ns)
+	switch {
+	case d >= float64(time.Second):
+		return fmt.Sprintf("%.3gs", d/float64(time.Second))
+	case d >= float64(time.Millisecond):
+		return fmt.Sprintf("%.3gms", d/float64(time.Millisecond))
+	case d >= float64(time.Microsecond):
+		return fmt.Sprintf("%.3gµs", d/float64(time.Microsecond))
+	default:
+		return fmt.Sprintf("%dns", int64(d))
+	}
+}
+
+const burninUsage = `usage: benchgate burnin [flags]
+
+Is THIS MACHINE fit to adjudicate a percentage gate? Runs a fixed,
+code-independent reference workload K times, discards the first few as warmup,
+and requires the rest to agree with each other.
+
+A machine that cannot reproduce a fixed loop cannot resolve a percentage gate
+on anything else either, so the answer is worth having BEFORE the benchmarks
+are sampled -- which is the only point at which "do not measure here" is cheap.
+
+exit 0  fit
+exit 2  invalid usage, or the workload did not compute its pinned checksum
+exit 3  RUNNER-UNFIT: re-measure elsewhere (the same code the adjudicator uses
+        for a row it could not measure)
+
+flags (each falls back to the matching BENCH_* environment variable):
+  -runs K        timed runs of the reference workload
+                 (env BENCH_BURNIN_RUNS, default 7)
+  -warmup W      leading runs discarded before the spread is computed
+                 (env BENCH_BURNIN_WARMUP, default 2)
+  -spread P      ceiling, in percent, for how far a kept sample may land from
+                 the median of the kept samples
+                 (env BENCH_BURNIN_SPREAD_PCT, default 10)
+  -rounds N      size of the reference workload, in iterations. Fixed work,
+                 measured duration -- never the other way round.
+                 (env BENCH_BURNIN_ROUNDS, default 48000)
+`
+
+// runBurnin is the `benchgate burnin` subcommand, with its I/O and its sampler
+// injected so the whole thing -- flags, env fallbacks, verdict, exit code -- is
+// testable without depending on how busy the machine running the tests is.
+func runBurnin(args []string, stdout, stderr io.Writer, sampler func(rounds int) sample) int {
+	fs := flag.NewFlagSet("benchgate burnin", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { pr(stderr, burninUsage) }
+
+	runsDef, err1 := envDefaultInt("BENCH_BURNIN_RUNS", defaultBurninRuns)
+	warmDef, err2 := envDefaultInt("BENCH_BURNIN_WARMUP", defaultBurninWarmup)
+	roundsDef, err3 := envDefaultInt("BENCH_BURNIN_ROUNDS", referenceRounds)
+	spreadDef, spreadStr, err4 := envDefaultFloat("BENCH_BURNIN_SPREAD_PCT", defaultBurninSpread)
+	for _, err := range []error{err1, err2, err3, err4} {
+		if err != nil {
+			pf(stderr, "benchgate burnin: %v.\n", err)
+			return 2
+		}
+	}
+
+	runs := fs.Int("runs", runsDef, "timed runs of the reference workload")
+	warmup := fs.Int("warmup", warmDef, "leading runs discarded as warmup")
+	rounds := fs.Int("rounds", roundsDef, "size of the reference workload, in iterations")
+	spread := fs.Float64("spread", spreadDef, "spread ceiling, percent")
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if len(fs.Args()) > 0 {
+		pf(stderr, "benchgate burnin: takes no positional arguments (got %q).\n", fs.Args()[0])
+		pr(stderr, burninUsage)
+		return 2
+	}
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "spread" {
+			spreadStr = f.Value.String()
+		}
+	})
+
+	cfg := burninConfig{runs: *runs, warmup: *warmup, rounds: *rounds, ceiling: *spread, ceilingStr: spreadStr}
+	switch {
+	case cfg.warmup < 0:
+		pf(stderr, "benchgate burnin: -warmup must not be negative (got %d).\n", cfg.warmup)
+		return 2
+	case cfg.rounds < 1:
+		pf(stderr, "benchgate burnin: -rounds must be at least 1 (got %d).\n", cfg.rounds)
+		return 2
+	case cfg.ceiling <= 0:
+		// A ceiling of zero demands that a real machine reproduce a duration to
+		// the nanosecond. It would fail every run, which is a check nobody
+		// leaves switched on -- refused rather than honoured.
+		pf(stderr, "benchgate burnin: -spread/BENCH_BURNIN_SPREAD_PCT must be a positive percentage (got %s).\n", trimFloat(cfg.ceiling))
+		return 2
+	case cfg.runs-cfg.warmup < minKept:
+		pf(stderr, "benchgate burnin: -runs %d with -warmup %d keeps %d sample(s); at least %d are needed for a spread to mean anything (over one sample it is identically zero, which is a check that cannot fail).\n",
+			cfg.runs, cfg.warmup, cfg.runs-cfg.warmup, minKept)
+		return 2
+	}
+
+	return burnin(cfg, stdout, stderr, sampler)
+}
+
+// burnin runs the workload and reports. Split from flag parsing so tests drive
+// the verdict directly.
+func burnin(cfg burninConfig, stdout, stderr io.Writer, sampler func(rounds int) sample) int {
+	pf(stdout, "benchgate burnin: %d run(s) of the reference workload (%d rounds), first %d discarded as warmup; GOMAXPROCS=%d NumCPU=%d %s/%s.\n",
+		cfg.runs, cfg.rounds, cfg.warmup, runtime.GOMAXPROCS(0), runtime.NumCPU(), runtime.GOOS, runtime.GOARCH)
+
+	samples := make([]time.Duration, 0, cfg.runs)
+	var first uint64
+	for i := range cfg.runs {
+		s := sampler(cfg.rounds)
+		if i == 0 {
+			first = s.sum
+		}
+		// Every run must compute the same answer as every other run, and -- at
+		// the default size -- the same answer as the pinned constant. A machine
+		// that disagrees with itself about arithmetic is not merely slow, and a
+		// workload that no longer produces the pinned value is no longer the
+		// workload whose cost profile this check was calibrated against.
+		if s.sum != first {
+			pf(stderr, "benchgate burnin: the reference workload computed %#x on run %d and %#x on run 1 -- the same fixed loop returned two different answers, so this machine (or this build) cannot be trusted to measure anything.\n", s.sum, i+1, first)
+			return 2
+		}
+		if cfg.rounds == referenceRounds && s.sum != referenceChecksum {
+			pf(stderr, "benchgate burnin: the reference workload returned %#x, want %#x -- the workload is not the one this check was calibrated against (edited, or optimised away). Refusing to report fitness from a measurement of nothing.\n", s.sum, referenceChecksum)
+			return 2
+		}
+		samples = append(samples, s.d)
+		mark := ""
+		if i < cfg.warmup {
+			mark = "  (warmup, discarded)"
+		}
+		pf(stdout, "  run %-2d  %10s%s\n", i+1, dur(float64(s.d)), mark)
+	}
+
+	st := computeStats(samples, cfg.warmup)
+	if st.spread >= cfg.ceiling {
+		// One line, on stderr, saying what was measured and what to do. Exit 3
+		// is the SAME code the adjudicator uses for a row it could not measure:
+		// both mean "this machine did not produce a usable measurement --
+		// re-measure", and a caller that handles one handles the other.
+		pf(stderr, "benchgate burnin: UNFIT -- %d kept sample(s) of a FIXED loop spread ±%s%% around their %s median (ceiling ±%s%%); a machine that cannot reproduce a fixed loop cannot resolve a percentage gate, so any comparison measured here is not evidence. Re-run on another runner.\n",
+			len(st.kept), awkNum(roundSpread(st.spread)), dur(st.median), cfg.ceilingStr)
+		return 3
+	}
+	pf(stdout, "benchgate burnin: FIT -- %d kept sample(s) agree to within ±%s%% of their %s median (ceiling ±%s%%).\n",
+		len(st.kept), awkNum(roundSpread(st.spread)), dur(st.median), cfg.ceilingStr)
+	return 0
+}

--- a/cmd/benchgate/burnin_test.go
+++ b/cmd/benchgate/burnin_test.go
@@ -1,0 +1,378 @@
+package main
+
+import (
+	"bytes"
+	"math"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The burn-in's arithmetic is tested with INJECTED durations, deliberately.
+// A unit test that timed the real loop and asserted a spread would be a test of
+// how busy the machine running `go test` happens to be -- which is the exact
+// confusion this whole feature exists to remove, and it would be the flakiest
+// test in the repository. The real loop is exercised by one smoke test at the
+// bottom, which asserts what is true regardless of load.
+
+// fixedSampler replays a canned list of durations, one per run, with a constant
+// checksum. It is the seam that makes the verdict deterministic.
+func fixedSampler(ds ...time.Duration) func(int) sample {
+	i := 0
+	return func(int) sample {
+		d := ds[i%len(ds)]
+		i++
+		return sample{d: d, sum: referenceChecksum}
+	}
+}
+
+func ms(n float64) time.Duration { return time.Duration(n * float64(time.Millisecond)) }
+
+func runBurninCase(t *testing.T, args []string, env map[string]*string, sampler func(int) sample) (int, string) {
+	t.Helper()
+	for _, k := range benchEnvVars {
+		old, had := os.LookupEnv(k)
+		t.Cleanup(func() {
+			if had {
+				_ = os.Setenv(k, old)
+			} else {
+				_ = os.Unsetenv(k)
+			}
+		})
+		_ = os.Unsetenv(k)
+	}
+	for k, v := range env {
+		if v != nil {
+			_ = os.Setenv(k, *v)
+		}
+	}
+	var out bytes.Buffer
+	rc := runBurnin(args, &out, &out, sampler)
+	return rc, out.String()
+}
+
+// TestBurninStats pins the two things the verdict is computed from: which
+// samples are kept, and how far apart they are called.
+func TestBurninStats(t *testing.T) {
+	cases := []struct {
+		name       string
+		samples    []time.Duration
+		warmup     int
+		wantKept   int
+		wantMedian time.Duration
+		wantSpread float64
+	}{{
+		// The warmup samples are DISCARDED, not merely down-weighted. This is
+		// the case that proves it: the two leading samples are wildly out and
+		// must not appear in either statistic.
+		name:    "warmup samples are discarded entirely",
+		samples: []time.Duration{ms(500), ms(200), ms(100), ms(100), ms(100)},
+		warmup:  2, wantKept: 3, wantMedian: ms(100), wantSpread: 0,
+	}, {
+		name:    "a perfectly reproducing machine spreads 0%",
+		samples: []time.Duration{ms(80), ms(80), ms(80), ms(80), ms(80)},
+		warmup:  0, wantKept: 5, wantMedian: ms(80), wantSpread: 0,
+	}, {
+		// ONE disrupted sample out of five is the shape this check exists to
+		// catch, and a range statistic reports it at full size. (A standard
+		// deviation would dilute it across the other four, which is why the
+		// spread is defined as the furthest sample from the median.)
+		name:    "one disrupted sample sets the spread on its own",
+		samples: []time.Duration{ms(100), ms(100), ms(150), ms(100), ms(100)},
+		warmup:  0, wantKept: 5, wantMedian: ms(100), wantSpread: 50,
+	}, {
+		name:    "the spread is symmetric: a fast outlier counts the same",
+		samples: []time.Duration{ms(100), ms(100), ms(50), ms(100), ms(100)},
+		warmup:  0, wantKept: 5, wantMedian: ms(100), wantSpread: 50,
+	}, {
+		// Even sample counts take the mean of the two middle values, so the
+		// median is not silently one of the samples.
+		name:    "an even number of kept samples averages the two middles",
+		samples: []time.Duration{ms(90), ms(100), ms(110), ms(120)},
+		warmup:  0, wantKept: 4, wantMedian: ms(105), wantSpread: 100.0 * 15 / 105,
+	}, {
+		name:    "warmup discard and an even kept count together",
+		samples: []time.Duration{ms(400), ms(90), ms(100), ms(110), ms(120)},
+		warmup:  1, wantKept: 4, wantMedian: ms(105), wantSpread: 100.0 * 15 / 105,
+	}, {
+		// A clock that reports nothing for a fixed loop is not a spread of 0%.
+		// Reported as an impossible spread so it can never read as "fit".
+		name:    "a zero median is not a perfect measurement",
+		samples: []time.Duration{0, 0, 0},
+		warmup:  0, wantKept: 3, wantMedian: 0, wantSpread: math.Inf(1),
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			st := computeStats(c.samples, c.warmup)
+			if len(st.kept) != c.wantKept {
+				t.Errorf("kept %d samples, want %d", len(st.kept), c.wantKept)
+			}
+			if math.Abs(st.median-float64(c.wantMedian)) > 1 {
+				t.Errorf("median %v, want %v", time.Duration(st.median), c.wantMedian)
+			}
+			if math.IsInf(c.wantSpread, 1) {
+				if !math.IsInf(st.spread, 1) {
+					t.Errorf("spread %v, want +Inf", st.spread)
+				}
+			} else if math.Abs(st.spread-c.wantSpread) > 1e-9 {
+				t.Errorf("spread %v, want %v", st.spread, c.wantSpread)
+			}
+			// The kept samples keep their ORDER, so the report lists the runs
+			// as they happened rather than sorted.
+			for i, d := range st.kept {
+				if d != c.samples[c.warmup+i] {
+					t.Errorf("kept[%d] = %v, want %v (the kept samples were reordered)", i, d, c.samples[c.warmup+i])
+				}
+			}
+		})
+	}
+}
+
+// TestBurninVerdict drives the whole subcommand -- flags, env, report, exit
+// code -- with the timing injected.
+func TestBurninVerdict(t *testing.T) {
+	cases := []struct {
+		name        string
+		env         map[string]*string
+		sampler     func(int) sample
+		args        []string
+		want        int
+		contains    []string
+		notContains []string
+	}{{
+		name:    "a machine that reproduces the loop is FIT",
+		args:    []string{"-runs", "5", "-warmup", "2"},
+		sampler: fixedSampler(ms(200), ms(120), ms(100), ms(101), ms(99)),
+		want:    0, contains: []string{"FIT", "3 kept sample(s)", "±1%"},
+		// The warmup samples were 100% and 20% out. If they reached the
+		// statistics, this machine would read as unfit.
+		notContains: []string{"UNFIT"},
+	}, {
+		// THE POINT OF THE CHECK. A fixed loop taking 100ms and then 180ms on
+		// the same machine within the same second is a machine that cannot
+		// resolve a 10% gate on anything.
+		name:    "a machine that cannot reproduce the loop is UNFIT",
+		args:    []string{"-runs", "5", "-warmup", "0"},
+		sampler: fixedSampler(ms(100), ms(100), ms(180), ms(100), ms(100)),
+		want:    3, contains: []string{"UNFIT", "±80%", "Re-run on another runner"},
+	}, {
+		// The boundary is at-or-above, the same convention the gate uses for a
+		// threshold. Exactly ±10% against a ±10% ceiling is unfit.
+		name:    "a spread exactly AT the ceiling is unfit",
+		args:    []string{"-runs", "3", "-warmup", "0"},
+		sampler: fixedSampler(ms(100), ms(110), ms(100)),
+		want:    3, contains: []string{"UNFIT", "±10%"},
+	}, {
+		name:    "a spread just below the ceiling is fit",
+		args:    []string{"-runs", "3", "-warmup", "0"},
+		sampler: fixedSampler(ms(100), ms(109), ms(100)),
+		want:    0, contains: []string{"FIT"},
+	}, {
+		name:    "the ceiling is configurable, and a tighter one reds the same samples",
+		args:    []string{"-runs", "3", "-warmup", "0", "-spread", "5"},
+		sampler: fixedSampler(ms(100), ms(109), ms(100)),
+		want:    3, contains: []string{"UNFIT", "ceiling ±5%"},
+	}, {
+		name:    "the ceiling comes from the environment too",
+		env:     map[string]*string{"BENCH_BURNIN_SPREAD_PCT": s("5")},
+		args:    []string{"-runs", "3", "-warmup", "0"},
+		sampler: fixedSampler(ms(100), ms(109), ms(100)),
+		want:    3, contains: []string{"UNFIT", "ceiling ±5%"},
+	}, {
+		name:    "runs and warmup come from the environment too",
+		env:     map[string]*string{"BENCH_BURNIN_RUNS": s("5"), "BENCH_BURNIN_WARMUP": s("2")},
+		sampler: fixedSampler(ms(500), ms(400), ms(100), ms(100), ms(100)),
+		want:    0, contains: []string{"5 run(s)", "first 2 discarded", "3 kept sample(s)"},
+	}, {
+		// Every run is printed, warmup included and labelled. A discarded
+		// sample that is never shown is a measurement nobody can review.
+		name:    "warmup runs are printed, and marked as discarded",
+		args:    []string{"-runs", "4", "-warmup", "1"},
+		sampler: fixedSampler(ms(500), ms(100), ms(100), ms(100)),
+		want:    0, contains: []string{"run 1", "(warmup, discarded)", "run 4"},
+	}, {
+		// A machine that computes a different answer from the same fixed input
+		// is not merely slow. Exit 2, not 3: nothing was measured at all.
+		name: "a run that disagrees with run 1 about the answer is a hard error",
+		args: []string{"-runs", "3", "-warmup", "0", "-rounds", "16"},
+		sampler: func() func(int) sample {
+			var i uint64
+			return func(int) sample {
+				i++
+				return sample{d: ms(100), sum: i}
+			}
+		}(),
+		want: 2, contains: []string{"two different answers"},
+	}, {
+		// At the DEFAULT workload size the checksum is pinned, so a workload
+		// that was edited (or optimised away) cannot quietly go on reporting
+		// fitness from a measurement of nothing.
+		name:    "a wrong checksum at the default size is a hard error",
+		args:    []string{"-runs", "3", "-warmup", "0"},
+		sampler: func(int) sample { return sample{d: ms(100), sum: 1} },
+		want:    2, contains: []string{"not the one this check was calibrated against"},
+	}, {
+		// ...and at a NON-default size there is nothing to pin it against, so
+		// the run proceeds on self-consistency alone.
+		name:    "a non-default workload size is judged on self-consistency alone",
+		args:    []string{"-runs", "3", "-warmup", "0", "-rounds", "16"},
+		sampler: func(int) sample { return sample{d: ms(100), sum: 1} },
+		want:    0, contains: []string{"FIT"},
+	}, {
+		// A single kept sample has a spread of exactly zero no matter what the
+		// machine did: a check that cannot fail. Refused rather than reported.
+		name:    "keeping fewer than three samples is a usage error",
+		args:    []string{"-runs", "3", "-warmup", "2"},
+		sampler: fixedSampler(ms(100)),
+		want:    2, contains: []string{"at least 3 are needed", "cannot fail"},
+	}, {
+		name:    "a zero spread ceiling is a usage error, not an impossible bar",
+		args:    []string{"-runs", "3", "-warmup", "0", "-spread", "0"},
+		sampler: fixedSampler(ms(100)),
+		want:    2, contains: []string{"must be a positive percentage"},
+	}, {
+		name:    "a negative warmup is a usage error",
+		args:    []string{"-runs", "5", "-warmup", "-1"},
+		sampler: fixedSampler(ms(100)),
+		want:    2, contains: []string{"must not be negative"},
+	}, {
+		name:    "a zero workload size is a usage error",
+		args:    []string{"-runs", "3", "-warmup", "0", "-rounds", "0"},
+		sampler: fixedSampler(ms(100)),
+		want:    2, contains: []string{"-rounds must be at least 1"},
+	}, {
+		name:    "a fractional run count is a typo, not a policy",
+		env:     map[string]*string{"BENCH_BURNIN_RUNS": s("7.5")},
+		sampler: fixedSampler(ms(100)),
+		want:    2, contains: []string{"is not a whole number"},
+	}, {
+		name:    "a positional argument is a usage error",
+		args:    []string{"table.txt"},
+		sampler: fixedSampler(ms(100)),
+		want:    2, contains: []string{"takes no positional arguments"},
+	}, {
+		name:    "an unknown flag is a usage error",
+		args:    []string{"-nope"},
+		sampler: fixedSampler(ms(100)),
+		want:    2,
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rc, out := runBurninCase(t, c.args, c.env, c.sampler)
+			if rc != c.want {
+				t.Errorf("exit %d, want %d\n%s", rc, c.want, out)
+			}
+			for _, want := range c.contains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output does not contain %q\n%s", want, out)
+				}
+			}
+			for _, bad := range c.notContains {
+				if strings.Contains(out, bad) {
+					t.Errorf("output unexpectedly contains %q\n%s", bad, out)
+				}
+			}
+		})
+	}
+}
+
+// TestBurninUnfitExitMatchesTheAdjudicator pins the two halves of #542 to the
+// SAME exit code. They are one claim ("this machine did not produce a usable
+// measurement -- re-measure"), and a caller that learns to handle one must not
+// have to learn a second code for the other.
+func TestBurninUnfitExitMatchesTheAdjudicator(t *testing.T) {
+	burninRC, _ := runBurninCase(t, []string{"-runs", "3", "-warmup", "0"}, nil,
+		fixedSampler(ms(100), ms(200), ms(100)))
+	gateRC, out := runGate(t, gateCase{
+		env:  noWaivers(),
+		args: elpsArgs("benchstat-runner-unfit-542.txt"),
+	})
+	if burninRC != 3 || gateRC != 3 {
+		t.Errorf("burnin exited %d and the adjudicator exited %d; both must be 3 (RUNNER-UNFIT)\n%s", burninRC, gateRC, out)
+	}
+}
+
+// TestReferenceWorkloadIsPinned is what stops the burn-in becoming a
+// measurement of nothing. If a compiler learns to elide the loop, or someone
+// edits it, the constant changes and this fails -- rather than the check
+// quietly reporting every machine fit in 4ns.
+func TestReferenceWorkloadIsPinned(t *testing.T) {
+	if got := referenceWork(referenceRounds); got != referenceChecksum {
+		t.Fatalf("referenceWork(%d) = %#x, want %#x -- the reference workload changed; if that was deliberate, re-pin referenceChecksum and say what the new cost profile is",
+			referenceRounds, got, referenceChecksum)
+	}
+	// Different sizes must produce different answers, or the checksum is not
+	// actually observing the loop count.
+	if referenceWork(referenceRounds/2) == referenceChecksum {
+		t.Error("half the workload produced the same checksum -- the checksum does not observe the loop")
+	}
+}
+
+// TestBurninSmoke runs the REAL loop, through the real subcommand dispatch, at
+// a tiny size. It asserts only what is true regardless of how loaded the
+// machine is: the samples are real, the checksum path is exercised, and the
+// verdict is one of the two the contract allows.
+func TestBurninSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("burn-in smoke test runs the real reference workload")
+	}
+	var out bytes.Buffer
+	// Dispatched through run(), so the `burnin` subcommand is proven reachable
+	// from argv and not only as a Go function.
+	rc := run([]string{"burnin", "-runs", "4", "-warmup", "1", "-rounds", "2000", "-spread", "10000"}, &out, &out)
+	s := out.String()
+	if rc != 0 {
+		t.Fatalf("exit %d, want 0 (a ±10000%% ceiling is unreachable even on a badly loaded machine)\n%s", rc, s)
+	}
+	for _, want := range []string{"run 1", "run 4", "(warmup, discarded)", "FIT", "3 kept sample(s)"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output does not contain %q\n%s", want, s)
+		}
+	}
+	// A sample of 0ns would mean the workload was optimised away and the
+	// "measurement" is of nothing at all.
+	if strings.Contains(s, "  0ns") {
+		t.Errorf("a run took 0ns -- the reference workload did not run\n%s", s)
+	}
+}
+
+// TestBurninTakesRealTime is the same claim as the 0ns check above, made
+// directly: a fixed workload four times the size must take measurably longer
+// than the small one. Ratios are not asserted (that would be a benchmark of the
+// test machine); only the ordering, which no amount of load can invert.
+func TestBurninTakesRealTime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs the real reference workload")
+	}
+	small := realSampler(2000)
+	large := realSampler(8000)
+	if small.d <= 0 || large.d <= 0 {
+		t.Fatalf("the reference workload reported no elapsed time (%v, %v)", small.d, large.d)
+	}
+	if large.d <= small.d {
+		t.Errorf("4x the work took %v against %v for the smaller loop -- the duration does not track the fixed iteration count", large.d, small.d)
+	}
+	if small.sum == large.sum {
+		t.Error("two different workload sizes produced the same checksum")
+	}
+}
+
+func TestDurRendering(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{950 * time.Nanosecond, "950ns"},
+		{1500 * time.Nanosecond, "1.5µs"},
+		{84231847 * time.Nanosecond, "84.2ms"},
+		{1213 * time.Millisecond, "1.21s"},
+	}
+	for _, c := range cases {
+		if got := dur(float64(c.in)); got != c.want {
+			t.Errorf("dur(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/cmd/benchgate/compare_test.go
+++ b/cmd/benchgate/compare_test.go
@@ -349,6 +349,60 @@ func TestBothFrontEndsAgree(t *testing.T) {
 	}
 }
 
+// TestRawModeRunnerUnfit is elps#542 reaching the structured front end. The
+// shape is substrate#424's: a base arm whose samples are scattered from 30ms to
+// 130ms by something that was not the code, against a head arm that reproduces
+// itself to within a percent.
+//
+// It is not enough to test this through the table front end alone. The two
+// front ends compute the spread by different routes -- one reads the "± 71%"
+// benchstat printed, the other derives it from benchmath.Summary -- and a
+// fitness check present in one and absent in the other would mean `make
+// bench-gate-arms` quietly certifying what CI refuses.
+func TestRawModeRunnerUnfit(t *testing.T) {
+	var baseS, headS []sampleLine
+	for i := range 10 {
+		// Base: 30ms .. 130ms, the incident's own range. Head: a tight cluster
+		// well above all of it, so the comparison is unambiguously significant
+		// and the move is far larger than the base arm's spread -- which is what
+		// keeps the resolution check out of it and leaves the fitness ceiling as
+		// the only thing that can withhold the verdict.
+		baseS = append(baseS, sampleLine{iters: 100, metrics: fmt.Sprintf("%d ns/op", 30000000+i*11111111)})
+		headS = append(headS, sampleLine{iters: 100, metrics: fmt.Sprintf("%d ns/op", 139000000+i*200000)})
+	}
+	base := arm(pkg, map[string][]sampleLine{"MockParallel": baseS})
+	head := arm(pkg, map[string][]sampleLine{"MockParallel": headS})
+
+	rc, out := runRaw(t, base, head, map[string]*string{"BENCH_WAIVERS": s("")})
+	if rc != 3 {
+		t.Fatalf("exit %d, want 3 (RUNNER-UNFIT)\n%s", rc, out)
+	}
+	for _, want := range []string{"UNMEASURABLE", "fitness ceiling", "certified nothing about them"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output does not contain %q\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "REGRESSION") {
+		t.Errorf("an unmeasurable row was adjudicated as a regression\n%s", out)
+	}
+
+	// The control, through the same front end: hand it a base arm that
+	// reproduces itself and the identical head arm, and the same move IS a
+	// regression. Only the base arm's dispersion differs between the two halves.
+	var tightS []sampleLine
+	for i := range 10 {
+		tightS = append(tightS, sampleLine{iters: 100, metrics: fmt.Sprintf("%d ns/op", 80000000+i*200000)})
+	}
+	base = arm(pkg, map[string][]sampleLine{"MockParallel": tightS})
+	rc, out = runRaw(t, base, head, map[string]*string{"BENCH_WAIVERS": s("")})
+	if rc != 1 {
+		t.Fatalf("exit %d, want 1 -- the same move on a fit base arm is a regression\n%s", rc, out)
+	}
+	if !strings.Contains(out, "REGRESSION") {
+		t.Errorf("the control did not produce a regression\n%s", out)
+	}
+}
+
 // TestPctRangeMatchesBenchstat pins the spread computation against
 // benchmath's own renderer, so a future benchstat change to PctRangeString
 // shows up here rather than as a silently different verdict.

--- a/cmd/benchgate/doc.go
+++ b/cmd/benchgate/doc.go
@@ -165,6 +165,80 @@
 // fire on a stable row, because it keys on a row disagreeing WITH ITSELF,
 // which a real regression does not do.
 //
+// # Was the MACHINE fit to measure? The two fitness checks
+//
+// Everything above judges the CODE. None of it asks whether the runner was in a
+// state to measure code at all, and issue #542 is what that costs. On
+// substrate#424 (head 850f118ef) this gate failed a PR twice:
+//
+//	run 1   base arm ±71% (samples ~30-130ms), pr arm ±3%   -> +83% REGRESSION
+//	run 2   base arm ±30%,                     pr arm ±2%   -> +34% REGRESSION
+//
+// on a head with ZERO Go-code delta from a tree the same gate had measured at
+// parity ±3% an hour earlier. Every package on that runner ran 1.5-2x slower in
+// absolute terms, and three independent measurements (a fresh runner, a local
+// interleaved n=12, a GOMAXPROCS=2 starvation A/B) all read parity-to-better. A
+// ±71% interval is not a measurement -- but the gate compared the two medians
+// and emitted a verdict anyway.
+//
+// Note that the resolution check above did NOT catch it: +83% is LARGER than
+// the ±71% spread, so the row passed "is this move bigger than what the row can
+// see?" while being drawn from an arm that could not see anything. The two
+// checks below close that gap from both ends.
+//
+//	benchgate burnin   before the benchmarks are sampled, run a FIXED,
+//	                   code-independent loop K times and require the samples to
+//	                   agree. A machine that cannot reproduce a fixed loop
+//	                   cannot resolve a percentage gate on anything else. See
+//	                   burnin.go for the workload, the defaults and why the
+//	                   iteration count is fixed and the duration measured.
+//
+//	the per-row        during adjudication, a TIMING row whose own confidence
+//	variance ceiling   interval is at or above -variance-ceiling (default 30%)
+//	                   is UNMEASURABLE: its delta is printed, and it is
+//	                   adjudicated in neither direction.
+//
+// Neither subsumes the other: burn-in catches a machine that is already sick
+// when the job starts, the ceiling catches one that degrades partway through --
+// which is exactly the shape above, where one arm was disrupted and the other
+// was not.
+//
+// The ceiling is a TIMING-metric rule, the same class boundary the resolution
+// check draws and for the same reason: a jittery allocation column is a
+// benchmark defect rather than a sick machine, and the one benign way an
+// allocation count jitters is already handled by the quantisation check. A row
+// with no computable interval ("± ∞ ¹") is not unmeasurable by this rule
+// either -- nothing was measured to compare against the ceiling -- and the
+// report says so on the row.
+//
+// # What UNMEASURABLE does to the verdict
+//
+// The contract is stated here, in `benchgate -h`, and pinned by tests:
+//
+//   - An over-gate delta on an UNMEASURABLE row does NOT produce exit 1. It is
+//     not a regression; it is not evidence of anything.
+//   - It does not produce exit 0 either. Reporting "no regression" from a
+//     comparison that could not size the move is the same defect as the 473
+//     green runs of a grep that could not match: green because it stopped
+//     looking. Those rows exit 3, RUNNER-UNFIT, which means RE-MEASURE.
+//   - An unmeasurable row BELOW its gate is reported as a warning and changes
+//     no exit code. This is the deliberate middle: a noisy row can hide a real
+//     regression, but failing every slightly-noisy minor row makes the gate
+//     brittle, and a brittle gate gets switched off. Whole-machine fitness is
+//     burn-in's job, and that is where this gap is closed.
+//   - Exit 1 beats exit 3. A regression found on a row that COULD be measured
+//     is a finding; an unmeasurable row elsewhere in the same table does not
+//     make it less of one, and "re-measure" over the top of it would only
+//     postpone it.
+//   - A row covered by a LIVE waiver, within its recorded ceiling, is still
+//     WAIVED. There is nothing left to certify on a row whose regression is
+//     already accepted, so there is nothing an unfit measurement invalidates.
+//     The consequence is a property worth stating plainly: the fitness ceiling
+//     can only ever WITHHOLD a regression finding (turning exit 1 into exit 3).
+//     It can never turn a run that would have passed into one that fails. An
+//     EXPIRED waiver, or a move past the recorded ceiling, is a new finding
+//     drawn from this measurement and gets no such treatment.
+//
 // # Reviewed waivers
 //
 // Sometimes a regression is real, understood and deliberately accepted. The
@@ -197,10 +271,12 @@
 // declare them as workflow-level `env:` entries next to the prose explaining
 // how each was measured, and this tool reads those same names
 // (BENCH_REGRESSION_THRESHOLD_PCT, BENCH_ALLOC_THRESHOLD_PCT, BENCH_ALPHA,
-// BENCH_WAIVERS, BENCH_WAIVER_TODAY) so the migration moved no policy. A
-// config file would add a second place for policy to live and a parse surface
-// that itself needs a "what if it does not parse" rule; flags plus those env
-// vars need neither.
+// BENCH_VARIANCE_CEILING_PCT, BENCH_WAIVERS, BENCH_WAIVER_TODAY) so the
+// migration moved no policy. A config file would add a second place for policy
+// to live and a parse surface that itself needs a "what if it does not parse"
+// rule; flags plus those env vars need neither. The burn-in's three knobs
+// follow the same convention (BENCH_BURNIN_RUNS, BENCH_BURNIN_WARMUP,
+// BENCH_BURNIN_SPREAD_PCT, BENCH_BURNIN_ROUNDS).
 //
 // # Exit codes
 //
@@ -208,11 +284,25 @@
 //	1  regression detected
 //	2  the input could not be interpreted (missing/empty file, or NO
 //	   comparison row at all -- which means benchstat's output format changed
-//	   or benchstat crashed), or the waiver file could not be interpreted.
+//	   or benchstat crashed), or the waiver file could not be interpreted, or
+//	   the flags were invalid.
+//	3  RUNNER-UNFIT: the machine did not produce a usable measurement, so
+//	   nothing was certified and nothing was found -- RE-MEASURE. Emitted by
+//	   `benchgate burnin` when the reference workload's samples disagree, and
+//	   by adjudication when a row at or above its gate had an interval at or
+//	   above the fitness ceiling.
 //
 // Exiting 2 rather than 0 is deliberate: an uninterpretable comparison must
 // fail loudly instead of reporting "no regression", which is exactly how the
 // old inline `grep -E '^\S.*\+$'` gate stayed green for 473 runs. The same
 // reasoning covers the waiver file: a malformed waiver list must never be read
-// as an empty one.
+// as an empty one -- and the same reasoning again is why an unmeasurable row
+// exits 3 rather than 0.
+//
+// Three codes became four rather than folding the new case into 1 or 2 because
+// the caller's response differs: exit 1 means read the diff, exit 2 means fix
+// the plumbing, exit 3 means run it again somewhere else. A caller that has not
+// been taught the difference still fails closed -- every consumer keys on
+// non-zero -- which is why 3 is safe to add to a tool two repositories already
+// run.
 package main

--- a/cmd/benchgate/gate_test.go
+++ b/cmd/benchgate/gate_test.go
@@ -40,8 +40,13 @@ var benchEnvVars = []string{
 	"BENCH_REGRESSION_THRESHOLD_PCT",
 	"BENCH_ALLOC_THRESHOLD_PCT",
 	"BENCH_ALPHA",
+	"BENCH_VARIANCE_CEILING_PCT",
 	"BENCH_WAIVERS",
 	"BENCH_WAIVER_TODAY",
+	"BENCH_BURNIN_RUNS",
+	"BENCH_BURNIN_WARMUP",
+	"BENCH_BURNIN_SPREAD_PCT",
+	"BENCH_BURNIN_ROUNDS",
 }
 
 type gateCase struct {
@@ -485,6 +490,204 @@ func TestQuantisationCheck(t *testing.T) {
 		env:  noWaivers(), args: elpsArgs("benchstat-allocs-quantisation-boundary.txt"),
 		want: 1,
 	}})
+}
+
+// TestVarianceCeiling is elps#542: every check above judges the CODE, and none
+// of them asks whether the MACHINE was in a state to measure code at all. On
+// substrate#424 that cost two consecutive REGRESSION verdicts on a head with no
+// Go-code delta, drawn from an arm measuring itself at ±71%.
+func TestVarianceCeiling(t *testing.T) {
+	check(t, []gateCase{{
+		// THE INCIDENT. +83.31% through a ±71% base arm: unmeasurable, exit 3,
+		// and specifically NOT the regression exit code -- an over-gate delta on
+		// a row nothing could size is not evidence of a regression.
+		name: "the substrate#424 shape is UNMEASURABLE and exits 3, not 1",
+		env:  noWaivers(), args: elpsArgs("benchstat-runner-unfit-542.txt"),
+		want: 3,
+		contains: []string{
+			"UNMEASURABLE", "+83.31%", "spread ±71%",
+			"fitness ceiling", "this run certified nothing about them",
+		},
+		// The verdict line, not the bare word: "REGRESSION" must not appear as
+		// this row's label, and the summary must not count it as one.
+		notContains: []string{"REGRESSION", "1 at or above the gate"},
+	}, {
+		// THE CONTROL. The ceiling must not be an off switch: a real move,
+		// measured on a fit machine, still reds the build.
+		name: "a real regression measured through TIGHT intervals still fires",
+		env:  noWaivers(), args: elpsArgs("benchstat-tight-regression-542.txt"),
+		want: 1, contains: []string{"REGRESSION", "+18.00%"},
+		notContains: []string{"UNMEASURABLE"},
+	}, {
+		// THE BOUNDARY, both sides. ±30% against a ±30% ceiling is at-or-above,
+		// matching the gate's own convention for the threshold.
+		name: "a spread exactly AT the ceiling is unmeasurable",
+		env:  noWaivers(), args: elpsArgs("benchstat-ceiling-at-542.txt"),
+		want: 3, contains: []string{"UNMEASURABLE", "spread ±30%"},
+	}, {
+		name: "one percentage point BELOW the ceiling is adjudicated normally",
+		env:  noWaivers(), args: elpsArgs("benchstat-ceiling-below-542.txt"),
+		want: 1, contains: []string{"REGRESSION", "+40.00%"},
+		notContains: []string{"UNMEASURABLE"},
+	}, {
+		// THE MIDDLE. Unfit interval, sub-gate move: reported, exit unchanged.
+		name: "an unfit row BELOW its gate is a warning and changes no exit code",
+		env:  noWaivers(), args: elpsArgs("benchstat-unfit-below-gate-542.txt"),
+		want: 0, contains: []string{
+			"below-gate", "at or above the ±30% fitness ceiling",
+			"below-gate here means UNMEASURED, not small",
+			"reported as warnings only",
+		},
+		notContains: []string{"UNMEASURABLE "},
+	}, {
+		// PRECEDENCE. A finding on a measurable row outranks "re-measure".
+		name: "a fit regression beside an unfit row exits 1, not 3",
+		env:  noWaivers(), args: elpsArgs("benchstat-unfit-and-regression-542.txt"),
+		want: 1, contains: []string{
+			"REGRESSION", "+22.00%", "UNMEASURABLE", "+83.31%",
+		},
+	}, {
+		// THE CEILING IS THE ONLY THING HOLDING IT BACK -- the same proof the
+		// threshold gets in TestThresholdIsTheOnlyThingHoldingItBack. Raise the
+		// ceiling past the incident's ±71% and the identical table is called a
+		// regression again, so the row is genuinely parsed, genuinely
+		// over-gate, and withheld only by the fitness rule.
+		name: "raising the ceiling past ±71% turns the incident back into a REGRESSION",
+		env:  noWaivers(), args: elpsArgs("benchstat-runner-unfit-542.txt", "-variance-ceiling", "80"),
+		want: 1, contains: []string{"REGRESSION", "+83.31%"},
+	}, {
+		name: "the ceiling is configurable through the environment too",
+		env: map[string]*string{
+			"BENCH_WAIVERS":              s(""),
+			"BENCH_VARIANCE_CEILING_PCT": s("80"),
+		},
+		args: elpsArgs("benchstat-runner-unfit-542.txt"), want: 1,
+		contains: []string{"REGRESSION"},
+	}, {
+		// ...and tightening it reaches rows the default leaves alone. #443's
+		// true-regression control sits at ±25%: under the default 30% ceiling it
+		// is a REGRESSION (asserted below), and under a 20% one it is not
+		// measurable at all. This is the case that decided the default -- see
+		// the derivation on defaultVarianceCeiling.
+		name: "a ceiling below elps' own measured noise floor withholds #443's control",
+		env:  noWaivers(),
+		args: elpsArgs("benchstat-parallel-true-regression.txt", "-variance-ceiling", "20"),
+		want: 3, contains: []string{"UNMEASURABLE", "+48.00%"},
+	}, {
+		name: "at the DEFAULT ceiling #443's control is still a regression",
+		env:  noWaivers(), args: elpsArgs("benchstat-parallel-true-regression.txt"),
+		want: 1, contains: []string{"REGRESSION", "+48.00%"},
+	}, {
+		// CLASS BOUNDARY. Allocation metrics are exempt, exactly as they are
+		// from the resolution check: a jittery allocation column is a benchmark
+		// defect, not a sick machine, and it must not be able to buy itself the
+		// timing metrics' treatment. Same fixture the resolution check uses --
+		// three rows at ±30%, differing only in class -- so if the ceiling ever
+		// leaks into the allocation metrics, this flips.
+		name: "an ALLOCATION row at the ceiling is still judged on its threshold",
+		env:  noWaivers(), args: elpsArgs("benchstat-alloc-with-spread.txt"),
+		want: 1, contains: []string{
+			"REGRESSION  github.com/luthersystems/elps/lisp             B/op",
+			"REGRESSION  github.com/luthersystems/elps/lisp             allocs/op",
+		},
+	}, {
+		// NO INTERVAL. "± ∞ ¹" is not a wide interval, it is the absence of one,
+		// and the ceiling must not be applied to a number that was never
+		// measured. Those rows fall back to the threshold and SAY SO.
+		name: "a row with no computable interval is gated on the threshold and says so",
+		env:  noWaivers(), args: elpsArgs("benchstat-regression-new.txt"),
+		want: 1, contains: []string{"neither did the ±30% fitness ceiling"},
+	}, {
+		// The check must not fire on rows that are not moving in the bad
+		// direction, or not significant, or already NOISE-FLOOR: every clean
+		// fixture in the corpus keeps its verdict.
+		name: "the REAL CI null comparison is untouched by the ceiling",
+		args: elpsArgs("benchstat-clean-ci.txt"), want: 0,
+		notContains: []string{"UNMEASURABLE"},
+	}, {
+		name: "a NOISE-FLOOR row keeps its more specific verdict, not this one",
+		env:  noWaivers(), args: elpsArgs("benchstat-parallel-noise-443.txt"),
+		want: 0, contains: []string{"NOISE-FLOOR"},
+		notContains: []string{"UNMEASURABLE"},
+	}, {
+		// WAIVERS. A live waiver, within its recorded ceiling, still WAIVES an
+		// unfit row: its regression is already reviewed and accepted, so there
+		// is nothing left to certify and nothing for an unfit measurement to
+		// invalidate. This is the case that keeps the fitness ceiling
+		// one-directional -- see TestFitnessCeilingNeverFailsAPassingRun.
+		name: "a live waiver still waives an unfit row, and the run passes",
+		env:  waivers(filepath.Join(elpsFixtures, "waivers-unfit-row-542.txt")),
+		args: elpsArgs("benchstat-runner-unfit-542.txt"),
+		want: 0, contains: []string{"WAIVED", "+83.31%", "elps#542"},
+		notContains: []string{"UNMEASURABLE"},
+	}, {
+		// ...and the other half: a waiver the move has OUTGROWN is normally a
+		// REGRESSION, because a waiver bounds an accepted cost. But "it has been
+		// outgrown" is a NEW finding drawn from THIS measurement, and there is
+		// no measurement here to draw it from. UNMEASURABLE, exit 3 -- the gate
+		// must not claim the ceiling was exceeded on evidence it has just
+		// declared worthless.
+		name: "a waiver the move has outgrown does NOT red an unmeasurable row",
+		env:  waivers(filepath.Join(elpsFixtures, "waivers-unfit-row-outgrown-542.txt")),
+		args: elpsArgs("benchstat-runner-unfit-542.txt"),
+		want: 3, contains: []string{
+			"UNMEASURABLE", "neither applied nor was outgrown here",
+		},
+		// ...and the report must not go on to advise DELETING the waiver on the
+		// strength of a measurement it has just called worthless.
+		notContains: []string{"EXCEEDS its waiver ceiling", "waiver-unused"},
+	}, {
+		// A ceiling of zero would make every row unmeasurable, i.e. a gate that
+		// can never certify anything. Refused rather than honoured, the same way
+		// a malformed waiver file is.
+		name: "a zero variance ceiling is a usage error, not 'no ceiling'",
+		env:  noWaivers(), args: elpsArgs("benchstat-clean-ci.txt", "-variance-ceiling", "0"),
+		want: 2, contains: []string{"must be a positive percentage"},
+	}, {
+		name: "a non-numeric ceiling in the environment is a usage error",
+		env:  map[string]*string{"BENCH_VARIANCE_CEILING_PCT": s("wide")},
+		args: elpsArgs("benchstat-clean-ci.txt"), want: 2,
+	}})
+}
+
+// TestFitnessCeilingNeverFailsAPassingRun is the property the whole design
+// hangs on, asserted over the entire fixture corpus rather than case by case:
+//
+//	the fitness ceiling can only ever WITHHOLD a regression finding.
+//
+// A run that exits 0 without it must still exit 0 with it. If that ever stops
+// holding, switching the ceiling on somewhere becomes a risk rather than a
+// safety measure -- and a safety measure people are afraid to switch on is one
+// that does not get switched on.
+func TestFitnessCeilingNeverFailsAPassingRun(t *testing.T) {
+	fixtures, err := filepath.Glob(filepath.Join(elpsFixtures, "benchstat-*.txt"))
+	if err != nil || len(fixtures) == 0 {
+		t.Fatalf("no fixtures found: %v", err)
+	}
+	subs, err := filepath.Glob(filepath.Join(subFixtures, "benchstat-*.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixtures = append(fixtures, subs...)
+
+	for _, fx := range fixtures {
+		t.Run(filepath.Base(fx), func(t *testing.T) {
+			// The ceiling raised out of reach: no row can be unmeasurable, so
+			// this is the verdict the gate reached before #542.
+			off, offOut := runGate(t, gateCase{
+				args: []string{"-waivers-default", shippedWaivers, "-variance-ceiling", "100000", fx},
+			})
+			on, onOut := runGate(t, gateCase{
+				args: []string{"-waivers-default", shippedWaivers, fx},
+			})
+			if off == 0 && on != 0 {
+				t.Errorf("exit %d with the ceiling and %d without it -- the fitness ceiling turned a passing run into a failing one\nwith:\n%s\nwithout:\n%s", on, off, onOut, offOut)
+			}
+			if off != on && (off != 1 || on != 3) {
+				t.Errorf("exit %d without the ceiling, %d with it -- the only transition the ceiling may cause is 1 -> 3", off, on)
+			}
+		})
+	}
 }
 
 func TestThresholdIsTheOnlyThingHoldingItBack(t *testing.T) {

--- a/cmd/benchgate/main.go
+++ b/cmd/benchgate/main.go
@@ -32,18 +32,43 @@ func trimFloat(v float64) string {
 	return strconv.FormatFloat(v, 'g', -1, 64)
 }
 
+// envDefaultInt is envDefaultFloat for the counts the burn-in takes (runs,
+// warmup, workload size). Separate rather than shared because a fractional run
+// count is a typo, not a policy, and parsing it as a float would silently
+// truncate it.
+func envDefaultInt(name string, def int) (int, error) {
+	raw, ok := os.LookupEnv(name)
+	if !ok || raw == "" {
+		return def, nil
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s=%q is not a whole number", name, raw)
+	}
+	return v, nil
+}
+
 var isoDate = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}$`)
 
 const usage = `usage: benchgate [flags] <benchstat-output-file>
        benchgate [flags] -base <go-test-output> -head <go-test-output>
+       benchgate burnin [flags]
 
 Adjudicate a benchmark comparison: exit 0 clean, 1 regression, 2 could not be
-interpreted.
+interpreted, 3 the RUNNER was not fit to measure -- re-measure.
 
 The first form reads a benchstat table (what CI already produces for the PR
 comment). The second reads raw ` + "`go test -bench`" + ` output for each arm and
 computes the comparison itself with golang.org/x/perf/benchfmt and benchmath --
-no benchstat binary required.
+no benchstat binary required. The third asks whether this MACHINE can measure
+anything at all, before it is trusted to; run ` + "`benchgate burnin -h`" + ` for its
+flags.
+
+Exit 3 (RUNNER-UNFIT) is a distinct code because it is a distinct thing: not
+"the code regressed" and not "the input was unreadable", but "this machine did
+not produce a usable measurement". It never replaces exit 1 -- a regression
+found on a row that COULD be measured is a finding, and telling the operator to
+re-measure would only postpone it.
 
 flags (each falls back to the matching BENCH_* environment variable, which is
 how both consuming repositories declare their policy):
@@ -52,6 +77,12 @@ how both consuming repositories declare their policy):
   -alloc-threshold N  allocation metrics: B/op, allocs/op
                       (env BENCH_ALLOC_THRESHOLD_PCT, default 5)
   -alpha N            significance level (env BENCH_ALPHA, default 0.05)
+  -variance-ceiling N per-row fitness ceiling, percent. A TIMING row whose own
+                      confidence interval is at or above this is UNMEASURABLE:
+                      its delta is reported but never adjudicated as a
+                      regression, and a delta at or above the gate on such a
+                      row exits 3 instead of 1.
+                      (env BENCH_VARIANCE_CEILING_PCT, default 30)
   -waivers PATH       reviewed waiver list (env BENCH_WAIVERS; empty = none).
                       Named explicitly, so a path that is not there is an
                       error rather than "no waivers configured".
@@ -85,6 +116,14 @@ func pr(w io.Writer, a ...any)                { _, _ = fmt.Fprint(w, a...) }
 // env fallbacks, the exit codes -- is exercised by the tests rather than only
 // the pieces underneath it.
 func run(args []string, stdout, stderr io.Writer) int {
+	// Subcommand dispatch, before flag parsing: `burnin` asks a question about
+	// the MACHINE and takes none of the adjudication policy below. It is
+	// matched as the first argument only, so a benchstat table that happens to
+	// be named "burnin" is still reachable as ./burnin.
+	if len(args) > 0 && args[0] == "burnin" {
+		return runBurnin(args[1:], stdout, stderr, realSampler)
+	}
+
 	fs := flag.NewFlagSet("benchgate", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.Usage = func() { pr(stderr, usage) }
@@ -92,7 +131,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 	thrDef, thrStr, err1 := envDefaultFloat("BENCH_REGRESSION_THRESHOLD_PCT", 15)
 	allocDef, allocStr, err2 := envDefaultFloat("BENCH_ALLOC_THRESHOLD_PCT", 5)
 	alphaDef, _, err3 := envDefaultFloat("BENCH_ALPHA", 0.05)
-	for _, err := range []error{err1, err2, err3} {
+	ceilDef, ceilStr, err4 := envDefaultFloat("BENCH_VARIANCE_CEILING_PCT", defaultVarianceCeiling)
+	for _, err := range []error{err1, err2, err3, err4} {
 		if err != nil {
 			pf(stderr, "benchgate: %v.\n", err)
 			return 2
@@ -102,6 +142,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	threshold := fs.Float64("threshold", thrDef, "timing-metric regression gate, percent")
 	allocThreshold := fs.Float64("alloc-threshold", allocDef, "allocation-metric regression gate, percent")
 	alpha := fs.Float64("alpha", alphaDef, "significance level")
+	varianceCeiling := fs.Float64("variance-ceiling", ceilDef, "per-row fitness ceiling on a timing row's own confidence interval, percent")
 	base := fs.String("base", "", "base arm: raw `go test -bench` output")
 	head := fs.String("head", "", "head arm: raw `go test -bench` output")
 
@@ -145,8 +186,19 @@ func run(args []string, stdout, stderr io.Writer) int {
 			thrStr = f.Value.String()
 		case "alloc-threshold":
 			allocStr = f.Value.String()
+		case "variance-ceiling":
+			ceilStr = f.Value.String()
 		}
 	})
+
+	// A ceiling of zero or less would make EVERY row unmeasurable, which is a
+	// gate that can never certify anything. Switching the check off is spelled
+	// with a ceiling far above any real interval (see the doc comment), not
+	// with a zero that reads like "no ceiling" and means "no verdict".
+	if *varianceCeiling <= 0 {
+		pf(stderr, "benchgate: -variance-ceiling/BENCH_VARIANCE_CEILING_PCT must be a positive percentage (got %s); every row would be unmeasurable and the gate could never certify anything.\n", trimFloat(*varianceCeiling))
+		return 2
+	}
 
 	rawMode := *base != "" || *head != ""
 	rest := fs.Args()
@@ -176,8 +228,10 @@ func run(args []string, stdout, stderr io.Writer) int {
 		alpha:             *alpha,
 		threshold:         *threshold,
 		allocThreshold:    *allocThreshold,
+		varianceCeiling:   *varianceCeiling,
 		thresholdStr:      thrStr,
 		allocThresholdStr: allocStr,
+		ceilingStr:        ceilStr,
 		waivers:           ws,
 		waiverSource:      ws.source,
 	}

--- a/cmd/benchgate/testdata/elps/benchstat-ceiling-at-542.txt
+++ b/cmd/benchgate/testdata/elps/benchstat-ceiling-at-542.txt
@@ -1,0 +1,21 @@
+# The fitness ceiling AT its boundary: the worse arm measures itself at exactly
+# ±30%, the default ceiling.
+#
+# The rule is AT-or-above, matching the gate's own "at or above the threshold"
+# convention, so this row is UNMEASURABLE and the run exits 3. Its pair,
+# benchstat-ceiling-below-542.txt, is one percentage point quieter and is
+# adjudicated normally -- the two together pin which side of the boundary is
+# which, so a `>` silently becoming a `>=` (or the reverse) cannot pass.
+#
+# The move is +40%, comfortably past both the 15% gate and the row's own spread,
+# so neither the threshold nor the resolution check is what decides this: the
+# ONLY thing standing between this row and a REGRESSION verdict is the ceiling.
+#
+# Expected verdict: UNMEASURABLE, exit 3.
+goos: linux
+goarch: arm64
+pkg: github.com/luthersystems/elps/lisp
+cpu: Neoverse-N1
+                        │     base     │                 pr                  │
+                        │    sec/op    │    sec/op     vs base               │
+BoundaryThing-2           100.0n ± 28%   140.0n ± 30%  +40.00% (p=0.000 n=10)

--- a/cmd/benchgate/testdata/elps/benchstat-ceiling-below-542.txt
+++ b/cmd/benchgate/testdata/elps/benchstat-ceiling-below-542.txt
@@ -1,0 +1,17 @@
+# The other side of the fitness ceiling's boundary: benchstat-ceiling-at-542.txt
+# with both arms one percentage point quieter, so the worse arm is ±29% against
+# a ±30% ceiling.
+#
+# Identical in every other respect -- same benchmark, same +40.00% move, same
+# p-value, same sample count. The two fixtures differ by ONE percent of spread
+# and must differ in verdict, which is what makes the boundary a boundary rather
+# than a description.
+#
+# Expected verdict: REGRESSION, exit 1.
+goos: linux
+goarch: arm64
+pkg: github.com/luthersystems/elps/lisp
+cpu: Neoverse-N1
+                        │     base     │                 pr                  │
+                        │    sec/op    │    sec/op     vs base               │
+BoundaryThing-2           100.0n ± 27%   140.0n ± 29%  +40.00% (p=0.000 n=10)

--- a/cmd/benchgate/testdata/elps/benchstat-runner-unfit-542.txt
+++ b/cmd/benchgate/testdata/elps/benchstat-runner-unfit-542.txt
@@ -1,0 +1,50 @@
+# The incident this gate's fitness ceiling was written for: luthersystems/elps#542,
+# from substrate#424 (head 850f118ef).
+#
+# The gate failed the same PR twice in a row, and both verdicts were runner
+# pathology rather than code:
+#
+#   run 1   base ±71% (samples ~30-130ms), pr ±3%   ->  +83.31% REGRESSION
+#   run 2   base ±30%,                     pr ±2%   ->  +34.00% REGRESSION
+#
+# The head had ZERO Go-code delta from a tree the same gate had measured at
+# parity ±3% an hour earlier. Every package on that runner ran 1.5-2x slower in
+# absolute terms. Three independent measurements -- a fresh runner, a local
+# interleaved n=12, and a GOMAXPROCS=2 starvation A/B -- all read
+# parity-to-better.
+#
+# Run 1 is reproduced below. The shape is the whole point:
+#
+#   * The BASE arm is the disrupted one (±71%), which is what makes the pr arm
+#     look slow. A rule that only looked at the head arm would see ±3% and
+#     conclude the measurement was excellent.
+#   * The resolution check (#443) does NOT catch this. It asks whether the move
+#     is larger than the row's own spread, and +83% IS larger than ±71%. The
+#     row passes "can this comparison resolve this move?" while being drawn
+#     from an arm that could not resolve anything.
+#   * The allocation columns are flat, as they were in the incident: this was
+#     never a code change, so nothing about the allocation profile moved. That
+#     is also why the fitness ceiling has to be a TIMING rule -- there is no
+#     allocation evidence here to corroborate or contradict it.
+#
+# Expected verdict: UNMEASURABLE on the sec/op row, exit 3 (RUNNER-UNFIT),
+# NOT exit 1. A +83% delta measured through a ±71% interval is not evidence of
+# a regression, and it is not evidence of a pass either.
+goos: linux
+goarch: amd64
+pkg: github.com/luthersystems/substrate/internal/substrate/shiro
+cpu: AMD EPYC 7763 64-Core Processor
+                    │     base     │                  pr                  │
+                    │    sec/op    │    sec/op      vs base               │
+MockParallel-2        45.30m ± 71%    83.04m ±  3%  +83.31% (p=0.008 n=10)
+geomean               45.30m          83.04m        +83.31%
+
+                    │     base     │                 pr                  │
+                    │     B/op     │     B/op      vs base               │
+MockParallel-2        1.412Mi ± 0%   1.412Mi ± 0%       ~ (p=1.000 n=10) ¹
+¹ all samples are equal
+
+                    │     base     │                 pr                  │
+                    │  allocs/op   │  allocs/op    vs base               │
+MockParallel-2        18.30k ± 0%    18.30k ± 0%        ~ (p=1.000 n=10) ¹
+¹ all samples are equal

--- a/cmd/benchgate/testdata/elps/benchstat-tight-regression-542.txt
+++ b/cmd/benchgate/testdata/elps/benchstat-tight-regression-542.txt
@@ -1,0 +1,27 @@
+# The control for benchstat-runner-unfit-542.txt, and the half that matters
+# more: a REAL regression, measured on a runner that was working.
+#
+# Same gate (15% timing), a move over it, and intervals a fit machine produces:
+# ±2% and ±3%. Nothing about the fitness ceiling may touch this row. If it ever
+# does, the ceiling has become an off switch for the gate -- which is the same
+# defect in a new costume as the `grep` that could not match, and exactly what
+# the #443 resolution check needed its own control fixture to rule out.
+#
+# Expected verdict: REGRESSION, exit 1.
+goos: linux
+goarch: arm64
+pkg: github.com/luthersystems/elps/lisp
+cpu: Neoverse-N1
+                        │     base     │                 pr                  │
+                        │    sec/op    │    sec/op     vs base               │
+EnvFunCallRecursion-2     1.000µ ± 2%    1.180µ ± 3%  +18.00% (p=0.000 n=10)
+
+                        │     base     │                 pr                  │
+                        │     B/op     │     B/op      vs base               │
+EnvFunCallRecursion-2     512.0 ± 0%     512.0 ± 0%        ~ (p=1.000 n=10) ¹
+¹ all samples are equal
+
+                        │     base     │                 pr                  │
+                        │  allocs/op   │  allocs/op    vs base               │
+EnvFunCallRecursion-2     8.000 ± 0%     8.000 ± 0%        ~ (p=1.000 n=10) ¹
+¹ all samples are equal

--- a/cmd/benchgate/testdata/elps/benchstat-unfit-and-regression-542.txt
+++ b/cmd/benchgate/testdata/elps/benchstat-unfit-and-regression-542.txt
@@ -1,0 +1,26 @@
+# Exit-code PRECEDENCE: one table, two rows, two different problems.
+#
+#   SickRow-2    ±71% base arm, +83.31% -- unmeasurable, exactly the
+#                substrate#424 shape.
+#   SolidRow-2   ±2% / ±3%, +22.00% -- a clean, fit measurement of a real
+#                regression.
+#
+# The run exits 1, not 3. A regression found on a row that COULD be measured is
+# a finding, and an unmeasurable row elsewhere in the same table does not make
+# it less of one; answering "re-measure" over the top of it would postpone a
+# real result and invite a re-run that finds the same thing again.
+#
+# Both rows are still printed, each with its own label. The unmeasurable row is
+# NOT quietly folded into the regression count -- that would claim the gate
+# measured something it did not.
+#
+# Expected verdict: one REGRESSION, one UNMEASURABLE, exit 1.
+goos: linux
+goarch: arm64
+pkg: github.com/luthersystems/elps/lisp
+cpu: Neoverse-N1
+                        │     base     │                 pr                  │
+                        │    sec/op    │    sec/op     vs base               │
+SickRow-2                 45.30m ± 71%   83.04m ±  3%  +83.31% (p=0.008 n=10)
+SolidRow-2                1.000µ ±  2%   1.220µ ±  3%  +22.00% (p=0.000 n=10)
+geomean                   6.729µ         10.07µ        +49.65%

--- a/cmd/benchgate/testdata/elps/benchstat-unfit-below-gate-542.txt
+++ b/cmd/benchgate/testdata/elps/benchstat-unfit-below-gate-542.txt
@@ -1,0 +1,24 @@
+# The deliberate middle of the exit-code contract: a row the machine could not
+# measure, whose move is BELOW the gate anyway.
+#
+#   * ±45% and ±40% intervals -- well past the ±30% fitness ceiling.
+#   * +4.00% at p=0.030 -- significant, in the bad direction, and nowhere near
+#     the 15% timing gate.
+#
+# This is reported as a warning and changes NO exit code. The argument in both
+# directions is real: a row this noisy could be hiding a genuine regression
+# underneath a small point estimate, but failing every slightly-noisy minor row
+# turns the gate into something that reds on the weather, and a gate that reds
+# on the weather gets switched off -- which is how a repository ends up with no
+# gate at all. The whole-machine version of this question is `benchgate burnin`,
+# which is answered BEFORE the samples are taken and does not need a per-row
+# judgement call.
+#
+# Expected verdict: below-gate, annotated as unmeasured, exit 0.
+goos: linux
+goarch: arm64
+pkg: github.com/luthersystems/elps/lisp
+cpu: Neoverse-N1
+                        │     base     │                 pr                  │
+                        │    sec/op    │    sec/op     vs base               │
+DrowsyThing-2             100.0n ± 45%   104.0n ± 40%   +4.00% (p=0.030 n=10)

--- a/cmd/benchgate/testdata/elps/waivers-unfit-row-542.txt
+++ b/cmd/benchgate/testdata/elps/waivers-unfit-row-542.txt
@@ -1,0 +1,10 @@
+# Self-test fixture: a LIVE waiver, comfortably above the measured move, on the
+# row of benchstat-runner-unfit-542.txt -- the row the fitness ceiling would
+# otherwise call UNMEASURABLE.
+#
+# It exists to pin the one direction the fitness check must never take: a run
+# that would have PASSED (this row's regression is already reviewed and
+# accepted) must not be turned into a failing one by a measurement being unfit.
+# There is nothing left to certify on a row whose regression is already
+# accepted, so there is nothing for an unfit measurement to invalidate.
+github.com/luthersystems/substrate/internal/substrate/shiro | MockParallel | sec/op | 90 | 2099-01-01 | elps#542 | accepted cost, ceiling deliberately above the measured move

--- a/cmd/benchgate/testdata/elps/waivers-unfit-row-outgrown-542.txt
+++ b/cmd/benchgate/testdata/elps/waivers-unfit-row-outgrown-542.txt
@@ -1,0 +1,10 @@
+# Self-test fixture: the same waiver as waivers-unfit-row-542.txt with a ceiling
+# BELOW the measured move (+83.31% against 10%).
+#
+# Normally that is a REGRESSION -- "EXCEEDS its waiver ceiling" -- because a
+# waiver bounds an accepted cost rather than blessing a benchmark. But exceeding
+# the ceiling is a NEW finding, drawn from THIS measurement, and on an
+# unmeasurable row there is no measurement to draw it from. So this must come
+# out as UNMEASURABLE and exit 3, not as a regression: the gate cannot claim the
+# accepted cost was outgrown on evidence it just declared worthless.
+github.com/luthersystems/substrate/internal/substrate/shiro | MockParallel | sec/op | 10 | 2099-01-01 | elps#542 | ceiling deliberately below the measured move

--- a/cmd/benchgate/waivers.go
+++ b/cmd/benchgate/waivers.go
@@ -26,6 +26,11 @@ type waiver struct {
 	used       bool // it suppressed a regression
 	exceeded   bool // the row moved past the recorded ceiling
 	expiredHit bool // the row regressed and the waiver had expired
+	// unmeasured records that the row was at or above its gate but the
+	// comparison could not size the move (issue #542). Without it, the report
+	// would tell the reader the waiver "can be deleted" on the strength of a
+	// measurement it had just declared worthless.
+	unmeasured bool
 }
 
 // waiverSet is a parsed waiver file plus the diagnostics from parsing it. A

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -165,6 +165,7 @@ case "$gate_status" in
   0) echo "No benchmark regression at or above the configured gates." ;;
   1) echo "::warning::Benchstat detected a significant benchmark regression." ;;
   2) echo "::warning::The benchmark comparison could not be interpreted." ;;
+  3) echo "::warning::The runner was not fit to measure; one or more rows are UNMEASURABLE and this run certified nothing about them." ;;
   *) echo "::warning::${GATE} exited ${gate_status} — it did not run to completion." ;;
 esac
 
@@ -183,10 +184,32 @@ waiver_lines="$(grep -E '^  (WAIVED|WAIVER-|waiver-)' gate-report.txt || true)"
 # above the fold rather than inside a collapsed block nobody expands.
 noise_lines="$(grep -E '^  NOISE-FLOOR' gate-report.txt || true)"
 
+# UNMEASURABLE lines (issue #542) get it too, and they are the most important of
+# the three to keep above the fold: they are the rows where the RUNNER, not the
+# code, is the finding. A row that moved past the gate on an interval too wide
+# to size the move certified nothing — reporting that inside a collapsed block
+# is how "we could not measure it" gets read as "it was fine".
+unfit_lines="$(grep -E '^  UNMEASURABLE' gate-report.txt || true)"
+
 {
   echo 'result<<BENCHSTAT_EOF'
   echo '## Benchmark Comparison (main baseline vs PR)'
   echo ''
+  if [ -n "$unfit_lines" ]; then
+    echo '### Rows the RUNNER could not measure'
+    echo ''
+    echo 'These rows moved at or above the gate, but on a confidence interval at or'
+    echo 'above the fitness ceiling — an arm that dispersed carries no information'
+    echo 'about the size of the move. They are NOT regressions and NOT passes: this'
+    echo 'run certified nothing about them, and the gate exits 3 (RUNNER-UNFIT)'
+    echo 'rather than reporting either. Re-run the job; see the fitness-check note'
+    echo 'in the `cmd/benchgate` package doc.'
+    echo ''
+    echo '```'
+    echo "$unfit_lines"
+    echo '```'
+    echo ''
+  fi
   if [ -n "$noise_lines" ]; then
     echo '### Rows this comparison could not resolve'
     echo ''

--- a/scripts/bench-gate-fail.sh
+++ b/scripts/bench-gate-fail.sh
@@ -9,11 +9,18 @@
 #
 # This script decides nothing. The workflow's `if:` already established that the
 # gate did not pass; all this does is name the reason before exiting 1. The
-# three-way split is deliberate and must be preserved:
+# four-way split is deliberate and must be preserved, because the reader's next
+# action differs in each case:
 #
 #   1  regressions found      -- a real, measured performance problem
 #   2  could not interpret    -- a hard failure BY DESIGN; a gate that cannot
 #                               read its input must never report success
+#   3  runner unfit           -- the machine did not produce a usable
+#                               measurement (issue #542), so nothing was found
+#                               and nothing was certified. Re-run the job. NOT
+#                               a performance problem, and telling the reader to
+#                               go and read the diff would send them after one
+#                               that does not exist.
 #   *  no verdict reached     -- e.g. exit 127, the script not being found.
 #                               This branch used to say "regressions detected",
 #                               which sent the reader hunting a performance
@@ -39,6 +46,9 @@ case "$status" in
     ;;
   2)
     echo "::error::The benchmark comparison could not be interpreted (gate exit 2). This is a hard failure by design — a gate that cannot read its input must never report success. See the job log above."
+    ;;
+  3)
+    echo "::error::The RUNNER was not fit to measure (gate exit 3). One or more rows moved past the gate on a confidence interval too wide to size the move, so this run found no regression AND certified nothing — see the UNMEASURABLE line(s) in the gate report. Re-run the job; if it recurs on a fresh runner, the benchmark itself needs a longer -benchtime or to leave the comparison set."
     ;;
   *)
     # Anything else means the gate did not reach a verdict at all --

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -710,6 +710,106 @@ if [ -n "$GATE" ]; then
 		env BENCH_WAIVERS= "$GATE" "$QUANT_EDGE"
 
 	echo
+	echo "== benchgate: runner fitness (#542) ================================="
+
+	# Every check above judges the CODE. None of them asks whether the MACHINE
+	# was in a state to measure code at all, and substrate#424 is what that
+	# costs: the gate failed the same PR twice, at +83% and then +34%, on a head
+	# with ZERO Go-code delta, drawn from a base arm measuring itself at ±71%
+	# and then ±30%. The pr arm read ±3% both times.
+	#
+	# Note that the resolution check does NOT catch this shape: +83% is LARGER
+	# than ±71%, so the row passes "is this move bigger than what the row can
+	# see?" while being drawn from an arm that could not see anything.
+	#
+	# The exit code is the contract, and it is a THIRD one on purpose: 3 means
+	# "this run found nothing AND certified nothing -- re-measure", which is
+	# neither exit 1 (a finding) nor exit 0 (a pass).
+	UNFIT_FIXTURE="${TESTDATA}/benchstat-runner-unfit-542.txt"
+	TIGHT_FIXTURE="${TESTDATA}/benchstat-tight-regression-542.txt"
+
+	assert_exit 3 "the substrate#424 shape exits 3 (RUNNER-UNFIT), not 1" \
+		env BENCH_WAIVERS= "$GATE" "$UNFIT_FIXTURE"
+	assert_contains "UNMEASURABLE" "the unmeasurable row is REPORTED, not dropped" \
+		env BENCH_WAIVERS= "$GATE" "$UNFIT_FIXTURE"
+	assert_contains "+83.31%" "...carrying the delta it was not allowed to adjudicate" \
+		env BENCH_WAIVERS= "$GATE" "$UNFIT_FIXTURE"
+	assert_not_contains "REGRESSION" "an over-gate delta on an unmeasurable row is NOT called a regression" \
+		env BENCH_WAIVERS= "$GATE" "$UNFIT_FIXTURE"
+
+	# The control, and the half that matters more: the ceiling must not become an
+	# off switch for the gate. Same 15% threshold, a move past it, measured
+	# through the ±2%/±3% intervals a working machine produces.
+	assert_exit 1 "a real regression measured through TIGHT intervals still fires" \
+		env BENCH_WAIVERS= "$GATE" "$TIGHT_FIXTURE"
+	assert_not_contains "UNMEASURABLE" "...and nothing in it is written off as unmeasurable" \
+		env BENCH_WAIVERS= "$GATE" "$TIGHT_FIXTURE"
+
+	# The ceiling is the ONLY thing holding the incident row back: raise it past
+	# ±71% and the identical table reds again, so the row is genuinely parsed and
+	# genuinely over-gate.
+	assert_exit 1 "raising the ceiling past ±71% turns the incident back into a regression" \
+		env BENCH_WAIVERS= BENCH_VARIANCE_CEILING_PCT=80 "$GATE" "$UNFIT_FIXTURE"
+
+	# Both sides of the boundary, one percentage point apart.
+	assert_exit 3 "a spread exactly AT the ±30% ceiling is unmeasurable" \
+		env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-ceiling-at-542.txt"
+	assert_exit 1 "one point below the ceiling is adjudicated normally" \
+		env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-ceiling-below-542.txt"
+
+	# The deliberate middle: unfit interval, sub-gate move. Reported as a
+	# warning, exit unchanged -- failing every slightly-noisy minor row makes a
+	# gate brittle, and a brittle gate gets switched off.
+	assert_exit 0 "an unfit row BELOW its gate changes no exit code" \
+		env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-unfit-below-gate-542.txt"
+	assert_contains "below-gate here means UNMEASURED, not small" \
+		"...and is still reported, rather than reading as reassurance" \
+		env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-unfit-below-gate-542.txt"
+
+	# PRECEDENCE. A finding on a row that COULD be measured outranks
+	# "re-measure": answering 3 over the top of a real regression would postpone
+	# it and invite a re-run that finds the same thing again.
+	assert_exit 1 "a fit regression beside an unfit row exits 1, not 3" \
+		env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-unfit-and-regression-542.txt"
+	assert_contains "UNMEASURABLE" "...and the unfit row is still named in the same report" \
+		env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-unfit-and-regression-542.txt"
+
+	# CLASS BOUNDARY. Timing metrics only, the same boundary the resolution check
+	# draws: a jittery ALLOCATION column is a benchmark defect, not a sick
+	# machine, and must not buy itself the timing metrics' treatment.
+	assert_exit 1 "an ALLOCATION row at the ceiling is still judged on its threshold" \
+		env BENCH_WAIVERS= "$GATE" "${TESTDATA}/benchstat-alloc-with-spread.txt"
+
+	echo
+	echo "== benchgate burnin: is the MACHINE fit to measure? ================="
+
+	# The other half of #542, and the half that runs BEFORE anything is sampled:
+	# a fixed, code-independent loop, K times, with the samples required to agree.
+	# A machine that cannot reproduce a fixed loop cannot resolve a percentage
+	# gate on anything else either.
+	#
+	# The ceiling here is deliberately unreachable (±1000%) so this assertion is
+	# about the SUBCOMMAND rather than about how loaded the runner is; the
+	# verdict arithmetic is pinned deterministically with injected durations in
+	# cmd/benchgate/burnin_test.go.
+	assert_exit 0 "burnin runs the reference workload and reports FIT" \
+		"${BENCHGATE_TMP}/benchgate" burnin -runs 4 -warmup 1 -rounds 2000 -spread 10000
+	assert_contains "(warmup, discarded)" "burnin prints every run, warmup included" \
+		"${BENCHGATE_TMP}/benchgate" burnin -runs 4 -warmup 1 -rounds 2000 -spread 10000
+	# A spread ceiling no real machine can meet is how the UNFIT path is proven
+	# to exist at all: a fitness check that cannot fail is the same defect as a
+	# gate that cannot fire.
+	assert_exit 3 "burnin exits 3 when the samples cannot meet the ceiling" \
+		"${BENCHGATE_TMP}/benchgate" burnin -runs 4 -warmup 1 -rounds 2000 -spread 0.0000001
+	assert_contains "UNFIT" "...and says so in one line on stderr" \
+		"${BENCHGATE_TMP}/benchgate" burnin -runs 4 -warmup 1 -rounds 2000 -spread 0.0000001
+	# Keeping fewer than three samples makes the spread arithmetic meaningless
+	# (over one sample it is identically zero), so it is refused rather than
+	# reported as fitness.
+	assert_exit 2 "burnin refuses a configuration that keeps too few samples" \
+		"${BENCHGATE_TMP}/benchgate" burnin -runs 3 -warmup 2
+
+	echo
 	echo "== benchgate: the threshold is the only thing holding it back ======="
 
 	# Proves the parser genuinely SEES the real comparison's significant deltas and
@@ -884,7 +984,7 @@ echo "== extracted workflow bodies: bench-gate-fail ============================
 
 GATE_FAIL="${SCRIPT_DIR}/bench-gate-fail.sh"
 
-# The three-way split is the whole point of this script, and the third branch is
+# The four-way split is the whole point of this script, and the last branch is
 # the subtle one: an exit code the gate never produces means it reached NO
 # verdict, and calling that "regressions detected" (which this branch used to
 # do) sends the reader hunting a performance problem that does not exist.
@@ -896,6 +996,20 @@ assert_contains "::error::Benchmark regressions detected (gate exit 1)" \
 assert_contains "::error::The benchmark comparison could not be interpreted (gate exit 2)" \
 	"bench-gate-fail: exit 2 is reported as uninterpretable, not as a regression" \
 	env GATE_STATUS=2 bash "$GATE_FAIL"
+# Exit 3 (#542) is a verdict the gate DOES produce, and it must not fall into
+# the "no verdict reached" branch -- that branch tells the reader the gate
+# crashed, when what actually happened is that the runner could not measure.
+assert_exit 1 "bench-gate-fail: a RUNNER-UNFIT verdict still fails the build" \
+	env GATE_STATUS=3 bash "$GATE_FAIL"
+assert_contains "::error::The RUNNER was not fit to measure (gate exit 3)" \
+	"bench-gate-fail: exit 3 is reported as an unfit runner" \
+	env GATE_STATUS=3 bash "$GATE_FAIL"
+assert_not_contains "did not run to completion" \
+	"bench-gate-fail: exit 3 is a verdict, not a crash" \
+	env GATE_STATUS=3 bash "$GATE_FAIL"
+assert_not_contains "regressions detected" \
+	"bench-gate-fail: the unfit branch does NOT claim a regression" \
+	env GATE_STATUS=3 bash "$GATE_FAIL"
 assert_exit 1 "bench-gate-fail: an unrecognised code still fails" \
 	env GATE_STATUS=127 bash "$GATE_FAIL"
 assert_contains "did not run to completion (exit 127)" \


### PR DESCRIPTION
Closes #542.

## Problem

benchgate adjudicated tonight's substrate incident (substrate#424) into two false REGRESSION verdicts from a visibly sick runner: the base arm's interval read **±71%** then **±30%** (samples spanning ~30–130ms) while the PR arm sat at ±2–3%, on a head with zero Go-code delta from a tree the same gate had measured at parity an hour earlier. A ±71% interval is not a measurement — but the gate compared the means and emitted REGRESSION anyway.

## What this adds

**Per-row variance ceiling** (`-variance-ceiling` / `BENCH_VARIANCE_CEILING_PCT`, default ±30, timing metrics only): a row where either arm's interval is at or above the ceiling becomes `UNMEASURABLE` instead of a regression or a pass, rendered in the gate report's existing column geometry with the spread and ceiling stated inline.

**`benchgate burnin` subcommand**: a fixed, code-independent fitness check — 48k rounds of an FNV-mixing loop with per-round allocation, 7 runs, 2 discarded as warmup, remaining spread required within ±10% (the tightest gate this tool adjudicates), checksum pinned and cross-checked. ~0.45s total. A machine that cannot run a fixed loop consistently cannot adjudicate a 10% gate.

**Exit-code contract** (documented in the command help):
- **3 = RUNNER-UNFIT**, shared by burn-in and adjudication — one claim, one code: *this machine did not produce a usable measurement; re-measure*.
- An over-gate delta on an UNMEASURABLE row exits 3, never 1 — and never 0.
- Unmeasurable-but-below-gate rows are warnings; exit unchanged (failing every slightly-noisy minor row makes gates brittle, and brittle gates get switched off).
- **Exit 1 outranks exit 3**: a finding on a row that *could* be measured is a finding; "re-measure" must not postpone it.
- The ceiling can only ever *withhold* a finding (1→3), never fail a passing run — asserted over the whole fixture corpus (`TestFitnessCeilingNeverFailsAPassingRun`). Waivers within their ceiling still waive; an expired/outgrown waiver falls through to UNMEASURABLE rather than being adjudicated on evidence just declared worthless.

## Why the default is 30, not 20

This repo's noisiest *legitimate* row measures itself at ±24–25% on identical code (#443); at 20, the existing `benchstat-parallel-true-regression.txt` control (+48% on a ±25% row) would flip to UNMEASURABLE and a real regression would become a re-measure loop. The incident measured ±71% and ±30%. Thirty, tested at-or-above, clears both bounds; both directions are boundary-tested (at 20 the #443 control flips to exit 3; at 80 the incident fixture flips back to REGRESSION). Allocation-class metrics are exempt — a jittery alloc column is a benchmark defect, not a sick machine.

## Test evidence

- `testdata/elps/benchstat-runner-unfit-542.txt` replays the incident shape (±71% vs ±3%, +83%): → UNMEASURABLE, exit 3, no REGRESSION — through both the benchstat front end and the raw benchfmt path, so the two cannot disagree.
- Tight-interval control (+18% at ±2/±3) still exits 1; ceiling boundaries at ±29/±30; precedence (unfit row + fit regression → exit 1); waivers both directions; alloc exemption; flag/env knobs; zero/non-numeric rejections.
- Burn-in arithmetic pinned with injected durations (7 stats + 18 verdict cases), plus a real-loop smoke test, pinned checksum, and a 4×-work-takes-longer test.
- `ci-gates-test.sh`: **371 passed, 0 failed**, run twice; full `go test ./...` green; golangci-lint clean on the changed package.

## Follow-up (substrate side, after this ships)

substrate's `scripts/benchgate.sh` wrapper needs a `3)` branch so RUNNER-UNFIT is labelled "re-measure on a different runner" rather than falling into the "gate did not run to completion" fallback — paired naturally with the `benchgate-ref.txt` bump.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3gJf2ntcqhhY3UBKuLMpu

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3gJf2ntcqhhY3UBKuLMpu)_