### PR TITLE
lisp: two seal-adjacent allocation cuts — Array dims copy, per-fork metadata rebuilds

### DIFF
--- a/docs/fork.md
+++ b/docs/fork.md
@@ -124,6 +124,7 @@ the same reasoning that exempts the nil/true/false singletons).
 | Limit configuration (`MaxAlloc`, stack bounds, step budget, ...) | copied |
 | `Profiler`, `Debugger` | do not travel (fork starts with none) |
 | Call stack, condition stack, step accounting | fresh |
+| Evaluator location register (`Source()`) | fresh — a fork starts with no position, so an error raised before its first evaluation reports `<native code>`, not the template's last position |
 | Env-ID and gensym counters | **continued** past the template's |
 
 `LoadCache` is shared for the same reason `Reader` is, and because

--- a/docs/sealed-ast.md
+++ b/docs/sealed-ast.md
@@ -253,7 +253,7 @@ writes — so those fields are unexported (#362 for `source`, #382 for
   environment, in every function value that closed over it — without
   passing `Put`, the seal, or elpsvet; `env.Loc = loc` aliased a caller's
   mutable location into every error and frame stamped afterwards (the #362
-  class).  `scope`, `funName`, `parent` and `loc` are unexported; reads go
+  class).  `scope`, `parent` and `loc` are unexported; reads go
   through `Bindings()` (an `iter.Seq2` over the immediate scope),
   `NumBindings()`, `Parent()` and `Source()` (a location *copy*).
   `Runtime` and `ID` stay exported — neither is a container an embedder can

--- a/lisp/array_test.go
+++ b/lisp/array_test.go
@@ -80,6 +80,29 @@ func TestArray(t *testing.T) {
 	elpstest.RunTestSuite(t, tests)
 }
 
+// TestArrayDoesNotAliasCallerDims pins the constraint that decides which
+// Array calls copy their dims.  An array rewrites its own cardinality in
+// place -- builtinSelect and builtinReject size a vector's dims to the
+// element count once the predicate has run -- so a caller-supplied dims list
+// must be copied or that write lands in a value the caller still holds.  Dims
+// Array constructs for itself (the dims == nil entry) are reachable from
+// nothing else, so they are stored directly and cost no copy.
+func TestArrayDoesNotAliasCallerDims(t *testing.T) {
+	dims := lisp.QExpr([]*lisp.LVal{lisp.Int(3)})
+	arr := lisp.Array(dims, []*lisp.LVal{lisp.Int(1), lisp.Int(2), lisp.Int(3)})
+	require.NotEqual(t, lisp.LError, arr.Type, "constructing the array: %v", arr)
+	require.NotSame(t, dims, arr.Cells[0], "the array stored the caller's dims list")
+	arr.Cells[0].Cells[0].Int = 2 // the resize select/reject perform
+	require.Equal(t, 3, dims.Cells[0].Int, "resizing the array rewrote the caller's dims")
+
+	// The vector path reports the dims it derived from the cells it was
+	// given, and each array owns its own dims list.
+	v1 := lisp.Vector([]*lisp.LVal{lisp.Int(1), lisp.Int(2)})
+	v2 := lisp.Vector([]*lisp.LVal{lisp.Int(1), lisp.Int(2)})
+	require.Equal(t, 2, v1.Cells[0].Cells[0].Int)
+	require.NotSame(t, v1.Cells[0], v2.Cells[0], "two vectors share one dims list")
+}
+
 // TestArrayWithoutBackingStorageIsReadable pins the fix for issue #367.
 //
 // lisp.Array documents that cells may be nil, and every internal caller uses

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -626,7 +626,7 @@ func builtinSet(env *LEnv, v *LVal) *LVal {
 			}
 			parts = append(parts, arg.Str)
 		}
-		env.Runtime.Package.symbolDocs[v.Cells[0].Str] = JoinDocStrings(parts)
+		env.Runtime.Package.setSymbolDoc(v.Cells[0].Str, JoinDocStrings(parts))
 	}
 	return env.GetGlobal(v.Cells[0])
 }

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -103,27 +103,32 @@ func InitializeTypedef(env *LEnv) *LVal {
 	return Nil()
 }
 
-// TODO(elps2): Remove the field LEnv.funName
-
 // LEnv is a lisp environment.
 //
-// The binding state (scope, funName), the lexical chain (parent) and the
-// evaluator's current location (loc) are unexported — the issue #382 close
-// applied one layer up from LVal.  `env.scope[sym] = v` used to let any
-// holder of an *LEnv rebind a symbol in a live environment — including a
-// closure's captured environment, shared by every function value that
-// closed over it — without going through Put, invisible to the runtime
-// seal and to elpsvet; `env.loc = loc` aliased a caller's mutable location
-// into every error and stack frame the evaluator stamped afterwards (the
-// #362 aliasing class).  Reads are mediated by Bindings, NumBindings,
-// Parent and Source; the writes are kernel-only.
+// The binding state (scope), the lexical chain (parent) and the evaluator's
+// current location (loc) are unexported — the issue #382 close applied one
+// layer up from LVal.  `env.scope[sym] = v` used to let any holder of an
+// *LEnv rebind a symbol in a live environment — including a closure's
+// captured environment, shared by every function value that closed over it
+// — without going through Put, invisible to the runtime seal and to
+// elpsvet; `env.loc = loc` aliased a caller's mutable location into every
+// error and stack frame the evaluator stamped afterwards (the #362 aliasing
+// class).  Reads are mediated by Bindings, NumBindings, Parent and Source;
+// the writes are kernel-only.
+//
+// There used to be a fourth unexported field, `funName map[string]string`,
+// carrying a TODO(elps2) to remove it.  It was dead the whole time: no site
+// in the repository ever wrote or read it, so every environment ever
+// created — one per function call, plus one per let/labels/dotimes scope —
+// allocated an empty map that nothing could observe, and Fork rebuilt one
+// per environment on top of that.  It is gone (issue #440 follow-up); the
+// live name lookup is Package.funNames, reached through GetFunName.
 //
 // Field order is layout-sensitive: the pointer-bearing fields lead so the GC
-// scan extent stops at 56 bytes instead of 64. Keep scalars (ID) trailing.
+// scan extent stops at 48 bytes instead of 56. Keep scalars (ID) trailing.
 type LEnv struct {
 	loc     *token.Location
 	scope   map[string]*LVal
-	funName map[string]string
 	parent  *LEnv
 	Runtime *Runtime
 	evalCtx context.Context // transient: set by call() at builtin boundary
@@ -214,7 +219,6 @@ func NewEnvRuntime(rt *Runtime) *LEnv {
 	env := &LEnv{
 		ID:      rt.GenEnvID(),
 		scope:   make(map[string]*LVal),
-		funName: make(map[string]string),
 		Runtime: rt,
 	}
 	return env
@@ -243,7 +247,6 @@ func newEnvN(parent *LEnv, n int) *LEnv {
 		ID:      runtime.GenEnvID(),
 		loc:     loc,
 		scope:   make(map[string]*LVal, n),
-		funName: make(map[string]string),
 		parent:  parent,
 		Runtime: runtime,
 		evalCtx: evalCtx,
@@ -275,7 +278,7 @@ func (env *LEnv) SetPackageDoc(doc string) {
 
 // SetSymbolDoc sets the documentation string for a symbol in the current package.
 func (env *LEnv) SetSymbolDoc(name, doc string) {
-	env.Runtime.Package.symbolDocs[name] = doc
+	env.Runtime.Package.setSymbolDoc(name, doc)
 }
 
 func (env *LEnv) InPackage(name *LVal) *LVal {

--- a/lisp/fork.go
+++ b/lisp/fork.go
@@ -271,19 +271,43 @@ type forker struct {
 }
 
 // pkg clones one package, remapping symbol values through the walker.
+//
+// The three metadata tables beside symbols — symbolDocs, funNames,
+// externals — are REBUILT, not shared, and the reason is the same for all
+// three: the template is a live writer of each of them, and Fork's contract
+// says the template "remains fully usable" after a fork.  Sharing a map
+// with a live writer is not a stale-read hazard, it is the issue #397
+// hazard: a fork reading pkg.funNames while the template's putName writes
+// it is a concurrent map read and map write, which the Go runtime turns
+// into a fatal throw that neither recover() nor handler-bind can intercept.
+// Making a share safe would take a copy-on-write flag that Fork sets on the
+// TEMPLATE's package — a template mutation, and a racing one under the
+// concurrent Fork calls this function is documented to support.  So the
+// per-package tables stay copies.  Measured on
+// BenchmarkEnvConstruction/mode=fork over a fully loaded environment (13
+// packages, 389 funNames entries): sharing funNames instead of copying it
+// is worth -45 allocs/op of 1273, and sharing externals another -14, which
+// is the price of keeping the template writable.  See the same
+// optimization-left-on-the-table note in lisp/loader.go.
+//
+// symbolDocs is the exception, and not by sharing: it is allocated lazily
+// (lisp/package.go), so an undocumented package now forks with a nil table
+// instead of an empty map.
 func (f *forker) pkg(p *Package) *Package {
 	np := &Package{
-		Name:       p.Name,
-		Doc:        p.Doc,
-		symbols:    make(map[string]*LVal, len(p.symbols)),
-		symbolDocs: make(map[string]string, len(p.symbolDocs)),
-		funNames:   make(map[string]string, len(p.funNames)),
+		Name:     p.Name,
+		Doc:      p.Doc,
+		symbols:  make(map[string]*LVal, len(p.symbols)),
+		funNames: make(map[string]string, len(p.funNames)),
 	}
 	for k, v := range p.symbols {
 		np.symbols[k] = f.val(v)
 	}
-	for k, v := range p.symbolDocs {
-		np.symbolDocs[k] = v
+	if len(p.symbolDocs) > 0 {
+		np.symbolDocs = make(map[string]string, len(p.symbolDocs))
+		for k, v := range p.symbolDocs {
+			np.symbolDocs[k] = v
+		}
 	}
 	for k, v := range p.funNames {
 		np.funNames[k] = v
@@ -298,6 +322,11 @@ func (f *forker) pkg(p *Package) *Package {
 // chain.  The template's env IDs are preserved: they were unique within the
 // template's runtime, so they are unique within the fork's, and inherited
 // FIDs ("_fun<envID>") keep referring to the right environments.
+//
+// The scope map is COPIED and always will be: it is the binding table, the
+// most mutable thing an environment owns, and both sides write it.  There
+// is no immutable subset to carve off cheaply — a binding's key is live
+// program state, not sealed structure — so the per-env scope rebuild stands.
 func (f *forker) env(e *LEnv) *LEnv {
 	if e == nil {
 		return nil
@@ -306,15 +335,34 @@ func (f *forker) env(e *LEnv) *LEnv {
 		return ne
 	}
 	ne := &LEnv{
-		// The env location is mutable state: the evaluator rebinds and
-		// mutates its own in place (#382), so a fork that aliased the
-		// template's pointer would let each runtime's evaluation write
-		// through into the other's.  Copy it, exactly as the kernel's
-		// other env-location consumers now do (ErrorCondition,
-		// ErrorConditionf, ErrorAssociate).
-		loc:     copyLocation(e.loc),
+		// loc DOES NOT TRAVEL, and it is not shared either: a fork starts
+		// with no current evaluator location at all.
+		//
+		// e.loc is not state the environment owns, it is the evaluator's
+		// location register — eval rebinds it to v.source on every step
+		// (see the //elps:aliases note on newEnvN, which aliases the
+		// parent's register for the same reason: "both registers are
+		// rebound on every eval step").  What a quiescent template holds
+		// there is the leftover location of the last node it evaluated
+		// before the fork, and a fork is not evaluating that node.  It is
+		// transient per-evaluation state of exactly the kind Fork already
+		// drops: the call stack starts empty, the condition stack starts
+		// empty, TotalSteps starts at zero, and evalCtx — the OTHER
+		// transient register on this struct — is not carried across
+		// either.  Dropping it is strictly more hermetic than the copy it
+		// replaces (nothing of the template's reaches the fork, not even a
+		// duplicated Location's contents), and it costs the walk one
+		// allocation per environment rather than one per distinct
+		// location: 557 of them per fork in the downstream template that
+		// motivated this (issue #440).
+		//
+		// The first eval in the fork sets it, so the only observable
+		// difference is an error raised in a forked environment BEFORE it
+		// evaluates anything: that error now reports "<native code>"
+		// (the nil-location convention) instead of a source position
+		// inherited from the template's last evaluation, which was never
+		// this environment's position to report.
 		scope:   make(map[string]*LVal, len(e.scope)),
-		funName: make(map[string]string, len(e.funName)),
 		Runtime: f.rt,
 		ID:      e.ID,
 	}
@@ -322,9 +370,6 @@ func (f *forker) env(e *LEnv) *LEnv {
 	f.envs[e] = ne
 	for k, v := range e.scope {
 		ne.scope[k] = f.val(v)
-	}
-	for k, v := range e.funName {
-		ne.funName[k] = v
 	}
 	ne.parent = f.env(e.parent)
 	return ne

--- a/lisp/fork_metadata_test.go
+++ b/lisp/fork_metadata_test.go
@@ -1,0 +1,235 @@
+// Copyright © 2026 The ELPS authors
+
+// Guards for the per-environment and per-package metadata Fork used to
+// rebuild wholesale (issue #440 follow-up): the evaluator's location
+// register, which no longer travels at all, and the package documentation
+// table, which is now allocated lazily and must still be copied rather than
+// shared.
+package lisp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// forkedEnvs enumerates every environment reachable from a forked (or
+// template) root: the lexical parent chain, plus the environment captured
+// by every function value bound in the registry and that environment's own
+// parents.  This is the same set forker.env visits.
+func forkedEnvs(root *LEnv) map[*LEnv]bool {
+	seen := map[*LEnv]bool{}
+	walk := func(e *LEnv) {
+		for ; e != nil && !seen[e]; e = e.parent {
+			seen[e] = true
+		}
+	}
+	walk(root)
+	if root.Runtime != nil && root.Runtime.Registry != nil {
+		for _, pkg := range root.Runtime.Registry.packages {
+			for _, v := range pkg.symbols {
+				if v.Type == LFun {
+					if fd := v.funData(); fd != nil {
+						walk(fd.env)
+					}
+				}
+			}
+		}
+	}
+	return seen
+}
+
+// TestForkDropsEvaluatorLocation pins the location register's fork
+// treatment: it does not travel.
+//
+// LEnv.loc is not state an environment owns, it is where eval parks the
+// source position of the node it is evaluating right now — rebound on every
+// step, aliased from the parent at construction (see newEnvN's
+// //elps:aliases note).  What a quiescent template holds there is the
+// leftover position of the last node it evaluated, which is not the fork's
+// to report, so a fork starts with an empty register exactly as it starts
+// with an empty call stack and no evalCtx.  Fork used to copyLocation it
+// per environment, which allocated once per environment to carry a value
+// the fork's first evaluation immediately overwrites.
+//
+// The test fails both ways the treatment could regress: reinstating the
+// copy leaves a non-nil register, and sharing the template's pointer leaves
+// one that is non-nil AND pointer-equal to the template's.
+func TestForkDropsEvaluatorLocation(t *testing.T) {
+	env := newForkTestEnv(t)
+
+	// A closure, so the forked tree is deeper than its root: its captured
+	// environment goes through forker.env too, and it is the environment
+	// whose register a template holds a *definition-site* location in.
+	lam := lambdaExpr()
+	templateLoc := &token.Location{File: "template.lisp", Path: "template.lisp", Line: 12, Col: 3, Pos: 40}
+	lam.SetSource(templateLoc)
+	fun := env.Eval(lam)
+	if fun.Type != LFun {
+		t.Fatalf("lambda eval: %v", fun)
+	}
+	if lerr := env.PutGlobal(Symbol("closure"), fun); lerr.Type == LError {
+		t.Fatalf("bind closure: %v", lerr)
+	}
+
+	// Anti-vacuity: the template must actually be holding a location, or
+	// "the fork holds none" is true of both sides and proves nothing.
+	if env.loc == nil {
+		t.Fatal("template's evaluator location register is empty; the assertions below would pass vacuously")
+	}
+	if got := env.Source(); got == nil || got.Line != 12 {
+		t.Fatalf("template Source() = %v, want the lambda's line 12", got)
+	}
+
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+
+	envs := forkedEnvs(fork)
+	if len(envs) < 2 {
+		t.Fatalf("forked tree has %d environments; the walk found no closure environment and the check is near-vacuous", len(envs))
+	}
+	for e := range envs {
+		if e.loc == nil {
+			continue
+		}
+		if e.loc == templateLoc {
+			t.Errorf("forked env %d SHARES the template's Location pointer (%v); the register must not travel", e.ID, e.loc)
+			continue
+		}
+		t.Errorf("forked env %d carries an evaluator location %v; a fork starts with an empty register", e.ID, e.loc)
+	}
+	if got := fork.Source(); got != nil {
+		t.Errorf("fork.Source() = %v, want nil (no evaluation has happened in the fork yet)", got)
+	}
+
+	// The register is empty, not broken: the fork's first evaluation fills
+	// it, and the two runtimes' registers then move independently.
+	probe := Symbol("closure")
+	forkLoc := &token.Location{File: "fork.lisp", Path: "fork.lisp", Line: 99, Col: 1, Pos: 7}
+	probe.SetSource(forkLoc)
+	if r := fork.Eval(probe); r.Type != LFun {
+		t.Fatalf("fork eval of the inherited closure: %v", r)
+	}
+	if got := fork.Source(); got == nil || got.Line != 99 {
+		t.Errorf("fork.Source() after evaluating = %v, want the fork's own line 99", got)
+	}
+	if got := env.Source(); got == nil || got.Line != 12 {
+		t.Errorf("template Source() = %v after the fork evaluated; want its own line 12 — the registers are not independent", got)
+	}
+}
+
+// TestPackageSymbolDocsLazyTable pins the lazy allocation of a package's
+// documentation table: absent until something is documented, and writable
+// from absent.  A write is the one operation a nil map cannot serve, so the
+// allocation guard in setSymbolDoc is what makes the whole saving legal —
+// remove it and this test panics rather than merely failing.
+func TestPackageSymbolDocsLazyTable(t *testing.T) {
+	pkg := NewPackage("lazy-docs")
+	if pkg.symbolDocs != nil {
+		t.Errorf("NewPackage allocated a documentation table for a package with no documented symbols")
+	}
+	if got := pkg.SymbolDoc("undocumented"); got != "" {
+		t.Errorf(`SymbolDoc on an empty table = %q, want ""`, got)
+	}
+	// The write path must allocate rather than assign into the nil map.
+	pkg.setSymbolDoc("answer", "the answer")
+	if got := pkg.SymbolDoc("answer"); got != "the answer" {
+		t.Errorf("SymbolDoc(answer) = %q, want %q", got, "the answer")
+	}
+	pkg.setSymbolDoc("second", "another")
+	if got := pkg.SymbolDoc("second"); got != "another" {
+		t.Errorf("SymbolDoc(second) = %q, want %q", got, "another")
+	}
+	if got := pkg.SymbolDoc("answer"); got != "the answer" {
+		t.Errorf("the second write dropped the first: SymbolDoc(answer) = %q", got)
+	}
+}
+
+// TestForkSymbolDocs covers the fork side of the same table: documented
+// symbols travel, undocumented packages fork without allocating a table,
+// and the two sides' tables are independent — the last is what makes the
+// per-package COPY (rather than a share) load-bearing, since the template
+// stays writable after a fork and `(set 'x v "doc")` is a lisp-reachable
+// write into it.
+func TestForkSymbolDocs(t *testing.T) {
+	env := newForkTestEnv(t)
+	userPkg := env.Runtime.Package.Name
+	if lerr := env.PutGlobal(Symbol("documented"), Int(1)); lerr.Type == LError {
+		t.Fatalf("bind: %v", lerr)
+	}
+	env.SetSymbolDoc("documented", "template doc")
+
+	// Anti-vacuity: at least one package must be documented and at least
+	// one must not, or neither half of the assertion means anything.
+	documented, undocumented := 0, 0
+	for _, p := range env.Runtime.Registry.packages {
+		if len(p.symbolDocs) > 0 {
+			documented++
+		} else {
+			undocumented++
+		}
+	}
+	if documented == 0 || undocumented == 0 {
+		t.Fatalf("template has %d documented and %d undocumented packages; need both for this test", documented, undocumented)
+	}
+
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+
+	for name, p := range env.Runtime.Registry.packages {
+		fp := fork.Runtime.Registry.packages[name]
+		if fp == nil {
+			t.Fatalf("package %q missing from the fork", name)
+		}
+		if len(p.symbolDocs) == 0 {
+			if fp.symbolDocs != nil {
+				t.Errorf("package %q has no documented symbols but forked with an allocated table", name)
+			}
+			continue
+		}
+		if fp.symbolDocs == nil {
+			t.Errorf("package %q forked without its documentation table", name)
+			continue
+		}
+		if reflect.ValueOf(fp.symbolDocs).Pointer() == reflect.ValueOf(p.symbolDocs).Pointer() {
+			t.Errorf("package %q: fork SHARES the template's documentation table; the template stays "+
+				"writable after a fork, so a shared table is a concurrent map write away from issue #397", name)
+		}
+		for sym, doc := range p.symbolDocs {
+			if got := fp.SymbolDoc(sym); got != doc {
+				t.Errorf("package %q symbol %q: fork doc %q, template doc %q", name, sym, got, doc)
+			}
+		}
+	}
+
+	// Independence in both directions.  Fork writes first, into the table
+	// it inherited, then the template writes into its own.
+	fork.Runtime.Package = fork.Runtime.Registry.packages[userPkg]
+	if lerr := fork.PutGlobal(Symbol("fork-only"), Int(2)); lerr.Type == LError {
+		t.Fatalf("fork bind: %v", lerr)
+	}
+	fork.SetSymbolDoc("fork-only", "fork doc")
+	fork.SetSymbolDoc("documented", "fork overwrote it")
+
+	env.SetSymbolDoc("template-only", "template doc 2")
+
+	tpl := env.Runtime.Registry.packages[userPkg]
+	if got := tpl.SymbolDoc("fork-only"); got != "" {
+		t.Errorf("the fork's documentation write reached the template: SymbolDoc(fork-only) = %q", got)
+	}
+	if got := tpl.SymbolDoc("documented"); got != "template doc" {
+		t.Errorf("the fork overwrote the template's doc: SymbolDoc(documented) = %q", got)
+	}
+	fpkg := fork.Runtime.Registry.packages[userPkg]
+	if got := fpkg.SymbolDoc("template-only"); got != "" {
+		t.Errorf("the template's documentation write reached the fork: SymbolDoc(template-only) = %q", got)
+	}
+	if got := fpkg.SymbolDoc("documented"); got != "fork overwrote it" {
+		t.Errorf("the fork's own doc write did not stick: SymbolDoc(documented) = %q", got)
+	}
+}

--- a/lisp/fork_metadata_test.go
+++ b/lisp/fork_metadata_test.go
@@ -14,10 +14,14 @@ import (
 	"github.com/luthersystems/elps/parser/token"
 )
 
-// forkedEnvs enumerates every environment reachable from a forked (or
-// template) root: the lexical parent chain, plus the environment captured
-// by every function value bound in the registry and that environment's own
-// parents.  This is the same set forker.env visits.
+// forkedEnvs enumerates the lexical parent chain, plus the environment
+// captured by every function value bound directly in the registry and that
+// environment's own parents.  This is a SUBSET of what forker.env visits:
+// the forker also reaches environments captured by closures stored inside
+// container values (vectors, sorted maps, non-package scopes).  For the
+// environments these tests build the two sets coincide, and the len >= 2
+// guard below keeps the assertions non-vacuous; a test that parks a closure
+// inside a container must extend this walk before reusing it.
 func forkedEnvs(root *LEnv) map[*LEnv]bool {
 	seen := map[*LEnv]bool{}
 	walk := func(e *LEnv) {

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -660,7 +660,11 @@ func Array(dims *LVal, cells []*LVal) *LVal {
 	// caller's dims into the returned value as far as the compiler can tell,
 	// and heap-allocate the literal every builtin call site passes.
 	var stored *LVal
+	totalSize := 1
 	if dims == nil {
+		// A self-built dims list is exactly [len(cells)], so its product
+		// needs no loop and cannot overflow.
+		totalSize = len(cells)
 		stored = QExpr([]*LVal{Int(len(cells))})
 	} else if dims.Type != LSExpr {
 		return Errorf("array dimensions are not a list: %v", dims.Type)
@@ -670,13 +674,11 @@ func Array(dims *LVal, cells []*LVal) *LVal {
 				return Errorf("array dimension is not an integer: %v", n.Type)
 			}
 		}
-		stored = dims.Copy()
-	}
-	totalSize := 1
-	for _, n := range stored.Cells {
-		totalSize *= n.Int
-		if totalSize < 0 {
-			return Errorf("integer overflow")
+		for _, n := range dims.Cells {
+			totalSize *= n.Int
+			if totalSize < 0 {
+				return Errorf("integer overflow")
+			}
 		}
 	}
 	if len(cells) > 0 && len(cells) != totalSize {
@@ -686,6 +688,10 @@ func Array(dims *LVal, cells []*LVal) *LVal {
 		for i := range cells {
 			cells[i] = Nil()
 		}
+	}
+	if stored == nil {
+		// Deferred past every check above so the error paths stay copy-free.
+		stored = dims.Copy()
 	}
 
 	return &LVal{

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -650,8 +650,18 @@ func MakeVector(n int) *LVal {
 // internal-panic is deliberately not catchable by handler-bind, so the host
 // had no way to contain it.  See issue #367.
 func Array(dims *LVal, cells []*LVal) *LVal {
+	// stored is the dims list the array keeps.  Caller-supplied dims are
+	// copied because the array writes its cardinality in place later --
+	// builtinSelect and builtinReject resize a vector's dims after filling
+	// it -- so sharing the caller's list would let that write land in a value
+	// the caller still holds.  Dims this function constructs are reachable
+	// from nothing else, so that path stores them directly.  The parameter is
+	// deliberately never assigned to stored: that flow would escape a
+	// caller's dims into the returned value as far as the compiler can tell,
+	// and heap-allocate the literal every builtin call site passes.
+	var stored *LVal
 	if dims == nil {
-		dims = QExpr([]*LVal{Int(len(cells))})
+		stored = QExpr([]*LVal{Int(len(cells))})
 	} else if dims.Type != LSExpr {
 		return Errorf("array dimensions are not a list: %v", dims.Type)
 	} else {
@@ -660,9 +670,10 @@ func Array(dims *LVal, cells []*LVal) *LVal {
 				return Errorf("array dimension is not an integer: %v", n.Type)
 			}
 		}
+		stored = dims.Copy()
 	}
 	totalSize := 1
-	for _, n := range dims.Cells {
+	for _, n := range stored.Cells {
 		totalSize *= n.Int
 		if totalSize < 0 {
 			return Errorf("integer overflow")
@@ -680,7 +691,7 @@ func Array(dims *LVal, cells []*LVal) *LVal {
 	return &LVal{
 		Type: LArray,
 		Cells: []*LVal{
-			dims.Copy(),
+			stored,
 			QExpr(cells),
 		},
 	}

--- a/lisp/lval_fields_seal_test.go
+++ b/lisp/lval_fields_seal_test.go
@@ -132,8 +132,8 @@ func TestLValFieldSeal(t *testing.T) {
 // environment aliasing channel internal/funraw's doc comment says an
 // embedder "cannot reach at all".  Every other privatized field was
 // already immune because it is an unexported FIELD (LVal.source, meta,
-// macroExpansion, quoted, spliced, sealed; LEnv.scope, funName, parent,
-// loc; MapData's backing) — reflect panics on those.  funData's fields
+// macroExpansion, quoted, spliced, sealed; LEnv.scope, parent, loc;
+// MapData's backing) — reflect panics on those.  funData's fields
 // were the asymmetry; they are unexported now.
 //
 // This guard fails if any of them is exported again, which would silently
@@ -208,7 +208,7 @@ func TestLEnvFieldSeal(t *testing.T) {
 		exported[f.Name] = true
 		if !allowed[f.Name] {
 			t.Errorf("LEnv exports field %q outside the sanctioned surface; the "+
-				"binding state (scope, funName), the lexical chain (parent) and the "+
+				"binding state (scope), the lexical chain (parent) and the "+
 				"evaluator location (loc) were unexported in issue #382 — a new "+
 				"exported field on the type every builtin receives needs a review "+
 				"conversation and an entry in this allowlist", f.Name)

--- a/lisp/package.go
+++ b/lisp/package.go
@@ -97,7 +97,20 @@ type Package struct {
 	// through Symbol/SymbolNames and write it through Put or Update.  Those
 	// maintain funNames alongside it, and nothing on the read path repairs a
 	// funNames entry a direct assignment would have skipped.
-	symbols    map[string]*LVal
+	symbols map[string]*LVal
+	// symbolDocs maps a bound name to its documentation string.  It is
+	// allocated LAZILY, by setSymbolDoc, and is nil in a package whose
+	// symbols carry no docs — which is most of them: a docstring on a
+	// *symbol* comes only from `(set 'name v "doc")` or the Go-side
+	// SetSymbolDoc, while a function's docstring rides in the LFun's own
+	// cells and never lands here.  Reading a nil map is legal Go and
+	// returns the empty string, which is exactly SymbolDoc's answer for an
+	// undocumented name, so every read path is nil-safe by construction;
+	// only setSymbolDoc may write it, and it allocates first.  Ten of the
+	// thirteen packages a fully loaded environment holds have no symbol
+	// docs at all, and each of those used to cost an empty map in
+	// NewPackage, another in every Fork, and another in every
+	// AddPackage admission.
 	symbolDocs map[string]string
 	// funNames maps a function's FID to the name it was most recently bound
 	// under in this package.  It is populated exclusively by the write path
@@ -110,10 +123,9 @@ type Package struct {
 // NewPackage initializes and returns a package with the given name.
 func NewPackage(name string) *Package {
 	return &Package{
-		Name:       name,
-		symbols:    make(map[string]*LVal),
-		symbolDocs: make(map[string]string),
-		funNames:   make(map[string]string),
+		Name:     name,
+		symbols:  make(map[string]*LVal),
+		funNames: make(map[string]string),
 	}
 }
 
@@ -188,6 +200,17 @@ func (pkg *Package) SymbolNames() []string {
 // empty string when name has no documentation.
 func (pkg *Package) SymbolDoc(name string) string {
 	return pkg.symbolDocs[name]
+}
+
+// setSymbolDoc records doc as the documentation string for name, allocating
+// the package's doc table on first use.  It is the ONLY writer of
+// symbolDocs; the field's doc comment states why that matters (a nil table
+// is the common case, and only a writer may not assume the map exists).
+func (pkg *Package) setSymbolDoc(name, doc string) {
+	if pkg.symbolDocs == nil {
+		pkg.symbolDocs = make(map[string]string, 1)
+	}
+	pkg.symbolDocs[name] = doc
 }
 
 // Externals returns the package's exported symbol names in declaration

--- a/lisp/package_admit.go
+++ b/lisp/package_admit.go
@@ -125,11 +125,10 @@ package lisp
 // goroutine may be writing p at the time (issue #397).
 func admitPackage(p *Package) *Package {
 	adm := &Package{
-		Name:       p.Name,
-		Doc:        p.Doc,
-		symbols:    make(map[string]*LVal, len(p.symbols)),
-		symbolDocs: make(map[string]string, len(p.symbolDocs)),
-		funNames:   make(map[string]string, len(p.funNames)),
+		Name:     p.Name,
+		Doc:      p.Doc,
+		symbols:  make(map[string]*LVal, len(p.symbols)),
+		funNames: make(map[string]string, len(p.funNames)),
 	}
 	if len(p.externals) > 0 {
 		adm.externals = make([]string, len(p.externals))
@@ -138,8 +137,13 @@ func admitPackage(p *Package) *Package {
 	for name, v := range p.symbols {
 		adm.symbols[name] = admitSymbolValue(v)
 	}
-	for name, doc := range p.symbolDocs {
-		adm.symbolDocs[name] = doc
+	// symbolDocs is allocated lazily (see the field comment): an undocumented
+	// package admits with a nil table rather than an empty one.
+	if len(p.symbolDocs) > 0 {
+		adm.symbolDocs = make(map[string]string, len(p.symbolDocs))
+		for name, doc := range p.symbolDocs {
+			adm.symbolDocs[name] = doc
+		}
 	}
 	// funNames is keyed by FID and admission never copies a function value
 	// (functions are not sealable), so every recorded FID still names the


### PR DESCRIPTION
Two independent allocation cuts plus adversarial-review follow-ups, one commit each. Both cuts came out of the #379 disposition profiling; the second is the elps-core remainder identified in substrate#440.

## Commit 1 — `lisp: stop deep-copying dims Array built for itself` (`1ccfbf8`)
- `lisp.Array(nil, cells)` built its own one-element dims list and then deep-copied it before storing — a defensive copy of a list nothing else can hold. The copy now happens only for **caller-supplied** dims, where it is load-bearing: `builtinSelect`/`builtinReject` resize a vector's stored dims in place, so aliasing a caller's list would be observable.
- Uses a separate `stored` variable instead of reassigning the `dims` parameter: the obvious one-liner defeats escape analysis and regresses the caller path 8→9 allocs/op; this way the caller path stays at 8 and the self-built path drops 8→6.
- `TestArrayDoesNotAliasCallerDims` pins the aliasing guard (fails if the remaining copy is removed).
- CI benchmark gate (interleaved, n=10, same runner): 0 rows at gate. Highlights: `libjson Load/default` −4.44% allocs; `lisp EnvFunCallPos/Key/Opt` −8.7…−9.1% allocs; `libelpspath` delete-compaction rows −20…−26% allocs, package geomean −10.7% sec/op.

## Commit 2 — `perf(lisp): stop rebuilding dead and empty per-fork metadata` (`aa9f9f7`)
Applying "prove immutable, then share" to Fork's per-env metadata found rebuilds of things carrying nothing:
- **`LEnv.funName` deleted** — dead state with a `TODO(elps2)`; no site in the repository writes or reads it, yet every env allocated it and every fork rebuilt it.
- **`copyLocation` per forked env dropped** — `LEnv.loc` is eval's location register, rebound on every step; a quiescent template holds only the leftover position of the last node it evaluated. A fork now starts with an empty register, exactly as it starts with an empty call stack and zero `TotalSteps`. Strictly more hermetic than the copy.
- **`symbolDocs` lazily allocated** — 10 of 13 packages in a loaded env document no symbol; `setSymbolDoc` is the sole writer and allocates on first write, all readers nil-safe.
- **`funNames`/`externals` sharing measured and declined** (recorded in code): both have live template-side writers, so sharing is the issue #397 fatal-concurrent-map hazard, and `Exports` sorts `externals` in place. Worth −45/−14 allocs/op; not worth the CoW machinery.
- Red-proofs executed for every guard (reinstating the location copy, sharing the location pointer, dropping the nil-map guard, sharing `symbolDocs` — each fails its test); no gate weakened, no exemption added. New `lisp/fork_metadata_test.go` carries the guards.
- Fork-mode env construction −2.20% allocs on the in-repo 9-env template; the two deleted per-env sites dominate downstream (substrate templates have ~557 envs; see substrate#440/substrate#441). Bonus: `EnvGet` −7.81% allocs — the `funName` removal lands on the evaluator's own path, helping environments nobody forks.

## Commit 3 — `review(lisp): copy-free Array error paths, fork.md loc row, test-helper honesty` (`f4cc506`)
Follow-ups from an adversarial review of the two commits above, which confirmed **no correctness bugs** (it specifically attacked and ruled out: a shared/interned `Int` in the uncopied dims, a missed `symbolDocs` writer, a nil `loc` deref on a fork's pre-first-eval error path):
- `Array` defers the caller-dims deep copy until every validation check passes, restoring copy-free error paths; error precedence unchanged.
- `docs/fork.md`'s what-is-shared table now records the evaluator location register as fresh (the embedder-visible half of commit 2).
- The `forkedEnvs` test-helper comment now states exactly what the helper walks instead of overclaiming parity with `forker.env`.
- Noted for a follow-up, deliberately not taken here: ~9 hot list-to-vector builtins still pass self-built dims as caller dims and could use the copy-free path (~3 allocs/vector), but that interacts with `select`/`reject`'s dims resizing and deserves its own measured change.

## Test Plan
- [x] `go test ./...` clean on all three commits; `-race ./lisp/` and `-tags elpscheck` clean
- [x] `make elpsvet` clean (both passes); `golangci-lint run ./lisp/...` 0 issues; `elps fmt -l` / `elps doc -m` clean
- [x] Red-proofs for every new guard executed and restored (details above)
- [x] CI benchmark gate on the PR: 0 rows at or above threshold (timing 15%, allocation 5%)

CI note: the mid-review red checks on this PR were cancellation artifacts of checkpoint pushes and a shard re-run racing each other in the same concurrency group. The one genuine fuzz finding (shard 6, `FuzzSharedProgramMultiEnv` crasher `f34b03570d1e03ac`) was triaged in the comments: a budget-bounded runaway input that replays green and identically on head and base; the worker death was wall-clock during minimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgShxM3EoPmeVnq1cmpcPK