### PR TITLE
lisp: native value contracts — complete the clone protocol, typed accessors, runtime affinity

### DIFF
--- a/docs/fork.md
+++ b/docs/fork.md
@@ -177,6 +177,23 @@ A shared stateful native is the one way to leak state between template and
 forks that no isolation test in this repository can see from the outside —
 audit your template's native census when adopting Fork.
 
+A payload type can also *declare* which runtime it belongs to, by
+implementing `RuntimeBound` (`BoundRuntime() *lisp.Runtime`, returning nil
+while unbound). Declaring costs a production build nothing — nothing there
+ever calls it. Under `-tags elpscheck` the declaration is asserted: at the
+ownership checker's instrumented points (shallow, per that checker's
+documented limits) and, deeply, at fork time, where every reachable native
+payload is checked against the fork's runtime whatever container it rides
+in — and whichever of the three tools above resolved it, a replacer's
+return value included. A fork *is* a different runtime, so a bound payload
+reaching a fork by the default share-by-reference policy fails the fork,
+loudly, rather than sitting in the fork until a request touches it. A
+payload that means to survive forking must therefore clone to something
+*unbound* (or bound to the destination): a clone that copies the template's
+binding trips the same check, which is only `NativeCloner`'s existing
+"retain no reference into the template's runtime" rule made checkable. See
+`lisp/runtime_bound.go`.
+
 ### Context
 
 The template's `context.Context` never travels into a fork. Bind a

--- a/docs/fork.md
+++ b/docs/fork.md
@@ -114,7 +114,7 @@ the same reasoning that exempts the nil/true/false singletons).
 | Sealed values (program AST, formals, quoted literals) | shared |
 | Singletons (`()`, `true`, `false`) | shared |
 | Functions (`LFun`) | header copied; captured environment remapped onto fork copies; builtin Go code travels by reference |
-| Native payloads | shared by reference, unless `NativeCloner` / `ForkWithNativeReplacer` (below) |
+| Native payloads | shared by reference, unless `NativeCloner` / `ForkWithNativeReplacer` (below). `NativeCloner` is not fork-specific: `copy` and `detach` honour it too |
 | Mutable data (vectors, sorted maps, bytes, error stacks, tagged values) | hermetically copied, aliasing and cycles preserved |
 | Source locations, format metadata (`Meta`) | shared (read-only after parse) |
 | Macro-expansion debug metadata | dropped (debugger-only; aliases template state) |
@@ -162,8 +162,13 @@ embedder's to handle, with three tools, in order of preference:
 2. **`NativeCloner`.** A payload type that implements
    `CloneNative() interface{}` is duplicated at fork time; the clone must
    be independent of the original and must not retain references into the
-   template's runtime. This is the fork half of the native contract
-   protocols sketched in issue #383.
+   template's runtime. It is the kernel's one clone protocol for native
+   payloads rather than a fork-only hook: the lisp `copy` builtin clones
+   through it too, and `detach` clones such a payload instead of refusing
+   the value outright. One `CloneNative` implementation therefore covers
+   all three paths — and adding one to a payload that is shared under
+   `copy` today starts cloning it there as well. This is the native half
+   of the contract protocols sketched in issue #383.
 3. **`ForkWithNativeReplacer`.** A per-fork substitution hook consulted
    before `NativeCloner`, for payload types the embedder cannot modify and
    for instance-specific rebinding (a per-fork storage handle).

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -205,10 +205,13 @@ var (
 			`Returns a deep copy of value that shares no storage with it:
 			lists, vectors, sorted-maps and bytes are rebuilt with fresh
 			backing, recursively, so mutating the copy at any depth cannot
-			be observed through the original. Function and native values
-			are shared by reference, not copied: a lambda carried into the
-			copy still reads and writes the bindings it captured, so
-			calling one can be observed through the original. Strings and
+			be observed through the original. Function values are shared by
+			reference, not copied: a lambda carried into the copy still
+			reads and writes the bindings it captured, so calling one can
+			be observed through the original. Native values are also shared
+			by reference, unless the Go payload declares its own clone
+			protocol (lisp.NativeCloner), in which case the copy holds an
+			independent clone of the payload. Strings and
 			numbers are immutable values. Sharing between values inside the
 			input is preserved in the copy, including cycles; sharing of a
 			backing array between distinct values -- what cdr, rest and

--- a/lisp/copy.go
+++ b/lisp/copy.go
@@ -38,6 +38,13 @@ package lisp
 //   - LNative: an opaque Go value the kernel cannot clone.  Sharing it is
 //     the same guarantee the rest of the language already gives it.
 //
+//     A payload implementing NativeCloner (lisp/fork.go) is the exception,
+//     and it is the payload's own doing: it has stated what a duplicate of
+//     itself is, so `copy` takes it at its word and the copy holds a clone
+//     rather than the original handle.  A stateful native that must not be
+//     shared with a copy therefore has exactly one lever to pull, and it is
+//     the same lever Fork and detach honour (issue #546).
+//
 //   - The three singletons (Nil(), Bool(true), Bool(false)) are shared,
 //     immutable, and unmutable from lisp; copying them would allocate a
 //     distinct value with no observable difference (see lisp/singleton.go).

--- a/lisp/copy_test.go
+++ b/lisp/copy_test.go
@@ -245,6 +245,71 @@ func TestCopySharesFunctionAndNativeLeaves(t *testing.T) {
 	}
 }
 
+// TestCopyClonesNativeCloner is the `copy` end of issue #546: a native leaf
+// is shared because the kernel has no way to duplicate it, not because
+// sharing is what `copy` wants at a native.  A payload implementing
+// NativeCloner (the fixture lives in detach_test.go) has removed that
+// obstacle, so the copy holds a clone — the same one lever Fork and detach
+// honour, so an embedder writes CloneNative once.
+func TestCopyClonesNativeCloner(t *testing.T) {
+	env := copyTestEnv(t)
+	payload := &cloneableNative{state: 5}
+	env.PutGlobal(lisp.Symbol("a-native"), lisp.Native(payload))
+	mustEval(t, env, `(set 'cp (copy a-native))`)
+
+	cp := env.GetGlobal(lisp.Symbol("cp"))
+	if cp.Type != lisp.LNative {
+		t.Fatalf("copy of a native produced a %v: %v", cp.Type, cp)
+	}
+	got, ok := cp.Native.(*cloneableNative)
+	if !ok {
+		t.Fatalf("copied payload has type %T", cp.Native)
+	}
+	if got == payload {
+		t.Errorf("the copy shares the payload with the original")
+	}
+	if got.state != 5 {
+		t.Errorf("clone state = %d; want 5", got.state)
+	}
+	if payload.clones != 1 {
+		t.Errorf("CloneNative called %d times; want 1", payload.clones)
+	}
+	if payload.state != 5 {
+		t.Errorf("`copy` wrote through the original payload: state=%d", payload.state)
+	}
+
+	// A native nested in a container takes the same path.
+	nested := &cloneableNative{state: 9}
+	env.PutGlobal(lisp.Symbol("nested-native"), lisp.Native(nested))
+	mustEval(t, env, `(set 'ncp (copy (sorted-map "n" nested-native)))`)
+	inner := env.GetGlobal(lisp.Symbol("ncp")).MapGet(lisp.String("n"))
+	if inner.Type == lisp.LError {
+		t.Fatalf("map get: %v", inner)
+	}
+	if inner.Native.(*cloneableNative) == nested {
+		t.Errorf("a native nested in a sorted-map was shared, not cloned")
+	}
+}
+
+// TestCopySharesNativeWithoutCloneProtocol pins the unchanged default: a
+// payload that declares no clone protocol is still shared by reference, so
+// adding the protocol is the only thing that moves a native off it.
+func TestCopySharesNativeWithoutCloneProtocol(t *testing.T) {
+	env := copyTestEnv(t)
+	payload := &opaqueNative{state: 5}
+	env.PutGlobal(lisp.Symbol("a-native"), lisp.Native(payload))
+	mustEval(t, env, `(set 'cp (copy (list a-native)))`)
+
+	cp := env.GetGlobal(lisp.Symbol("cp"))
+	got, ok := cp.Cells[0].Native.(*opaqueNative)
+	if !ok {
+		t.Fatalf("copied payload has type %T", cp.Cells[0].Native)
+	}
+	if got != payload {
+		t.Errorf("a payload with no clone protocol was not shared by reference")
+	}
+}
+
 // TestCopySharedClosureKeepsTheOriginalsBindings pins the consequence of
 // sharing LFun leaves that the docstring used to deny ("they hold no
 // lisp-mutable state").  A closure captures BINDINGS, not values, so a

--- a/lisp/detach.go
+++ b/lisp/detach.go
@@ -40,10 +40,16 @@ import (
 // dropped (nil in the copy): it exists only while a debugger is attached and
 // its context holds unevaluated argument values inside the source runtime.
 //
-// Two shapes cannot be hermetically copied, and detach rejects them rather
-// than silently sharing state while claiming isolation:
+// Two shapes resist hermetic copying, and detach rejects them rather than
+// silently sharing state while claiming isolation:
 //
-//   - LNative values wrap arbitrary Go data that detach cannot clone.
+//   - LNative values wrap arbitrary Go data the kernel has no way to clone.
+//     A payload that implements NativeCloner (lisp/fork.go) is the carve-out:
+//     it has declared what its own duplicate is, and only the embedder can
+//     know that, so detach clones through the protocol and the value
+//     transfers.  The carve-out is strictly more permissive — it converts
+//     refusals into successes and leaves every value that already detached
+//     alone (issue #546).
 //   - LFun values.  A builtin holds a Go function; a lambda captures its
 //     defining LEnv and, through it, the whole source runtime.  Either way a
 //     by-value copy would smuggle the source runtime across the transfer.
@@ -71,11 +77,13 @@ type detacher struct {
 
 	// shareOpaque switches the walk from transfer semantics (detach) to
 	// within-env ownership semantics (deepCopy, lisp/copy.go): the two
-	// shapes that cannot be hermetically cloned — LFun and LNative — plus
-	// the process-wide singletons are returned by reference instead of
-	// rejected.  Every data container is still rebuilt with fresh backing
-	// either way; this flag only decides what happens at a leaf the
-	// kernel cannot clone.
+	// shapes that cannot be hermetically cloned — LFun and an LNative whose
+	// payload supplies no NativeCloner — plus the process-wide singletons
+	// are returned by reference instead of rejected.  A cloneable native is
+	// neither shared nor rejected in either mode: the payload's own protocol
+	// settles it before this flag is consulted.  Every data container is
+	// still rebuilt with fresh backing either way; this flag only decides
+	// what happens at a leaf the kernel cannot clone.
 	shareOpaque bool
 }
 
@@ -93,6 +101,13 @@ func (d *detacher) detach(v *LVal) (*LVal, error) {
 	}
 	switch v.Type {
 	case LNative:
+		if _, ok := v.Native.(NativeCloner); ok {
+			// The payload declares its own duplication protocol
+			// (lisp/fork.go), which is the only authority on what copying an
+			// opaque handle means.  Fall through to the general path; the
+			// payload is replaced with a clone below.
+			break
+		}
 		if d.shareOpaque {
 			return v, nil
 		}
@@ -133,33 +148,44 @@ func (d *detacher) detach(v *LVal) (*LVal, error) {
 	// The struct copy above aliased v.Native.  Every payload a detachable
 	// type is documented to carry is replaced with a hermetic copy; anything
 	// unrecognized is rejected rather than smuggled through.
-	switch native := v.Native.(type) {
-	case nil:
-	case *[]byte:
-		if v.Type != LBytes {
+	//
+	// LNative takes its own arm, mirroring the fork walker's dispatch
+	// (lisp/fork.go): an embedder handle is the payload's business, and the
+	// switch below is about elps's OWN storage — the *[]byte behind LBytes,
+	// the *MapData behind LSortMap, the *CallStack behind LError — whose
+	// guards key off the elps type carrying them.  Only cloneable payloads
+	// reach here; the type switch above returned for every other LNative.
+	if v.Type == LNative {
+		cp.Native = v.Native.(NativeCloner).CloneNative()
+	} else {
+		switch native := v.Native.(type) {
+		case nil:
+		case *[]byte:
+			if v.Type != LBytes {
+				return nil, unexpectedNativeError(v)
+			}
+			if native != nil {
+				b := make([]byte, len(*native))
+				copy(b, *native)
+				cp.Native = &b
+			}
+		case *MapData:
+			if v.Type != LSortMap {
+				return nil, unexpectedNativeError(v)
+			}
+			mdata, err := d.detachMapData(native)
+			if err != nil {
+				return nil, err
+			}
+			cp.Native = mdata
+		case *CallStack:
+			if v.Type != LError {
+				return nil, unexpectedNativeError(v)
+			}
+			cp.Native = detachCallStack(native)
+		default:
 			return nil, unexpectedNativeError(v)
 		}
-		if native != nil {
-			b := make([]byte, len(*native))
-			copy(b, *native)
-			cp.Native = &b
-		}
-	case *MapData:
-		if v.Type != LSortMap {
-			return nil, unexpectedNativeError(v)
-		}
-		mdata, err := d.detachMapData(native)
-		if err != nil {
-			return nil, err
-		}
-		cp.Native = mdata
-	case *CallStack:
-		if v.Type != LError {
-			return nil, unexpectedNativeError(v)
-		}
-		cp.Native = detachCallStack(native)
-	default:
-		return nil, unexpectedNativeError(v)
 	}
 
 	cells, err := d.detachCells(v.Cells)

--- a/lisp/detach.go
+++ b/lisp/detach.go
@@ -99,13 +99,20 @@ func (d *detacher) detach(v *LVal) (*LVal, error) {
 		// only in its address (lisp/singleton.go).
 		return v, nil
 	}
+	// cloner is non-nil exactly when v is an LNative whose payload declares
+	// its own duplication protocol (lisp/fork.go) — the only authority on
+	// what copying an opaque handle means.  Captured here rather than
+	// re-asserted at the clone site below, so that a future change to the
+	// LNative arm that lets another payload through degrades into the
+	// payload switch's unexpectedNativeError instead of a type-assertion
+	// panic.
+	var cloner NativeCloner
 	switch v.Type {
 	case LNative:
-		if _, ok := v.Native.(NativeCloner); ok {
-			// The payload declares its own duplication protocol
-			// (lisp/fork.go), which is the only authority on what copying an
-			// opaque handle means.  Fall through to the general path; the
-			// payload is replaced with a clone below.
+		if c, ok := v.Native.(NativeCloner); ok {
+			// Fall through to the general path; the payload is replaced
+			// with a clone below.
+			cloner = c
 			break
 		}
 		if d.shareOpaque {
@@ -153,10 +160,17 @@ func (d *detacher) detach(v *LVal) (*LVal, error) {
 	// (lisp/fork.go): an embedder handle is the payload's business, and the
 	// switch below is about elps's OWN storage — the *[]byte behind LBytes,
 	// the *MapData behind LSortMap, the *CallStack behind LError — whose
-	// guards key off the elps type carrying them.  Only cloneable payloads
-	// reach here; the type switch above returned for every other LNative.
-	if v.Type == LNative {
-		cp.Native = v.Native.(NativeCloner).CloneNative()
+	// guards key off the elps type carrying them.
+	if cloner != nil {
+		clone := cloner.CloneNative()
+		if !d.shareOpaque {
+			// A strict detach is the sanctioned cross-runtime transfer, and
+			// CloneNative cannot know the destination, so the only clone
+			// that can be right is an unbound one.  Checked builds assert
+			// it (no-op in production; see lisp/runtime_bound.go).
+			checkDetachedNativeUnbound(clone)
+		}
+		cp.Native = clone
 	} else {
 		switch native := v.Native.(type) {
 		case nil:

--- a/lisp/detach_test.go
+++ b/lisp/detach_test.go
@@ -549,6 +549,124 @@ func TestDetachRejectsNativeWithPath(t *testing.T) {
 	}
 }
 
+// cloneableNative is the NativeCloner fixture for the walker's clone path.
+// It is shared with copy_test.go: detach and `copy` are one walker in two
+// modes, and the protocol has to hold in both.  clones counts the clones
+// taken FROM an instance, which is how a test pins that a payload reachable
+// along several paths was consulted exactly once.
+type cloneableNative struct {
+	state  int
+	clones int
+}
+
+func (c *cloneableNative) CloneNative() interface{} {
+	c.clones++
+	return &cloneableNative{state: c.state}
+}
+
+// opaqueNative implements nothing: the payload class the kernel still has
+// no copy strategy for.
+type opaqueNative struct{ state int }
+
+// TestDetachClonesNativeCloner: a payload that publishes its own
+// duplication protocol is no longer a shape detach has to refuse (issue
+// #546).  Only the embedder can say what duplicating an opaque handle
+// means, and NativeCloner is that statement, so the walker takes it.
+func TestDetachClonesNativeCloner(t *testing.T) {
+	payload := &cloneableNative{state: 7}
+	orig := lisp.Native(payload)
+	cp, err := lisp.Detach(orig)
+	if err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+	if cp == orig {
+		t.Fatalf("detach returned its argument; the LVal header must be copied too")
+	}
+	got, ok := cp.Native.(*cloneableNative)
+	if !ok {
+		t.Fatalf("detached payload has type %T", cp.Native)
+	}
+	if got == payload {
+		t.Errorf("detached value shares the payload with the original")
+	}
+	if got.state != 7 {
+		t.Errorf("clone state = %d; want 7 (CloneNative decides what a clone carries)", got.state)
+	}
+	if payload.clones != 1 {
+		t.Errorf("CloneNative called %d times; want 1", payload.clones)
+	}
+	if payload.state != 7 {
+		t.Errorf("the walker wrote through the original payload: state=%d", payload.state)
+	}
+}
+
+// TestDetachRejectsNativeWithoutCloneProtocol pins the other half: the
+// carve-out is the payload's own doing, so a payload that declares nothing
+// keeps the refusal verbatim.
+func TestDetachRejectsNativeWithoutCloneProtocol(t *testing.T) {
+	_, err := lisp.Detach(lisp.Native(&opaqueNative{state: 1}))
+	if err == nil {
+		t.Fatalf("expected an error detaching a payload with no clone protocol")
+	}
+	const want = "native value (*lisp_test.opaqueNative) cannot be detached"
+	if err.Error() != want {
+		t.Errorf("wrong error:\n got: %s\nwant: %s", err, want)
+	}
+}
+
+// TestDetachClonesNativeClonerInsideList: the clone happens wherever the
+// walk reaches the payload, not only at the root — a native buried in a
+// container used to poison the whole detach.
+func TestDetachClonesNativeClonerInsideList(t *testing.T) {
+	payload := &cloneableNative{state: 3}
+	orig := lisp.QExpr([]*lisp.LVal{
+		lisp.Symbol("head"),
+		lisp.QExpr([]*lisp.LVal{lisp.Native(payload)}),
+	})
+	cp, err := lisp.Detach(orig)
+	if err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+	inner := cp.Cells[1].Cells[0]
+	if inner == orig.Cells[1].Cells[0] {
+		t.Fatalf("the nested native LVal was shared with the original")
+	}
+	got, ok := inner.Native.(*cloneableNative)
+	if !ok {
+		t.Fatalf("detached payload has type %T", inner.Native)
+	}
+	if got == payload {
+		t.Errorf("the nested payload was shared with the original")
+	}
+	if payload.clones != 1 {
+		t.Errorf("CloneNative called %d times; want 1", payload.clones)
+	}
+}
+
+// TestDetachNativeClonerPreservesAliasing: a cloneable native now takes the
+// general copy path, which means it is memoized like every other node.  One
+// *LVal reachable through two cells must become ONE new *LVal in the copy,
+// cloned once — a per-occurrence clone would both break the aliasing the
+// detach contract preserves and charge the embedder for duplicates.
+func TestDetachNativeClonerPreservesAliasing(t *testing.T) {
+	payload := &cloneableNative{state: 1}
+	shared := lisp.Native(payload)
+	orig := lisp.QExpr([]*lisp.LVal{shared, shared})
+	cp, err := lisp.Detach(orig)
+	if err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+	if cp.Cells[0] != cp.Cells[1] {
+		t.Errorf("aliased native copied twice: %p vs %p", cp.Cells[0], cp.Cells[1])
+	}
+	if cp.Cells[0] == shared {
+		t.Errorf("the detached copy points at the original native value")
+	}
+	if payload.clones != 1 {
+		t.Errorf("CloneNative called %d times; want 1", payload.clones)
+	}
+}
+
 // TestDetachRejectsNativeInsideMap: the path must also thread through
 // sorted-map values.
 func TestDetachRejectsNativeInsideMap(t *testing.T) {

--- a/lisp/fork.go
+++ b/lisp/fork.go
@@ -480,19 +480,34 @@ func (f *forker) val(v *LVal) *LVal {
 // native resolves the fork policy for one native payload: the per-fork
 // replacer hook first, the NativeCloner protocol second, share-by-reference
 // last.
+//
+// Whichever of the three produced it, the RESOLVED payload is then checked
+// against the fork's own runtime (checkNativeAffinity — a no-op in
+// production builds, the established pattern for checkOwnership's
+// unconditional calls from Put and eval).  A payload that declares a
+// binding to another Runtime must not travel into the fork, and this is the
+// deep half of that rule: the walk reaches natives riding inside containers,
+// which the use-time checks are too shallow to see (issue #546,
+// lisp/runtime_bound.go).  A replacer's return value is checked like any
+// other — an embedder's hook handing back a template-bound instance is
+// precisely the bug class, not an exception to it.
 func (f *forker) native(payload interface{}) interface{} {
 	if payload == nil {
 		return nil
 	}
+	resolved, replaced := payload, false
 	if f.nativeReplacer != nil {
 		if replacement, ok := f.nativeReplacer(payload); ok {
-			return replacement
+			resolved, replaced = replacement, true
 		}
 	}
-	if cloner, ok := payload.(NativeCloner); ok {
-		return cloner.CloneNative()
+	if !replaced {
+		if cloner, ok := payload.(NativeCloner); ok {
+			resolved = cloner.CloneNative()
+		}
 	}
-	return payload
+	checkNativeAffinity(f.rt, resolved)
+	return resolved
 }
 
 // mapData rebuilds md as a fresh sorted map whose keys and values are

--- a/lisp/fork.go
+++ b/lisp/fork.go
@@ -63,19 +63,25 @@ import (
 // pre-hook ordering, pool-refill and test-runner patterns) and measured
 // numbers.
 
-// NativeCloner is the opt-in fork-time duplication protocol for native
+// NativeCloner is the kernel's opt-in duplication protocol for native
 // payloads, shared with the broader native-contract design of issue #383.
 // The kernel cannot copy an LVal's Native payload — it is an opaque
-// interface{} — so Fork shares payloads by reference by default.  A payload
-// type whose identity or state must NOT be shared between a template and
-// its forks (an accumulator, a stateful handle) implements NativeCloner;
-// Fork then stores the value returned by CloneNative in the forked LVal
-// instead of the shared reference.
+// interface{} — so every primitive that duplicates a value shares payloads
+// by reference by default.  A payload type whose identity or state must NOT
+// be shared with the duplicate (an accumulator, a stateful handle)
+// implements NativeCloner, and one implementation settles the question
+// everywhere the kernel copies a value: Fork, the lisp `copy` builtin
+// (deepCopy, lisp/copy.go) and detach (lisp/detach.go), which clones such a
+// payload rather than refusing it (issue #546).
 //
 // CloneNative must return a payload that is independent of the receiver:
-// mutations on either side must be invisible to the other.  It must not
-// retain references into the template's Runtime or LEnv tree — the clone
-// crosses a runtime boundary.
+// mutations on either side must be invisible to the other.  It must also
+// retain no reference into the Runtime or LEnv tree the receiver lives in:
+// Fork and detach both land the clone on a DIFFERENT runtime, where such a
+// reference reconnects the two trees the primitive exists to separate.
+// Under `copy` the duplicate stays inside one environment, so a payload
+// written for that path alone still has to meet the stricter bar to be
+// fork-safe.
 type NativeCloner interface {
 	CloneNative() interface{}
 }

--- a/lisp/native.go
+++ b/lisp/native.go
@@ -2,6 +2,8 @@
 
 package lisp
 
+import "reflect"
+
 // NativeValue reads the Go payload of an LNative value as a T, reporting
 // whether the value actually was one.  It replaces the hand-rolled pair
 // every embedder writes at each boundary where lisp hands Go data back —
@@ -49,6 +51,10 @@ package lisp
 // assertion.  A T of `any` succeeds for every non-nil payload of an
 // LNative and is the way to ask "is there anything here" without naming the
 // type.
+//
+// A caller whose false branch only builds an error message wants
+// RequireNative, which runs these same three gates and renders the failure
+// as an LError.
 func NativeValue[T any](v *LVal) (T, bool) {
 	var zero T
 	if v == nil || v.Type != LNative {
@@ -59,6 +65,64 @@ func NativeValue[T any](v *LVal) (T, bool) {
 		return zero, false
 	}
 	return x, true
+}
+
+// RequireNative reads the Go payload of an LNative value as a T, rendering
+// the failure as an LError rather than as a bool.  On success it returns the
+// payload and a nil second value; the second value is nil ON SUCCESS ONLY,
+// so a caller's whole failure branch is
+//
+//	h, lerr := lisp.RequireNative[*Handle](v)
+//	if lerr != nil {
+//		return lerr
+//	}
+//
+// which is the message the accessor pair was introduced to supply once
+// instead of at each boundary (issue #546).  NativeValue's `false` says only
+// that something did not match, so every caller of it that reports a failure
+// writes its own wording, and the substrate accumulated eleven of them —
+// differing in which of the three gates they name, and none naming the type
+// that was expected, which is the one fact the caller has and the value does
+// not.
+//
+// The gate sequence is NativeValue's, because this is a call to it: nil v,
+// then v.Type == LNative, then the assertion, with the LVal type checked
+// before the payload for the reasons documented there.  RequireNative only
+// re-examines v afterwards to say which gate refused it, so there is no
+// second copy of the check to drift.
+//
+// The three messages name the expected type and what was found:
+//
+//	expected native *pkg.Handle value, got nil
+//	expected native *pkg.Handle value, got bytes
+//	expected native *pkg.Handle value, got native *pkg.Other
+//
+// The expected type comes from reflect.TypeFor[T] rather than a %T verb
+// because T is a type parameter, not a value: %T of the zero T renders an
+// interface T as <nil>, which loses precisely the type the message exists to
+// report.  The reflection is confined to the failure path.
+//
+// The error carries no call stack of its own: with no *LEnv parameter
+// there is no environment to capture one from, so it is built with the
+// package-level Errorf (the env.Errorf methods attach a stack eagerly;
+// this accessor cannot).  Nothing is lost — an error returned up through
+// eval acquires the current stack from LEnv.ErrorAssociate, which fills
+// one in for any error still lacking it.
+func RequireNative[T any](v *LVal) (T, *LVal) {
+	x, ok := NativeValue[T](v)
+	if ok {
+		return x, nil
+	}
+	var zero T
+	want := reflect.TypeFor[T]()
+	switch {
+	case v == nil:
+		return zero, Errorf("expected native %v value, got nil", want)
+	case v.Type != LNative:
+		return zero, Errorf("expected native %v value, got %v", want, v.Type)
+	default:
+		return zero, Errorf("expected native %v value, got native %T", want, v.Native)
+	}
 }
 
 // NativeOf is the typed constructor counterpart of Native: it wraps x in an

--- a/lisp/native.go
+++ b/lisp/native.go
@@ -1,0 +1,82 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+// NativeValue reads the Go payload of an LNative value as a T, reporting
+// whether the value actually was one.  It replaces the hand-rolled pair
+// every embedder writes at each boundary where lisp hands Go data back —
+//
+//	if v.Type != lisp.LNative {
+//		return fmt.Errorf("not a native value: %v", v.Type)
+//	}
+//	h, ok := v.Native.(*Handle)
+//
+// — which is unremarkable once and a liability eleven times (issue #546):
+// the two halves are separable, and the half that gets dropped when a
+// caller is in a hurry is the type check, because the assertion alone
+// *looks* like it is doing the work.
+//
+// The three gates run in this order, and any failure returns the zero T and
+// false.  NativeValue never panics:
+//
+//  1. v is non-nil;
+//  2. v.Type == LNative;
+//  3. v.Native asserts to T.
+//
+// Gate 2 preceding gate 3 is the point of the function, not a stylistic
+// preference, because LVal.Native is NOT reserved for embedder payloads.
+// It is also the interpreter's own backing storage for three lisp-reachable
+// types: an LBytes value keeps its *[]byte there, an LSortMap its
+// *MapData, and an LError its *CallStack.  A bare `v.Native.(*[]byte)`
+// therefore succeeds on any ordinary lisp bytes value and hands the caller
+// the pointer the interpreter is itself holding — a write through it
+// mutates a live value behind the kernel's back, past the ownership and
+// seal invariants that make sharing safe (docs/sealed-ast.md, lisp/seal.go)
+// and past `copy`'s promise that a copy shares no storage with its original
+// (issue #378).  The same shape reaches a sorted map's whole backing
+// implementation, and an error's captured call stack, whose Go-stack
+// snapshot is the non-forgeable marker IsInternalPanic keys off.  Gate 2
+// makes all three unreachable through this accessor.
+//
+// The gate is on the LVAL's type, never on the payload's, and the
+// difference is deliberate: an embedder who stores a *[]byte of their own
+// with Native(&b) gets it back from NativeValue[*[]byte], because that
+// value is an LNative and the slice is theirs.  What is refused is the
+// interpreter's storage, not a Go type.
+//
+// T may be an interface: a payload stored as a concrete type is retrieved
+// through any interface it implements, since gate 3 is an ordinary type
+// assertion.  A T of `any` succeeds for every non-nil payload of an
+// LNative and is the way to ask "is there anything here" without naming the
+// type.
+func NativeValue[T any](v *LVal) (T, bool) {
+	var zero T
+	if v == nil || v.Type != LNative {
+		return zero, false
+	}
+	x, ok := v.Native.(T)
+	if !ok {
+		return zero, false
+	}
+	return x, true
+}
+
+// NativeOf is the typed constructor counterpart of Native: it wraps x in an
+// LNative exactly as Native does, and is implemented as a call to it, so the
+// two produce indistinguishable values.
+//
+// What it buys is a compiler check at the write end of a boundary whose read
+// end is NativeValue.  Native takes an interface{}, so it accepts whatever
+// the caller happens to be holding and any mismatch with what readers ask
+// for surfaces later as a `false` from a type assertion, at a call site far
+// from the mistake.  Writing NativeOf[Handle](h) instead states the stored
+// type in the source and makes storing something else a build failure —
+// worth doing wherever the payload type is spelled out again in the
+// NativeValue[Handle] that reads it back (issue #546).
+//
+// A payload whose state must not be shared across a Fork should also
+// implement NativeCloner; NativeOf stores the value as-is and takes no
+// position on that.
+func NativeOf[T any](x T) *LVal {
+	return Native(x)
+}

--- a/lisp/native_test.go
+++ b/lisp/native_test.go
@@ -1,0 +1,335 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// These tests cover the checked native accessors of issue #546:
+// NativeValue, which reads an LNative's Go payload as a T, and NativeOf,
+// its typed constructor counterpart.
+//
+// Two properties are under test, and they are not equally interesting.
+// The round-trip ones (1-7 below) say the accessor is usable: pointers,
+// value types and interface type parameters all survive, and every
+// no-match shape answers (zero, false) instead of panicking.
+//
+// The load-bearing ones are TestNativeValueRefusesInternalStorage and its
+// companion TestNativeValueGatesOnLValTypeNotPayloadType.  LVal.Native is
+// the interpreter's OWN backing storage for LBytes (*[]byte), LSortMap
+// (*MapData) and LError (*CallStack), so an accessor that asserted on the
+// payload without first checking v.Type would hand an embedder the live
+// storage of an ordinary lisp value.  Those tests are what fails if the
+// type gate is ever removed or reordered after the assertion; each one
+// first proves the internal payload really is present, so a false from
+// NativeValue is the gate refusing it rather than an assertion that had
+// nothing to match.
+
+// nativeTestEnv returns an initialized environment with a reader, so that
+// LoadString can parse and evaluate program text.
+func nativeTestEnv(t testing.TB) *lisp.LEnv {
+	t.Helper()
+	return newCowTestEnv(t)
+}
+
+// handle is a stateful payload of the shape embedders actually store: an
+// opaque Go object reached through a pointer.
+type handle struct {
+	name string
+	seq  int
+}
+
+// String makes *handle an fmt.Stringer, for the interface-type-parameter
+// case.
+func (h *handle) String() string { return fmt.Sprintf("handle(%s/%d)", h.name, h.seq) }
+
+// point is a value-type payload: stored by copy, not by reference.
+type point struct {
+	X, Y int
+}
+
+// other is an unrelated payload type, for the wrong-type case.
+type other struct {
+	id string
+}
+
+// TestNativeValueRoundTripsPointer stores a pointer payload with Native and
+// reads back the SAME instance, not an equal copy.
+func TestNativeValueRoundTripsPointer(t *testing.T) {
+	h := &handle{name: "conn", seq: 7}
+	v := lisp.Native(h)
+	got, ok := lisp.NativeValue[*handle](v)
+	if !ok {
+		t.Fatalf("NativeValue[*handle] returned ok=false for %v", v)
+	}
+	if got != h {
+		t.Errorf("NativeValue returned %p, want the stored instance %p", got, h)
+	}
+	// Identity, not equality: a mutation through the retrieved pointer is
+	// visible through the original.
+	got.seq = 8
+	if h.seq != 8 {
+		t.Errorf("retrieved value is a copy: h.seq = %d, want 8", h.seq)
+	}
+}
+
+// TestNativeValueRoundTripsThroughNativeOf is the same round trip with the
+// typed constructor at the write end.  NativeOf must produce a value
+// NativeValue accepts on identical terms.
+func TestNativeValueRoundTripsThroughNativeOf(t *testing.T) {
+	h := &handle{name: "conn", seq: 1}
+	v := lisp.NativeOf[*handle](h)
+	if v.Type != lisp.LNative {
+		t.Fatalf("NativeOf produced type %v, want %v", v.Type, lisp.LNative)
+	}
+	got, ok := lisp.NativeValue[*handle](v)
+	if !ok {
+		t.Fatalf("NativeValue[*handle] returned ok=false for a NativeOf value")
+	}
+	if got != h {
+		t.Errorf("NativeValue returned %p, want the stored instance %p", got, h)
+	}
+}
+
+// TestNativeValueRoundTripsValueType covers a non-pointer struct payload,
+// which travels by copy.  The retrieved value must equal what was stored.
+func TestNativeValueRoundTripsValueType(t *testing.T) {
+	p := point{X: 3, Y: 4}
+	got, ok := lisp.NativeValue[point](lisp.NativeOf(p))
+	if !ok {
+		t.Fatalf("NativeValue[point] returned ok=false")
+	}
+	if got != p {
+		t.Errorf("NativeValue returned %+v, want %+v", got, p)
+	}
+	// Asking for the pointer type when a value was stored is a different
+	// type and must not match.
+	if _, ok := lisp.NativeValue[*point](lisp.NativeOf(p)); ok {
+		t.Error("NativeValue[*point] matched a payload stored as point")
+	}
+}
+
+// TestNativeValueThroughInterface asserts T may be an interface: a payload
+// stored as a concrete type is retrievable through any interface it
+// implements, because the third gate is an ordinary type assertion.
+func TestNativeValueThroughInterface(t *testing.T) {
+	h := &handle{name: "iface", seq: 2}
+	v := lisp.NativeOf[*handle](h)
+	s, ok := lisp.NativeValue[fmt.Stringer](v)
+	if !ok {
+		t.Fatalf("NativeValue[fmt.Stringer] returned ok=false for a *handle payload")
+	}
+	if s.String() != h.String() {
+		t.Errorf("Stringer returned %q, want %q", s.String(), h.String())
+	}
+	// `any` is the way to ask "is there a payload at all".
+	if _, ok := lisp.NativeValue[any](v); !ok {
+		t.Error("NativeValue[any] returned ok=false for a non-nil payload")
+	}
+}
+
+// TestNativeValueWrongType asks for a type the payload is not, and requires
+// both a false and a zero value — a caller that ignores ok must not get
+// something usable.
+func TestNativeValueWrongType(t *testing.T) {
+	v := lisp.NativeOf[*handle](&handle{name: "conn"})
+	got, ok := lisp.NativeValue[*other](v)
+	if ok {
+		t.Error("NativeValue[*other] matched a *handle payload")
+	}
+	if got != nil {
+		t.Errorf("NativeValue returned %v on failure, want the zero value", got)
+	}
+	gotVal, ok := lisp.NativeValue[point](v)
+	if ok {
+		t.Error("NativeValue[point] matched a *handle payload")
+	}
+	if gotVal != (point{}) {
+		t.Errorf("NativeValue returned %+v on failure, want the zero value", gotVal)
+	}
+	// The other direction, so the test cannot pass by refusing everything:
+	// the same two type parameters against a payload of the other type.
+	w := lisp.NativeOf[*other](&other{id: "xyz"})
+	if _, ok := lisp.NativeValue[*handle](w); ok {
+		t.Error("NativeValue[*handle] matched an *other payload")
+	}
+	o, ok := lisp.NativeValue[*other](w)
+	if !ok {
+		t.Fatal("NativeValue[*other] returned ok=false for an *other payload")
+	}
+	if o.id != "xyz" {
+		t.Errorf("retrieved payload has id %q, want %q", o.id, "xyz")
+	}
+}
+
+// TestNativeValueNilLVal covers the first gate.  A nil *LVal reaches this
+// accessor whenever a caller forwards an un-checked result, and it must
+// answer false rather than panic.
+func TestNativeValueNilLVal(t *testing.T) {
+	got, ok := lisp.NativeValue[*handle](nil)
+	if ok {
+		t.Error("NativeValue returned ok=true for a nil *LVal")
+	}
+	if got != nil {
+		t.Errorf("NativeValue returned %v for a nil *LVal, want nil", got)
+	}
+	if _, ok := lisp.NativeValue[any](nil); ok {
+		t.Error("NativeValue[any] returned ok=true for a nil *LVal")
+	}
+}
+
+// TestNativeValueNilPayload covers an LNative whose payload is nil.  The
+// LVal passes the first two gates; the assertion is what refuses it,
+// including for T = any, because a type assertion on a nil interface never
+// succeeds.
+func TestNativeValueNilPayload(t *testing.T) {
+	v := lisp.Native(nil)
+	if v.Type != lisp.LNative {
+		t.Fatalf("Native(nil) produced type %v, want %v", v.Type, lisp.LNative)
+	}
+	if _, ok := lisp.NativeValue[any](v); ok {
+		t.Error("NativeValue[any] returned ok=true for a nil payload")
+	}
+	got, ok := lisp.NativeValue[*handle](v)
+	if ok {
+		t.Error("NativeValue[*handle] returned ok=true for a nil payload")
+	}
+	if got != nil {
+		t.Errorf("NativeValue returned %v for a nil payload, want nil", got)
+	}
+}
+
+// TestNativeValueRefusesInternalStorage is the reason the type gate runs
+// before the payload assertion (issue #546).  Each subtest builds a real
+// lisp value of a type whose backing the interpreter keeps in LVal.Native,
+// proves the payload is there, and then requires NativeValue to refuse it.
+//
+// Removing the v.Type == LNative gate makes every subtest here fail: the
+// assertions all succeed on the raw payload, which is exactly the leak —
+// an embedder holding a lisp bytes value's *[]byte, a sorted map's
+// *MapData, or an error's *CallStack can write through it and corrupt a
+// live value past the kernel's ownership and seal invariants.
+func TestNativeValueRefusesInternalStorage(t *testing.T) {
+	t.Run("LBytes backing", func(t *testing.T) {
+		for _, v := range []*lisp.LVal{
+			lisp.Bytes([]byte("ABCD")),
+			mustEvalNative(t, `(to-bytes "ABCD")`),
+		} {
+			if v.Type != lisp.LBytes {
+				t.Fatalf("value has type %v, want %v", v.Type, lisp.LBytes)
+			}
+			// Positive control: the *[]byte really is in Native, so a
+			// false below is the gate and not an empty payload.
+			if got := string(v.Bytes()); got != "ABCD" {
+				t.Fatalf("bytes payload is %q, want %q", got, "ABCD")
+			}
+			b, ok := lisp.NativeValue[*[]byte](v)
+			if ok {
+				t.Errorf("NativeValue[*[]byte] exposed the backing of a lisp bytes value: %q", string(*b))
+			}
+			if b != nil {
+				t.Errorf("NativeValue returned %v for a bytes value, want nil", b)
+			}
+			// The same leak asked for through `any`.
+			if x, ok := lisp.NativeValue[any](v); ok {
+				t.Errorf("NativeValue[any] exposed a bytes value's payload: %T", x)
+			}
+		}
+	})
+
+	t.Run("LSortMap backing", func(t *testing.T) {
+		for _, v := range []*lisp.LVal{
+			lisp.SortedMap(),
+			mustEvalNative(t, `(sorted-map "k" 1)`),
+		} {
+			if v.Type != lisp.LSortMap {
+				t.Fatalf("value has type %v, want %v", v.Type, lisp.LSortMap)
+			}
+			// Positive control: the *MapData really is in Native.
+			if v.Map() == nil {
+				t.Fatal("sorted-map has no MapData payload")
+			}
+			md, ok := lisp.NativeValue[*lisp.MapData](v)
+			if ok {
+				t.Error("NativeValue[*lisp.MapData] exposed the backing of a lisp sorted-map")
+			}
+			if md != nil {
+				t.Errorf("NativeValue returned %v for a sorted-map, want nil", md)
+			}
+			if x, ok := lisp.NativeValue[any](v); ok {
+				t.Errorf("NativeValue[any] exposed a sorted-map's payload: %T", x)
+			}
+		}
+	})
+
+	t.Run("LError call stack", func(t *testing.T) {
+		env := nativeTestEnv(t)
+		v := env.LoadString("native_test.lisp", `(car 1)`)
+		if v.Type != lisp.LError {
+			t.Fatalf("evaluating (car 1) produced %v, want an error", v.Type)
+		}
+		// Positive control: the *CallStack really is in Native.  It is
+		// also what IsInternalPanic keys off, so handing it out lets an
+		// embedder forge the interpreter's own panic marker.
+		if v.CallStack() == nil {
+			t.Fatal("error value carries no call stack")
+		}
+		stack, ok := lisp.NativeValue[*lisp.CallStack](v)
+		if ok {
+			t.Error("NativeValue[*lisp.CallStack] exposed a lisp error's call stack")
+		}
+		if stack != nil {
+			t.Errorf("NativeValue returned %v for an error value, want nil", stack)
+		}
+		if x, ok := lisp.NativeValue[any](v); ok {
+			t.Errorf("NativeValue[any] exposed an error value's payload: %T", x)
+		}
+	})
+}
+
+// TestNativeValueGatesOnLValTypeNotPayloadType is the other half of the
+// contract.  The gate refuses the interpreter's storage, not a Go type: an
+// embedder who stores a *[]byte of their own gets it back, because that
+// value is an LNative and the slice is theirs.
+func TestNativeValueGatesOnLValTypeNotPayloadType(t *testing.T) {
+	b := []byte("mine")
+	v := lisp.Native(&b)
+	got, ok := lisp.NativeValue[*[]byte](v)
+	if !ok {
+		t.Fatalf("NativeValue[*[]byte] refused an embedder's own *[]byte in an LNative")
+	}
+	if got != &b {
+		t.Fatalf("NativeValue returned %p, want the stored instance %p", got, &b)
+	}
+	// It is the caller's own slice, so writing through it is theirs to do.
+	(*got)[0] = 'M'
+	if string(b) != "Mine" {
+		t.Errorf("write through the retrieved pointer did not reach the original: %q", string(b))
+	}
+	// Same payload type stored via NativeOf.
+	if _, ok := lisp.NativeValue[*[]byte](lisp.NativeOf(&b)); !ok {
+		t.Error("NativeValue[*[]byte] refused a NativeOf-stored *[]byte")
+	}
+	// And an embedder's own *MapData in an LNative is likewise theirs.
+	md := lisp.NewMapData(nil)
+	if _, ok := lisp.NativeValue[*lisp.MapData](lisp.NativeOf(md)); !ok {
+		t.Error("NativeValue[*lisp.MapData] refused an embedder's own MapData in an LNative")
+	}
+}
+
+// mustEvalNative evaluates src in a fresh environment and fails the test on
+// an error result.  It exists so the internal-storage tests can build their
+// subjects the way lisp programs do, not only through the Go constructors.
+func mustEvalNative(t *testing.T, src string) *lisp.LVal {
+	t.Helper()
+	env := nativeTestEnv(t)
+	v := env.LoadString("native_test.lisp", src)
+	if v.Type == lisp.LError {
+		t.Fatalf("eval %q: %v", src, v)
+	}
+	return v
+}

--- a/lisp/native_test.go
+++ b/lisp/native_test.go
@@ -3,6 +3,7 @@
 package lisp_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -10,8 +11,9 @@ import (
 )
 
 // These tests cover the checked native accessors of issue #546:
-// NativeValue, which reads an LNative's Go payload as a T, and NativeOf,
-// its typed constructor counterpart.
+// NativeValue, which reads an LNative's Go payload as a T, RequireNative,
+// which is NativeValue with the failure rendered as an LError, and NativeOf,
+// the typed constructor counterpart.
 //
 // Two properties are under test, and they are not equally interesting.
 // The round-trip ones (1-7 below) say the accessor is usable: pointers,
@@ -318,6 +320,214 @@ func TestNativeValueGatesOnLValTypeNotPayloadType(t *testing.T) {
 	md := lisp.NewMapData(nil)
 	if _, ok := lisp.NativeValue[*lisp.MapData](lisp.NativeOf(md)); !ok {
 		t.Error("NativeValue[*lisp.MapData] refused an embedder's own MapData in an LNative")
+	}
+}
+
+// RequireNative shares NativeValue's three gates and adds only the failure
+// message, so the tests below pin the messages in full.  A substring match
+// would pass on a message that named the wrong gate or omitted the expected
+// type, which is the whole content of the addition.
+//
+// Message renderings are reflect's, not fmt's %T: an unexported type in this
+// package renders as *lisp_test.handle, and []byte renders through its
+// element's underlying name as []uint8.
+
+// requireNativeErrorMessage asserts lerr is an LError and returns its bare
+// message, without the source-location prefix Error() adds.
+func requireNativeErrorMessage(t *testing.T, lerr *lisp.LVal) string {
+	t.Helper()
+	if lerr == nil {
+		t.Fatal("RequireNative returned a nil error on a failing call")
+	}
+	if lerr.Type != lisp.LError {
+		t.Fatalf("RequireNative returned type %v, want %v", lerr.Type, lisp.LError)
+	}
+	var ev *lisp.ErrorVal
+	if !errors.As(lisp.GoError(lerr), &ev) {
+		t.Fatalf("RequireNative error does not convert to *ErrorVal: %v", lerr)
+	}
+	return ev.ErrorMessage()
+}
+
+// TestRequireNativeSuccess is the nil-on-success half of the contract: a
+// matching payload comes back with a nil second return, through both
+// constructors.
+func TestRequireNativeSuccess(t *testing.T) {
+	h := &handle{name: "conn", seq: 7}
+	for _, v := range []*lisp.LVal{lisp.Native(h), lisp.NativeOf[*handle](h)} {
+		got, lerr := lisp.RequireNative[*handle](v)
+		if lerr != nil {
+			t.Fatalf("RequireNative[*handle] failed on a *handle payload: %v", lerr)
+		}
+		if got != h {
+			t.Errorf("RequireNative returned %p, want the stored instance %p", got, h)
+		}
+	}
+	// A value type travels by copy, as with NativeValue.
+	p := point{X: 3, Y: 4}
+	gotVal, lerr := lisp.RequireNative[point](lisp.NativeOf(p))
+	if lerr != nil {
+		t.Fatalf("RequireNative[point] failed on a point payload: %v", lerr)
+	}
+	if gotVal != p {
+		t.Errorf("RequireNative returned %+v, want %+v", gotVal, p)
+	}
+}
+
+// TestRequireNativeThroughInterface asserts an interface type parameter
+// reaches a payload stored as a concrete type, since the gate it inherits is
+// an ordinary type assertion.
+func TestRequireNativeThroughInterface(t *testing.T) {
+	h := &handle{name: "iface", seq: 2}
+	s, lerr := lisp.RequireNative[fmt.Stringer](lisp.NativeOf[*handle](h))
+	if lerr != nil {
+		t.Fatalf("RequireNative[fmt.Stringer] failed on a *handle payload: %v", lerr)
+	}
+	if s.String() != h.String() {
+		t.Errorf("Stringer returned %q, want %q", s.String(), h.String())
+	}
+	// The message for an interface T names the interface.  This is what a
+	// %T verb over the zero T cannot do: it renders <nil>.
+	_, lerr = lisp.RequireNative[fmt.Stringer](nil)
+	if msg := requireNativeErrorMessage(t, lerr); msg != "expected native fmt.Stringer value, got nil" {
+		t.Errorf("message = %q, want the interface named", msg)
+	}
+}
+
+// TestRequireNativeNilLVal covers the first gate.  A nil *LVal reaches this
+// accessor whenever a caller forwards an un-checked result.
+func TestRequireNativeNilLVal(t *testing.T) {
+	got, lerr := lisp.RequireNative[*handle](nil)
+	if msg := requireNativeErrorMessage(t, lerr); msg != "expected native *lisp_test.handle value, got nil" {
+		t.Errorf("message = %q", msg)
+	}
+	if got != nil {
+		t.Errorf("RequireNative returned %v on failure, want the zero value", got)
+	}
+	gotVal, lerr := lisp.RequireNative[point](nil)
+	if msg := requireNativeErrorMessage(t, lerr); msg != "expected native lisp_test.point value, got nil" {
+		t.Errorf("message = %q", msg)
+	}
+	if gotVal != (point{}) {
+		t.Errorf("RequireNative returned %+v on failure, want the zero value", gotVal)
+	}
+}
+
+// TestRequireNativeRefusesInternalStorage is the load-bearing case.  Each
+// subject is a real lisp value whose backing the interpreter keeps in
+// LVal.Native, and each is refused by the SECOND gate — so the message names
+// the lisp type found, and the payload never leaves.  An implementation that
+// asserted on v.Native without checking v.Type would return the interpreter's
+// live storage here with a nil error.
+func TestRequireNativeRefusesInternalStorage(t *testing.T) {
+	t.Run("LBytes backing", func(t *testing.T) {
+		for _, v := range []*lisp.LVal{
+			lisp.Bytes([]byte("ABCD")),
+			mustEvalNative(t, `(to-bytes "ABCD")`),
+		} {
+			// Positive control: the *[]byte really is in Native, so the
+			// failure below is the gate and not an empty payload.
+			if got := string(v.Bytes()); got != "ABCD" {
+				t.Fatalf("bytes payload is %q, want %q", got, "ABCD")
+			}
+			b, lerr := lisp.RequireNative[*[]byte](v)
+			if b != nil {
+				t.Errorf("RequireNative[*[]byte] exposed the backing of a lisp bytes value: %q", string(*b))
+			}
+			if msg := requireNativeErrorMessage(t, lerr); msg != "expected native *[]uint8 value, got bytes" {
+				t.Errorf("message = %q", msg)
+			}
+			// The same leak asked for through `any`.
+			x, lerr := lisp.RequireNative[any](v)
+			if x != nil {
+				t.Errorf("RequireNative[any] exposed a bytes value's payload: %T", x)
+			}
+			if msg := requireNativeErrorMessage(t, lerr); msg != "expected native interface {} value, got bytes" {
+				t.Errorf("message = %q", msg)
+			}
+		}
+	})
+
+	t.Run("LSortMap backing", func(t *testing.T) {
+		v := mustEvalNative(t, `(sorted-map "k" 1)`)
+		if v.Map() == nil {
+			t.Fatal("sorted-map has no MapData payload")
+		}
+		md, lerr := lisp.RequireNative[*lisp.MapData](v)
+		if md != nil {
+			t.Error("RequireNative[*lisp.MapData] exposed the backing of a lisp sorted-map")
+		}
+		if msg := requireNativeErrorMessage(t, lerr); msg != "expected native *lisp.MapData value, got sorted-map" {
+			t.Errorf("message = %q", msg)
+		}
+	})
+
+	t.Run("LError call stack", func(t *testing.T) {
+		env := nativeTestEnv(t)
+		v := env.LoadString("native_test.lisp", `(car 1)`)
+		if v.Type != lisp.LError {
+			t.Fatalf("evaluating (car 1) produced %v, want an error", v.Type)
+		}
+		// Positive control: the *CallStack really is in Native.  It is also
+		// what IsInternalPanic keys off.
+		if v.CallStack() == nil {
+			t.Fatal("error value carries no call stack")
+		}
+		stack, lerr := lisp.RequireNative[*lisp.CallStack](v)
+		if stack != nil {
+			t.Error("RequireNative[*lisp.CallStack] exposed a lisp error's call stack")
+		}
+		if msg := requireNativeErrorMessage(t, lerr); msg != "expected native *lisp.CallStack value, got error" {
+			t.Errorf("message = %q", msg)
+		}
+	})
+}
+
+// TestRequireNativeWrongPayloadType covers the third gate: the LVal is an
+// LNative, so the message names both the type asked for and the type stored.
+func TestRequireNativeWrongPayloadType(t *testing.T) {
+	v := lisp.NativeOf[*handle](&handle{name: "conn"})
+	got, lerr := lisp.RequireNative[*other](v)
+	if got != nil {
+		t.Errorf("RequireNative returned %v on failure, want the zero value", got)
+	}
+	if msg := requireNativeErrorMessage(t, lerr); msg != "expected native *lisp_test.other value, got native *lisp_test.handle" {
+		t.Errorf("message = %q", msg)
+	}
+	// The other direction, so the test cannot pass by refusing everything.
+	w := lisp.NativeOf[*other](&other{id: "xyz"})
+	o, lerr := lisp.RequireNative[*other](w)
+	if lerr != nil {
+		t.Fatalf("RequireNative[*other] failed on an *other payload: %v", lerr)
+	}
+	if o.id != "xyz" {
+		t.Errorf("retrieved payload has id %q, want %q", o.id, "xyz")
+	}
+	// An embedder's own *[]byte in an LNative is theirs, and reaching it is
+	// not a wrong-payload failure: the gate is on the LVal's type.
+	b := []byte("mine")
+	if _, lerr := lisp.RequireNative[*[]byte](lisp.Native(&b)); lerr != nil {
+		t.Errorf("RequireNative[*[]byte] refused an embedder's own *[]byte in an LNative: %v", lerr)
+	}
+}
+
+// TestRequireNativeNilPayload covers an LNative carrying nothing.  It passes
+// the first two gates and fails the assertion, including for T = any, so the
+// message is the third one with a <nil> payload type.
+func TestRequireNativeNilPayload(t *testing.T) {
+	v := lisp.Native(nil)
+	if v.Type != lisp.LNative {
+		t.Fatalf("Native(nil) produced type %v, want %v", v.Type, lisp.LNative)
+	}
+	got, lerr := lisp.RequireNative[*handle](v)
+	if got != nil {
+		t.Errorf("RequireNative returned %v for a nil payload, want nil", got)
+	}
+	if msg := requireNativeErrorMessage(t, lerr); msg != "expected native *lisp_test.handle value, got native <nil>" {
+		t.Errorf("message = %q", msg)
+	}
+	if _, lerr := lisp.RequireNative[any](v); lerr == nil {
+		t.Error("RequireNative[any] succeeded on a nil payload")
 	}
 }
 

--- a/lisp/ownership_check_default.go
+++ b/lisp/ownership_check_default.go
@@ -21,6 +21,13 @@ func checkOwnership(_ *Runtime, _ *LVal) {}
 // time) and at every payload a fork resolves (fork time).
 func checkNativeAffinity(_ *Runtime, _ interface{}) {}
 
+// checkDetachedNativeUnbound is a zero-cost no-op in production builds.  In
+// the elpscheck build it asserts that a clone minted by a strict detach —
+// the sanctioned cross-runtime transfer — is unbound: CloneNative cannot
+// know the destination Runtime, so a detached clone that still reports a
+// binding (RuntimeBound, lisp/runtime_bound.go) panics.
+func checkDetachedNativeUnbound(_ interface{}) {}
+
 // rethrowOwnershipViolation is a no-op in production builds.  In the
 // elpscheck build it re-panics ownership violations inside env.eval's
 // recover() so they stay hard panics instead of becoming catchable LError

--- a/lisp/ownership_check_default.go
+++ b/lisp/ownership_check_default.go
@@ -12,6 +12,15 @@ package lisp
 // the honest list of what it does and does not catch.
 func checkOwnership(_ *Runtime, _ *LVal) {}
 
+// checkNativeAffinity is a zero-cost no-op in production builds — a native
+// payload's declared runtime binding is never consulted here, so
+// implementing RuntimeBound costs a production build nothing.  In the
+// elpscheck build it asserts that binding: a payload implementing
+// RuntimeBound (lisp/runtime_bound.go) that names a Runtime other than the
+// one using it panics, at the ownership checker's instrumented points (use
+// time) and at every payload a fork resolves (fork time).
+func checkNativeAffinity(_ *Runtime, _ interface{}) {}
+
 // rethrowOwnershipViolation is a no-op in production builds.  In the
 // elpscheck build it re-panics ownership violations inside env.eval's
 // recover() so they stay hard panics instead of becoming catchable LError

--- a/lisp/ownership_check_elpscheck.go
+++ b/lisp/ownership_check_elpscheck.go
@@ -178,6 +178,28 @@ import (
 // or file it like #363) or a deliberate design (document it HERE, with
 // the reasoning, so the next reader knows which it was).
 //
+// # Declared affinity
+//
+// A second, narrower rule rides on this file's machinery: a native payload
+// may DECLARE which Runtime it belongs to (RuntimeBound,
+// lisp/runtime_bound.go), and checkNativeAffinity asserts the declaration.
+// No adoption table is involved and no allowlist entry can apply, because
+// there is nothing to infer and nothing to sanction — the payload carries
+// its own truth, and a payload that answers nil is simply unchecked.  It is
+// the type-level replacement for an embedder's load-time probe over the
+// natives a loaded environment happens to hold (issue #546).
+//
+// The rule is enforced at the same instrumented points as ownership, and is
+// therefore shallow in the same way: checkOwnership examines the payload of
+// an LNative value crossing Put/PutGlobal/eval and never the payloads of
+// natives riding inside its Cells.  The deep half is at FORK time, where
+// the fork walker visits every reachable native payload whatever container
+// it rides in, and checks whichever payload its replacer/NativeCloner/share
+// policy resolved (lisp/fork.go, forker.native).  A violation raises the
+// same ownershipViolation panic value as the ownership rule, for the same
+// reason: an affinity bug found in a checked build must stop the test, not
+// become a catchable LError.
+//
 // # Memory
 //
 // The table grows with every distinct LVal the process touches.  Go has no
@@ -243,6 +265,13 @@ func checkOwnership(rt *Runtime, v *LVal) {
 	if v == nil || rt == nil || isSingleton(v) || (v.sealed && sealableNodeType(v.Type)) {
 		return
 	}
+	// Declared affinity (see the section of that name above).  Type-gated on
+	// the LVal so the interface assertion is only ever paid by real native
+	// handles — an LFun's *funData and the kernel's own internal payloads
+	// (*MapData, *CallStack, *[]byte) never reach it.
+	if v.Type == LNative {
+		checkNativeAffinity(rt, v.Native)
+	}
 	// See allowlist entry 3.  A builtin that captured no environment holds no
 	// mutable per-runtime state, and evaluation never writes it.
 	if isClosureFreeBuiltin(v) {
@@ -260,6 +289,30 @@ func checkOwnership(rt *Runtime, v *LVal) {
 		return
 	}
 	panic(ownershipViolation{msg: ownershipViolationMessage(owner.(*Runtime), rt, v)})
+}
+
+// checkNativeAffinity asserts a native payload's DECLARED runtime binding:
+// a payload implementing RuntimeBound (lisp/runtime_bound.go) may only be
+// used by the Runtime it names.  A payload that does not implement the
+// interface, or that reports nil (unbound), is unchecked — declaring is
+// opt-in and nil is the sanctioned "not bound to anything yet" answer.
+//
+// It is called from checkOwnership for LNative values (use time) and from
+// forker.native for every payload a fork resolves (fork time).  The panic
+// value is deliberately ownershipViolation, the same type the ownership
+// rule raises, so rethrowOwnershipViolation keeps it a hard panic through
+// env.eval's recover(): an affinity bug in a checked build must stop the
+// test, not be laundered into an LError that ignore-errors absorbs.
+func checkNativeAffinity(rt *Runtime, payload interface{}) {
+	b, ok := payload.(RuntimeBound)
+	if !ok {
+		return
+	}
+	bound := b.BoundRuntime()
+	if bound == nil || bound == rt {
+		return
+	}
+	panic(ownershipViolation{msg: affinityViolationMessage(bound, rt, payload)})
 }
 
 // rethrowOwnershipViolation re-panics when r is an ownership violation.
@@ -302,6 +355,25 @@ func ownershipViolationMessage(owner, second *Runtime, v *LVal) string {
 		v, v.Type, str, len(v.Cells), loc,
 		owner, runtimePackageName(owner),
 		second, runtimePackageName(second))
+}
+
+// affinityViolationMessage renders the panic message for a declared-affinity
+// violation: the payload's Go type and both runtime identities.  It
+// deliberately renders the payload with %T alone, for the same reason
+// ownershipViolationMessage avoids LVal.String() — rendering an arbitrary
+// embedder value inside a panic path is how one panic becomes two.  Even %p
+// is out: on a value-type payload fmt falls back to %!p(type=value), which
+// formats the value and so calls straight into an embedder String method.
+func affinityViolationMessage(bound, using *Runtime, payload interface{}) string {
+	return fmt.Sprintf("native affinity violation: payload used by a foreign Runtime\n"+
+		"  payload type: %T\n"+
+		"  bound runtime: %p (package %s)\n"+
+		"  using runtime: %p (package %s)\n"+
+		"a RuntimeBound native payload may only be used by the Runtime it declares;"+
+		" see lisp/runtime_bound.go",
+		payload,
+		bound, runtimePackageName(bound),
+		using, runtimePackageName(using))
 }
 
 func runtimePackageName(rt *Runtime) string {

--- a/lisp/ownership_check_elpscheck.go
+++ b/lisp/ownership_check_elpscheck.go
@@ -315,6 +315,35 @@ func checkNativeAffinity(rt *Runtime, payload interface{}) {
 	panic(ownershipViolation{msg: affinityViolationMessage(bound, rt, payload)})
 }
 
+// checkDetachedNativeUnbound asserts that a clone minted for a strict
+// detach carries no runtime binding.  detach is the sanctioned way to move
+// a value BETWEEN Runtimes, and CloneNative has no way to know the
+// destination, so unbound is the only answer a detached clone can give:
+// one still bound anywhere — most likely to the source, the exact tether
+// the transfer exists to sever — is the same bug class the fork-time check
+// catches, surfacing at the one other point where the kernel manufactures
+// a cross-runtime clone.  Without this, a binding-retaining clone rides
+// into the destination inside a container, below what the shallow use-time
+// check can see.  The panic value is ownershipViolation for the usual
+// reason: hard panic, never a catchable LError.
+func checkDetachedNativeUnbound(payload interface{}) {
+	b, ok := payload.(RuntimeBound)
+	if !ok {
+		return
+	}
+	bound := b.BoundRuntime()
+	if bound == nil {
+		return
+	}
+	panic(ownershipViolation{msg: fmt.Sprintf(
+		"native affinity violation: detached clone retains a runtime binding\n"+
+			"  payload type: %T\n"+
+			"  bound runtime: %p (package %s)\n"+
+			"a clone produced for detach must be unbound - CloneNative cannot know the"+
+			" destination runtime; see lisp/runtime_bound.go",
+		payload, bound, runtimePackageName(bound))})
+}
+
 // rethrowOwnershipViolation re-panics when r is an ownership violation.
 // env.eval's recover() calls it first so the violation stays a hard panic
 // instead of becoming a CondInternalPanic LError — an ownership bug found

--- a/lisp/runtime_bound.go
+++ b/lisp/runtime_bound.go
@@ -32,6 +32,14 @@ package lisp
 //     from the template, whatever container it rides in, and checks each
 //     one against the fork's runtime.  That is the deep half, and it is
 //     what covers the natives use-time checking cannot see.
+//   - DETACH TIME — a strict detach is the kernel's other sanctioned
+//     cross-runtime transfer, and it clones a native through the same
+//     NativeCloner protocol.  CloneNative has no way to know the
+//     destination, so the one answer a detached clone can rightly give is
+//     unbound; a clone that retains any binding panics at the detach.
+//     (The lisp `copy` builtin uses the same walker within one runtime and
+//     is exempt: a copy's clone staying bound to the copy's own runtime is
+//     correct.)
 //
 // # Forking
 //

--- a/lisp/runtime_bound.go
+++ b/lisp/runtime_bound.go
@@ -1,0 +1,74 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+// RuntimeBound is the opt-in runtime-affinity protocol for native payloads
+// (issue #546).  Some native payloads are only meaningful inside the
+// Runtime they were built for — a handle onto that runtime's storage, a
+// cache keyed by its package registry, an accumulator whose contents only
+// mean anything to one environment tree.  Such a payload declares the
+// binding here, and checked builds assert it is never used from a foreign
+// Runtime.
+//
+// BoundRuntime returns the Runtime the payload is affined to, or nil while
+// the payload is UNBOUND.  A nil return disables all checking for that
+// payload, which is what lets a type whose instances are sometimes bound
+// and sometimes free — a pooled buffer before checkout, a clone minted for
+// a fork it has not been handed to yet — answer with what is true at the
+// moment it is asked instead of lying in one direction or the other.
+//
+// Declaring the interface costs nothing.  This file compiles into every
+// build, but no production build ever calls BoundRuntime: enforcement lives
+// entirely behind `-tags elpscheck`, where there are two points.
+//
+//   - USE TIME — the ownership checker's instrumented points (LEnv.Put,
+//     LEnv.PutGlobal, and entry to env.eval).  Every LNative value crossing
+//     one of them has its payload checked against that environment's
+//     Runtime.  This inherits the checker's documented SHALLOWNESS (see
+//     lisp/ownership_check_elpscheck.go): only the *LVal that actually
+//     crosses the point is examined, never its Cells, so a native riding
+//     inside a list or a sorted map is invisible here.
+//   - FORK TIME — the fork walker visits every native payload reachable
+//     from the template, whatever container it rides in, and checks each
+//     one against the fork's runtime.  That is the deep half, and it is
+//     what covers the natives use-time checking cannot see.
+//
+// # Forking
+//
+// A fork lands on a DIFFERENT Runtime.  That is not incidental, it is
+// Fork's whole purpose and the concurrency contract the Runtime doc comment
+// states.  So a bound payload that reaches a fork by the default
+// share-by-reference policy IS a violation, and it is caught at fork time
+// rather than later, inside the fork, when some request finally touches the
+// template's handle.  Failing at the fork is the point: the fork is where
+// the mistake was made and where the stack still names the culprit.
+//
+// A bound payload type that wants to survive forking implements
+// NativeCloner (or the embedder substitutes it per fork with
+// ForkWithNativeReplacer) and returns a clone that is unbound, or bound to
+// the destination.  A clone that copies the template's binding still trips
+// the fork-time check, deliberately: such a clone is independent in its
+// bytes yet still tethered to the runtime it came from, which is exactly
+// what NativeCloner's own contract already forbids — a clone must retain no
+// reference into the Runtime or LEnv tree the receiver lives in.
+//
+// # What this closes
+//
+// This is the type-level replacement for a load-time dynamic probe: an
+// embedder walking a loaded environment and asking each native whether it
+// reads runtime state out of a context.  A probe answers only for the
+// natives that exist on the day it runs, and only for the ones whose state
+// reads take the shape it recognizes.  A declared binding answers for two
+// cases it cannot:
+//
+//   - A NEW builtin that captures runtime state and forgets to declare it.
+//     A probe cannot flag what it never saw; the affinity check catches the
+//     payload the first time it crosses a runtime boundary, in whatever
+//     test happens to fork or share it.
+//   - A mutable native that never touches the context at all — a cache, a
+//     counter, a pooled buffer.  There is no context read to probe for, yet
+//     the payload is just as unsafe to share, and declaring the binding
+//     says so directly instead of leaving it to be inferred.
+type RuntimeBound interface {
+	BoundRuntime() *Runtime
+}

--- a/lisp/runtime_bound_elpscheck_test.go
+++ b/lisp/runtime_bound_elpscheck_test.go
@@ -196,6 +196,100 @@ func TestRuntimeBound_ForkAcceptsRebindingClone(t *testing.T) {
 	}
 }
 
+// stickyNative is the bug class the detach-time check exists to catch: its
+// CloneNative COPIES the receiver's binding, so every clone stays tethered
+// to the runtime it came from.  Fork already rejects such a clone; detach
+// must too.
+type stickyNative struct {
+	rt *Runtime
+}
+
+func (b *stickyNative) BoundRuntime() *Runtime { return b.rt }
+
+func (b *stickyNative) CloneNative() interface{} { return &stickyNative{rt: b.rt} }
+
+// TestRuntimeBound_DetachRejectsBindingRetainingClone: a strict detach is a
+// cross-runtime transfer, and CloneNative cannot know the destination, so a
+// detached clone that retains a binding is a violation however deep the
+// native rides — here inside a list, below what any use-time check sees.
+func TestRuntimeBound_DetachRejectsBindingRetainingClone(t *testing.T) {
+	env := newForkTestEnv(t)
+	payload := &stickyNative{rt: env.Runtime}
+	orig := QExpr([]*LVal{Native(payload)})
+
+	// Not expectAffinityPanic: a detach violation names only the bound
+	// runtime, deliberately — there is no destination runtime to print.
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected a native-affinity panic, got none — the gate cannot fail")
+		}
+		v, ok := r.(ownershipViolation)
+		if !ok {
+			t.Fatalf("expected panic value of type ownershipViolation, got %T: %v", r, r)
+		}
+		if !strings.Contains(v.msg, "detached clone retains a runtime binding") ||
+			!strings.Contains(v.msg, "bound runtime") ||
+			!strings.Contains(v.msg, "stickyNative") {
+			t.Fatalf("panic message should name the retained binding and payload type; got:\n%s", v.msg)
+		}
+	}()
+	if _, err := orig.detach(); err != nil {
+		t.Fatalf("detach returned an error instead of panicking: %v", err)
+	}
+}
+
+// TestRuntimeBound_DetachAcceptsUnbindingClone is the sanctioned shape: a
+// clone that arrives unbound detaches cleanly, carrying no tether for the
+// destination to trip over.
+func TestRuntimeBound_DetachAcceptsUnbindingClone(t *testing.T) {
+	env := newForkTestEnv(t)
+	payload := &rebindingNative{rt: env.Runtime}
+
+	cp, err := Native(payload).detach()
+	if err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+	clone, ok := cp.Native.(*rebindingNative)
+	if !ok {
+		t.Fatalf("detached payload has type %T, want *rebindingNative", cp.Native)
+	}
+	if clone == payload {
+		t.Fatal("detach shared the template's payload; CloneNative was not honored")
+	}
+	if clone.BoundRuntime() != nil {
+		t.Fatalf("detached clone carries a binding to %p; it must arrive unbound", clone.BoundRuntime())
+	}
+	if payload.BoundRuntime() != env.Runtime {
+		t.Fatal("detach mutated the original payload's binding")
+	}
+}
+
+// TestRuntimeBound_CopyKeepsBoundCloneUnchecked is the control that scopes
+// the detach-time rule to strict detach: the lisp `copy` builtin runs the
+// same walker WITHIN one runtime, where a clone keeping the copy's own
+// runtime binding is correct, so a binding-copying payload must deep-copy
+// without a panic.
+func TestRuntimeBound_CopyKeepsBoundCloneUnchecked(t *testing.T) {
+	env := newForkTestEnv(t)
+	payload := &stickyNative{rt: env.Runtime}
+
+	cp, err := Native(payload).deepCopy()
+	if err != nil {
+		t.Fatalf("deepCopy: %v", err)
+	}
+	clone, ok := cp.Native.(*stickyNative)
+	if !ok {
+		t.Fatalf("copied payload has type %T, want *stickyNative", cp.Native)
+	}
+	if clone == payload {
+		t.Fatal("deepCopy shared the payload; CloneNative was not honored")
+	}
+	if clone.BoundRuntime() != env.Runtime {
+		t.Fatal("the copy's clone lost its binding; within one runtime it should keep it")
+	}
+}
+
 // TestRuntimeBound_ForkChecksReplacerResult proves the fork-time check
 // applies to the RESOLVED payload whichever policy produced it.  The
 // template holds an unbound payload — a plain fork of it succeeds, which is

--- a/lisp/runtime_bound_elpscheck_test.go
+++ b/lisp/runtime_bound_elpscheck_test.go
@@ -1,0 +1,228 @@
+// Copyright © 2026 The ELPS authors
+
+//go:build elpscheck
+
+package lisp
+
+import (
+	"strings"
+	"testing"
+)
+
+// Declared runtime affinity for native payloads (issue #546).  RuntimeBound
+// is production code — it compiles into every build — but its enforcement
+// exists only under `-tags elpscheck`, which is why these tests are tagged.
+// They pin both directions at both enforcement points: the sanctioned uses
+// (same runtime, unbound payload, a clone that drops the binding) must pass
+// untouched, and the violations (a foreign use, a bound native shared into
+// a fork, a replacer handing one back) must panic.
+//
+// Conventions follow lisp/fork_ownership_elpscheck_test.go and
+// lisp/detach_ownership_elpscheck_test.go: package lisp, environments from
+// newForkTestEnv (a private Runtime each), panics captured by recover.
+
+// boundNative is a native payload declaring an affinity to one Runtime.  A
+// zero value is UNBOUND (nil Runtime), which is the protocol's "not tied to
+// anything yet" answer and disables checking for that instance.
+type boundNative struct {
+	rt *Runtime
+}
+
+func (b *boundNative) BoundRuntime() *Runtime { return b.rt }
+
+// rebindingNative is a bound payload that survives forking the sanctioned
+// way: it implements NativeCloner and its clone comes back UNBOUND, ready
+// for the destination runtime to claim.  A clone that copied b.rt would
+// trip the fork-time check exactly as a shared payload does.
+type rebindingNative struct {
+	rt *Runtime
+}
+
+func (b *rebindingNative) BoundRuntime() *Runtime { return b.rt }
+
+func (b *rebindingNative) CloneNative() interface{} { return &rebindingNative{} }
+
+// expectAffinityPanic runs fn and fails the test unless fn panics with an
+// ownershipViolation naming an affinity violation on a payload of the named
+// Go type.  The panic type matters as much as the message: affinity
+// violations reuse ownershipViolation so rethrowOwnershipViolation keeps
+// them hard panics through env.eval's recover().
+func expectAffinityPanic(t *testing.T, payloadType string, fn func()) {
+	t.Helper()
+	defer func() {
+		t.Helper()
+		r := recover()
+		if r == nil {
+			t.Fatal("expected a native-affinity panic, got none — the gate cannot fail")
+		}
+		v, ok := r.(ownershipViolation)
+		if !ok {
+			t.Fatalf("expected panic value of type ownershipViolation, got %T: %v", r, r)
+		}
+		if !strings.Contains(v.msg, "native affinity violation") ||
+			!strings.Contains(v.msg, "bound runtime") ||
+			!strings.Contains(v.msg, "using runtime") {
+			t.Fatalf("panic message should identify both runtimes; got:\n%s", v.msg)
+		}
+		if !strings.Contains(v.msg, payloadType) {
+			t.Fatalf("panic message should name the payload type %q; got:\n%s", payloadType, v.msg)
+		}
+	}()
+	fn()
+}
+
+// TestRuntimeBound_SameRuntimeUseIsAllowed is the baseline: a payload bound
+// to the environment's own Runtime is used through every instrumented point
+// (PutGlobal, the eval entry by symbol lookup, and eval of the native value
+// itself) and none of them may fire.
+func TestRuntimeBound_SameRuntimeUseIsAllowed(t *testing.T) {
+	env := newForkTestEnv(t)
+	payload := &boundNative{rt: env.Runtime}
+
+	if lerr := env.PutGlobal(Symbol("handle"), Native(payload)); lerr.Type == LError {
+		t.Fatalf("put bound native: %v", lerr)
+	}
+	res := env.Eval(Symbol("handle"))
+	if res.Type == LError {
+		t.Fatalf("read bound native: %v", res)
+	}
+	if res.Native != interface{}(payload) {
+		t.Fatalf("read back a different payload: %#v", res.Native)
+	}
+	if out := env.Eval(Native(payload)); out.Type == LError {
+		t.Fatalf("eval bound native: %v", out)
+	}
+}
+
+// TestRuntimeBound_UnboundPayloadCrossesFreely pins the nil answer: an
+// unbound payload is not checked at all, so two runtimes may hold it.  Each
+// runtime gets its own wrapper LVal — sharing one *LVal would be a genuine
+// ownership violation and would prove nothing about affinity.
+func TestRuntimeBound_UnboundPayloadCrossesFreely(t *testing.T) {
+	env1 := newForkTestEnv(t)
+	env2 := newForkTestEnv(t)
+	payload := &boundNative{} // unbound: BoundRuntime returns nil
+
+	if lerr := env1.PutGlobal(Symbol("handle"), Native(payload)); lerr.Type == LError {
+		t.Fatalf("put in runtime 1: %v", lerr)
+	}
+	if lerr := env2.PutGlobal(Symbol("handle"), Native(payload)); lerr.Type == LError {
+		t.Fatalf("put in runtime 2: %v", lerr)
+	}
+	if out := env2.Eval(Native(payload)); out.Type == LError {
+		t.Fatalf("eval in runtime 2: %v", out)
+	}
+}
+
+// TestRuntimeBound_ForeignUseAtPutTime is the use-time gate's load-bearing
+// test.  The payload is bound to runtime 1 and then bound into runtime 2
+// inside a FRESH lisp.Native wrapper: the per-*LVal ownership table has
+// never seen that wrapper, so it cannot fire, and the only mechanism left
+// that can produce a panic is the payload-level affinity check.
+func TestRuntimeBound_ForeignUseAtPutTime(t *testing.T) {
+	env1 := newForkTestEnv(t)
+	env2 := newForkTestEnv(t)
+	payload := &boundNative{rt: env1.Runtime}
+
+	if lerr := env1.PutGlobal(Symbol("handle"), Native(payload)); lerr.Type == LError {
+		t.Fatalf("put in the owning runtime: %v", lerr)
+	}
+	expectAffinityPanic(t, "boundNative", func() {
+		env2.PutGlobal(Symbol("handle"), Native(payload))
+	})
+}
+
+// TestRuntimeBound_ForkRejectsSharedBoundNative is the fork-time gate's
+// load-bearing test, and it is deliberately nested: the bound native lives
+// inside a sorted map, never at a binding's top level, so no use-time check
+// can ever see it (checkOwnership is shallow by design).  Only the fork
+// walker's deep visit reaches it.  A fork is a different Runtime, so
+// sharing the payload by reference into one is the violation.
+func TestRuntimeBound_ForkRejectsSharedBoundNative(t *testing.T) {
+	env := newForkTestEnv(t)
+	payload := &boundNative{rt: env.Runtime}
+
+	m := SortedMap()
+	if lerr := m.MapSet("handle", Native(payload)); lerr.Type == LError {
+		t.Fatalf("map-set: %v", lerr)
+	}
+	if lerr := env.PutGlobal(Symbol("state"), m); lerr.Type == LError {
+		t.Fatalf("put state map: %v", lerr)
+	}
+
+	expectAffinityPanic(t, "boundNative", func() {
+		if _, err := env.Fork(); err != nil {
+			t.Fatalf("fork returned an error instead of panicking: %v", err)
+		}
+	})
+}
+
+// TestRuntimeBound_ForkAcceptsRebindingClone is the sanctioned way to carry
+// a bound payload across a fork: implement NativeCloner and return an
+// UNBOUND clone.  The fork must succeed, the fork's payload must be that
+// clone (not the template's instance, and carrying no binding), and the
+// template's payload must be untouched — Fork never mutates the template.
+func TestRuntimeBound_ForkAcceptsRebindingClone(t *testing.T) {
+	env := newForkTestEnv(t)
+	payload := &rebindingNative{rt: env.Runtime}
+	if lerr := env.PutGlobal(Symbol("handle"), Native(payload)); lerr.Type == LError {
+		t.Fatalf("put bound native: %v", lerr)
+	}
+
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	got := fork.GetGlobal(Symbol("handle"))
+	if got.Type != LNative {
+		t.Fatalf("fork lost the native binding: %v", got)
+	}
+	clone, ok := got.Native.(*rebindingNative)
+	if !ok {
+		t.Fatalf("fork payload has type %T, want *rebindingNative", got.Native)
+	}
+	if clone == payload {
+		t.Fatal("fork shares the template's payload; CloneNative was not honored")
+	}
+	if clone.BoundRuntime() != nil {
+		t.Fatalf("clone carried a binding to %p; it must arrive unbound", clone.BoundRuntime())
+	}
+	if payload.BoundRuntime() != env.Runtime {
+		t.Fatal("fork mutated the template's payload binding")
+	}
+	// The clone is now free to be claimed by the fork's runtime.
+	if lerr := fork.PutGlobal(Symbol("handle2"), Native(clone)); lerr.Type == LError {
+		t.Fatalf("bind clone in the fork: %v", lerr)
+	}
+}
+
+// TestRuntimeBound_ForkChecksReplacerResult proves the fork-time check
+// applies to the RESOLVED payload whichever policy produced it.  The
+// template holds an unbound payload — a plain fork of it succeeds, which is
+// the control — and a ForkWithNativeReplacer hook swaps in an instance
+// bound to the TEMPLATE's runtime.  Nothing but the replacer's return value
+// can trip the gate here, and it must.
+func TestRuntimeBound_ForkChecksReplacerResult(t *testing.T) {
+	env := newForkTestEnv(t)
+	if lerr := env.PutGlobal(Symbol("handle"), Native(&boundNative{})); lerr.Type == LError {
+		t.Fatalf("put unbound native: %v", lerr)
+	}
+
+	// Control: without the replacer the same template forks cleanly, so the
+	// panic below is attributable to the replacement and nothing else.
+	if _, err := env.Fork(); err != nil {
+		t.Fatalf("control fork: %v", err)
+	}
+
+	replacer := ForkWithNativeReplacer(func(payload interface{}) (interface{}, bool) {
+		if _, ok := payload.(*boundNative); ok {
+			return &boundNative{rt: env.Runtime}, true
+		}
+		return nil, false
+	})
+	expectAffinityPanic(t, "boundNative", func() {
+		if _, err := env.Fork(replacer); err != nil {
+			t.Fatalf("fork returned an error instead of panicking: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Closes #546. Implements items A, B and C as one commit each, plus a hardening commit from an adversarial review pass and a follow-up closing an Item B gap; item D stays deliberately unbuilt (no consumer), and the substrate-side static check stays out of scope per the issue.

## Summary

- **Item A — `NativeCloner` is now the general clone protocol** (`3c0ce8f`). `copy` (`deepCopy`) and `detach` consult it in the one switch arm both funnel through: a cloneable native is cloned by `copy` instead of shared, transferred by `detach` instead of rejected, and still cloned by `Fork`. The consult lives on the `LNative` arm only — the internal `*[]byte`/`*MapData`/`*CallStack` payloads keep their existing hermetic-copy paths, mirroring the fork walker's dispatch. Strictly more permissive; non-cloneable payloads keep today's behavior on all three paths, pinned by tests.
- **Item B — checked typed accessors** (`cab0319`, completed by `97b817f`). `NativeValue[T](*LVal) (T, bool)` runs nil → `v.Type == LNative` → payload assertion, in that order; the type gate before the assertion is what keeps elps's internal storage (an `LBytes`'s backing, a sorted-map's `MapData`, an error's `CallStack`) unreachable through the accessor. `NativeOf[T]` is the typed constructor counterpart that turns a write/read type mismatch into a build failure. `RequireNative[T](*LVal) (T, *LVal)` delivers the issue's "one good error message instead of N hand-written ones": it runs NativeValue's gates through NativeValue itself (no second copy of the type gate to drift) and renders the failure as an LError naming the expected type — via `reflect.TypeFor`, so interface type parameters render — and what was found instead.
- **Item C — `RuntimeBound` runtime affinity** (`cfca685`). A native payload may declare the `Runtime` it is bound to (`nil` = unbound). Enforcement is elpscheck-only, zero production cost, at three points: the ownership checker's instrumented points (use time, shallow), the fork walker (deep — every resolved payload, whether produced by the replacer, `NativeCloner`, or share-by-reference, is checked against the fork's runtime), and strict detach (a detached clone must arrive unbound — `CloneNative` cannot know the destination). Violations reuse the `ownershipViolation` panic so they stay hard panics through `env.eval`'s recover.
- **Adversarial-review hardening** (`f33518f`): the lisp-facing `copy` docstring now names the `NativeCloner` carve-out instead of contradicting it; detach's clone site captures the cloner where the type switch discovers it (a future arm change degrades into `unexpectedNativeError` instead of a type-assertion panic); and the detach-time unbound check above was added after the review showed detach was a checked-build blind spot for binding-retaining clones.
- **Item B gap closed** (`97b817f`): a second adversarial pass flagged that shipping only the `(T, bool)` accessor left the issue's promised single error message undelivered — every caller's false branch still hand-wrote its own. `RequireNative` (above) closes it. The branch also merged `main` (`9576404`, CI-runner changes only) to stay current with the base.

## Verification

Per the issue's house bar — every guard is red-proofed (broken in a scratch tree, shown failing, restored):

- Item A: removing the `NativeCloner` consult fails exactly the four new capability tests; the behavior-pinning tests and `TestForkNativeCloner` stay green.
- Item B: removing the `v.Type == LNative` gate fails exactly the three internal-storage refusal tests (bytes backing, `MapData`, `CallStack`) and nothing else; a `RequireNative` variant that bypasses the gate hands out a live `LBytes` backing with a nil error, and the refusal tests catch it.
- Item C: removing the use-time hook fails only the foreign-use test; removing the fork-time check fails only the fork-sharing and replacer tests; removing the detach-time check fails only the binding-retaining-clone test — the three enforcement points are independently load-bearing.

## Test Plan

- [x] `go build ./...` (plain and `-tags elpscheck`)
- [x] `make test` (full suite incl. lisp examples); `go test ./...` plain; `go test -tags elpscheck ./lisp/`; `go test -race ./lisp/`
- [x] Red-proof for every new guard (see above)
- [x] `TestNoCrossEnvironmentLValSharing` green with no new exemption
- [x] `make elpsvet` (both passes) clean; `golangci-lint run ./...` 0 issues
- [x] `./elps fmt -l ./...` clean; `./elps lint ./...` byte-identical to main's output; `./elps doc -m` clean
- [x] Fork benchmark allocation sanity: `BenchmarkEnvConstruction/mode=fork` at 1245 allocs/op, in line with the documented baseline; the production fork path adds only a no-op call
- [x] CI benchmark gate on the PR: allocation columns flat (`allocs/op` geomean +0.00% in every package), 0 moves at or above the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGXgwLDV76ULTTD9tQQDig