### PR TITLE
ci: run the Linux jobs on 4-vCPU ARM runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,20 +33,33 @@ env:
   # generous headroom over the measured floor; read the threshold note in that
   # script before changing either.
   #
-  # CAVEAT: those noise figures were measured on the amd64 ubuntu-latest fleet,
-  # before the move to ARM. They have NOT been re-measured on the ARM pool. If
-  # the gate starts firing spuriously, re-measure on identical code before
-  # widening a threshold -- widening it to silence real noise you have not
-  # characterised is how a gate stops meaning anything.
+  # CAVEAT, AND IT HAS GROWN A SECOND HALF. Those noise figures were measured
+  # on the amd64 ubuntu-latest fleet. They were never re-measured after the
+  # move to ARM, and they have not been re-measured on the GitHub-hosted
+  # `ubuntu-24.04-arm` pool this job now uses either. Read every number in
+  # this block as HISTORICAL, measured on hardware this workflow no longer
+  # runs on -- not as a description of the pool in use. If the gate starts
+  # firing spuriously, re-measure on identical code before widening a
+  # threshold; widening it to silence real noise you have not characterised is
+  # how a gate stops meaning anything.
   #
-  # One ARM datapoint exists so far (the first run where this gate reached a
-  # verdict): 82 delta rows, ONE significant bad-direction move, libjson
+  # One ARM datapoint exists so far, and it was taken on the PREVIOUS ARM
+  # runner (`2vcpu-ubuntu-2204-arm`, an org runner-group box), not on this
+  # one: 82 delta rows, ONE significant bad-direction move, libjson
   # Package/get-nested-baseline-2 at +1.65% (p=0.043) -- same order as the
-  # +1.52% worst case measured on amd64. It bounds nothing, because that
-  # comparison DOES change Go code and the move may be real rather than noise.
-  # It is recorded only so the next person does not read "not re-measured" as
-  # "possibly catastrophic". A proper characterisation still needs a null
-  # comparison (identical code on both arms) on this pool.
+  # +1.52% worst case measured on amd64. It bounded nothing even then, because
+  # that comparison DOES change Go code and the move may be real rather than
+  # noise; on this pool it is not even the same silicon. It is recorded only
+  # so the next person does not read "not re-measured" as "possibly
+  # catastrophic". A proper characterisation still needs a null comparison
+  # (identical code on both arms) on whichever pool is current.
+  #
+  # What does NOT depend on any of this: the gate's internal validity. Both
+  # arms are measured interleaved, in this one job, on this one runner, so a
+  # noisier or faster pool moves both arms together and the comparison stays
+  # sound. A pool too noisy to adjudicate is caught explicitly rather than
+  # guessed at -- see BENCH_VARIANCE_CEILING_PCT below, which turns exactly
+  # that into "re-measure" (exit 3) instead of a verdict.
   BENCH_REGRESSION_THRESHOLD_PCT: "15"
   BENCH_ALLOC_THRESHOLD_PCT: "5"
   # Runner fitness, not a gate (issue #542). A TIMING row whose own confidence
@@ -75,9 +88,28 @@ env:
   # touched this gate -- cannot move the suffix. scripts/bench-arms-check.sh
   # is the backstop that names the failure if this pin is ever removed.
   #
-  # 2 matches the ARM runner below. These benchmarks are single-goroutine, so
-  # this constrains only the runtime's own parallelism; keeping it fixed also
-  # keeps raw numbers comparable across runs as the runner pool changes.
+  # HELD AT 2 THROUGH THE MOVE TO A 4-vCPU RUNNER, DELIBERATELY. This used to
+  # read "2 matches the ARM runner below", which made it look derived; it is
+  # not, and the whole point of a pin is that it does not follow the hardware.
+  # The runner below is now `ubuntu-24.04-arm` (4 vCPU) and this stays 2, so:
+  #
+  #   * every benchmark keeps the `-2` name suffix it has always had, which is
+  #     what benchstat pairs rows by. Raising this to 4 would rename all 80+
+  #     rows at once -- harmless to THIS job, whose two arms would both be
+  #     renamed together, but it would unpair every historical raw result and
+  #     any future cross-run look at them;
+  #   * the runtime's own parallelism is unchanged, so the only measurement
+  #     variable that actually moved is the microarchitecture (and the machine
+  #     it is sharing), not the Go scheduler's shape.
+  #
+  # These benchmarks are single-goroutine, so this constrains only the
+  # runtime's background work (GC assist/marker Ps), which is exactly the part
+  # that would otherwise silently double.
+  #
+  # Absolute numbers are of course NOT comparable with results recorded on the
+  # old runner -- different silicon is different silicon. Nothing in the gate
+  # depends on that: it compares two arms measured against each other, here,
+  # today.
   GOMAXPROCS: "2"
 
 permissions:
@@ -95,7 +127,11 @@ jobs:
   # build, and must report even when the benchmark job is cancelled or skipped.
   gates:
     name: CI Gate Self-Test
-    runs-on: ubuntu-latest
+    # ARM for the reason spelled out on elps.yml's lint-and-test job. This one
+    # runs no Go and no compiler, so it moves purely so the fleet is uniform;
+    # what had to be checked before moving it is the shellcheck assumption in
+    # the `env:` block below.
+    runs-on: ubuntu-24.04-arm
     # 10 minutes against an observed 17-22s. Not a performance budget -- a
     # liveness bound. This job is aggregated into the REQUIRED check below, and
     # a required check that is stuck `in_progress` never goes red: the PR sits
@@ -118,13 +154,21 @@ jobs:
       # "-fuzz must carry -fuzztime" scan, the workflow-shape guards and
       # shellcheck -- still runs here.
       CI_GATES_SKIP_GO: "1"
-      # shellcheck is PREINSTALLED on the ubuntu-latest image, so the gate
-      # script's `command -v shellcheck` branch is always taken here. Without
-      # this variable the script only prints "SKIP shellcheck not installed"
-      # when it is absent -- a silent downgrade that would turn a shell-lint
-      # gate into nothing at all the day the image drops the package. Setting
-      # it makes absence LOUD (red), which is the whole point of running the
-      # lint in CI. See the shellcheck block in scripts/ci-gates-test.sh.
+      # shellcheck is PREINSTALLED on the runner image, so the gate script's
+      # `command -v shellcheck` branch is always taken here. Without this
+      # variable the script only prints "SKIP shellcheck not installed" when
+      # it is absent -- a silent downgrade that would turn a shell-lint gate
+      # into nothing at all the day the image drops the package. Setting it
+      # makes absence LOUD (red), which is the whole point of running the lint
+      # in CI. See the shellcheck block in scripts/ci-gates-test.sh.
+      #
+      # CHECKED BEFORE MOVING THIS JOB TO ARM, because this variable is
+      # precisely a promise about the image: the Arm Ubuntu 24.04 image's
+      # generated inventory lists `shellcheck | 0.9.0-1`, the same package and
+      # version as the x64 image
+      # (actions/partner-runner-images images/Ubuntu2404-Readme.md, apt
+      # packages table). Had it been absent, the correct move would have been
+      # to leave this job on x64 rather than to drop the variable.
       CI_GATES_REQUIRE_SHELLCHECK: "1"
     steps:
       - name: Check out code
@@ -135,7 +179,7 @@ jobs:
       # It never installed anything. Every run logged
       #     shellcheck is already the newest version (0.9.0-1).
       #     0 upgraded, 0 newly installed, 0 to remove
-      # because shellcheck ships in the ubuntu-latest image. What the step DID
+      # because shellcheck ships in the runner image. What the step DID
       # do was make this job -- part of a required check -- depend on reaching
       # five package repositories (azure.archive.ubuntu.com,
       # packages.microsoft.com, dl.google.com and friends) over the network on
@@ -162,9 +206,19 @@ jobs:
   # polls the run's own job list, turning "silently absent" into "loudly red".
   # Logic lives in scripts/ci-queue-watchdog.cjs so it is reviewable and
   # guarded by scripts/ci-gates-test.sh rather than buried in YAML.
+  #
+  # KEPT even though the job it watches now names a STANDARD GitHub-hosted
+  # label, which cannot be unreachable the way an org runner-group label can.
+  # `vars.BENCH_RUNNER` is still an override, and an override pointed at a
+  # label this repo cannot reach re-creates the exact failure -- so the
+  # watchdog guards the escape hatch, not just the default.
   queue-watchdog:
     name: Runner Reachability Watchdog
-    runs-on: ubuntu-latest
+    # "Always available" is the requirement, and ubuntu-24.04-arm meets it:
+    # standard GitHub-hosted, free on public repositories, no runner-group
+    # membership involved. ARM otherwise for the reason on elps.yml's
+    # lint-and-test job.
+    runs-on: ubuntu-24.04-arm
     # Generous: the budget below is the real bound, and this only backstops a
     # watchdog that itself wedges.
     timeout-minutes: 30
@@ -189,42 +243,65 @@ jobs:
   benchmark:
     name: Benchmark Comparison
     # ARM, deliberately. The consumers that pin this module ship ARM, so
-    # benchmarking elps on amd64 tuned against a machine nobody runs -- and
+    # benchmarking elps on amd64 tunes against a machine nobody runs -- and
     # that matters most for exactly what this gate exists to catch, since
     # struct layout, padding and GC scan extent are not arch-invariant.
     #
-    # `2vcpu-ubuntu-2204-arm` is the ARM runner actually shared with THIS repo
-    # (Settings -> Actions -> Runners). An earlier revision named
-    # ubuntu-arm-4core-150gb, which substrate uses but elps cannot reach, so
-    # the job sat queued across five pushes -- silently, because a job that
-    # never starts reports no status to fail on.
+    # THE DEFAULT MOVED from `2vcpu-ubuntu-2204-arm` (an org runner-group box
+    # shared with this repo, reachable via Settings -> Actions -> Runners) to
+    # the standard GitHub-hosted `ubuntu-24.04-arm`, so the whole repository
+    # sits on one 4-vCPU ARM fleet. What was checked before moving a gate that
+    # adjudicates PRs:
     #
-    # Two vCPUs is enough, and arguably better: these benchmarks are
-    # single-goroutine, so the extra cores only served the runtime, and fewer
-    # cores means less scheduler noise in the timings. It does halve the
-    # GOMAXPROCS suffix benchstat keys on (EnvGet-2, not EnvGet-4) -- harmless
-    # now that both arms are measured in one job, but it would have been fatal
-    # to the old cached-baseline design, which would have compared EnvGet-4
-    # against EnvGet-2 and paired nothing at all.
+    #   * MEASUREMENT CONDITIONS. GOMAXPROCS is pinned at the workflow level
+    #     and STAYS AT 2 -- it is not derived from the runner and did not
+    #     follow it. So every benchmark keeps its `-2` name suffix and the
+    #     runtime keeps 2 Ps; the microarchitecture is the variable, not the
+    #     scheduler. See the long note on GOMAXPROCS above.
+    #   * INTERNAL VALIDITY IS UNAFFECTED, which is the reason this move is
+    #     safe at all. Both arms are checked out, built and measured
+    #     interleaved in THIS job on THIS runner, so base and head see the
+    #     same silicon, the same thermal state and the same neighbours. The
+    #     verdict is a comparison of two arms against each other, never
+    #     against a stored number, so a fleet change cannot leak into it.
+    #   * ABSOLUTE numbers are NOT comparable with anything recorded on the
+    #     old runner. Nothing consumes them that way -- the cached-baseline
+    #     design that did was removed -- but raw ns/op read out of an old log
+    #     is a different machine's number.
+    #   * NOISE was characterised on hardware this job no longer uses, and the
+    #     env block above now says so rather than presenting stale figures as
+    #     current. The backstop for "this pool is too noisy to adjudicate" is
+    #     BENCH_VARIANCE_CEILING_PCT, which reports UNMEASURABLE and exits 3
+    #     ("re-measure") instead of returning a verdict it cannot support.
     #
-    # `vars.BENCH_RUNNER` is an escape hatch: if the ARM pool is unavailable
-    # the runner can be repointed from repo settings without a code change.
-    # It is safe to flip because both arms are measured in this job on
-    # whatever runner it lands on -- a swap changes the absolute numbers but
-    # never compares across architectures. It cannot move the benchmark-name
-    # suffix either, because GOMAXPROCS is pinned at the workflow level; see
-    # the note there for why that matters.
+    # A standard label also retires the reachability hazard this job was
+    # bitten by: an earlier revision named ubuntu-arm-4core-150gb, which
+    # substrate uses but elps cannot reach, and the job sat queued across five
+    # pushes -- silently, because a job that never starts reports no status to
+    # fail on. The queue-watchdog above stays anyway, because the override
+    # below can still name an unreachable label.
+    #
+    # `vars.BENCH_RUNNER` remains the escape hatch: if this pool is
+    # unavailable or too noisy, the runner can be repointed from repo settings
+    # without a code change. NOTE THAT IT WINS OVER THIS DEFAULT -- if the
+    # repo variable is currently set to the old runner, this line changes
+    # nothing until the variable is cleared or updated. It is safe to flip
+    # because both arms are measured in this job on whatever runner it lands
+    # on; a swap changes the absolute numbers but never compares across
+    # architectures. It cannot move the benchmark-name suffix either, because
+    # GOMAXPROCS is pinned at the workflow level.
     #
     # NOTE: `runs-on` cannot read the `env` context, which is why this is a
     # literal plus a `vars` override rather than a workflow-level env var.
-    runs-on: ${{ vars.BENCH_RUNNER || '2vcpu-ubuntu-2204-arm' }}
+    runs-on: ${{ vars.BENCH_RUNNER || 'ubuntu-24.04-arm' }}
     # 45 minutes against an observed 10m25s for BENCH_COUNT=10 interleaved
-    # rounds on the 2vcpu ARM runner. Deliberately loose -- benchmark wall time
-    # legitimately moves with the runner and with how many benchmarks the tree
-    # carries, and this bound exists to stop a hang holding the required check
-    # open, not to police benchmark duration. If it ever fires, read it as "the
-    # job wedged", not "the benchmarks got slower"; the budget to re-derive is
-    # BENCH_COUNT, not this number.
+    # rounds -- measured on the previous 2vcpu ARM runner, so treat it as an
+    # order of magnitude rather than a current figure. Deliberately loose --
+    # benchmark wall time legitimately moves with the runner and with how many
+    # benchmarks the tree carries, and this bound exists to stop a hang holding
+    # the required check open, not to police benchmark duration. If it ever
+    # fires, read it as "the job wedged", not "the benchmarks got slower"; the
+    # budget to re-derive is BENCH_COUNT, not this number.
     timeout-minutes: 45
     steps:
       # Two working trees, measured on the SAME runner in the SAME job. This
@@ -395,7 +472,11 @@ jobs:
   # green rather than red.
   required:
     name: "Required: benchmark"
-    runs-on: ubuntu-latest
+    # ARM for the reason on elps.yml's lint-and-test job. Note this is the
+    # PLAIN label, not `vars.BENCH_RUNNER`: the aggregate must report even
+    # when the override points somewhere unreachable, which is the entire
+    # scenario the watchdog above exists for.
+    runs-on: ubuntu-24.04-arm
     # 5 minutes against an observed 6s (checkout plus one bash assertion).
     # This is the job whose NAME is in branch protection, so it is the one job
     # here for which "stuck in_progress" and "blocks the PR forever" are the

--- a/.github/workflows/elps.yml
+++ b/.github/workflows/elps.yml
@@ -20,7 +20,34 @@ concurrency:
 jobs:
   lint-and-test:
     name: Lint & Test
-    runs-on: ubuntu-latest
+    # THE RATIONALE FOR ubuntu-24.04-arm, ONCE. Every other Linux job in this
+    # repository carries a one-line pointer back here rather than a copy.
+    #
+    # ARM, and specifically the 4-vCPU GitHub-hosted image rather than the
+    # `2vcpu-ubuntu-2204-arm` box the benchmark job used to name. This job is
+    # dominated by two PARALLEL Go test runs -- `make race` and
+    # `make test-elpscheck` were 2m39s and 1m09s of a 5m27s job on
+    # ubuntu-latest (run 32917687879) -- so halving the core count would cost
+    # more than ARM's per-core advantage returns. `ubuntu-24.04-arm` keeps 4
+    # vCPUs (16 GB RAM, Cobalt 100), is free for public repositories, and is
+    # the same distro release `ubuntu-latest` currently resolves to, so the
+    # only deliberate variable is the architecture.
+    #
+    # It is a STANDARD GitHub-hosted label, not an org runner-group label, so
+    # it cannot reproduce the "queues forever, reports nothing" failure that
+    # `ubuntu-arm-4core-150gb` caused here (see benchmark.yml). Public repos
+    # only: the label is rejected in private ones, which elps is not.
+    #
+    # setup-go's cache key includes the architecture, so the first run after
+    # this lands is cold by construction and the comparison against the 5m27s
+    # baseline is only fair from the second run onward.
+    #
+    # scripts/ci-gates-test.sh pins this: every Linux `runs-on` in this
+    # repository must be `ubuntu-24.04-arm`, so a workflow added later on
+    # ubuntu-latest fails the gate rather than quietly splitting the fleet.
+    # Windows is the deliberate exception -- build-windows below exists FOR
+    # the platform coverage.
+    runs-on: ubuntu-24.04-arm
     # 30 minutes against an observed 3m57s (golangci-lint, make test,
     # make race, elpscheck, elps fmt/lint/doc). `make race` alone is ~2m and is
     # the part most sensitive to a slow runner, so the headroom is deliberate.
@@ -158,7 +185,11 @@ jobs:
   # green rather than red.
   required:
     name: "Required: build & test"
-    runs-on: ubuntu-latest
+    # ARM for the reason spelled out on lint-and-test above. This job is one
+    # checkout and one bash assertion, so the architecture buys it nothing --
+    # it moves so that "every Linux job is on ubuntu-24.04-arm" is a rule with
+    # no exceptions to remember, which is what makes it checkable.
+    runs-on: ubuntu-24.04-arm
     # 5 minutes against an observed 2s. This job's name is the one in
     # branch protection; wedged here means the PR is blocked with no red.
     timeout-minutes: 5

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -68,7 +68,11 @@ jobs:
     # -- but it is a remembered number in a file whose whole argument is that
     # the shard count must be derived. This one now derives itself.
     name: Fuzz shard ${{ matrix.shard }}/${{ strategy.job-total }}
-    runs-on: ubuntu-latest
+    # ARM for the reason spelled out on elps.yml's lint-and-test job. The
+    # per-target -fuzztime budget is wall clock, not work, so a faster core
+    # buys more executions per target rather than a shorter job -- the budget
+    # arithmetic in scripts/fuzz-budget-check.sh is unaffected either way.
+    runs-on: ubuntu-24.04-arm
     strategy:
       # Sharded so wall clock is set by the LARGEST shard rather than by the
       # total. Serial, the nightly sweep cost (targets x FUZZTIME) grew every
@@ -300,7 +304,8 @@ jobs:
   # required check reads as green.
   required:
     name: "Required: fuzz"
-    runs-on: ubuntu-latest
+    # ARM for the reason on elps.yml's lint-and-test job.
+    runs-on: ubuntu-24.04-arm
     # 5 minutes for one bash assertion over the matrix result. The `fuzz` job
     # above already carries its own derived timeout-minutes; this aggregate had
     # none, and it is the job whose NAME is in branch protection -- so a wedge

--- a/.github/workflows/govulncheck-scheduled.yml
+++ b/.github/workflows/govulncheck-scheduled.yml
@@ -32,7 +32,16 @@ permissions:
 
 jobs:
   govulncheck:
-    runs-on: ubuntu-latest
+    # ARM for the reason spelled out on elps.yml's lint-and-test job -- and
+    # see the note in .github/workflows/govulncheck.yml on why the scan's
+    # verdict does not depend on the host architecture.
+    #
+    # One thing here DOES: the binary-mode pass builds each main package and
+    # scans the artifact, so on this runner it scans a linux/arm64 elps rather
+    # than a linux/amd64 one. That is the right direction -- ARM is what the
+    # consumers pinning this module ship -- and source mode, which is the
+    # broader of the two, is arch-independent regardless.
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     steps:
       # SHA-pinned, and reusing SHAs already present elsewhere in this tree, so

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -27,7 +27,13 @@ permissions:
 
 jobs:
   govulncheck:
-    runs-on: ubuntu-latest
+    # ARM for the reason spelled out on elps.yml's lint-and-test job.
+    # govulncheck is installed with `go install`, so it is built from source
+    # for whatever host it lands on -- there is no prebuilt-binary download to
+    # go arch-shaped on. What it reports is a property of this module's call
+    # graph and the pinned toolchain's stdlib, neither of which the host
+    # architecture selects.
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -88,7 +94,8 @@ jobs:
   # green rather than red.
   required:
     name: "Required: govulncheck"
-    runs-on: ubuntu-latest
+    # ARM for the reason on elps.yml's lint-and-test job.
+    runs-on: ubuntu-24.04-arm
     # 5 minutes for one bash assertion over `needs` results. The scanning
     # job above already carries timeout-minutes: 15.
     timeout-minutes: 5

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -42,7 +42,21 @@ concurrency:
 jobs:
   release:
     name: Cut release ${{ inputs.version }}
-    runs-on: ubuntu-22.04
+    # ARM for the reason spelled out on elps.yml's lint-and-test job. This job
+    # builds nothing and ships nothing -- it validates a version string and
+    # calls `gh release create` -- so the architecture is about fleet
+    # uniformity, not speed.
+    #
+    # Two variables moved at once here (22.04 -> 24.04 as well as x64 -> ARM),
+    # because there is no 22.04 in this repo's chosen fleet and the 22.04
+    # hosted image is the older of the two anyway. The one dependency worth
+    # naming is claude-code-action, which installs the CLI for the host
+    # platform; linux-arm64 is a supported target. It is also the one job here
+    # that cannot be exercised by a PR, so VALIDATE IT WITH A dry_run=true
+    # DISPATCH before relying on it for a real release -- dry_run stops before
+    # `gh release create`, so the run proves the toolchain came up without
+    # publishing anything.
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/tree-sitter.yml
+++ b/.github/workflows/tree-sitter.yml
@@ -35,7 +35,12 @@ concurrency:
 jobs:
   test:
     name: Tree-sitter Tests
-    runs-on: ubuntu-latest
+    # ARM for the reason spelled out on elps.yml's lint-and-test job.
+    # go-tree-sitter is cgo, but it COMPILES the grammar's C sources from the
+    # module rather than downloading a prebuilt object, and the image ships
+    # gcc for aarch64 -- so there is no arch-shaped artifact to be missing.
+    # Nothing here runs the npm/node-gyp side of tree-sitter-elps.
+    runs-on: ubuntu-24.04-arm
     # 20 minutes for a Go module download plus `go test ./...` over the
     # grammar package. A liveness bound, not a performance budget.
     timeout-minutes: 20
@@ -76,7 +81,8 @@ jobs:
   # green rather than red.
   required:
     name: "Required: tree-sitter"
-    runs-on: ubuntu-latest
+    # ARM for the reason on elps.yml's lint-and-test job.
+    runs-on: ubuntu-24.04-arm
     # 5 minutes for one bash assertion over `needs` results.
     timeout-minutes: 5
     needs: [test]

--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -8,7 +8,17 @@ on:
 jobs:
   build-binaries:
     name: Build elps (${{ matrix.target }})
-    runs-on: ubuntu-latest
+    # ARM for the reason spelled out on elps.yml's lint-and-test job -- this
+    # is the HOST the cross-compile runs on, and nothing else.
+    #
+    # THE MATRIX BELOW IS THE SHIPPED ARTIFACT SET AND MUST NOT FOLLOW IT.
+    # Every leg sets GOOS/GOARCH explicitly with CGO_ENABLED=0, so the same
+    # four binaries (linux-x64, linux-arm64, darwin-x64, darwin-arm64) come
+    # out of an ARM host exactly as they did out of an x64 one. Go's linker
+    # and the whole toolchain cross-compile natively; there is no
+    # host-architecture ingredient in a CGO_ENABLED=0 build. Changing a
+    # `goarch:` here would drop a platform for real users.
+    runs-on: ubuntu-24.04-arm
     # A cross-compile per matrix leg. 20 minutes is a liveness bound: the
     # `go build` is seconds, but Go module download reaches the network and
     # this workflow gates a release, so a wedged leg stalls the publish with
@@ -57,7 +67,15 @@ jobs:
   publish-platform:
     name: Publish (${{ matrix.target }})
     needs: build-binaries
-    runs-on: ubuntu-latest
+    # ARM for the reason on elps.yml's lint-and-test job. `--target` below is
+    # the VS Code platform package being published, NOT the host: it is a
+    # label vsce writes into the VSIX, so it is unaffected. The npm side is
+    # arch-clean too -- esbuild resolves a per-platform optional dependency,
+    # and editors/vscode/package-lock.json carries @esbuild/linux-arm64 (it
+    # records every platform package regardless of where it was generated), so
+    # `npm ci` installs rather than failing with "installed for another
+    # platform".
+    runs-on: ubuntu-24.04-arm
     # `npm ci` and `npx vsce publish` both talk to third-party registries
     # (npm, the VS Code Marketplace) which can and do hang. 20 minutes turns
     # that into a red leg instead of a release that never finishes.
@@ -110,7 +128,9 @@ jobs:
   publish-universal:
     name: Publish (universal)
     needs: build-binaries
-    runs-on: ubuntu-latest
+    # ARM for the reason on elps.yml's lint-and-test job; same npm/esbuild
+    # note as publish-platform above.
+    runs-on: ubuntu-24.04-arm
     # Same third-party-registry exposure as publish-platform above.
     timeout-minutes: 20
     steps:

--- a/scripts/bench-arms-check.sh
+++ b/scripts/bench-arms-check.sh
@@ -113,8 +113,10 @@ done
 # the configuration key, so two arms drawn from a heterogeneous pool pair
 # nothing even though goos/goarch agree.
 #
-# NOTE: `go test` emits no `cpu:` header on linux/arm64 -- confirmed on the
-# runner this gate uses, where every measured run logs "header absent ...
+# NOTE: `go test` emits no `cpu:` header on linux/arm64 -- an architecture
+# property (the model string comes from CPUID, which Go only reads on x86),
+# observed directly on the 2vcpu ARM runner this gate used before it moved to
+# `ubuntu-24.04-arm`, where every measured run logged "header absent ...
 # skipping". So on ARM this particular check is INERT, and it is the one-job
 # design (both arms on one runner) that actually prevents the failure; this is
 # a backstop for amd64 and for anyone who reintroduces a cross-machine

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -1868,7 +1868,20 @@ except ImportError:
 # Labels GitHub always provides. Anything else -- a larger-runner label, a
 # self-hosted label, or an expression whose value cannot be read here -- is
 # only as reachable as the repo's runner settings happen to make it.
-STANDARD = re.compile(r"^(ubuntu|windows|macos)-[0-9a-z.]+$")
+#
+# The optional `-arm` tail is the arm64 standard fleet (ubuntu-24.04-arm,
+# ubuntu-22.04-arm, windows-11-arm), which is GitHub-hosted and free on public
+# repositories -- as reachable as ubuntu-latest, and this repository's default
+# fleet. Without it every job here read as "non-standard runner, must be
+# queue-watched", which is the wrong diagnosis: nothing about a standard label
+# can queue for want of a runner group.
+#
+# It stays TIGHT on purpose. `[0-9a-z.]+` cannot match a hyphen, so this
+# admits exactly `<os>-<version>-arm` and still rejects the shapes that really
+# are settings-dependent: `2vcpu-ubuntu-2204-arm` (does not start with an OS
+# name), `ubuntu-arm-4core-150gb` -- the org runner-group label that left this
+# repo's benchmark job queued across five pushes -- and any self-hosted label.
+STANDARD = re.compile(r"^(ubuntu|windows|macos)-[0-9a-z.]+(-arm)?$")
 
 failures, passes = [], []
 for f in sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.y*ml"))):
@@ -1931,6 +1944,232 @@ case "$watch_out" in
 		else
 			bad "runner-reachability guard did not run"
 		fi
+		;;
+esac
+
+# EVERY LINUX JOB IN THIS REPOSITORY RUNS ON ubuntu-24.04-arm.
+#
+# Not a style rule. The fleet is a measurement and caching input, and a
+# repository that is half x64 and half ARM pays for it in ways that do not
+# announce themselves:
+#
+#   * setup-go keys its module/build cache on the architecture, so a job that
+#     drifts back to ubuntu-latest is permanently cold against everything
+#     else's warm cache -- slower, and for no stated reason;
+#   * `go test` bakes GOARCH into the benchmark header block, which is part of
+#     what benchstat treats as a configuration. Two arms on two fleets pair
+#     NOTHING, from a table that looks entirely normal (this is the same trap
+#     the GOMAXPROCS pin exists for; see bench-arms-check.sh);
+#   * govulncheck's binary pass scans the artifact it just built, so the
+#     architecture decides which binary was actually examined;
+#   * and the failure mode of an accidental split is invisible. Nothing goes
+#     red. A workflow added six months from now with a copy-pasted
+#     `runs-on: ubuntu-latest` simply runs, greenly, on the other fleet.
+#
+# So the intent is pinned here rather than left in a comment. The rule is
+# uniform and has exactly one carve-out, which is a PLATFORM carve-out and not
+# a runner one: windows-* and macos-* jobs exist FOR the platform they name
+# (elps.yml's build-windows is the whole Windows coverage this repo has), so
+# they are recognised and reported rather than allowlisted.
+#
+# EXEMPT below is for a Linux job that genuinely cannot be on the ARM fleet.
+# It is empty today -- every Linux job in the tree is on the target label,
+# including the benchmark job, whose move is safe because both of its arms are
+# measured interleaved on whichever single runner the job lands on. A row
+# added here must carry a reason, and the list may only ever shrink.
+arm_probe() { # <root> -- prints PASS/FAIL lines plus __COUNTS__
+	python3 - "$1" <<'PY_INNER'
+import glob, os, re, sys
+
+root = sys.argv[1]
+try:
+    import yaml
+except ImportError:
+    print("__SKIP__ pyyaml unavailable")
+    sys.exit(0)
+
+# The one Linux label this repository uses: 4 vCPU / 16 GB, arm64, standard
+# GitHub-hosted, free on public repos.
+TARGET = "ubuntu-24.04-arm"
+
+# Deliberately-not-ARM LINUX jobs, keyed (workflow file, job name or id) ->
+# reason. Empty on purpose. Delete rows; do not add them without a reason
+# that would survive being read out loud.
+EXEMPT = {
+    # ("some-workflow.yml", "Some Job"): "why this one cannot be on ARM",
+}
+
+# A `runs-on` may be an expression. `${{ vars.BENCH_RUNNER || 'label' }}` is
+# the shape this repo uses to keep an operator override while pinning the
+# DEFAULT, and the quoted literals inside are the part that can be checked
+# from here -- so the rule is that every literal in the expression is TARGET.
+# An expression carrying no literal at all is a `runs-on` nobody reviewing
+# this repository can evaluate, which is reported rather than waved through.
+LITERAL = re.compile(r"'([^']*)'|\"([^\"]*)\"")
+NON_LINUX = ("windows-", "macos-")
+
+failures, passes = [], []
+files = sorted(glob.glob(os.path.join(root, ".github", "workflows", "*.y*ml")))
+if not files:
+    print("__SKIP__ no workflow files found under {}".format(root))
+    sys.exit(0)
+
+for f in files:
+    base = os.path.basename(f)
+    try:
+        doc = yaml.safe_load(open(f))
+    except Exception:  # noqa: BLE001 -- the YAML-parse guard above owns this
+        continue
+    if not isinstance(doc, dict):
+        continue
+
+    jobs = {k: v for k, v in (doc.get("jobs") or {}).items() if isinstance(v, dict)}
+    on_target, other_platform = 0, []
+    dirty = False
+
+    for jid, spec in sorted(jobs.items()):
+        name = str(spec.get("name") or jid)
+        ro = spec.get("runs-on")
+        if ro is None:
+            # A reusable-workflow call has no runner of its own; the called
+            # workflow's jobs carry it, and this same guard covers them when
+            # that workflow lives in this repository.
+            continue
+
+        if isinstance(ro, str):
+            labels = [ro]
+        elif isinstance(ro, list):
+            labels = [str(x) for x in ro]
+        elif isinstance(ro, dict):
+            labels = [str(x) for x in (ro.get("labels") or [])]
+        else:
+            labels = [str(ro)]
+
+        # Platform carve-out, recognised rather than allowlisted: a windows-*
+        # or macos-* job is not a Linux job that drifted, it is coverage for
+        # the platform it names.
+        if labels and all(x.startswith(NON_LINUX) for x in labels):
+            other_platform.append(f"{name} ({', '.join(labels)})")
+            continue
+
+        if (base, name) in EXEMPT or (base, jid) in EXEMPT:
+            reason = EXEMPT.get((base, name)) or EXEMPT[(base, jid)]
+            passes.append(f"{base}: job {name!r} is an allowlisted non-ARM Linux job ({reason})")
+            continue
+
+        # Resolve what is actually checkable: literals in an expression,
+        # otherwise the labels themselves.
+        checkable = []
+        for lab in labels:
+            if "${{" in lab:
+                lits = [a or b for a, b in LITERAL.findall(lab)]
+                if not lits:
+                    failures.append(
+                        f"{base}: job {name!r} has runs-on: {lab} -- an expression with no "
+                        f"literal fallback, so neither this gate nor a reviewer can tell which "
+                        f"fleet it lands on. Spell it `${{{{ vars.X || '{TARGET}' }}}}`."
+                    )
+                    dirty = True
+                checkable.extend(lits)
+            else:
+                checkable.append(lab)
+
+        wrong = [x for x in checkable if x != TARGET]
+        if wrong:
+            failures.append(
+                f"{base}: job {name!r} runs on {wrong} -- every Linux job in this repository "
+                f"runs on {TARGET} (4-vCPU arm64). A second fleet splits the setup-go cache, "
+                f"changes the GOARCH benchmarks are recorded under, and announces none of it. "
+                f"Move it, or add a row to EXEMPT in scripts/ci-gates-test.sh with a reason."
+            )
+            dirty = True
+        elif checkable:
+            on_target += 1
+
+    if jobs and not dirty:
+        note = f"{base}: all {on_target} Linux job(s) on {TARGET}"
+        if other_platform:
+            note += f"; {len(other_platform)} non-Linux by design ({'; '.join(other_platform)})"
+        passes.append(note)
+
+for p_ in passes:
+    print(f"PASS  {p_}")
+for f_ in failures:
+    print(f"FAIL  {f_}")
+print(f"__COUNTS__ {len(passes)} {len(failures)}")
+PY_INNER
+}
+
+arm_out="$(arm_probe "$REPO_ROOT")"
+case "$arm_out" in
+	__SKIP__*) echo "SKIP  Linux-fleet uniformity guard ($arm_out)" ;;
+	*)
+		echo "$arm_out" | grep -v '^__COUNTS__' || true
+		arm_counts="$(echo "$arm_out" | sed -n 's/^__COUNTS__ //p')"
+		if [ -n "$arm_counts" ]; then
+			read -r a_pass a_fail <<<"$arm_counts"
+			pass=$((pass + a_pass))
+			fail=$((fail + a_fail))
+		else
+			bad "Linux-fleet uniformity guard did not run"
+		fi
+
+		# NEGATIVE CONTROL. A rule that only ever reports success is
+		# indistinguishable from a rule that is looking at the wrong thing --
+		# which is the failure this whole file exists to prevent, and exactly
+		# how the original benchstat grep stayed dead for 473 runs. So put the
+		# mistake into a throwaway copy of the tree and require the guard to
+		# name it.
+		ARM_SANDBOX="$(mktemp -d)"
+		mkdir -p "${ARM_SANDBOX}/.github/workflows"
+		cp "$REPO_ROOT"/.github/workflows/*.y*ml "${ARM_SANDBOX}/.github/workflows/" 2>/dev/null || true
+		# Keyed on shape, not on a particular job: rewrite the FIRST job-level
+		# ARM label in the main CI workflow back to ubuntu-latest, which is the
+		# drift this guard exists for (a copy-pasted `runs-on` that nobody
+		# notices because nothing goes red).
+		neg_arm="${ARM_SANDBOX}/.github/workflows/elps.yml"
+		if [ -f "$neg_arm" ] && grep -qE '^    runs-on: ubuntu-24\.04-arm$' "$neg_arm" &&
+			sed -i '0,/^    runs-on: ubuntu-24\.04-arm$/s//    runs-on: ubuntu-latest/' "$neg_arm"; then
+			neg_arm_out="$(arm_probe "$ARM_SANDBOX")"
+			neg_arm_counts="$(echo "$neg_arm_out" | sed -n 's/^__COUNTS__ //p')"
+			read -r _ neg_arm_fail <<<"${neg_arm_counts:-0 0}"
+			if [ "${neg_arm_fail:-0}" -ge 1 ]; then
+				ok "negative control: a Linux job moved back to ubuntu-latest IS reported (${neg_arm_fail} finding(s))"
+			else
+				bad "negative control: a Linux job on ubuntu-latest was NOT reported — this guard cannot fail"
+			fi
+			if echo "$neg_arm_out" | grep -q "every Linux job in this repository"; then
+				ok "negative control: the finding names the rule and how to opt out of it"
+			else
+				bad "negative control: the guard fired but not with the split-fleet diagnosis"
+				echo "$neg_arm_out" | sed 's/^/        | /'
+			fi
+		else
+			bad "negative control: could not construct a split-fleet fixture"
+		fi
+		# The other half of the rule: the benchmark job's `vars.BENCH_RUNNER`
+		# indirection must keep pinning its DEFAULT to the target label. An
+		# expression whose fallback drifts is the one shape a plain grep for
+		# `ubuntu-latest` would never catch.
+		#
+		# Restore elps.yml first, so this control is measured against a tree
+		# whose ONLY defect is the one it introduces.
+		cp "$REPO_ROOT/.github/workflows/elps.yml" "$neg_arm" 2>/dev/null || true
+		neg_bench="${ARM_SANDBOX}/.github/workflows/benchmark.yml"
+		if [ -f "$neg_bench" ] &&
+			sed -i "s/|| 'ubuntu-24\.04-arm' }}/|| '2vcpu-ubuntu-2204-arm' }}/" "$neg_bench" &&
+			grep -q "2vcpu-ubuntu-2204-arm' }}" "$neg_bench"; then
+			neg_b_out="$(arm_probe "$ARM_SANDBOX")"
+			if echo "$neg_b_out" | grep -q "^FAIL.*2vcpu-ubuntu-2204-arm"; then
+				ok "negative control: a runs-on EXPRESSION whose default drifts off the fleet IS reported"
+			else
+				bad "negative control: an expression default off the fleet was NOT reported — the vars.BENCH_RUNNER indirection is unguarded"
+				echo "$neg_b_out" | sed 's/^/        | /'
+			fi
+		else
+			bad "negative control: could not construct a drifted-expression fixture"
+		fi
+		rm -rf "$ARM_SANDBOX"
 		;;
 esac
 
@@ -3680,8 +3919,10 @@ if command -v shellcheck >/dev/null 2>&1; then
 		echo "$sc_out" | sed 's/^/        | /'
 	fi
 elif [ -n "${CI_GATES_REQUIRE_SHELLCHECK:-}" ]; then
-	# In CI the tool is expected to be present (it ships in the ubuntu-latest
-	# image), so absence is a broken environment, not a reason to shrug. Left
+	# In CI the tool is expected to be present (the Arm Ubuntu 24.04 image
+	# this repository's jobs run on ships shellcheck 0.9.0-1, the same package
+	# and version as the x64 image), so absence is a broken environment, not a
+	# reason to shrug. Left
 	# as a SKIP this would silently downgrade the shell lint to nothing at all
 	# the day the image drops the package, and the board would stay green --
 	# the same "a gate that cannot fail" shape this whole script exists to

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -3557,13 +3557,34 @@ open(path, "w").write(new)
 PY_MUT
 		}
 
+		# NOTE ON THE SHAPE OF THE THREE CONTROLS BELOW: each captures the
+		# checker's output and greps the VARIABLE with a herestring, rather
+		# than piping the checker straight into `grep -q`.
+		#
+		# That is not style. This file runs under `set -o pipefail`, and
+		# `producer | grep -q PATTERN` under pipefail is a race whenever the
+		# producer writes anything AFTER the matching line: `grep -q` exits the
+		# instant it matches, the producer's next write hits a closed pipe, and
+		# pipefail then reports the PIPELINE as failed -- even though the match
+		# succeeded. check.py prints its `__COUNTS__` trailer last, so it lost
+		# that race about 7% of the time (measured: 4 failures in 60 runs, on
+		# an unmodified tree). The visible symptom is the worst possible one:
+		# a control that FIRED CORRECTLY is reported as "this guard is dead",
+		# complete with a BrokenPipeError traceback, and the required check
+		# goes red for a reason that is not in the tree at all.
+		#
+		# A herestring is not a pipeline, so pipefail has nothing to observe
+		# and the grep's own verdict is the only verdict.
+
 		# Control 1 -- check (A): re-inline the shared script's loop into a
 		# workflow that now delegates. The guard must object.
 		if mutate elps.yml reinline mut_reinline; then
-			if python3 "${agg_tmp}/check.py" "${agg_tmp}/mut_reinline" | grep -q '^FAIL.*INLINES a job-success check'; then
+			agg_neg1="$(python3 "${agg_tmp}/check.py" "${agg_tmp}/mut_reinline" 2>&1)"
+			if grep -q '^FAIL.*INLINES a job-success check' <<<"$agg_neg1"; then
 				ok "negative control: RE-INLINING the shared loop into elps.yml is caught (#493)"
 			else
 				bad "negative control: an inlined job-success loop was NOT caught — the anti-duplication half of the guard is dead"
+				printf '%s\n' "$agg_neg1" | sed 's/^/        | /'
 			fi
 		else
 			bad "negative control: could not re-inline the loop into elps.yml — has the delegation line been reworded? (#493)"
@@ -3574,10 +3595,12 @@ PY_MUT
 		# this one, so only the behavioural run can catch it. This is what
 		# proves (B) is load-bearing rather than decorative.
 		if mutate fuzz.yml vacuous-scalar mut_scalar; then
-			if python3 "${agg_tmp}/check.py" "${agg_tmp}/mut_scalar" | grep -q '^FAIL.*verified nothing'; then
+			agg_neg2="$(python3 "${agg_tmp}/check.py" "${agg_tmp}/mut_scalar" 2>&1)"
+			if grep -q '^FAIL.*verified nothing' <<<"$agg_neg2"; then
 				ok "negative control: a NON-join vacuous body is caught by running it (#493)"
 			else
 				bad "negative control: a vacuous inline aggregate body went undetected — the behavioural half of the guard is dead"
+				printf '%s\n' "$agg_neg2" | sed 's/^/        | /'
 			fi
 		else
 			bad "negative control: could not construct the vacuous-scalar fixture from fuzz.yml — has the body changed? (#493)"
@@ -3586,10 +3609,12 @@ PY_MUT
 		# Control 3 -- the discovery floor. Point the checker at a tree with no
 		# workflows at all; it must refuse rather than report clean over zero.
 		mkdir -p "${agg_tmp}/empty/.github/workflows"
-		if python3 "${agg_tmp}/check.py" "${agg_tmp}/empty" | grep -q '^FAIL.*floor'; then
+		agg_neg3="$(python3 "${agg_tmp}/check.py" "${agg_tmp}/empty" 2>&1)"
+		if grep -q '^FAIL.*floor' <<<"$agg_neg3"; then
 			ok "negative control: an EMPTY workflow tree fails the floor rather than passing vacuously (#493)"
 		else
 			bad "negative control: the aggregate guard reported clean over ZERO aggregates — it cannot fail"
+			printf '%s\n' "$agg_neg3" | sed 's/^/        | /'
 		fi
 		;;
 esac


### PR DESCRIPTION
Every Linux job in `.github/workflows/` moves to `ubuntu-24.04-arm` — the standard GitHub-hosted arm64 image: 4 vCPU / 16 GB, free on public repositories, and the same Ubuntu release `ubuntu-latest` currently resolves to, so **architecture is the only deliberate variable**.

**Why 4 vCPU and not the 2-vCPU ARM box** the benchmark job used to name: the baseline is `Lint & Test` at 5m27s on `ubuntu-latest` (run 32917687879 — race 2m39s, elpscheck 1m09s, golangci-lint 24s, tests 48s). That job is dominated by two *parallel* Go test runs, so halving the cores would cost more than ARM's per-core advantage returns.

**Why the standard label and not `ubuntu-arm-4core-150gb`** (the org runner-group label substrate uses): that label previously caused a "queues forever, publishes no status at all" failure here across five consecutive pushes. A standard hosted label cannot reproduce that class.

`setup-go` keys its cache on architecture, so the first run after this lands is cold by construction — only the second run onward is a fair comparison against 5m27s.

## Per workflow — 17 Linux jobs moved, 1 deliberately not

| Workflow | Moved |
|---|---|
| `elps.yml` | `lint-and-test`, `Required: build & test`. **`build-windows` stays on `windows-latest`** — that job is the repo's entire Windows coverage |
| `benchmark.yml` | `gates`, `queue-watchdog`, `Required: benchmark`, and `Benchmark Comparison`'s `runs-on` default (see below) |
| `fuzz.yml` | the 10-shard matrix, `Required: fuzz` |
| `govulncheck.yml` / `govulncheck-scheduled.yml` | both jobs / the scheduled job |
| `tree-sitter.yml` | `Tree-sitter Tests`, `Required: tree-sitter` |
| `vscode-publish.yml` | `build-binaries`, `publish-platform`, `publish-universal`. **The GOOS/GOARCH cross-compile matrix is untouched** — that's the shipped artifact set, not a host property |
| `release-tag.yml` | `release` (was `ubuntu-22.04`) |

`release-tag.yml` is the one job a PR cannot exercise — validate it with a `dry_run=true` dispatch before relying on it.

## The benchmark job: moved, with the GOMAXPROCS pin held at 2

The pin is a workflow-level `GOMAXPROCS: "2"` env var, not a runner-derived value (its old comment claimed "2 matches the ARM runner below", which made it *look* derived — it isn't). It exists because `go test` appends GOMAXPROCS to every benchmark name and benchstat pairs rows by full name — two arms at different core counts share no names and pair nothing, from a table that looks entirely normal.

It is **held at 2, not raised to 4**, so the runner change carries one variable rather than three:

- the name suffix stays `-2`, so no row is renamed. Raising it would rename 80+ rows at once — harmless to this job (both arms rename together) but it unpairs every historical raw result;
- the runtime keeps 2 Ps. These benchmarks are single-goroutine, so the pin constrains only the runtime's background work (GC assist/marker Ps) — exactly the part that would otherwise silently double.

**Comparability, explicitly.** Row names are unchanged, so nothing pairable becomes unpairable. Absolute ns/op values are *not* comparable with anything recorded on `2vcpu-ubuntu-2204-arm` — different silicon is different silicon. Nothing consumes them that way (the cached-baseline design that did was removed), but a raw number read out of an old log is a different machine's number.

**Internal validity is preserved regardless of runner**, which is why the move is safe at all: base and head are checked out, built and measured *interleaved in the same job on the same runner*, so both arms see the same silicon, thermal state and neighbours. The verdict compares two arms against each other, never against a stored number. A pool too noisy to adjudicate is detected rather than guessed at — `BENCH_VARIANCE_CEILING_PCT` makes benchgate report UNMEASURABLE and exit 3 ("re-measure").

The stale noise-envelope figures in the env block are now labelled as such rather than left reading as current: the thresholds were derived on the amd64 `ubuntu-latest` fleet, and the single ARM datapoint recorded beside them (libjson `get-nested-baseline-2`, +1.65%, p=0.043) was taken on `2vcpu-ubuntu-2204-arm`, not this pool.

`vars.BENCH_RUNNER` indirection is kept and only its default changed — **if that repo variable is set it still wins**, so an operator must clear or update it for this to take effect. The queue-watchdog stays for exactly that reason: an override can still name an unreachable label.

## Arch-compat findings

- **shellcheck** — the `gates` job sets `CI_GATES_REQUIRE_SHELLCHECK=1`, making absence a hard failure by design. Verified before moving it: the Arm Ubuntu 24.04 image ships `shellcheck 0.9.0-1`, same as x64.
- **esbuild / `npm ci`** — `editors/vscode/package-lock.json` already carries `@esbuild/linux-arm64`.
- **tree-sitter** — go-tree-sitter is cgo but compiles the grammar's C from the module; no prebuilt arch artifact.
- **govulncheck** — installed from source; its binary pass now scans a linux/arm64 elps, which is what consumers ship.
- No script or workflow fetches a prebuilt binary with a hardcoded arch in its URL.

## Second commit: a pre-existing flake the verification run exposed

`19a749d` — three negative controls in the "required aggregates" section piped `check.py` into `grep -q` under `set -o pipefail`. `grep -q` exits on match, the checker's trailing `__COUNTS__` write hits a closed pipe, and pipefail reports the pipeline as failed — so a control that *fired correctly* was reported as "this guard is dead", with a BrokenPipeError traceback, turning `Required: benchmark` red. Measured 18/200 with the old shape and **4/60 on an unmodified `main` checkout** (so pre-existing, not introduced here), 0/200 after switching to capture-then-herestring. Scoped to the three demonstrated call sites.

## Drift guards

`scripts/ci-gates-test.sh` grows a new guard: every Linux `runs-on` in the repository must be `ubuntu-24.04-arm`. It checks quoted literals *inside* `runs-on` expressions, so the `vars.BENCH_RUNNER` indirection is guarded rather than exempted, and flags an expression with no literal fallback. windows/macos are recognised as platform coverage rather than allowlisted. `EXEMPT` is empty and may only shrink.

Gates: **372 passed / 0 failed** on pristine `main`; **372 / 1 failed** with the runner label changed alone (the pre-existing reachability regex `^(ubuntu|windows|macos)-[0-9a-z.]+$` cannot match a hyphenated arm64 label — widened to `(-arm)?$`, verified it still rejects `2vcpu-ubuntu-2204-arm`, `ubuntu-arm-4core-150gb`, `ubuntu-24.04-arm-8core` and self-hosted labels); **383 passed / 0 failed, exit 0** on this branch.

Mutation proofs, each run through the whole suite on the real tree and reverted:

| Mutation | Result |
|---|---|
| govulncheck scan job → `ubuntu-latest` | `FAIL … runs on ['ubuntu-latest'] — every Linux job in this repository runs on ubuntu-24.04-arm` |
| `BENCH_RUNNER` default → `'2vcpu-ubuntu-2204-arm'` (shape intact, only the fallback moved — invisible to a grep for "ubuntu-latest") | `FAIL … 'Benchmark Comparison' runs on ['2vcpu-ubuntu-2204-arm']` |
| both together | 381 passed / 2 failed, exit 1; restored → 383 / 0 |
| `runs-on: ${{ vars.BENCH_RUNNER }}` with no literal | `FAIL … an expression with no literal fallback` |
| reverse control: `build-windows` → `macos-14` | no finding; reported as "1 non-Linux by design" |

Also verified: `bash -n` and `shellcheck -S warning` clean across `scripts/`, confidentiality guard clean (795 files), all 8 workflow files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178XitBproE5c8jkHj24U7a