### PR TITLE
lisp,libjson: GoValue returns the bytes of an LBytes, not a bound method

### DIFF
--- a/lisp/embed.go
+++ b/lisp/embed.go
@@ -73,22 +73,37 @@ func (v *LVal) goValueNode(g cycleGuard) interface{} {
 	case LSymbol, LString:
 		return v.Str
 	case LBytes:
-		// v.Bytes is a METHOD, not a field (lisp/lisp.go:1182), so the
-		// obvious `return v.Bytes` handed the embedder a func() []byte
-		// where every other arm of this switch returns plain data.  It
-		// type-checks, because the arm's result is interface{}, and only
-		// fails at use -- which is why it survived (issue #548).
+		// v.Bytes is a METHOD, not a field (lisp/lisp.go), so the obvious
+		// `return v.Bytes` handed the embedder a func() []byte where every
+		// other arm of this switch returns plain data.  It type-checks,
+		// because the arm's result is interface{}, and only fails at use --
+		// which is why it survived (issue #548).
 		//
-		// The result is a COPY, for the reason the neighbouring arms are:
-		// goSlice and goMap build fresh containers rather than handing out
-		// the value's own storage.  An LBytes keeps its bytes in a *[]byte
-		// under Native so append! can grow them in place, and returning
-		// that backing would let an embedder mutate a live lisp value
-		// behind the kernel's back -- past the ownership and seal
-		// invariants that make sharing safe, and past `copy`'s promise
-		// that a copy shares no storage with its original (#378).  It is
-		// the same hazard NativeValue's type gate exists to prevent
-		// (#546), reached through a different door.
+		// The result is a COPY, and the reason is WHOSE DATA IT IS rather
+		// than any blanket no-aliasing rule: GoValue's doc comment promises
+		// none, and the LNative arm below hands its payload straight back
+		// uncopied.  That is right for LNative -- the payload is the
+		// EMBEDDER's, so returning it shares what they already own.  An
+		// LBytes is the other case: its bytes live in a *[]byte under Native
+		// so append! can grow them in place, so the storage is the
+		// INTERPRETER's and lisp code observes writes through it.  Handing it
+		// out would let an embedder mutate a live lisp value behind the
+		// kernel's back, past the ownership and seal invariants that make
+		// sharing safe.
+		//
+		// COST: O(len), unbounded by anything the kernel controls -- the
+		// only arm in this switch of which that is true.  Order of magnitude
+		// on the authoring machine: ~200ns at 16 bytes, but hundreds of
+		// microseconds and a megabyte allocated at a megabyte, against
+		// single-digit nanoseconds and zero allocations for an LNative
+		// carrying the same megabyte.  Deliberately stated as magnitudes:
+		// the absolute figures move by ~2x run to run on a shared box, so
+		// BenchmarkGoValueBytes is where the number lives.  The cost is
+		// affordable because of who calls this: GoValue has no caller inside
+		// elps at all (libjson's GoValue is a different method on
+		// Serializer), so it is purely an embedder API, and the copy is what
+		// an embedder handing the result to something that outlives the call
+		// -- a logger, a queue, a serializer -- actually needs.
 		b := v.Bytes()
 		out := make([]byte, len(b))
 		copy(out, b)

--- a/lisp/embed.go
+++ b/lisp/embed.go
@@ -26,6 +26,13 @@ func Not(v *LVal) bool {
 // and all lists are turned into slices.  Symbols are converted to strings.
 // The value Nil() is converted to nil.  Functions are returned as is.
 //
+// A bytes value is returned as a []byte that COPIES the lisp value's storage,
+// so writing to it cannot be observed through the original (issue #548).  The
+// cost is proportional to the length; see the LBytes arm of goValueNode for
+// why the copy is not optional.  A native value is the opposite case and is
+// returned BY REFERENCE: the payload is the embedder's own, so GoValue hands
+// back what the caller already owns.
+//
 // NOTE:  These semantics may change.  It's unclear what the exact need is in
 // corner cases.
 func GoValue(v *LVal) interface{} {
@@ -77,33 +84,54 @@ func (v *LVal) goValueNode(g cycleGuard) interface{} {
 		// `return v.Bytes` handed the embedder a func() []byte where every
 		// other arm of this switch returns plain data.  It type-checks,
 		// because the arm's result is interface{}, and only fails at use --
-		// which is why it survived (issue #548).
+		// which is why it survived (issue #548).  libjson's Serializer had
+		// the identical arm and the identical bug; both are fixed.
 		//
 		// The result is a COPY, and the reason is WHOSE DATA IT IS rather
-		// than any blanket no-aliasing rule: GoValue's doc comment promises
-		// none, and the LNative arm below hands its payload straight back
-		// uncopied.  That is right for LNative -- the payload is the
+		// than any blanket no-aliasing rule: GoValue's doc comment does not
+		// promise one, and the LNative arm below hands its payload straight
+		// back uncopied.  That is right for LNative -- the payload is the
 		// EMBEDDER's, so returning it shares what they already own.  An
 		// LBytes is the other case: its bytes live in a *[]byte under Native
 		// so append! can grow them in place, so the storage is the
-		// INTERPRETER's and lisp code observes writes through it.  Handing it
-		// out would let an embedder mutate a live lisp value behind the
-		// kernel's back, past the ownership and seal invariants that make
-		// sharing safe.
+		// INTERPRETER's and lisp code observes writes through it.
 		//
-		// COST: O(len), unbounded by anything the kernel controls -- the
-		// only arm in this switch of which that is true.  Order of magnitude
-		// on the authoring machine: ~200ns at 16 bytes, but hundreds of
-		// microseconds and a megabyte allocated at a megabyte, against
-		// single-digit nanoseconds and zero allocations for an LNative
-		// carrying the same megabyte.  Deliberately stated as magnitudes:
-		// the absolute figures move by ~2x run to run on a shared box, so
-		// BenchmarkGoValueBytes is where the number lives.  The cost is
-		// affordable because of who calls this: GoValue has no caller inside
-		// elps at all (libjson's GoValue is a different method on
-		// Serializer), so it is purely an embedder API, and the copy is what
-		// an embedder handing the result to something that outlives the call
-		// -- a logger, a queue, a serializer -- actually needs.
+		// Two concrete failures, neither of which needs that framing to bite:
+		//
+		//   - append! REPLACES the slice header (builtinAppendMutate ->
+		//     appendMutateBytes assigns through the *[]byte), so a live slice
+		//     handed out before an append is silently STALE afterwards:
+		//     right contents, wrong length, no error.
+		//   - (slice 'bytes ...) mints a distinct LBytes over the SAME
+		//     backing array, so a write through one live result corrupts its
+		//     siblings.
+		//
+		// Ownership, not seal: sealableNodeType (lisp/seal.go) does not
+		// include LBytes, so a bytes value is never sealed and only the
+		// ownership invariant is in play.
+		//
+		// COST: O(len).  This is the only LEAF arm here that is unbounded --
+		// NOT the only unbounded arm, which an earlier draft of this comment
+		// claimed and which is wrong: LSExpr, LSortMap and LArray all scale
+		// with their input and cost far more (a 65k-entry sorted map runs to
+		// ~150ms and tens of megabytes).  What is unusual here is copying
+		// PAYLOAD rather than building a container spine.
+		//
+		// Magnitudes on the authoring machine: tens of nanoseconds at 16
+		// bytes; hundreds of microseconds and a megabyte allocated at a
+		// megabyte; against single-digit nanoseconds and no allocation for
+		// an LNative carrying the same megabyte.  Magnitudes rather than
+		// figures on purpose -- the absolute numbers move by ~2x run to run
+		// on a shared box -- so BenchmarkGoValueBytes is where they live.
+		//
+		// One amplification worth knowing: N references to ONE LBytes inside
+		// a converted structure produce N copies, since each is converted
+		// where it is reached.  Strings do not do this (v.Str is shared).
+		//
+		// The cost is affordable because of who calls this: GoValue has no
+		// caller inside elps at all, so it is purely an embedder API, and a
+		// copy is what an embedder handing the result to something that
+		// outlives the call -- a logger, a queue, a serializer -- needs.
 		b := v.Bytes()
 		out := make([]byte, len(b))
 		copy(out, b)

--- a/lisp/embed.go
+++ b/lisp/embed.go
@@ -73,7 +73,26 @@ func (v *LVal) goValueNode(g cycleGuard) interface{} {
 	case LSymbol, LString:
 		return v.Str
 	case LBytes:
-		return v.Bytes
+		// v.Bytes is a METHOD, not a field (lisp/lisp.go:1182), so the
+		// obvious `return v.Bytes` handed the embedder a func() []byte
+		// where every other arm of this switch returns plain data.  It
+		// type-checks, because the arm's result is interface{}, and only
+		// fails at use -- which is why it survived (issue #548).
+		//
+		// The result is a COPY, for the reason the neighbouring arms are:
+		// goSlice and goMap build fresh containers rather than handing out
+		// the value's own storage.  An LBytes keeps its bytes in a *[]byte
+		// under Native so append! can grow them in place, and returning
+		// that backing would let an embedder mutate a live lisp value
+		// behind the kernel's back -- past the ownership and seal
+		// invariants that make sharing safe, and past `copy`'s promise
+		// that a copy shares no storage with its original (#378).  It is
+		// the same hazard NativeValue's type gate exists to prevent
+		// (#546), reached through a different door.
+		b := v.Bytes()
+		out := make([]byte, len(b))
+		copy(out, b)
+		return out
 	case LInt:
 		return v.Int
 	case LFloat:

--- a/lisp/embed_bench_test.go
+++ b/lisp/embed_bench_test.go
@@ -25,7 +25,7 @@ func BenchmarkGoValueBytes(b *testing.B) {
 		v := Bytes(make([]byte, n))
 		b.Run(fmt.Sprintf("size=%d", n), func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				goValueSink = GoValue(v)
 			}
 		})
@@ -47,7 +47,7 @@ func BenchmarkGoValueLeafArms(b *testing.B) {
 	for _, arm := range arms {
 		b.Run(arm.name, func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				goValueSink = GoValue(arm.v)
 			}
 		})

--- a/lisp/embed_bench_test.go
+++ b/lisp/embed_bench_test.go
@@ -1,0 +1,58 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkGoValueBytes pins the cost of GoValue's LBytes arm across sizes.
+//
+// The arm copies (see lisp/embed.go for why), so its cost is O(len) and
+// unbounded by anything the kernel controls -- the only such arm in the
+// switch.  This benchmark exists so that is a measured number in CI rather
+// than folklore, and so a future change that makes the cost worse, or that
+// removes the copy to make it better, has to move a row here.
+//
+// Read it against BenchmarkGoValueLeafArms below: an LNative carrying the
+// identical megabyte returns in single-digit nanoseconds with no allocation,
+// because its payload is the embedder's own and is shared rather than
+// copied.  The gap between those two rows is the price of the LBytes arm's
+// safety property, stated rather than implied.
+func BenchmarkGoValueBytes(b *testing.B) {
+	for _, n := range []int{16, 1024, 64 * 1024, 1024 * 1024} {
+		v := Bytes(make([]byte, n))
+		b.Run(fmt.Sprintf("size=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				goValueSink = GoValue(v)
+			}
+		})
+	}
+}
+
+// BenchmarkGoValueLeafArms is the comparison set: the other leaf arms that
+// return without walking anything, so the LBytes numbers above can be read
+// against arms that do no copying at all.
+func BenchmarkGoValueLeafArms(b *testing.B) {
+	arms := []struct {
+		name string
+		v    *LVal
+	}{
+		{"native-1MB", Native(make([]byte, 1024*1024))},
+		{"string", String("here I stand")},
+		{"int", Int(42)},
+	}
+	for _, arm := range arms {
+		b.Run(arm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				goValueSink = GoValue(arm.v)
+			}
+		})
+	}
+}
+
+// goValueSink keeps the benchmarked conversions from being optimized away.
+var goValueSink interface{}

--- a/lisp/embed_bench_test.go
+++ b/lisp/embed_bench_test.go
@@ -42,7 +42,10 @@ func BenchmarkGoValueLeafArms(b *testing.B) {
 	}{
 		{"native-1MB", Native(make([]byte, 1024*1024))},
 		{"string", String("here I stand")},
-		{"int", Int(42)},
+		// Deliberately NOT a small int: Go boxes 0..255 from a static table,
+		// so Int(42) would measure that cache rather than the arm and read
+		// as 0 allocs where a real int costs one.
+		{"int", Int(1 << 20)},
 	}
 	for _, arm := range arms {
 		b.Run(arm.name, func(b *testing.B) {

--- a/lisp/embed_test.go
+++ b/lisp/embed_test.go
@@ -82,12 +82,27 @@ func TestBytesGoValue(t *testing.T) {
 			after, want)
 	}
 
-	// Empty and nil inputs go through the same path; neither should return
-	// a func, and neither should panic.
-	for _, empty := range [][]byte{{}, nil} {
-		got := GoValue(Bytes(empty))
-		if _, ok := got.([]byte); !ok {
-			t.Errorf("GoValue of empty LBytes returned %T, want []byte", got)
+	// Empty and nil inputs go through the same path.  Bytes(nil) does NOT
+	// short-circuit in goValue -- IsNil() is (LSExpr && no Cells), and this
+	// value is LBytes -- so the arm really is reached.
+	//
+	// Asserting the type alone was too weak: an implementation returning
+	// some other zero-length or arbitrary slice for len(b)==0 passed it.
+	// Assert the length and emptiness too, and name which input failed, so
+	// a failure distinguishes {} from nil.
+	for _, empty := range []struct {
+		name string
+		in   []byte
+	}{{"empty", []byte{}}, {"nil", nil}} {
+		got := GoValue(Bytes(empty.in))
+		b, ok := got.([]byte)
+		if !ok {
+			t.Errorf("GoValue of %s LBytes returned %T, want []byte", empty.name, got)
+			continue
+		}
+		if len(b) != 0 {
+			t.Errorf("GoValue of %s LBytes returned %q (len %d), want a zero-length slice",
+				empty.name, b, len(b))
 		}
 	}
 }

--- a/lisp/embed_test.go
+++ b/lisp/embed_test.go
@@ -34,3 +34,60 @@ func TestVectorGoValue(t *testing.T) {
 		}
 	}
 }
+
+// TestBytesGoValue pins what GoValue hands an embedder for an LBytes value.
+//
+// The bug this covers (#548) was `return v.Bytes` in goValueNode's LBytes
+// arm: Bytes is a METHOD, not a field, so the arm returned a bound method
+// value -- a func() []byte -- rather than the bytes.  The arm's result type
+// is interface{}, so it compiled, and every caller that only passed the
+// result along kept working; it failed at use, far from the mistake.
+//
+// Hence the assertion on the CONCRETE DYNAMIC TYPE.  A test that only did
+// reflect.DeepEqual against []byte would have caught this one, but a test
+// asserting the type says what the contract is: this arm returns data, like
+// every other arm.
+func TestBytesGoValue(t *testing.T) {
+	src := []byte("here I stand")
+	// Captured as a string BEFORE anything runs, and compared against
+	// throughout.  Bytes(src) stores a slice header over src's OWN backing
+	// array, so an assertion phrased against src after a mutation compares
+	// two values that both changed and passes whatever the code does --
+	// which is how the first draft of this test let a no-copy
+	// implementation through its own red-proof.  A string conversion copies.
+	want := string(src)
+	v := Bytes(src)
+
+	got := GoValue(v)
+	b, ok := got.([]byte)
+	if !ok {
+		t.Fatalf("GoValue of an LBytes returned %T, want []byte", got)
+	}
+	if string(b) != want {
+		t.Errorf("GoValue returned %q, want %q", b, want)
+	}
+
+	// The copy is the other half of the contract, and it is not cosmetic:
+	// an LBytes stores its bytes in a *[]byte under Native so append! can
+	// grow them in place, so handing back that backing would let an
+	// embedder mutate a live lisp value the kernel still owns.  goSlice and
+	// goMap build fresh containers for the same reason.
+	//
+	// Written as a mutation rather than a pointer comparison because that
+	// is the property that matters: whatever the aliasing, a write through
+	// the result must not be observable in the lisp value.
+	b[0] = 'H'
+	if after := string(v.Bytes()); after != want {
+		t.Errorf("writing through GoValue's result changed the lisp value to %q, want %q",
+			after, want)
+	}
+
+	// Empty and nil inputs go through the same path; neither should return
+	// a func, and neither should panic.
+	for _, empty := range [][]byte{{}, nil} {
+		got := GoValue(Bytes(empty))
+		if _, ok := got.([]byte); !ok {
+			t.Errorf("GoValue of empty LBytes returned %T, want []byte", got)
+		}
+	}
+}

--- a/lisp/lisplib/libjson/json.go
+++ b/lisp/lisplib/libjson/json.go
@@ -709,7 +709,20 @@ func (s *Serializer) GoValue(v *lisp.LVal, stringNums bool) interface{} {
 		}
 		return v.Str
 	case lisp.LBytes:
-		return v.Bytes
+		// The same defect lisp.GoValue carried until issue #548: Bytes is a
+		// METHOD, so `return v.Bytes` hands back a func() []byte where every
+		// other arm returns data.  Found by an adversarial review of the fix
+		// to the other one, which had cited this method as "a different
+		// GoValue" without checking it for the same bug.
+		//
+		// Copied, for the reason lisp/embed.go's arm gives: the *[]byte
+		// under Native is the interpreter's storage, which lisp code
+		// observes writes through, and this method is exported and
+		// documented as kept for outside callers.
+		b := v.Bytes()
+		out := make([]byte, len(b))
+		copy(out, b)
+		return out
 	case lisp.LInt:
 		if stringNums {
 			return strconv.Itoa(v.Int)

--- a/lisp/lisplib/libjson/libjson_test.go
+++ b/lisp/lisplib/libjson/libjson_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/luthersystems/elps/elpstest"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libjson"
 )
 
 func TestPackage(t *testing.T) {
@@ -41,4 +43,44 @@ func BenchmarkPackage(b *testing.B) {
 	r := &elpstest.Runner{}
 	defer r.Close()
 	r.RunBenchmarkFile(b, "libjson_test.lisp")
+}
+
+// TestGoValueBytes covers the LBytes arm of the deprecated
+// Serializer.GoValue, which carried the same defect lisp.GoValue did until
+// issue #548: `return v.Bytes` returns a bound METHOD VALUE, a func()
+// []byte, where every other arm returns data.
+//
+// It survived the fix to the other one because that fix's own comment cited
+// this method -- as "a different GoValue" -- without checking it for the
+// same bug. An adversarial review caught that. Hence a test rather than
+// only a fix: the two implementations are independent and can drift again.
+//
+// Asserts the concrete dynamic type for the reason its counterpart in
+// lisp/embed_test.go does: the arm's result is interface{}, so the wrong
+// type compiles and only fails at use, far from the mistake.
+func TestGoValueBytes(t *testing.T) {
+	src := []byte("here I stand")
+	// Captured before anything runs: lisp.Bytes stores a slice header over
+	// src's OWN backing array, so an assertion phrased against src after a
+	// mutation compares two values that both changed.
+	want := string(src)
+
+	v := lisp.Bytes(src)
+	got := libjson.DefaultSerializer().GoValue(v, false)
+	b, ok := got.([]byte)
+	if !ok {
+		t.Fatalf("Serializer.GoValue of an LBytes returned %T, want []byte", got)
+	}
+	if string(b) != want {
+		t.Errorf("Serializer.GoValue returned %q, want %q", b, want)
+	}
+
+	// And it is a copy, so a write through the result cannot reach the lisp
+	// value -- this method is exported and documented as kept for outside
+	// callers, which is precisely who would mutate it.
+	b[0] = 'H'
+	if after := string(v.Bytes()); after != want {
+		t.Errorf("writing through Serializer.GoValue's result changed the lisp value to %q, want %q",
+			after, want)
+	}
 }


### PR DESCRIPTION
Fixes #548. Worth landing before v1.57.0 so substrate takes one bump rather than v1.57.0 followed immediately by a v1.57.1.

## The bug, in two places

`goValueNode`'s LBytes arm was:

```go
case LBytes:
    return v.Bytes
```

`Bytes` is a **method**, not a field, so the arm handed the embedder a `func() []byte` where every other arm of the switch returns plain data. The arm's result type is `interface{}`, so it compiled, and any caller that only passed the result along kept working — it failed at *use*, far from the mistake. That is how it survived.

**The identical arm, with the identical bug, was also in `libjson`** (`Serializer.GoValue`). Exported, on an exported type, and its own doc says it is deprecated and *"kept only for outside callers"* — exactly the population #548 is about. It survived the first pass of this PR because that pass's comment **cited this very method** as "a different GoValue on `Serializer`" while arguing elps has no internal caller: I looked straight at it and did not check it for the same bug. An adversarial review caught that. Both are fixed, each with its own regression test, because the two implementations are independent and can drift again.

No compatibility concern either side: the previous return value was a function nobody could have been using as bytes.

## Why a copy

**Not** because of any blanket no-aliasing rule — that was this PR's first argument and it does not survive scrutiny. `GoValue`'s doc comment promises nothing about storage, and the `LNative` arm four lines below hands its payload straight back uncopied.

The distinction that holds is **whose data it is**. An `LNative` payload is the *embedder's* — they put it there — so returning it shares what they already own. An LBytes keeps its bytes in a `*[]byte` under `Native` so `append!` can grow them in place: that storage is the *interpreter's*, and lisp code observes writes through it.

Two concrete failures, neither needing that framing to bite:

- `append!` **replaces the slice header** (`builtinAppendMutate` → `appendMutateBytes` assigns *through* the `*[]byte`), so a live slice handed out before an append is silently **stale** afterwards — right contents, wrong length, no error.
- `(slice 'bytes ...)` mints a distinct LBytes over the **same** backing array, so a write through one live result corrupts its siblings.

## Cost, measured

O(len) — the only *leaf* arm here that is unbounded. (An earlier version of this description said "the only unbounded arm", which is wrong: `LSExpr`, `LSortMap` and `LArray` all scale with input and cost far more — ~150 ms and tens of MB for a 65k-entry sorted map.) What is unusual about this one is copying *payload* rather than building a container spine.

`BenchmarkGoValueBytes` pins the scaling, with a comparison set so the copying-vs-sharing gap is visible rather than implied. CI's numbers:

| | ns/op | allocs |
|---|---|---|
| `GoValueBytes/size=16` | 44.6 | 2 |
| `GoValueBytes/size=1048576` | 128,900 | 2 |
| `GoValueLeafArms/native-1MB` | **3.7** | **0** |

Affordable because of **who calls this**: `lisp.GoValue` has no caller inside elps at all, so it is purely an embedder API. Its one known downstream caller (substrate's `cc:log-fields`) hands the result to a logger that may retain it past the builtin's return — the case where a copy is what you want rather than what you tolerate. On `main` that log field became a `func() []uint8`, rendering as a pointer address, so there is no working behaviour to regress.

Corroborated by the gate: 565 benchmark rows, **0 at or above the gate**, and every byte-path row (`AliasSliceBytes`, `AliasAppendBytes{Once,Chain,Mutate}`) flat.

## Tests

Both assert the **concrete dynamic type**, not only the value: the arm's result is `interface{}`, so the wrong type compiles and only fails at use.

**The first draft was vacuous on its aliasing assertion, and the red-proof caught it.** Phrased against `src` after the mutation, it compared two values that had *both* changed — `Bytes(src)` stores a slice header over `src`'s own backing — so it passed a no-copy implementation. Rewritten to compare against a string captured before anything runs. The review reconstructed the old phrasing and confirmed it passes a broken implementation while the shipped phrasing fails it.

Every guard red-proofs independently:

| mutation | fails with |
|---|---|
| `return v.Bytes` (the original bug) | `returned func() []uint8, want []byte` |
| `return v.Bytes()` (right type, live backing) | `writing through GoValue's result changed the lisp value to "Here I stand"` |
| `make` without `copy` | `returned "\x00\x00…", want "here I stand"` |
| `copy(out, b[1:])` | `returned "ere I stand\x00"` |
| libjson: `return v.Bytes` | `Serializer.GoValue of an LBytes returned func() []uint8, want []byte` |
| non-empty return for `len==0` | `GoValue of empty LBytes returned "surprise" (len 8), want a zero-length slice` |

The exported `GoValue` doc comment now states the bytes behaviour. #548 asked copy-or-live; answering it only inside `goValueNode` is not where a godoc reader looks — and leaning on "the doc promises none" is a reason to fix that doc rather than to cite it.

## Also from the review

- `BenchmarkGoValueLeafArms/int` used `Int(42)`; Go boxes 0–255 from a static table, so it measured that cache and read 0 allocs. Now `Int(1<<20)`.
- A related report (#551, `(*LVal).Copy` sharing LBytes storage) was investigated and **closed as not-a-bug**: `Copy` shares storage within a runtime by design — its doc comment says it is "not a tool for transferring values between Runtimes; the in-kernel detach covers that" — and `TestCopyAliasesBytesAndMapValues` exists specifically to pin that, as a control for the `Detach` disjointness tests. `LArray` behaves identically and is pinned the same way.

## Test Plan

- [x] `go build ./...`; `go test ./...`; `go test -tags elpscheck ./lisp/`
- [x] `go vet ./...` clean; `make elpsvet` clean on both passes
- [x] **`golangci-lint run ./...`** — clean on this branch's files. (Skipping this is what broke CI mid-PR with `intrange`; the host copy is version-skewed from CI's, which is a reason a local *pass* may not guarantee a CI pass, never a reason to skip the run.)
- [x] `./elps doc -m`; `./elps fmt -l ./...` clean
- [x] Red-proof for every guard (table above)
- [x] Benchmark gate: 0 rows at or above the gate

Related: #546, #547, #551, #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgShxM3EoPmeVnq1cmpcPK