### PR TITLE
lisp: let Array derive the dims for the vector-building builtins

### DIFF
--- a/lisp/array_test.go
+++ b/lisp/array_test.go
@@ -187,17 +187,18 @@ func TestVectorConstructorDims(t *testing.T) {
 
 // TestArrayDoesNotAliasCallerDims pins the constraint that decides which
 // Array calls copy their dims.  An array rewrites its own cardinality in
-// place -- builtinSelect and builtinReject size a vector's dims to the
-// element count once the predicate has run -- so a caller-supplied dims list
-// must be copied or that write lands in a value the caller still holds.  Dims
-// Array constructs for itself (the dims == nil entry) are reachable from
+// place -- append! (builtinAppendMutate) grows a vector's dims as it adds
+// cells, and select/reject shrink theirs once the predicate has run -- so a
+// caller-supplied dims list must be copied or that write lands in a value
+// the caller still holds.  Dims Array constructs for itself (the dims == nil
+// entry, which every in-tree vector builtin now uses) are reachable from
 // nothing else, so they are stored directly and cost no copy.
 func TestArrayDoesNotAliasCallerDims(t *testing.T) {
 	dims := lisp.QExpr([]*lisp.LVal{lisp.Int(3)})
 	arr := lisp.Array(dims, []*lisp.LVal{lisp.Int(1), lisp.Int(2), lisp.Int(3)})
 	require.NotEqual(t, lisp.LError, arr.Type, "constructing the array: %v", arr)
 	require.NotSame(t, dims, arr.Cells[0], "the array stored the caller's dims list")
-	arr.Cells[0].Cells[0].Int = 2 // the resize select/reject perform
+	arr.Cells[0].Cells[0].Int = 2 // the in-place resize append!/select/reject perform
 	require.Equal(t, 3, dims.Cells[0].Int, "resizing the array rewrote the caller's dims")
 
 	// The vector path reports the dims it derived from the cells it was

--- a/lisp/array_test.go
+++ b/lisp/array_test.go
@@ -80,6 +80,111 @@ func TestArray(t *testing.T) {
 	elpstest.RunTestSuite(t, tests)
 }
 
+// TestVectorConstructorDims covers the dims of every vector the sequence
+// builtins construct.
+//
+// Those builtins used to spell their own one-element dims list out and hand it
+// to Array as caller-supplied dims; they now let Array derive it (via
+// MakeVector/Vector, the dims == nil path).  The derived list is the reason
+// the copy can be skipped, so it is also the thing that has to be right, and
+// nothing above notices if it is not: an array RENDERS from its backing cells,
+// so `(vector 0 1 2)` prints identically whatever the dims say.  `length` and
+// `aref` are the readers that go through the dims (LVal.Len and
+// LVal.ArrayIndex both read Cells[0].Cells[0].Int), which is why every case
+// below asserts through one of them rather than through the printed form.
+//
+// The select/reject rows are the load-bearing ones: those two size the vector
+// for the whole input and then rewrite its cardinality in place once the
+// predicate has run, so they read a dims list AFTER a write, and the
+// out-of-bounds rows are what distinguishes a shrunk dims list from an unshrunk
+// one.
+func TestVectorConstructorDims(t *testing.T) {
+	tests := elpstest.TestSuite{
+		{"map", elpstest.TestSequence{
+			{`(length (map 'vector (lambda (x) (+ x 1)) '(1 2 3)))`, "3", ""},
+			{`(aref (map 'vector (lambda (x) (+ x 1)) '(1 2 3)) 2)`, "4", ""},
+			{`(ignore-errors (aref (map 'vector (lambda (x) x) '(1 2 3)) 3))`, "()", ""},
+			{`(length (map 'vector (lambda (x) x) '()))`, "0", ""},
+		}},
+		{"concat", elpstest.TestSequence{
+			{`(length (concat 'vector '(1 2) (vector 3)))`, "3", ""},
+			{`(aref (concat 'vector '(1 2) (vector 3)) 2)`, "3", ""},
+			{`(ignore-errors (aref (concat 'vector '(1 2) (vector 3)) 3))`, "()", ""},
+			// The empty arm returns before any storage is built.
+			{`(length (concat 'vector))`, "0", ""},
+			{`(length (concat 'vector '() '()))`, "0", ""},
+			{`(ignore-errors (aref (concat 'vector) 0))`, "()", ""},
+		}},
+		{"insert-index", elpstest.TestSequence{
+			{`(length (insert-index 'vector (vector 1 2) 1 9))`, "3", ""},
+			{`(aref (insert-index 'vector (vector 1 2) 1 9) 1)`, "9", ""},
+			{`(ignore-errors (aref (insert-index 'vector (vector 1 2) 1 9) 3))`, "()", ""},
+			{`(length (insert-index 'vector (vector) 0 1))`, "1", ""},
+		}},
+		{"insert-sorted", elpstest.TestSequence{
+			{`(length (insert-sorted 'vector (vector 1 3) < 2))`, "3", ""},
+			{`(aref (insert-sorted 'vector (vector 1 3) < 2) 1)`, "2", ""},
+			{`(ignore-errors (aref (insert-sorted 'vector (vector 1 3) < 2) 3))`, "()", ""},
+		}},
+		{"select", elpstest.TestSequence{
+			// The vector is sized for six elements and resized to three.
+			{`(length (select 'vector (expr (< % 3)) '(0 1 2 3 4 5)))`, "3", ""},
+			{`(aref (select 'vector (expr (< % 3)) '(0 1 2 3 4 5)) 2)`, "2", ""},
+			{`(ignore-errors (aref (select 'vector (expr (< % 3)) '(0 1 2 3 4 5)) 3))`, "()", ""},
+			// Resized all the way to empty, and not resized at all.
+			{`(length (select 'vector (lambda (x) false) '(0 1 2)))`, "0", ""},
+			{`(ignore-errors (aref (select 'vector (lambda (x) false) '(0 1 2)) 0))`, "()", ""},
+			{`(length (select 'vector (lambda (x) true) '(0 1 2)))`, "3", ""},
+			{`(aref (select 'vector (lambda (x) true) '(0 1 2)) 2)`, "2", ""},
+		}},
+		{"reject", elpstest.TestSequence{
+			{`(length (reject 'vector (expr (< % 3)) '(0 1 2 3 4 5)))`, "3", ""},
+			{`(aref (reject 'vector (expr (< % 3)) '(0 1 2 3 4 5)) 0)`, "3", ""},
+			{`(ignore-errors (aref (reject 'vector (expr (< % 3)) '(0 1 2 3 4 5)) 3))`, "()", ""},
+			{`(length (reject 'vector (lambda (x) true) '(0 1 2)))`, "0", ""},
+			{`(ignore-errors (aref (reject 'vector (lambda (x) true) '(0 1 2)) 0))`, "()", ""},
+		}},
+		{"select does not resize its input", elpstest.TestSequence{
+			// The resize must land on the new vector's own dims list.  The
+			// input is a vector of the same length the result was sized to,
+			// so a shared dims list would show up here as a shrunken input.
+			{`(set 'src (vector 0 1 2 3 4 5))`, "(vector 0 1 2 3 4 5)", ""},
+			{`(length (select 'vector (expr (< % 3)) src))`, "3", ""},
+			{`(length src)`, "6", ""},
+			{`(aref src 5)`, "5", ""},
+			{`(length (reject 'vector (expr (< % 3)) src))`, "3", ""},
+			{`(length src)`, "6", ""},
+		}},
+		{"zip", elpstest.TestSequence{
+			// The outer vector and every inner vector are separate arrays,
+			// so both levels of dims are asserted.
+			{`(length (zip 'vector '(1 2 3) '('a 'b 'c)))`, "3", ""},
+			{`(length (aref (zip 'vector '(1 2 3) '('a 'b 'c)) 0))`, "2", ""},
+			{`(aref (aref (zip 'vector '(1 2 3) '('a 'b 'c)) 2) 1)`, "'c", ""},
+			{`(ignore-errors (aref (aref (zip 'vector '(1 2 3) '('a 'b 'c)) 0) 2))`, "()", ""},
+			// Truncated to the shortest input.
+			{`(length (zip 'vector '(1 2 3) '(1)))`, "1", ""},
+			{`(length (zip 'vector '() '() '(1)))`, "0", ""},
+		}},
+		{"reverse", elpstest.TestSequence{
+			{`(length (reverse 'vector '(1 2 3)))`, "3", ""},
+			{`(aref (reverse 'vector '(1 2 3)) 0)`, "3", ""},
+			{`(ignore-errors (aref (reverse 'vector '(1 2 3)) 3))`, "()", ""},
+			{`(length (reverse 'vector '()))`, "0", ""},
+		}},
+		{"slice", elpstest.TestSequence{
+			{`(length (slice 'vector (vector 0 1 2 3 4) 1 3))`, "2", ""},
+			{`(aref (slice 'vector (vector 0 1 2 3 4) 1 3) 1)`, "2", ""},
+			{`(ignore-errors (aref (slice 'vector (vector 0 1 2 3 4) 1 3) 2))`, "()", ""},
+			{`(length (slice 'vector (vector 0 1 2) 2 2))`, "0", ""},
+			// The sealed empty carve-out: the window is dropped and the
+			// vector owns fresh (empty) backing, so its dims must be zero.
+			{`(length (slice 'vector (rest '(1)) 0 0))`, "0", ""},
+		}},
+	}
+	elpstest.RunTestSuite(t, tests)
+}
+
 // TestArrayDoesNotAliasCallerDims pins the constraint that decides which
 // Array calls copy their dims.  An array rewrites its own cardinality in
 // place -- builtinSelect and builtinReject size a vector's dims to the

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -1506,6 +1506,10 @@ func builtinConcatSeq(env *LEnv, args *LVal) *LVal {
 		// of every input and the slice was made with that capacity -- so the
 		// dims Vector derives are the dims this site used to spell out, and
 		// deriving them costs no copy (issue #544's dims == nil path).
+		// Spelling them out carried an implicit dims-vs-cells consistency
+		// check that deriving drops; that divergence is unconstructible
+		// in-tree, because every cardinality writer updates the dims header
+		// and the backing cells together.
 		return Vector(cells)
 	}
 	return QExpr(cells)
@@ -1777,11 +1781,17 @@ func builtinSelect(env *LEnv, args *LVal) *LVal {
 	switch typespec.Str {
 	case "vector":
 		// MakeVector sizes the vector for the whole input and lets Array
-		// derive the dims, which is the case TestArrayDoesNotAliasCallerDims
-		// exists for: the resize below writes the cardinality in place, so
-		// the dims list it lands on must belong to this array alone.  Array
-		// builds that list itself here (dims == nil), so it is reachable
-		// from nothing else and needs no defensive copy.
+		// derive the dims.  The resize below writes the cardinality in
+		// place, so the dims list it lands on must belong to this array
+		// alone; on the derived path Array builds that list itself, so it
+		// is reachable from nothing else and needs no defensive copy (the
+		// caller-dims path keeps its copy for exactly this write -- see
+		// TestArrayDoesNotAliasCallerDims).  MakeVector is load-bearing
+		// here: it is the only constructor that yields an n-CAPACITY
+		// backing through the derived-dims path.  Vector(make([]*LVal, 0,
+		// n)) would lose the capacity -- Array replaces an empty cells
+		// slice with a fresh full-length one -- and the cells[0:0:n]
+		// reslice below depends on it.
 		v = MakeVector(list.Len())
 		cells = seqCells(v)
 		cells = cells[0:0:list.Len()]

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -1058,7 +1058,7 @@ func builtinMap(env *LEnv, args *LVal) *LVal {
 	} else {
 		switch typespec.Str {
 		case "vector":
-			v = Array(QExpr([]*LVal{Int(lis.Len())}), nil)
+			v = MakeVector(lis.Len())
 			cells = seqCells(v)
 		case "list":
 			cells = make([]*LVal, lis.Len())
@@ -1477,7 +1477,7 @@ func builtinConcatSeq(env *LEnv, args *LVal) *LVal {
 	if size == 0 {
 		switch typespec.Str {
 		case "vector":
-			return Array(QExpr([]*LVal{Int(0)}), nil)
+			return MakeVector(0)
 		case "list":
 			return Nil()
 		}
@@ -1502,7 +1502,11 @@ func builtinConcatSeq(env *LEnv, args *LVal) *LVal {
 		cells = append(cells, seqCells(v)...)
 	}
 	if typespec.Str == "vector" {
-		return Array(QExpr([]*LVal{Int(size)}), cells)
+		// len(cells) is exactly size -- the appends above copy every element
+		// of every input and the slice was made with that capacity -- so the
+		// dims Vector derives are the dims this site used to spell out, and
+		// deriving them costs no copy (issue #544's dims == nil path).
+		return Vector(cells)
 	}
 	return QExpr(cells)
 }
@@ -1635,7 +1639,7 @@ func builtinInsertIndex(env *LEnv, args *LVal) *LVal {
 	var cells []*LVal
 	switch typespec.Str {
 	case "vector":
-		v = Array(QExpr([]*LVal{Int(1 + list.Len())}), nil)
+		v = MakeVector(1 + list.Len())
 		cells = seqCells(v)
 	case "list":
 		cells = make([]*LVal, 1+list.Len())
@@ -1708,7 +1712,7 @@ func builtinInsertSorted(env *LEnv, args *LVal) *LVal {
 	var cells []*LVal
 	switch typespec.Str {
 	case "vector":
-		v = Array(QExpr([]*LVal{Int(1 + list.Len())}), nil)
+		v = MakeVector(1 + list.Len())
 		cells = seqCells(v)
 	case "list":
 		cells = make([]*LVal, 1+list.Len())
@@ -1772,7 +1776,13 @@ func builtinSelect(env *LEnv, args *LVal) *LVal {
 	var cells []*LVal
 	switch typespec.Str {
 	case "vector":
-		v = Array(QExpr([]*LVal{Int(list.Len())}), nil)
+		// MakeVector sizes the vector for the whole input and lets Array
+		// derive the dims, which is the case TestArrayDoesNotAliasCallerDims
+		// exists for: the resize below writes the cardinality in place, so
+		// the dims list it lands on must belong to this array alone.  Array
+		// builds that list itself here (dims == nil), so it is reachable
+		// from nothing else and needs no defensive copy.
+		v = MakeVector(list.Len())
 		cells = seqCells(v)
 		cells = cells[0:0:list.Len()]
 	case "list":
@@ -1821,7 +1831,9 @@ func builtinReject(env *LEnv, args *LVal) *LVal {
 	var cells []*LVal
 	switch typespec.Str {
 	case "vector":
-		v = Array(QExpr([]*LVal{Int(list.Len())}), nil)
+		// Array-derived dims, for the reason spelled out in builtinSelect:
+		// the resize below writes this array's cardinality in place.
+		v = MakeVector(list.Len())
 		cells = seqCells(v)
 		cells = cells[0:0:list.Len()]
 	case "list":
@@ -1870,7 +1882,7 @@ func builtinZip(env *LEnv, args *LVal) *LVal {
 	var cells []*LVal
 	switch typespec.Str {
 	case "vector":
-		v = Array(QExpr([]*LVal{Int(n)}), nil)
+		v = MakeVector(n)
 		cells = seqCells(v)
 	case "list":
 		cells = make([]*LVal, n)
@@ -1883,7 +1895,7 @@ func builtinZip(env *LEnv, args *LVal) *LVal {
 		var elemCells []*LVal
 		switch typespec.Str {
 		case "vector":
-			elem = Array(QExpr([]*LVal{Int(len(lists))}), nil)
+			elem = MakeVector(len(lists))
 			elemCells = seqCells(elem)
 		case "list":
 			elemCells = make([]*LVal, len(lists))
@@ -1951,7 +1963,7 @@ func builtinReverse(env *LEnv, args *LVal) *LVal {
 	var cells []*LVal
 	switch typespec.Str {
 	case "vector":
-		v = Array(QExpr([]*LVal{Int(list.Len())}), nil)
+		v = MakeVector(list.Len())
 		cells = seqCells(v)
 	case "list":
 		cells = make([]*LVal, list.Len())
@@ -2099,7 +2111,11 @@ func builtinSlice(env *LEnv, args *LVal) *LVal {
 			// window entirely so the vector owns (empty) fresh backing.
 			cells = nil
 		}
-		return Array(QExpr([]*LVal{Int(len(cells))}), cells)
+		// The dims are literally [len(cells)] on both branches above -- the
+		// window's length, or zero for the sealed empty carve-out -- so
+		// Vector derives the identical value without copying a dims list
+		// this site would otherwise build only to have Array duplicate.
+		return Vector(cells)
 	default:
 		return env.Errorf("type specifier is not valid: %v", typespec)
 	}

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -652,10 +652,13 @@ func MakeVector(n int) *LVal {
 func Array(dims *LVal, cells []*LVal) *LVal {
 	// stored is the dims list the array keeps.  Caller-supplied dims are
 	// copied because the array writes its cardinality in place later --
-	// builtinSelect and builtinReject resize a vector's dims after filling
-	// it -- so sharing the caller's list would let that write land in a value
-	// the caller still holds.  Dims this function constructs are reachable
-	// from nothing else, so that path stores them directly.  The parameter is
+	// builtinAppendMutate grows a vector's dims as append! adds cells --
+	// so sharing the caller's list would let that write land in a value
+	// the caller still holds.  No in-tree production caller passes dims
+	// any more (the vector-building builtins all derive them; only the
+	// fuzz harness's multi-dimensional constructor remains), so this
+	// branch now chiefly serves embedders.  Dims this function constructs
+	// are reachable from nothing else, so that path stores them directly.  The parameter is
 	// deliberately never assigned to stored: that flow would escape a
 	// caller's dims into the returned value as far as the compiler can tell,
 	// and heap-allocate the literal every builtin call site passes.

--- a/lisp/vector_alloc_test.go
+++ b/lisp/vector_alloc_test.go
@@ -1,12 +1,19 @@
 // Copyright © 2018 The ELPS authors
 
 // The allocation assertions for the vector-constructing builtins live behind
-// !race because the race detector allocates on its own account, and behind
 // !elpscheck because the checked build adds ownership bookkeeping to every
 // eval (lisp/ownership_check_elpscheck.go), which moves the insert-sorted
-// count.  Pinning either configuration would pin the instrumentation rather
-// than the builtins.  Every other build runs them, including the plain
+// count (31 -> 43; the other nine rows are unchanged).  The !race guard is
+// precautionary, following the libjson/encode_alloc_test.go precedent: on
+// the authoring toolchain every row measures identically under -race, but
+// these pins should not be coupled to race-instrumentation behavior across
+// toolchains.  Every other build runs them, including the plain
 // `go test ./...` the CI gate uses.
+//
+// Reading a red row: for map/select/reject roughly 37 of the ~39 pinned
+// allocations are env.FunCall machinery, not vector construction, so a
+// regression there usually points at the evaluator; zip is the row where
+// construction dominates.
 
 //go:build !race && !elpscheck
 

--- a/lisp/vector_alloc_test.go
+++ b/lisp/vector_alloc_test.go
@@ -1,0 +1,108 @@
+// Copyright © 2018 The ELPS authors
+
+// The allocation assertions for the vector-constructing builtins live behind
+// !race because the race detector allocates on its own account, and behind
+// !elpscheck because the checked build adds ownership bookkeeping to every
+// eval (lisp/ownership_check_elpscheck.go), which moves the insert-sorted
+// count.  Pinning either configuration would pin the instrumentation rather
+// than the builtins.  Every other build runs them, including the plain
+// `go test ./...` the CI gate uses.
+
+//go:build !race && !elpscheck
+
+package lisp
+
+import "testing"
+
+// TestVectorBuiltinAllocations pins what each vector-constructing builtin
+// allocates.
+//
+// These builtins used to build their own one-element dims list and pass it to
+// Array as CALLER-supplied dims, which costs the validation loop and, more
+// expensively, the deferred dims.Copy() Array must perform on a list it does
+// not own (issue #544 and TestArrayDoesNotAliasCallerDims explain why that
+// copy is not optional for caller dims).  They now let Array derive the
+// identical dims for itself through MakeVector/Vector, which is copy-free.
+//
+// The counts are equalities, not bounds, and they are the point of the change:
+// each vector constructed is exactly 2 allocations cheaper than it was.  The
+// "was" column was measured on origin/main at 63fc6b2:
+//
+//	map 'vector            41 -> 39
+//	select 'vector         41 -> 39
+//	reject 'vector         41 -> 39
+//	reverse 'vector         9 -> 7
+//	concat 'vector          9 -> 7
+//	concat 'vector (empty)  8 -> 6
+//	zip 'vector            81 -> 63
+//	slice 'vector           9 -> 7
+//	insert-index 'vector    9 -> 7
+//	insert-sorted 'vector  33 -> 31
+//
+// zip moves by 18 rather than 2 because it builds nine vectors for this input
+// -- one per element plus the outer one -- which is what makes it the row that
+// shows the saving is per-vector and not per-call.
+//
+// The fixtures are built once, outside the measured closure, so what is
+// counted is the builtin's own work.  Every builtin here is deterministic, so
+// AllocsPerRun's mean over its runs is the count itself.
+func TestVectorBuiltinAllocations(t *testing.T) {
+	env := NewEnv(nil)
+	if rc := InitializeUserEnv(env); rc.Type == LError {
+		t.Fatalf("initialize-user-env: %v", rc)
+	}
+	// Go-implemented predicates: a lisp lambda would put the evaluator's own
+	// allocations, which this change does not touch, into every count.
+	even := FunInPackage(DefaultUserPackage, "even?", Formals("x"), func(env *LEnv, args *LVal) *LVal {
+		return Bool(args.Cells[0].Int%2 == 0)
+	})
+	less := FunInPackage(DefaultUserPackage, "less?", Formals("a", "b"), func(env *LEnv, args *LVal) *LVal {
+		return Bool(args.Cells[0].Int < args.Cells[1].Int)
+	})
+	vec := MakeVector(8)
+	for i := range vec.Cells[1].Cells {
+		vec.Cells[1].Cells[i] = Int(i)
+	}
+	vector := Symbol("vector")
+
+	mapArgs := QExpr([]*LVal{vector, even, vec})
+	predArgs := QExpr([]*LVal{vector, even, vec})
+	seqArgs := QExpr([]*LVal{vector, vec})
+	concatArgs := QExpr([]*LVal{vector, vec, vec})
+	concatEmptyArgs := QExpr([]*LVal{vector})
+	zipArgs := QExpr([]*LVal{vector, vec, vec})
+	sliceArgs := QExpr([]*LVal{vector, vec, Int(1), Int(4)})
+	insertArgs := QExpr([]*LVal{vector, vec, Int(2), Int(99)})
+	insertSortedArgs := QExpr([]*LVal{vector, vec, less, Int(3)})
+
+	tests := []struct {
+		name string
+		call func() *LVal
+		want int
+	}{
+		{"map", func() *LVal { return builtinMap(env, mapArgs) }, 39},
+		{"select", func() *LVal { return builtinSelect(env, predArgs) }, 39},
+		{"reject", func() *LVal { return builtinReject(env, predArgs) }, 39},
+		{"reverse", func() *LVal { return builtinReverse(env, seqArgs) }, 7},
+		{"concat", func() *LVal { return builtinConcatSeq(env, concatArgs) }, 7},
+		{"concat-empty", func() *LVal { return builtinConcatSeq(env, concatEmptyArgs) }, 6},
+		{"zip", func() *LVal { return builtinZip(env, zipArgs) }, 63},
+		{"slice", func() *LVal { return builtinSlice(env, sliceArgs) }, 7},
+		{"insert-index", func() *LVal { return builtinInsertIndex(env, insertArgs) }, 7},
+		{"insert-sorted", func() *LVal { return builtinInsertSorted(env, insertSortedArgs) }, 31},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Anti-vacuity: a builtin that errored out early would allocate
+			// less and pass a bound, so assert it produced a vector first.
+			got := test.call()
+			if got.Type != LArray {
+				t.Fatalf("%s did not build a vector: %v", test.name, got)
+			}
+			n := testing.AllocsPerRun(200, func() { test.call() })
+			if int(n) != test.want {
+				t.Errorf("%s allocated %v times per call, want %d", test.name, n, test.want)
+			}
+		})
+	}
+}

--- a/lisp/vector_alloc_test.go
+++ b/lisp/vector_alloc_test.go
@@ -46,6 +46,21 @@ import "testing"
 // The fixtures are built once, outside the measured closure, so what is
 // counted is the builtin's own work.  Every builtin here is deterministic, so
 // AllocsPerRun's mean over its runs is the count itself.
+//
+// These counts are the only measurement most of these builtins get: the repo
+// has no benchmark that calls map, select, reject, zip, reverse, insert-index
+// or insert-sorted.  The four that a benchmark does reach agree with them
+// (interleaved n=10 against 63fc6b2, benchgate: 0 rows at threshold, 0
+// allocation regressions anywhere):
+//
+//	AliasSliceVector            allocs -9.07%, B/op -6.45%
+//	AliasConcatCopy             allocs -9.07%, B/op -2.04%
+//	AliasSliceThenAppendMutate  allocs -8.03%, B/op -3.17%
+//	AliasStableSortSliceView    allocs -0.05%, B/op -0.04%
+//
+// AliasSliceVector performs 1000 slices and drops exactly 2000 allocations,
+// which is the same 2-per-vector this test pins, arrived at from the other
+// end.
 func TestVectorBuiltinAllocations(t *testing.T) {
 	env := NewEnv(nil)
 	if rc := InitializeUserEnv(env); rc.Type == LError {


### PR DESCRIPTION
The follow-up noted on #544 commit 3: eleven call sites across ten builtins (`map`, `select`, `reject`, `zip` ×2, `reverse`, `concat` ×2, `slice`, `insert-index`, `insert-sorted`) built a one-element dims list by hand and paid `Array`'s caller-dims validation + deferred deep copy, when the copy-free `dims == nil` path derives the identical value. All now route through the existing `MakeVector`/`Vector` constructors. One remaining caller-dims site deliberately declined: the fuzz harness's `arrayND` genuinely builds multi-dimensional arrays.

## Summary
- **Exactly 2 allocations saved per constructed vector** (`zip` −18: nine vectors per call): `reverse`/`slice`/`concat`/`insert-*` 9→7 allocs (−22%), `map`/`select`/`reject` 41→39, `zip` 81→63.
- The sensitive case — `select`/`reject` shrinking stored dims in place after filling — is safe because the derived dims list is freshly allocated inside `Array` and reachable from nothing else (`Int` does not intern); the reasoning is recorded in comments at those sites.
- New `TestVectorBuiltinAllocations` pins every converted builtin's exact allocation count via `testing.AllocsPerRun` (red-proofed: with the change stashed, all ten rows fail with precisely the old counts). New `TestVectorConstructorDims` asserts dims-dependent semantics through `length`/`aref` — shrink-to-3, shrink-to-0, no-shrink, out-of-bounds after shrink, zip inner+outer dims, and select-does-not-resize-its-input. `TestArrayDoesNotAliasCallerDims` untouched and passing.
- Benchstat (interleaved, n=10): **8 allocation improvements, zero allocation regressions** — `AliasSliceVector` −9.07% allocs (exactly 2,000 fewer over 1,000 slices, independently confirming the per-vector figure), `AliasConcatCopy` −9.07%, `AliasSliceThenAppendMutate` −8.03%. `make bench-gate`: 0 rows at threshold. Program-wide the geomeans are small (lisp allocs −0.32%) — this is a zero-complexity waste removal, not a headline win.

## Test Plan
- [x] `go test ./...`, `go test -race ./lisp/...`, `go test -tags elpscheck ./lisp/...` all pass
- [x] `make elpsvet` clean (both passes; `Vector`/`MakeVector` already in the freshness whitelist); `elps fmt -l` / `elps doc -m` clean
- [x] AllocsPerRun pins red-proofed against base; per-site qualification recorded (dims == [len(cells)] or shrink-on-unshared-dims)
- [x] Interleaved benchstat n=10 across `lisp`, `libjson`, `libelpspath`: zero allocation regressions; bench-gate exit 0
- [ ] In flight, results to be posted before merge: an independent adversarial review of the diff (any findings will be pushed to this branch), and an extended local fuzz burst (4 min each on `FuzzSharedProgramMultiEnv` and `FuzzEval`, the corruption-oracle targets covering these builtins — CI runs them 30s/shard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgShxM3EoPmeVnq1cmpcPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgShxM3EoPmeVnq1cmpcPK)_