### PR TITLE
lint: Go-style deprecation annotations for functions

### DIFF
--- a/.claude/skills/add-linter-check/SKILL.md
+++ b/.claude/skills/add-linter-check/SKILL.md
@@ -37,7 +37,6 @@ var AnalyzerMyCheck = &Analyzer{
 				pass.Report(Diagnostic{
 					Message: "descriptive error message",
 					Pos:     posFromSource(src.Source),
-					Notes:   []string{"; nolint:my-check"},
 				})
 			}
 		})
@@ -71,7 +70,10 @@ func walkMyCheck(pass *Pass, v *lisp.LVal, insideTarget bool) {
 }
 ```
 
-**Always include `; nolint:analyzer-name`** in the diagnostic Notes — this enables suppression.
+**Do not add a `; nolint:analyzer-name` note yourself** — the CLI renderer
+(`cmd/diagnostic.go`) appends a suppression hint to every diagnostic
+automatically, and a hand-written note renders as a duplicate. Use Notes for
+check-specific context (e.g. "first defined at ...").
 
 ### 3. File 2: `lint/lint.go` — Register in `DefaultAnalyzers()`
 
@@ -142,7 +144,7 @@ Common patterns that cause false positives:
 ## Checklist
 
 - [ ] Analyzer defined in `lint/analyzers.go` with Name, Doc, Run
-- [ ] Diagnostic includes `; nolint:` suppression hint in Notes
+- [ ] No hand-written `; nolint:` note (the CLI appends the hint automatically)
 - [ ] Registered in `DefaultAnalyzers()` in `lint/lint.go`
 - [ ] Positive, negative, and nolint tests in `lint/lint_test.go`
 - [ ] `TestDefaultAnalyzers` count updated

--- a/analysis/analysis_test.go
+++ b/analysis/analysis_test.go
@@ -270,6 +270,65 @@ func TestAnalyze_DefunDocstring(t *testing.T) {
 	assert.Equal(t, "Add two numbers.", sym.DocString)
 }
 
+// TestAnalyze_DefunDocstringParagraphs pins prescan to the runtime's rule: the
+// docstring is the whole run of leading string literals joined by
+// lisp.JoinDocStrings, not just the first one. ELPS strings cannot hold a raw
+// line break, so an empty string is how source spells a paragraph break — and
+// that is the shape a "Deprecated:" paragraph arrives in.
+func TestAnalyze_DefunDocstringParagraphs(t *testing.T) {
+	result := parseAndAnalyze(t, "(defun blend-paths (a b)\n"+
+		"  \"Combines two paths.\"\n"+
+		"  \"\"\n"+
+		"  \"Deprecated: use join-paths instead.\"\n"+
+		"  (join-paths a b))")
+	sym := result.RootScope.LookupLocal("blend-paths")
+	require.NotNil(t, sym)
+	assert.Equal(t, "Combines two paths.\n\nDeprecated: use join-paths instead.", sym.DocString)
+	assert.Equal(t, sym.DocString, docstringViaRuntime(t,
+		"(defun blend-paths (a b)\n"+
+			"  \"Combines two paths.\"\n"+
+			"  \"\"\n"+
+			"  \"Deprecated: use join-paths instead.\"\n"+
+			"  (join-paths a b))"),
+		"analysis and lisp.(*LVal).Docstring must agree")
+}
+
+// TestAnalyze_DefunDocstringJoinsWithSpaces covers the other half of the join
+// rule: adjacent non-empty strings are one paragraph, joined by single spaces.
+func TestAnalyze_DefunDocstringJoinsWithSpaces(t *testing.T) {
+	result := parseAndAnalyze(t, `(defun add (a b) "Add two" "numbers." (+ a b))`)
+	sym := result.RootScope.LookupLocal("add")
+	require.NotNil(t, sym)
+	assert.Equal(t, "Add two numbers.", sym.DocString)
+}
+
+// TestAnalyze_DefunStringOnlyBodyIsNotADocstring: a body that is nothing but
+// strings is a constant function, so it has no docstring however many strings
+// it holds.
+func TestAnalyze_DefunStringOnlyBodyIsNotADocstring(t *testing.T) {
+	result := parseAndAnalyze(t, `(defun version () "1.0.0")`)
+	sym := result.RootScope.LookupLocal("version")
+	require.NotNil(t, sym)
+	assert.Empty(t, sym.DocString)
+
+	result = parseAndAnalyze(t, `(defun version () "Deprecated: gone." "1.0.0")`)
+	sym = result.RootScope.LookupLocal("version")
+	require.NotNil(t, sym)
+	assert.Empty(t, sym.DocString, "an all-string body is a constant function, not documentation")
+}
+
+// docstringViaRuntime evaluates a single defun and returns the docstring the
+// interpreter itself reports, so the analysis tests can assert equality with
+// the authority rather than with a transcription of it.
+func docstringViaRuntime(t *testing.T, source string) string {
+	t.Helper()
+	env := newTestEnv(t)
+	evalSource(t, env, source)
+	fun := env.GetGlobal(lisp.Symbol("blend-paths"))
+	require.Equal(t, lisp.LFun, fun.Type, "expected a function binding")
+	return fun.Docstring()
+}
+
 // --- Analyze: lambda ---
 
 func TestAnalyze_Lambda(t *testing.T) {

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -151,15 +151,6 @@ func (a *analyzer) prescanDefun(expr *lisp.LVal, scope *Scope, kind SymbolKind, 
 		return
 	}
 
-	// Extract docstring
-	var docStr string
-	if astutil.ArgCount(expr) >= 3 && expr.Cells[3].Type == lisp.LString {
-		// Has body after docstring
-		if astutil.ArgCount(expr) >= 4 {
-			docStr = expr.Cells[3].Str
-		}
-	}
-
 	sym := &Symbol{
 		Name:      nameVal.Str,
 		Package:   pkg,
@@ -167,7 +158,7 @@ func (a *analyzer) prescanDefun(expr *lisp.LVal, scope *Scope, kind SymbolKind, 
 		Source:    astutil.SourceLoc(nameVal),
 		Node:      nameVal,
 		Signature: signatureFromFormals(formalsVal),
-		DocString: docStr,
+		DocString: DefunDocstring(expr),
 	}
 	scope.Define(sym)
 	a.result.Symbols = append(a.result.Symbols, sym)
@@ -475,13 +466,9 @@ func (a *analyzer) analyzeDefun(node *lisp.LVal, scope *Scope, kind SymbolKind, 
 	// Add parameters to body scope
 	a.addParams(formalsVal, bodyScope)
 
-	// Walk body (skip head, name, formals, and optional docstring)
-	bodyStart := 3
-	if astutil.ArgCount(node) >= 3 && node.Cells[3].Type == lisp.LString {
-		if astutil.ArgCount(node) >= 4 {
-			bodyStart = 4
-		}
-	}
+	// Walk body (skip head, name, formals, and the docstring's whole run of
+	// leading strings -- the same run DefunDocstring reads).
+	bodyStart := defunBodyStart + docstringRun(node, defunBodyStart)
 	for i := bodyStart; i < len(node.Cells); i++ {
 		a.analyzeExpr(node.Cells[i], bodyScope, currentPkg)
 	}
@@ -745,13 +732,9 @@ func (a *analyzer) analyzeLambda(node *lisp.LVal, scope *Scope, currentPkg strin
 	bodyScope := NewScope(ScopeLambda, scope, node)
 	a.addParams(formalsVal, bodyScope)
 
-	// Walk body (skip head, formals, optional docstring)
-	bodyStart := 2
-	if astutil.ArgCount(node) >= 2 && node.Cells[2].Type == lisp.LString {
-		if astutil.ArgCount(node) >= 3 {
-			bodyStart = 3
-		}
-	}
+	// Walk body (skip head, formals, and the docstring's run of leading
+	// strings)
+	bodyStart := lambdaBodyStart + docstringRun(node, lambdaBodyStart)
 	for i := bodyStart; i < len(node.Cells); i++ {
 		a.analyzeExpr(node.Cells[i], bodyScope, currentPkg)
 	}

--- a/analysis/docstring.go
+++ b/analysis/docstring.go
@@ -1,0 +1,70 @@
+// Copyright © 2026 The ELPS authors
+
+package analysis
+
+import (
+	"github.com/luthersystems/elps/astutil"
+	"github.com/luthersystems/elps/lisp"
+)
+
+// Cell index the body of a definition form starts at:
+// (defun name (formals) body...) and (lambda (formals) body...).
+const (
+	defunBodyStart  = 3
+	lambdaBodyStart = 2
+)
+
+// DefunDocstring returns the docstring of a defun or defmacro form, read
+// exactly the way the interpreter reads it in lisp.(*LVal).Docstring.
+//
+// The docstring is the whole run of consecutive leading string literals in the
+// body, joined by lisp.JoinDocStrings: non-empty parts with single spaces, an
+// empty string opening a new paragraph. An ELPS string literal cannot hold a
+// raw line break, so a separate "" is how source spells a paragraph break --
+// which is exactly how the guide teaches a "Deprecated:" paragraph is written.
+// Reading only the first string would drop every paragraph after it, and the
+// tooling would then disagree with `elps doc` about the same definition.
+//
+// A body that is nothing but strings is a constant function returning a string
+// rather than a documented one, so it has no docstring.
+//
+// expr is only read positionally; validating that it is a definition form at
+// all is the caller's job. Indexing is guarded rather than assumed: analysis
+// runs over fault-tolerant parses of arbitrary bytes, where a definition can
+// be truncated to any shape.
+func DefunDocstring(expr *lisp.LVal) string {
+	n := docstringRun(expr, defunBodyStart)
+	if n == 0 {
+		return ""
+	}
+	parts := make([]string, n)
+	for i := range parts {
+		parts[i] = expr.Cells[defunBodyStart+i].Str
+	}
+	return lisp.JoinDocStrings(parts)
+}
+
+// docstringRun returns the number of leading string literals at bodyStart that
+// make up the form's docstring, and 0 when those strings are the body rather
+// than documentation.
+func docstringRun(expr *lisp.LVal, bodyStart int) int {
+	// astutil.ArgCount is 0 for a nil or headless form, so this single guard
+	// covers every truncated shape: a docstring needs a string at bodyStart
+	// and at least one form after it, hence bodyStart arguments at minimum.
+	if expr == nil || expr.Type != lisp.LSExpr || astutil.ArgCount(expr) < bodyStart {
+		return 0
+	}
+	n := 0
+	for i := bodyStart; i < len(expr.Cells); i++ {
+		cell := expr.Cells[i]
+		if cell == nil || cell.Type != lisp.LString {
+			break
+		}
+		n++
+	}
+	if bodyStart+n >= len(expr.Cells) {
+		// Every body form is a string: a constant function, not documentation.
+		return 0
+	}
+	return n
+}

--- a/analysis/workspace.go
+++ b/analysis/workspace.go
@@ -477,21 +477,12 @@ func scanDefun(expr *lisp.LVal, kind SymbolKind) *ExternalSymbol {
 		return nil
 	}
 
-	// Extract docstring: (defun name (args) "docstring" body...)
-	var docStr string
-	if astutil.ArgCount(expr) >= 3 && expr.Cells[3].Type == lisp.LString {
-		// Only treat as docstring if there's at least one body form after it.
-		if astutil.ArgCount(expr) >= 4 {
-			docStr = expr.Cells[3].Str
-		}
-	}
-
 	return &ExternalSymbol{
 		Name:      nameVal.Str,
 		Kind:      kind,
 		Signature: signatureFromFormals(formalsVal),
 		Source:    astutil.SourceLoc(nameVal),
-		DocString: docStr,
+		DocString: DefunDocstring(expr),
 	}
 }
 

--- a/analysis/workspace_test.go
+++ b/analysis/workspace_test.go
@@ -252,6 +252,31 @@ func TestScanWorkspace_DocStringExtracted(t *testing.T) {
 	assert.Equal(t, "Say hello to someone.", syms[0].DocString)
 }
 
+// TestScanWorkspace_DocStringParagraphs is the workspace-scan counterpart of
+// TestAnalyze_DefunDocstringParagraphs: the scanner reads the same run of
+// leading strings the runtime does, so a "Deprecated:" paragraph written as its
+// own string reaches ExternalSymbol.DocString.
+func TestScanWorkspace_DocStringParagraphs(t *testing.T) {
+	dir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(dir, "lib.lisp"), []byte(`
+(defun blend-paths (a b)
+  "Combines two paths."
+  ""
+  "Deprecated: use join-paths instead."
+  (join-paths a b))
+(export 'blend-paths)
+`), 0600)
+	require.NoError(t, err)
+
+	syms, err := ScanWorkspace(dir)
+	require.NoError(t, err)
+
+	require.Len(t, syms, 1)
+	assert.Equal(t, "blend-paths", syms[0].Name)
+	assert.Equal(t, "Combines two paths.\n\nDeprecated: use join-paths instead.", syms[0].DocString)
+}
+
 func TestScanWorkspace_NoDocStringWhenNoBody(t *testing.T) {
 	dir := t.TempDir()
 
@@ -268,6 +293,25 @@ func TestScanWorkspace_NoDocStringWhenNoBody(t *testing.T) {
 	require.Len(t, syms, 1)
 	assert.Equal(t, "version", syms[0].Name)
 	assert.Empty(t, syms[0].DocString, "string-only body should not be treated as docstring")
+}
+
+func TestScanWorkspace_NoDocStringWhenBodyIsAllStrings(t *testing.T) {
+	dir := t.TempDir()
+
+	// Several strings and nothing else is still a constant function: the run of
+	// strings has to be shorter than the body for it to be documentation.
+	err := os.WriteFile(filepath.Join(dir, "lib.lisp"), []byte(`
+(defun version () "Deprecated: gone." "1.0.0")
+(export 'version)
+`), 0600)
+	require.NoError(t, err)
+
+	syms, err := ScanWorkspace(dir)
+	require.NoError(t, err)
+
+	require.Len(t, syms, 1)
+	assert.Equal(t, "version", syms[0].Name)
+	assert.Empty(t, syms[0].DocString, "an all-string body is a constant function, not documentation")
 }
 
 func TestScanWorkspaceFull_SkipsHiddenDirs(t *testing.T) {

--- a/docs/embed.md
+++ b/docs/embed.md
@@ -470,6 +470,47 @@ diags, err := l.LintFiles(&lint.LintConfig{
 Without the `Registry` field, the linter only knows about stdlib symbols and
 will report false positives for embedder-provided bindings.
 
+### Deprecating a builtin
+
+An embedder retires a Go builtin the way Go retires an identifier: a docstring
+paragraph beginning `Deprecated:` (or `DEPRECATED:`) marks the function, and
+the rest of that paragraph says what to call instead. Register the builtin with
+`elpsutil.FunctionDoc` so the docstring reaches the runtime — any definition
+type with a `Docstring() string` method carries it the same way.
+
+```go
+import (
+    "github.com/luthersystems/elps/elpsutil"
+    "github.com/luthersystems/elps/lisp"
+)
+
+env.AddBuiltins(true,
+    elpsutil.FunctionDoc("blend-paths", lisp.Formals("a", "b"), blendPaths,
+        "Combines two paths into one.\n\nDeprecated: use join-paths instead."),
+    elpsutil.FunctionDoc("join-paths", lisp.Formals("a", "b"), joinPaths,
+        "Combines two paths into one."),
+)
+```
+
+Lint the embedded lisp sources with that environment's registry — the same
+`LintConfig` as above — and the `deprecated` check reports every call site,
+quoting the notice:
+
+```go
+diags, err := l.LintFiles(&lint.LintConfig{
+    Workspace: workspaceDir,
+    Registry:  env.Runtime.Registry,
+}, files)
+// paths.lisp:1:2: use of deprecated function 'substrate:blend-paths':
+// use join-paths instead.
+```
+
+The check needs the registry: without it the builtin has no docstring to read
+and its call sites go unreported. Passing the same registry to the language
+server (`lsp.WithRegistry`) or the MCP server (`mcpserver.WithRegistry`) gives
+authors the same treatment in the editor — struck-through call sites, a
+**Deprecated.** banner on hover, and a deprecated tag in completion lists.
+
 ### Documentation
 
 The `libhelp` package provides rendering functions that accept any `*lisp.LEnv`.

--- a/docs/lang.md
+++ b/docs/lang.md
@@ -1083,15 +1083,25 @@ paragraph tells callers what to use instead. `DEPRECATED:` is accepted too.
 
 ```lisp
 (defun blend-paths (a b)
+  "Combines two paths into one."
+  ""
+  "Deprecated: use join-paths instead."
+  (join-paths a b))
+```
+
+A string literal cannot contain a line break, so the empty string above is what
+opens the second paragraph — the same paragraph break docstrings use everywhere
+else. Writing the whole docstring as one string with a `\n\n` escape works
+identically:
+
+```lisp
+(defun blend-paths (a b)
   "Combines two paths into one.\n\nDeprecated: use join-paths instead."
   (join-paths a b))
 ```
 
-Write the whole docstring as a single string, as above. Strings cannot contain
-line breaks, so `\n\n` opens the second paragraph. Consecutive docstrings are
-joined for `elps doc`, but the tooling reads a definition's documentation from
-the leading string literal, so a marker written as a separate string is not
-seen by the linter or the language server.
+Both forms read the same to `elps doc`, the linter and the language server: a
+definition's documentation is the run of leading strings, joined.
 
 The `deprecated` lint check reports every use of a deprecated symbol and quotes
 the notice. It requires semantic analysis, so run the linter over a workspace:

--- a/docs/lang.md
+++ b/docs/lang.md
@@ -1075,6 +1075,44 @@ spaces. An empty string `""` inserts a paragraph break.
 A body consisting entirely of strings (no executable expression after them)
 is treated as a constant function returning a string, not as a docstring.
 
+### Deprecating functions
+
+A docstring paragraph beginning with `Deprecated:` marks a function or macro
+as deprecated, the same convention Go doc comments use. The rest of that
+paragraph tells callers what to use instead. `DEPRECATED:` is accepted too.
+
+```lisp
+(defun blend-paths (a b)
+  "Combines two paths into one.\n\nDeprecated: use join-paths instead."
+  (join-paths a b))
+```
+
+Write the whole docstring as a single string, as above. Strings cannot contain
+line breaks, so `\n\n` opens the second paragraph. Consecutive docstrings are
+joined for `elps doc`, but the tooling reads a definition's documentation from
+the leading string literal, so a marker written as a separate string is not
+seen by the linter or the language server.
+
+The `deprecated` lint check reports every use of a deprecated symbol and quotes
+the notice. It requires semantic analysis, so run the linter over a workspace:
+
+```
+$ elps lint --workspace . paths.lisp
+warning: use of deprecated function 'blend-paths': use join-paths instead. (deprecated)
+```
+
+The declaration itself is never flagged, and neither is a use inside the body
+of a definition that is itself deprecated — deprecated code may call deprecated
+code. Suppress an individual use with a trailing comment:
+
+```lisp
+(blend-paths a b) ; nolint:deprecated
+```
+
+Editors connected to the language server strike deprecated uses through, show
+a **Deprecated.** banner with the notice on hover, and mark the symbol
+deprecated in completion lists.
+
 ### Variable and constant documentation
 
 The `set` special operator accepts optional trailing strings after the value.

--- a/docs/lint-checks.md
+++ b/docs/lint-checks.md
@@ -410,6 +410,46 @@ Functions with `&rest` are variadic (no maximum). Threading macro children
 (add 1 2 3)    ; too many
 ```
 
+### `deprecated`
+
+**Reports uses of symbols marked deprecated by their docstring.**
+
+Requires semantic analysis (workspace mode). A symbol is deprecated when a
+paragraph of its docstring begins with `Deprecated:` (or `DEPRECATED:`) —
+the same convention Go doc comments use. The rest of that paragraph is
+quoted in the diagnostic, so it is the place to say what to use instead.
+`defun`, `defmacro`, workspace-scanned definitions, the interpreter's own
+builtins and the builtins a Go embedder registers (`elpsutil.FunctionDoc`)
+are all covered.
+
+Only *uses* are flagged, never the declaration, and a use inside the body
+of a definition that is itself deprecated is not flagged — deprecated code
+is allowed to call deprecated code, exactly as in Go.
+
+```lisp
+;; The declaration itself is never flagged
+(defun blend-paths (a b)
+  "Blend two paths.
+
+  Deprecated: use join-paths instead."
+  (join-paths a b))
+
+;; WARNING — use of deprecated function 'blend-paths': use join-paths instead.
+(blend-paths "a" "b")
+
+;; GOOD — call the replacement
+(join-paths "a" "b")
+
+;; OK — a deprecated function may use deprecated functions
+(defun old-blend (a b)
+  "Deprecated: use join-paths instead."
+  (blend-paths a b))
+```
+
+A marker only counts at the start of a paragraph, so prose mentioning the
+word mid-paragraph does not deprecate anything. To keep a call that must
+stay, suppress it with `; nolint:deprecated`.
+
 ### `unused-nolint`
 
 **Warns about `; nolint` directives that do not suppress any diagnostic.**

--- a/docs/lint-checks.md
+++ b/docs/lint-checks.md
@@ -454,8 +454,9 @@ escape inside a single string — is how the marker paragraph is written.
 A marker only counts at the start of a paragraph, so prose mentioning the
 word mid-paragraph does not deprecate anything. A body made up entirely of
 strings is a constant function rather than a documented one, so nothing in
-it deprecates anything either. To keep a call that must stay, suppress it
-with `; nolint:deprecated`.
+it deprecates anything either. A quoted symbol is data, not a reference, so
+`(funcall 'blend-paths a b)` is not flagged — `#'blend-paths` is. To keep a
+call that must stay, suppress it with `; nolint:deprecated`.
 
 ### `unused-nolint`
 

--- a/docs/lint-checks.md
+++ b/docs/lint-checks.md
@@ -426,12 +426,17 @@ Only *uses* are flagged, never the declaration, and a use inside the body
 of a definition that is itself deprecated is not flagged — deprecated code
 is allowed to call deprecated code, exactly as in Go.
 
+A docstring is the whole run of leading string literals, joined the way
+`elps doc` joins them: an empty string `""` opens a new paragraph. A string
+literal cannot contain a raw line break, so that empty string — or a `\n\n`
+escape inside a single string — is how the marker paragraph is written.
+
 ```lisp
 ;; The declaration itself is never flagged
 (defun blend-paths (a b)
-  "Blend two paths.
-
-  Deprecated: use join-paths instead."
+  "Blend two paths."
+  ""
+  "Deprecated: use join-paths instead."
   (join-paths a b))
 
 ;; WARNING — use of deprecated function 'blend-paths': use join-paths instead.
@@ -447,8 +452,10 @@ is allowed to call deprecated code, exactly as in Go.
 ```
 
 A marker only counts at the start of a paragraph, so prose mentioning the
-word mid-paragraph does not deprecate anything. To keep a call that must
-stay, suppress it with `; nolint:deprecated`.
+word mid-paragraph does not deprecate anything. A body made up entirely of
+strings is a constant function rather than a documented one, so nothing in
+it deprecates anything either. To keep a call that must stay, suppress it
+with `; nolint:deprecated`.
 
 ### `unused-nolint`
 

--- a/docs/lsp-guide.md
+++ b/docs/lsp-guide.md
@@ -7,6 +7,7 @@ ELPS source files. It supports any editor with LSP client capabilities.
 |----------------------|----------------------------------------------------|
 | Diagnostics          | Parse errors and lint warnings as you type          |
 | Hover                | Function signatures, docstrings, source locations   |
+| Deprecation          | Struck-through uses, hover banner, completion tag   |
 | Go to Definition     | Jump to defun/defmacro/set definition sites         |
 | Find References      | Find all uses of a symbol across the file           |
 | Document Symbols     | Outline of top-level definitions (defun, set, etc.) |
@@ -152,12 +153,19 @@ Two kinds of diagnostics are reported:
 Diagnostics can be suppressed with `; nolint:check-name` comments, the same
 syntax used by `elps lint`.
 
+Diagnostics from the `deprecated` check carry the LSP "deprecated" tag, so
+editors strike the use out instead of only underlining it. Unused-code
+diagnostics carry the "unnecessary" tag, which editors render as faded text.
+
 ### Hover
 
 Hovering over a symbol shows:
 
 - **Kind** (function, macro, variable, builtin, special operator, type)
 - **Signature** for callables (with `&optional`, `&rest`, `&key` annotations)
+- **Deprecation banner** — a **Deprecated.** line quoting the notice, shown
+  above the docstring when the symbol's documentation has a `Deprecated:`
+  paragraph
 - **Docstring** if available
 - **Source location** (file:line) for user-defined symbols
 
@@ -187,6 +195,9 @@ Two completion modes:
 
 2. **Package-qualified**: Type `package-name:` to get completions for all
    exported symbols in that package.
+
+Deprecated symbols are still offered, tagged deprecated so the editor renders
+them struck through in the completion list.
 
 Trigger characters: `(` and `:`.
 

--- a/elpsutil/elpsutil.go
+++ b/elpsutil/elpsutil.go
@@ -13,8 +13,27 @@ import (
 // that takes no arguments is declared with lisp.Formals(), the empty list; a
 // nil formals list is not a valid spelling of that and is rejected by
 // PackageLoader and Validate.
+//
+// A function constructed with Function has no documentation.  Use FunctionDoc
+// to give it a docstring.
 func Function(name string, formals *lisp.LVal, fun lisp.LBuiltin) *Builtin {
-	return &Builtin{formals, fun, name}
+	return &Builtin{formals, fun, name, ""}
+}
+
+// FunctionDoc is a helper to construct documented builtins.  It is Function
+// plus the docstring the function is registered with, which is what `elps doc`
+// prints, what the language server shows on hover, and what the linter reads.
+//
+// The docstring follows the same conventions as the interpreter's own
+// builtins.  In particular a paragraph beginning "Deprecated:" (or
+// "DEPRECATED:") marks the function deprecated, exactly as it does in a Go doc
+// comment: the `deprecated` lint check then reports every use of the function
+// and quotes the rest of that paragraph as the reason.  For example
+//
+//	elpsutil.FunctionDoc("blend-paths", lisp.Formals("a", "b"), blendPaths,
+//		"Blend two paths.\n\nDeprecated: use join-paths instead.")
+func FunctionDoc(name string, formals *lisp.LVal, fun lisp.LBuiltin, docs string) *Builtin {
+	return &Builtin{formals, fun, name, docs}
 }
 
 // Builtin captures Go functions that are callable from elps.
@@ -22,6 +41,7 @@ type Builtin struct {
 	formals *lisp.LVal
 	fun     lisp.LBuiltin
 	name    string
+	docs    string
 }
 
 // Name returns the name of a function.
@@ -37,6 +57,14 @@ func (fun *Builtin) Formals() *lisp.LVal {
 // Eval evaluates a function on an environment.
 func (fun *Builtin) Eval(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	return fun.fun(env, args)
+}
+
+// Docstring returns the documentation for a function, which is empty for a
+// function constructed with Function.  It satisfies the interface lisp checks
+// for when registering a definition, so the string reaches the registered
+// value and everything that reads documentation from it.
+func (fun *Builtin) Docstring() string {
+	return fun.docs
 }
 
 // Loader is a generic function to initialize/load an LEnv.  A Loader should

--- a/elpsutil/elpsutil_test.go
+++ b/elpsutil/elpsutil_test.go
@@ -5,6 +5,7 @@ package elpsutil_test
 import (
 	"testing"
 
+	"github.com/luthersystems/elps/analysis"
 	"github.com/luthersystems/elps/elpsutil"
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/parser"
@@ -372,4 +373,63 @@ func TestPackageLoader_SubstrateShape(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFunctionDoc_Docstring checks the constructor and the accessor. Builtin
+// must satisfy the unexported interface lisp checks for when it registers a
+// definition -- a duck-typed `interface{ Docstring() string }` -- which is why
+// the assertion is written against that shape rather than against the concrete
+// type.
+func TestFunctionDoc_Docstring(t *testing.T) {
+	const docs = "Blend two paths.\n\nDeprecated: use join-paths instead."
+
+	documented, ok := interface{}(elpsutil.FunctionDoc(
+		"blend-paths", lisp.Formals("a", "b"), nilFun, docs)).(interface{ Docstring() string })
+	require.True(t, ok, "*Builtin must satisfy the docstring interface lisp duck-types")
+	assert.Equal(t, docs, documented.Docstring())
+
+	// Function keeps working unchanged, with no documentation.
+	plain, ok := interface{}(elpsutil.Function(
+		"blend-paths", lisp.Formals("a", "b"), nilFun)).(interface{ Docstring() string })
+	require.True(t, ok)
+	assert.Empty(t, plain.Docstring())
+}
+
+// TestFunctionDoc_ReachesRegisteredValue follows the docstring all the way
+// along the path an embedder's linter run uses: FunctionDoc -> AddBuiltins ->
+// the registered LVal -> analysis.ExtractPackageExports -> the deprecation
+// detector. Every link is somebody else's code, so the round trip is the
+// assertion rather than the accessor on its own.
+func TestFunctionDoc_ReachesRegisteredValue(t *testing.T) {
+	const docs = "Blend two paths.\n\nDeprecated: use join-paths instead."
+
+	env := newTestEnv(t)
+	require.True(t, env.DefinePackage(lisp.Symbol("substrate")).IsNil())
+	require.True(t, env.InPackage(lisp.Symbol("substrate")).IsNil())
+	env.AddBuiltins(true,
+		elpsutil.FunctionDoc("blend-paths", lisp.Formals("a", "b"), nilFun, docs),
+		elpsutil.Function("join-paths", lisp.Formals("a", "b"), nilFun),
+	)
+	require.True(t, env.InPackage(lisp.String(lisp.DefaultUserPackage)).IsNil())
+
+	pkg := env.Runtime.Registry.Package("substrate")
+	require.NotNil(t, pkg)
+	val, ok := pkg.Symbol("blend-paths")
+	require.True(t, ok, "blend-paths should be registered")
+	assert.Equal(t, docs, val.Docstring(), "the docstring must reach the registered value")
+
+	exports := analysis.ExtractPackageExports(env.Runtime.Registry)
+	byName := make(map[string]analysis.ExternalSymbol)
+	for _, sym := range exports["substrate"] {
+		byName[sym.Name] = sym
+	}
+	require.Contains(t, byName, "blend-paths")
+	require.Contains(t, byName, "join-paths")
+
+	notice, deprecated := lisp.DeprecationNotice(byName["blend-paths"].DocString)
+	assert.True(t, deprecated, "the exported symbol must read as deprecated")
+	assert.Equal(t, "use join-paths instead.", notice)
+
+	_, deprecated = lisp.DeprecationNotice(byName["join-paths"].DocString)
+	assert.False(t, deprecated, "an undocumented builtin must not read as deprecated")
 }

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -1183,13 +1183,17 @@ var AnalyzerDeprecated = &Analyzer{
 		}
 		// Source spans of the definitions that are themselves deprecated. Go's
 		// rule is that deprecated code may use deprecated code, so references
-		// from inside those bodies are exempt.
-		exempt := deprecatedBodySpans(pass.Exprs)
+		// from inside those bodies are exempt. Built lazily: almost every file
+		// has no deprecated reference at all, and the LSP runs this on each
+		// keystroke.
+		var exempt byteSpans
+		exemptBuilt := false
+		passFile := analysis.NormalizePath(pass.Filename)
 
 		// References is a slice, in resolution order. Never iterate a Go map
 		// here: diagnostic order is part of the CLI's output contract and
 		// FuzzLintSource asserts two runs over the same bytes agree.
-		reported := make(map[*lisp.LVal]bool)
+		reported := make(map[int]bool)
 		for _, ref := range pass.Semantics.References {
 			if ref == nil || ref.Symbol == nil || ref.Source == nil {
 				continue
@@ -1198,18 +1202,33 @@ var AnalyzerDeprecated = &Analyzer{
 			if !ok {
 				continue
 			}
+			// A configured MacroExpander analyzes expanded forms whose nodes
+			// come from the macro's defining file, not the file being linted.
+			// Their byte offsets are meaningless against this file -- reporting
+			// them misattributes the diagnostic, and testing them against this
+			// file's exemption spans can silently drop real findings. A
+			// deprecated use inside a macro template is reported when the
+			// template's own file is linted.
+			if analysis.NormalizePath(ref.Source.File) != passFile {
+				continue
+			}
+			if !exemptBuilt {
+				exempt = deprecatedBodySpans(pass.Exprs)
+				exemptBuilt = true
+			}
 			if exempt.contains(ref.Source.Pos) {
 				continue
 			}
 			// One use, one diagnostic. A call to a user macro is resolved
 			// twice -- analyzeCall records the head before trying expansion
-			// and resolveSymbol records it again -- so the same site arrives
-			// here as two References sharing a node.
-			if ref.Node != nil {
-				if reported[ref.Node] {
+			// and resolveSymbol records it again -- and with an expander the
+			// two References need not share a node, so the key is the byte
+			// offset of the use, which they always share.
+			if ref.Source.Pos >= 0 {
+				if reported[ref.Source.Pos] {
 					continue
 				}
-				reported[ref.Node] = true
+				reported[ref.Source.Pos] = true
 			}
 			// Name it as the reference site spells it, so a qualified use
 			// reports 'pkg:name' rather than the bare symbol.
@@ -1229,9 +1248,12 @@ var AnalyzerDeprecated = &Analyzer{
 			if decl != nil && decl.Pos < 0 {
 				decl = nil
 			}
-			notes := []string{"; nolint:deprecated"}
+			// No hand-written nolint note: the CLI appends the suppression
+			// hint to every diagnostic (cmd/diagnostic.go), and no other
+			// analyzer duplicates it.
+			var notes []string
 			if decl != nil {
-				notes = []string{"deprecated at " + sourceString(decl), "; nolint:deprecated"}
+				notes = []string{"deprecated at " + sourceString(decl)}
 			}
 			pass.Report(Diagnostic{
 				Message:    msg,

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -1349,9 +1349,10 @@ func collectDeprecatedSpans(v *lisp.LVal, spans byteSpans) byteSpans {
 }
 
 // isDeprecatedDefinition reports whether v is a defun/defmacro whose own
-// docstring is deprecated. The docstring rule matches analysis.prescanDefun:
-// a string in the third argument position is a docstring only when a body
-// follows it, otherwise it is the body.
+// docstring is deprecated. The docstring is read through
+// analysis.DefunDocstring, the same function that fills the DocString this
+// check reads off a reference's symbol -- so the definition a use is
+// suppressed inside is judged by exactly the rule that deprecated it.
 func isDeprecatedDefinition(v *lisp.LVal) bool {
 	if v == nil || v.Type != lisp.LSExpr || v.IsQuoted() {
 		return false
@@ -1361,14 +1362,7 @@ func isDeprecatedDefinition(v *lisp.LVal) bool {
 	default:
 		return false
 	}
-	if astutil.ArgCount(v) < 4 {
-		return false
-	}
-	doc := v.Cells[3]
-	if doc == nil || doc.Type != lisp.LString {
-		return false
-	}
-	_, ok := lisp.DeprecationNotice(doc.Str)
+	_, ok := lisp.DeprecationNotice(analysis.DefunDocstring(v))
 	return ok
 }
 

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -1160,6 +1160,218 @@ var AnalyzerDuplicateDefinition = &Analyzer{
 	},
 }
 
+// AnalyzerDeprecated reports uses of symbols whose docstring marks them
+// deprecated, following the convention Go doc comments use: a docstring
+// paragraph beginning with "Deprecated:" (or "DEPRECATED:") deprecates the
+// symbol and the rest of the paragraph says what to use instead.
+// lisp.DeprecationNotice is the canonical detector.
+//
+// Every symbol kind semantic analysis records a docstring for is covered:
+// same-file defun/defmacro, workspace-scanned definitions, the compiled-in
+// builtins, special operators and macros, and the builtins an embedder
+// registers through a lisp.PackageRegistry (LintConfig.Registry).
+//
+// Requires semantic analysis (pass.Semantics != nil).
+var AnalyzerDeprecated = &Analyzer{
+	Name:     "deprecated",
+	Severity: SeverityWarning,
+	Semantic: true,
+	Doc:      "Report uses of symbols marked deprecated by their docstring.\n\nRequires semantic analysis (--workspace flag). A symbol is deprecated when a paragraph of its docstring begins with \"Deprecated:\", the same convention Go doc comments use; the rest of that paragraph is reported as the notice. Definitions are never flagged, only uses, and a use inside the body of a definition that is itself deprecated is not reported — deprecated code may call deprecated code.",
+	Run: func(pass *Pass) error {
+		if pass.Semantics == nil {
+			return nil
+		}
+		// Source spans of the definitions that are themselves deprecated. Go's
+		// rule is that deprecated code may use deprecated code, so references
+		// from inside those bodies are exempt.
+		exempt := deprecatedBodySpans(pass.Exprs)
+
+		// References is a slice, in resolution order. Never iterate a Go map
+		// here: diagnostic order is part of the CLI's output contract and
+		// FuzzLintSource asserts two runs over the same bytes agree.
+		reported := make(map[*lisp.LVal]bool)
+		for _, ref := range pass.Semantics.References {
+			if ref == nil || ref.Symbol == nil || ref.Source == nil {
+				continue
+			}
+			notice, ok := lisp.DeprecationNotice(ref.Symbol.DocString)
+			if !ok {
+				continue
+			}
+			if exempt.contains(ref.Source.Pos) {
+				continue
+			}
+			// One use, one diagnostic. A call to a user macro is resolved
+			// twice -- analyzeCall records the head before trying expansion
+			// and resolveSymbol records it again -- so the same site arrives
+			// here as two References sharing a node.
+			if ref.Node != nil {
+				if reported[ref.Node] {
+					continue
+				}
+				reported[ref.Node] = true
+			}
+			// Name it as the reference site spells it, so a qualified use
+			// reports 'pkg:name' rather than the bare symbol.
+			name := ref.Symbol.Name
+			if ref.Node != nil && ref.Node.Type == lisp.LSymbol && ref.Node.Str != "" {
+				name = ref.Node.Str
+			}
+			msg := fmt.Sprintf("use of deprecated %s '%s'", deprecatedKind(ref.Symbol.Kind), name)
+			if notice != "" {
+				msg += ": " + notice
+			}
+			// A builtin has no declaration to point at, and neither does a
+			// symbol whose location was synthesised rather than scanned
+			// (Location.Pos < 0 is the "no position" spelling token.Location
+			// itself uses). Both leave the diagnostic with only its message.
+			decl := ref.Symbol.Source
+			if decl != nil && decl.Pos < 0 {
+				decl = nil
+			}
+			notes := []string{"; nolint:deprecated"}
+			if decl != nil {
+				notes = []string{"deprecated at " + sourceString(decl), "; nolint:deprecated"}
+			}
+			pass.Report(Diagnostic{
+				Message:    msg,
+				Pos:        posFromSource(ref.Source),
+				EndPos:     endPosFromNode(ref.Node),
+				Notes:      notes,
+				Related:    relatedFromSource(decl, "deprecated declaration here"),
+				Deprecated: true,
+			})
+		}
+		return nil
+	},
+}
+
+// deprecatedKind renders a symbol kind for the deprecated diagnostic. It is
+// deliberately not analysis.SymbolKind.String(): that spells SymSpecialOp
+// "special-op", which reads as an identifier rather than prose in a sentence.
+func deprecatedKind(k analysis.SymbolKind) string {
+	switch k {
+	case analysis.SymFunction:
+		return "function"
+	case analysis.SymMacro:
+		return "macro"
+	case analysis.SymBuiltin:
+		return "builtin"
+	case analysis.SymSpecialOp:
+		return "special operator"
+	default:
+		return "symbol"
+	}
+}
+
+// byteSpan is a half-open [start, end) range of byte offsets into the file
+// being linted.
+type byteSpan struct {
+	start int
+	end   int
+}
+
+// byteSpans is a sorted, non-overlapping set of source spans.
+type byteSpans []byteSpan
+
+// contains reports whether the byte offset pos falls inside any span.
+func (s byteSpans) contains(pos int) bool {
+	if pos < 0 || len(s) == 0 {
+		return false
+	}
+	// The first span that could contain pos is the last one starting at or
+	// before it.
+	i := sort.Search(len(s), func(i int) bool { return s[i].start > pos })
+	if i == 0 {
+		return false
+	}
+	return pos < s[i-1].end
+}
+
+// deprecatedBodySpans returns the source spans of the defun/defmacro forms in
+// exprs whose own docstring is deprecated.
+//
+// Suppression is keyed on source position rather than on node identity because
+// the two ASTs an analyzer sees are two separate parses of the same bytes:
+// LintFileWithContext parses pass.Exprs with the format-preserving parser,
+// while pass.Semantics was analyzed over a plain parse (LintFileWithAnalysis).
+// No *lisp.LVal is ever shared between them, so a node-identity set would
+// silently match nothing. Byte offsets are assigned by the shared scanner and
+// do agree.
+//
+// The returned spans are sorted and non-overlapping: the walk stops descending
+// at the first deprecated definition it finds, so a deprecated definition
+// nested inside another contributes no span of its own.
+func deprecatedBodySpans(exprs []*lisp.LVal) byteSpans {
+	var spans byteSpans
+	for _, expr := range exprs {
+		spans = collectDeprecatedSpans(expr, spans)
+	}
+	// The end is part of the ordering only so that two spans sharing a start
+	// -- which disjoint spans cannot produce, but a fault-tolerant parse of
+	// malformed source might -- still sort into one fixed order. sort.Slice is
+	// not stable, and contains() reads the last span starting at or before the
+	// offset, so an ambiguous order would be an ambiguous answer.
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].start != spans[j].start {
+			return spans[i].start < spans[j].start
+		}
+		return spans[i].end < spans[j].end
+	})
+	return spans
+}
+
+// collectDeprecatedSpans appends the span of every deprecated definition at or
+// below v to spans.
+//
+// The traversal is hand-rolled rather than astutil.Walk because Walk stops at
+// a quasiquote — but analysis.resolveTemplateSymbol resolves symbols inside
+// templates and records References for them, so a macro's template body does
+// produce references. Suppression has to cover the same source a reference can
+// come from, or a deprecated macro whose template calls a deprecated function
+// would report against itself.
+func collectDeprecatedSpans(v *lisp.LVal, spans byteSpans) byteSpans {
+	if v == nil {
+		return spans
+	}
+	if isDeprecatedDefinition(v) {
+		// A definition with untracked offsets yields no span: the check then
+		// reports uses inside it, which is the conservative direction.
+		if loc := astutil.SourceLoc(v); loc != nil && loc.EndPos > loc.Pos {
+			return append(spans, byteSpan{start: loc.Pos, end: loc.EndPos})
+		}
+		return spans
+	}
+	for _, cell := range v.Cells {
+		spans = collectDeprecatedSpans(cell, spans)
+	}
+	return spans
+}
+
+// isDeprecatedDefinition reports whether v is a defun/defmacro whose own
+// docstring is deprecated. The docstring rule matches analysis.prescanDefun:
+// a string in the third argument position is a docstring only when a body
+// follows it, otherwise it is the body.
+func isDeprecatedDefinition(v *lisp.LVal) bool {
+	if v == nil || v.Type != lisp.LSExpr || v.IsQuoted() {
+		return false
+	}
+	switch astutil.HeadSymbol(v) {
+	case "defun", "defmacro":
+	default:
+		return false
+	}
+	if astutil.ArgCount(v) < 4 {
+		return false
+	}
+	doc := v.Cells[3]
+	if doc == nil || doc.Type != lisp.LString {
+		return false
+	}
+	_, ok := lisp.DeprecationNotice(doc.Str)
+	return ok
+}
+
 // AnalyzerNames returns a sorted list of all default analyzer names.
 func AnalyzerNames() []string {
 	analyzers := DefaultAnalyzers()

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -832,5 +832,6 @@ func DefaultAnalyzers() []*Analyzer {
 		AnalyzerShadowing,
 		AnalyzerUserArity,
 		AnalyzerDuplicateDefinition,
+		AnalyzerDeprecated,
 	}
 }

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -268,6 +268,10 @@ type Diagnostic struct {
 	// Unnecessary marks the diagnostic as "unnecessary" code (e.g., unused
 	// variables). Editors may render these with faded text.
 	Unnecessary bool `json:"unnecessary,omitempty"`
+
+	// Deprecated marks the diagnostic as a use of deprecated code. Editors
+	// may render the flagged range with strikethrough text.
+	Deprecated bool `json:"deprecated,omitempty"`
 }
 
 // RelatedInformation describes an additional source location associated with a

--- a/lint/lint_fuzz_guard_test.go
+++ b/lint/lint_fuzz_guard_test.go
@@ -4,6 +4,8 @@ package lint
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -124,4 +126,63 @@ func parseForGuard(t *testing.T, src string) []*lisp.LVal {
 	t.Helper()
 	return rdparser.New(token.NewScanner(lintFileA, bytes.NewReader([]byte(src)))).
 		ParseProgramFaultTolerant().Exprs
+}
+
+// TestLintFuzzSeedsReachDeprecated checks the corpus actually reaches the
+// `deprecated` check's REPORTING half, in both of the ways a docstring gets to
+// it: from the workspace scan of the neighbouring file, and from a definition
+// in the file being linted.
+//
+// It is the same hazard TestLintFuzzSeedsProduceDiagnostics guards in
+// aggregate, sharpened for one analyzer. `deprecated` fires only on a docstring
+// carrying the marker, and a corpus of ordinary docstrings would run its whole
+// reference loop, report nothing, and leave the diagnostic it builds -- the
+// notice text, the kind word, the span suppression -- entirely unreached while
+// the seeds still looked healthy.
+func TestLintFuzzSeedsReachDeprecated(t *testing.T) {
+	deprecatedDiags := func(dir string, files ...string) []Diagnostic {
+		t.Helper()
+		linter := &Linter{Analyzers: DefaultAnalyzers()}
+		diags, err := linter.LintFiles(&LintConfig{Workspace: dir}, files)
+		require.NoError(t, err)
+		var found []Diagnostic
+		for _, d := range diags {
+			if d.Analyzer == AnalyzerDeprecated.Name {
+				found = append(found, d)
+			}
+		}
+		return found
+	}
+	write := func(dir, name, src string) string {
+		t.Helper()
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+		return path
+	}
+
+	t.Run("cross file", func(t *testing.T) {
+		dir := t.TempDir()
+		uses := write(dir, lintFileA, lintSeedUses)
+		write(dir, lintFileB, lintSeedDefs)
+		found := deprecatedDiags(dir, uses)
+		require.NotEmpty(t, found,
+			"the primary seed pair produces no deprecated diagnostic, so the check's"+
+				" reporting half is unreached from the corpus")
+		for _, d := range found {
+			assert.True(t, d.Deprecated, "the deprecated check must set Deprecated")
+		}
+	})
+
+	t.Run("same file", func(t *testing.T) {
+		dir := t.TempDir()
+		src := write(dir, lintFileA, "(in-package 'user)\n"+
+			"(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n"+
+			"(defun also-old (y) \"Deprecated:\" (old-fn y))\n"+
+			"(old-fn 1)\n")
+		found := deprecatedDiags(dir, src)
+		require.Len(t, found, 1,
+			"expected exactly the top-level use: the declaration is not a use and the"+
+				" call from also-old's body is suppressed")
+		assert.Equal(t, 4, found[0].Pos.Line)
+	})
 }

--- a/lint/lint_fuzz_test.go
+++ b/lint/lint_fuzz_test.go
@@ -544,15 +544,18 @@ const (
 	lintSeedDefs = `(in-package 'demo)
 (use-package 'lisp)
 (defun add (a b) "add two" (+ a b))
+(defun old-add (a b) "Sum two numbers.\n\nDeprecated: use add instead." (add a b))
 (defmacro twice (x) (quasiquote (+ (unquote x) (unquote x))))
 (defmacro defthing (name args &rest body)
   (quasiquote (defun (unquote name) (unquote args) (unquote-splicing body))))
 (export 'add)
+(export 'old-add)
 (export 'twice)`
 
 	lintSeedUses = `(in-package 'user)
 (use-package 'demo)
 (defun main () (add 1 2))
+(defun legacy () (old-add 1 2))
 (defun unused-arg (x y) x)
 (defthing helper (q) (+ q 1))
 (let ([shadow 1]) (let ([shadow 2]) shadow))
@@ -628,6 +631,18 @@ func FuzzLintSource(f *testing.F) {
 	add("(in-package 'user)\n(defun dup () 1)\n(defun dup () 2)\n(defmacro dup (x) x)",
 		lintSeedDefs, scripts[0])
 	add("(in-package 'demo)\n(defun add (a b) 1)", lintSeedDefs, scripts[0])
+
+	// Deprecation, same-file: the definition, a use, a use from inside another
+	// deprecated definition (suppressed), a use inside a quasiquote template,
+	// and a marker that is prose rather than a marker. The check reads
+	// docstrings and source spans, neither of which any other seed varies.
+	add("(in-package 'user)\n"+
+		"(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n"+
+		"(defun also-old (y) \"Deprecated:\" (old-fn y))\n"+
+		"(defmacro old-mac (z) \"Deprecated: gone.\" (quasiquote (old-fn (unquote z))))\n"+
+		"(defun not-old (w) \"Fine.\\nDeprecated: not at a paragraph start.\" w)\n"+
+		"(old-fn 1)\n(old-mac 2)\n(not-old 3)\n(map 'list old-fn '(1 2))",
+		lintSeedDefs, scripts[0])
 
 	// Shapes chosen for what breaks the analyzers rather than the parser:
 	// arity errors, shadowing, rethrow patterns, dead branches, deep nesting.

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -14,7 +14,9 @@ import (
 	"testing"
 
 	"github.com/luthersystems/elps/analysis"
+	"github.com/luthersystems/elps/elpsutil"
 	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
 	"github.com/luthersystems/elps/parser/rdparser"
 	"github.com/luthersystems/elps/parser/token"
 	"github.com/stretchr/testify/assert"
@@ -1234,13 +1236,14 @@ func TestBracketListIgnored(t *testing.T) {
 
 func TestDefaultAnalyzers(t *testing.T) {
 	analyzers := DefaultAnalyzers()
-	assert.Len(t, analyzers, 17)
+	assert.Len(t, analyzers, 18)
 	names := AnalyzerNames()
 	assert.Equal(t, []string{
 		"builtin-arity",
 		"cond-missing-else",
 		"cond-structure",
 		"defun-structure",
+		"deprecated",
 		"duplicate-definition",
 		"if-arity",
 		"in-package-toplevel",
@@ -1592,6 +1595,7 @@ func TestSeverity_AnalyzerDefaults(t *testing.T) {
 		"shadowing":            SeverityInfo,
 		"user-arity":           SeverityError,
 		"duplicate-definition": SeverityWarning,
+		"deprecated":           SeverityWarning,
 	}
 	for _, a := range DefaultAnalyzers() {
 		want, ok := expected[a.Name]
@@ -2810,6 +2814,323 @@ func TestDuplicateDefinition_HasNotes(t *testing.T) {
 	assert.Contains(t, diags[0].Notes[0], "first defined at")
 }
 
+// --- deprecated ---
+
+func TestDeprecated_Positive_Call(t *testing.T) {
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n(old-fn 1)\n"
+	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
+	require.Len(t, diags, 1)
+	assertHasDiag(t, diags, "use of deprecated function 'old-fn': use new-fn instead.")
+	// The call, not the definition.
+	assertDiagOnLine(t, diags, 2, "use of deprecated function 'old-fn'")
+	assert.Equal(t, 2, diags[0].Pos.Line, "the definition line must never be flagged")
+	assert.True(t, diags[0].Deprecated,
+		"the diagnostic must carry Deprecated so editors can strike the range through")
+	assert.Equal(t, SeverityWarning, diags[0].Severity)
+}
+
+func TestDeprecated_Positive_ValueReference(t *testing.T) {
+	// Passing the function as a value is a use too, not only calling it.
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n(map 'list old-fn '(1 2))\n"
+	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
+	require.Len(t, diags, 1)
+	assertDiagOnLine(t, diags, 2, "use of deprecated function 'old-fn'")
+}
+
+func TestDeprecated_Positive_Macro(t *testing.T) {
+	source := "(defmacro old-mac (x) \"Deprecated: use new-mac instead.\" x)\n(old-mac 1)\n"
+	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
+	// A macro call resolves twice inside the analyzer (analyzeCall records the
+	// head, then resolveSymbol records it again); the check reports it once.
+	require.Len(t, diags, 1)
+	assertHasDiag(t, diags, "use of deprecated macro 'old-mac': use new-mac instead.")
+}
+
+func TestDeprecated_Positive_Shouting(t *testing.T) {
+	source := "(defun old-fn (x) \"Blend.\\n\\nDEPRECATED: use new-fn instead.\" x)\n(old-fn 1)\n"
+	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
+	require.Len(t, diags, 1)
+	assertHasDiag(t, diags, "use of deprecated function 'old-fn': use new-fn instead.")
+}
+
+func TestDeprecated_Positive_LaterParagraph(t *testing.T) {
+	source := "(defun old-fn (x) \"Blend two paths.\\n\\nDeprecated: use join-paths instead.\" x)\n(old-fn 1)\n"
+	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
+	require.Len(t, diags, 1)
+	assertHasDiag(t, diags, "use of deprecated function 'old-fn': use join-paths instead.")
+}
+
+func TestDeprecated_Positive_NoticeOmittedWhenEmpty(t *testing.T) {
+	source := "(defun old-fn (x) \"Deprecated:\" x)\n(old-fn 1)\n"
+	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
+	require.Len(t, diags, 1)
+	assert.Equal(t, "use of deprecated function 'old-fn'", diags[0].Message,
+		"an empty notice must not leave a dangling colon")
+}
+
+func TestDeprecated_Positive_EveryUseReported(t *testing.T) {
+	source := "(defun old-fn (x) \"Deprecated: use new-fn.\" x)\n" +
+		"(defun caller () (old-fn 1))\n" +
+		"(defun caller2 () (old-fn 2))\n"
+	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
+	require.Len(t, diags, 2)
+	assertDiagOnLine(t, diags, 2, "use of deprecated function 'old-fn'")
+	assertDiagOnLine(t, diags, 3, "use of deprecated function 'old-fn'")
+}
+
+func TestDeprecated_Negative_NormalDocstring(t *testing.T) {
+	source := "(defun ok-fn (x) \"Return x unchanged.\" x)\n(ok-fn 1)\n"
+	assertNoDiags(t, lintCheckSemantic(t, AnalyzerDeprecated, source))
+}
+
+func TestDeprecated_Negative_MidParagraphMention(t *testing.T) {
+	// "Deprecated:" that does not start a paragraph is prose, not a marker.
+	source := "(defun ok-fn (x) \"Blend two paths.\\nDeprecated: is a word.\" x)\n(ok-fn 1)\n"
+	assertNoDiags(t, lintCheckSemantic(t, AnalyzerDeprecated, source))
+}
+
+func TestDeprecated_Negative_DefinitionOnly(t *testing.T) {
+	// The declaration is not a use. A file that only defines the deprecated
+	// function is clean.
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n"
+	assertNoDiags(t, lintCheckSemantic(t, AnalyzerDeprecated, source))
+}
+
+func TestDeprecated_Negative_ExportIsNotAUse(t *testing.T) {
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n(export 'old-fn)\n"
+	assertNoDiags(t, lintCheckSemantic(t, AnalyzerDeprecated, source))
+}
+
+func TestDeprecated_Negative_StringBodyIsNotADocstring(t *testing.T) {
+	// A string in the docstring position with no body after it is the body,
+	// exactly as analysis.prescanDefun reads it.
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\")\n(old-fn 1)\n"
+	assertNoDiags(t, lintCheckSemantic(t, AnalyzerDeprecated, source))
+}
+
+func TestDeprecated_Negative_InsideDeprecatedFunction(t *testing.T) {
+	// Go's rule: deprecated code may use deprecated code.
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n" +
+		"(defun also-old (y) \"Deprecated: going away too.\" (old-fn y))\n"
+	assertNoDiags(t, lintCheckSemantic(t, AnalyzerDeprecated, source))
+}
+
+func TestDeprecated_Negative_RecursiveDeprecatedFunction(t *testing.T) {
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" (old-fn x))\n"
+	assertNoDiags(t, lintCheckSemantic(t, AnalyzerDeprecated, source))
+}
+
+func TestDeprecated_Negative_InsideDeprecatedMacroTemplate(t *testing.T) {
+	// A quasiquote template inside a deprecated macro is still that macro's
+	// body. astutil.Walk stops at quasiquote but the analyzer resolves
+	// template symbols, so suppression has to reach in here too.
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n" +
+		"(defmacro old-mac (y) \"Deprecated: going away too.\" (quasiquote (old-fn (unquote y))))\n"
+	assertNoDiags(t, lintCheckSemantic(t, AnalyzerDeprecated, source))
+}
+
+func TestDeprecated_TemplateReferenceIsFlagged(t *testing.T) {
+	// The deliberate counterpart to the test above: a quasiquote template in a
+	// macro that is NOT deprecated expands into real calls at every use site,
+	// so the reference analysis.resolveTemplateSymbol records is reported.
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n" +
+		"(defmacro live-mac (y) (quasiquote (old-fn (unquote y))))\n"
+	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
+	require.Len(t, diags, 1)
+	assertDiagOnLine(t, diags, 2, "use of deprecated function 'old-fn'")
+}
+
+func TestDeprecated_Nolint(t *testing.T) {
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n(old-fn 1) ; nolint:deprecated\n"
+	assertNoDiags(t, lintCheckSemantic(t, AnalyzerDeprecated, source))
+}
+
+func TestDeprecated_NotesAndRelated(t *testing.T) {
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n(old-fn 1)\n"
+	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
+	require.Len(t, diags, 1)
+	require.Len(t, diags[0].Notes, 2)
+	assert.Contains(t, diags[0].Notes[0], "deprecated at test.lisp:1:8")
+	assert.Equal(t, "; nolint:deprecated", diags[0].Notes[1])
+	require.Len(t, diags[0].Related, 1)
+	assert.Equal(t, "deprecated declaration here", diags[0].Related[0].Message)
+	assert.Equal(t, 1, diags[0].Related[0].Location.Line)
+}
+
+func TestDeprecated_NilSemantics(t *testing.T) {
+	// Without semantic analysis the check reports nothing at all.
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n(old-fn 1)\n"
+	assertNoDiags(t, lintCheck(t, AnalyzerDeprecated, source))
+}
+
+func TestDeprecated_KindWords(t *testing.T) {
+	// The kind word comes from the symbol's Kind. Builtins and special
+	// operators cannot be deprecated from lisp source, so they are injected
+	// the way an embedder's registry would supply them.
+	tests := []struct {
+		name string
+		kind analysis.SymbolKind
+		want string
+	}{
+		{"function", analysis.SymFunction, "use of deprecated function 'ext-sym'"},
+		{"macro", analysis.SymMacro, "use of deprecated macro 'ext-sym'"},
+		{"builtin", analysis.SymBuiltin, "use of deprecated builtin 'ext-sym'"},
+		{"special op", analysis.SymSpecialOp, "use of deprecated special operator 'ext-sym'"},
+		{"variable falls back to symbol", analysis.SymVariable, "use of deprecated symbol 'ext-sym'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &Linter{Analyzers: []*Analyzer{AnalyzerDeprecated}}
+			cfg := &analysis.Config{
+				ExtraGlobals: []analysis.ExternalSymbol{{
+					Name:      "ext-sym",
+					Kind:      tt.kind,
+					DocString: "Deprecated: use the new one.",
+				}},
+			}
+			diags, err := l.LintFileWithAnalysis([]byte("(ext-sym 1)\n"), "test.lisp", cfg)
+			require.NoError(t, err)
+			require.Len(t, diags, 1)
+			assert.Equal(t, tt.want+": use the new one.", diags[0].Message)
+		})
+	}
+}
+
+func TestDeprecated_MarshalsAsJSON(t *testing.T) {
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n(old-fn 1)\n"
+	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
+	require.Len(t, diags, 1)
+
+	var buf bytes.Buffer
+	require.NoError(t, FormatJSON(&buf, diags))
+	assert.Contains(t, buf.String(), `"deprecated": true`)
+
+	var round []Diagnostic
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &round))
+	require.Len(t, round, 1)
+	assert.True(t, round[0].Deprecated)
+	assert.Equal(t, "deprecated", round[0].Analyzer)
+}
+
+// TestDeprecated_RegistryBuiltin is the driving use case: an embedder registers
+// a Go builtin through elpsutil, marks it deprecated in its docstring, and runs
+// the linter over its own sources with LintConfig.Registry set. Both spellings
+// of the use -- qualified and imported with use-package -- must be flagged, and
+// the qualified one must be named as it is written.
+func TestDeprecated_RegistryBuiltin(t *testing.T) {
+	reg := deprecatedTestRegistry(t)
+
+	dir := t.TempDir()
+	source := "(use-package 'substrate)\n" +
+		"(substrate:blend-paths 1 2)\n" +
+		"(blend-paths 3 4)\n" +
+		"(substrate:join-paths 5 6)\n"
+	file := writeTempLisp(t, dir, "phylum.lisp", source)
+
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerDeprecated}}
+	diags, err := l.LintFiles(&LintConfig{Workspace: dir, Registry: reg}, []string{file})
+	require.NoError(t, err)
+	require.Len(t, diags, 2, "both the qualified and the imported use must be flagged")
+
+	assertDiagOnLine(t, diags, 2,
+		"use of deprecated function 'substrate:blend-paths': use join-paths instead.")
+	assertDiagOnLine(t, diags, 3,
+		"use of deprecated function 'blend-paths': use join-paths instead.")
+	for _, d := range diags {
+		assert.True(t, d.Deprecated)
+		assert.NotEqual(t, 4, d.Pos.Line, "join-paths is not deprecated")
+		// A Go builtin has no lisp declaration to point at.
+		assert.Empty(t, d.Related, "a registered builtin has no source location")
+		assert.Equal(t, []string{"; nolint:deprecated"}, d.Notes)
+	}
+}
+
+// TestDeprecated_RegistryBuiltin_NoDocstring guards the other half of the
+// elpsutil change: a builtin built with Function (no docs) must stay clean.
+func TestDeprecated_RegistryBuiltin_NoDocstring(t *testing.T) {
+	reg := deprecatedTestRegistry(t)
+	dir := t.TempDir()
+	file := writeTempLisp(t, dir, "phylum.lisp", "(substrate:undocumented 1)\n")
+
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerDeprecated}}
+	diags, err := l.LintFiles(&LintConfig{Workspace: dir, Registry: reg}, []string{file})
+	require.NoError(t, err)
+	assertNoDiags(t, diags)
+}
+
+// deprecatedTestRegistry builds the registry an embedder would pass in
+// LintConfig.Registry: a package of Go builtins, one of them deprecated
+// through its elpsutil docstring.
+func deprecatedTestRegistry(t *testing.T) *lisp.PackageRegistry {
+	t.Helper()
+	nop := func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal { return lisp.Nil() }
+
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = rdparser.NewReader()
+	env.Runtime.Stderr = &bytes.Buffer{}
+	require.NotEqual(t, lisp.LError, lisp.InitializeUserEnv(env).Type)
+	require.NotEqual(t, lisp.LError, lisplib.LoadLibrary(env).Type)
+
+	require.True(t, env.DefinePackage(lisp.Symbol("substrate")).IsNil())
+	require.True(t, env.InPackage(lisp.Symbol("substrate")).IsNil())
+	env.AddBuiltins(true,
+		elpsutil.FunctionDoc("blend-paths", lisp.Formals("a", "b"), nop,
+			"Blend two paths.\n\nDeprecated: use join-paths instead."),
+		elpsutil.FunctionDoc("join-paths", lisp.Formals("a", "b"), nop,
+			"Join two paths."),
+		elpsutil.Function("undocumented", lisp.Formals("a"), nop),
+	)
+	require.True(t, env.InPackage(lisp.String(lisp.DefaultUserPackage)).IsNil())
+	return env.Runtime.Registry
+}
+
+// TestDeprecated_SpanHelpers covers the degenerate shapes the fuzzer reaches
+// but well-formed source does not: a definition whose source offsets were
+// never tracked, a quoted list that only looks like a definition, and a
+// reference with no offset of its own.
+func TestDeprecated_SpanHelpers(t *testing.T) {
+	const doc = "Deprecated: use new-fn instead."
+
+	// A defun assembled without any source location. It is deprecated, but it
+	// contributes no span, so uses inside it are reported rather than
+	// suppressed — the conservative direction.
+	untracked := lisp.SExpr([]*lisp.LVal{
+		lisp.Symbol("defun"), lisp.Symbol("old-fn"),
+		lisp.SExpr([]*lisp.LVal{lisp.Symbol("x")}),
+		lisp.String(doc), lisp.Symbol("x"),
+	})
+	assert.True(t, isDeprecatedDefinition(untracked))
+	assert.Empty(t, deprecatedBodySpans([]*lisp.LVal{untracked}),
+		"a definition with untracked offsets must contribute no span")
+
+	// Shapes that are not definitions at all.
+	quoted := lisp.QExpr([]*lisp.LVal{
+		lisp.Symbol("defun"), lisp.Symbol("old-fn"),
+		lisp.SExpr([]*lisp.LVal{lisp.Symbol("x")}),
+		lisp.String(doc), lisp.Symbol("x"),
+	})
+	assert.False(t, isDeprecatedDefinition(quoted), "quoted data is not a definition")
+	assert.False(t, isDeprecatedDefinition(nil))
+	assert.False(t, isDeprecatedDefinition(lisp.String(doc)))
+	assert.False(t, isDeprecatedDefinition(lisp.SExpr([]*lisp.LVal{lisp.Symbol("defun")})),
+		"a truncated defun must not index past its cells")
+	assert.False(t, isDeprecatedDefinition(lisp.SExpr([]*lisp.LVal{
+		lisp.Symbol("defun"), lisp.Symbol("f"),
+		lisp.SExpr([]*lisp.LVal{}), lisp.Int(1), lisp.Int(2),
+	})), "a non-string in the docstring position is not a docstring")
+
+	spans := byteSpans{{start: 10, end: 20}, {start: 30, end: 40}}
+	assert.False(t, spans.contains(-1), "an untracked offset is inside nothing")
+	assert.False(t, spans.contains(9))
+	assert.True(t, spans.contains(10))
+	assert.True(t, spans.contains(19))
+	assert.False(t, spans.contains(20), "spans are half-open")
+	assert.False(t, spans.contains(25))
+	assert.True(t, spans.contains(39))
+	assert.False(t, spans.contains(100))
+	assert.False(t, byteSpans(nil).contains(5))
+}
+
 // --- unused-nolint ---
 
 func TestUnusedNolint_Unused(t *testing.T) {
@@ -3034,6 +3355,7 @@ func TestDefaultAnalyzers_SemanticField(t *testing.T) {
 		"shadowing":            true,
 		"user-arity":           true,
 		"duplicate-definition": true,
+		"deprecated":           true,
 	}
 	for _, a := range DefaultAnalyzers() {
 		if semanticNames[a.Name] {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -3008,9 +3008,10 @@ func TestDeprecated_NotesAndRelated(t *testing.T) {
 	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n(old-fn 1)\n"
 	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
 	require.Len(t, diags, 1)
-	require.Len(t, diags[0].Notes, 2)
+	// The nolint hint is appended by the CLI renderer for every diagnostic,
+	// so the analyzer itself contributes only the declaration note.
+	require.Len(t, diags[0].Notes, 1)
 	assert.Contains(t, diags[0].Notes[0], "deprecated at test.lisp:1:8")
-	assert.Equal(t, "; nolint:deprecated", diags[0].Notes[1])
 	require.Len(t, diags[0].Related, 1)
 	assert.Equal(t, "deprecated declaration here", diags[0].Related[0].Message)
 	assert.Equal(t, 1, diags[0].Related[0].Location.Line)
@@ -3100,8 +3101,88 @@ func TestDeprecated_RegistryBuiltin(t *testing.T) {
 		assert.NotEqual(t, 4, d.Pos.Line, "join-paths is not deprecated")
 		// A Go builtin has no lisp declaration to point at.
 		assert.Empty(t, d.Related, "a registered builtin has no source location")
-		assert.Equal(t, []string{"; nolint:deprecated"}, d.Notes)
+		assert.Empty(t, d.Notes, "no declaration note, and the CLI adds the nolint hint")
 	}
+}
+
+// TestDeprecated_ExpanderForeignRefsSkipped: with a macro expander configured
+// (LintConfig.Env), analysis records references for expanded forms too, and
+// those nodes come from the macro's defining file. Linting a file that merely
+// calls such a macro must not leak the template's foreign positions into this
+// file's diagnostics — and a foreign byte offset must never be tested against
+// this file's exemption spans, where it could silently cancel a real finding.
+func TestDeprecated_ExpanderForeignRefsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	lib := writeTempLisp(t, dir, "lib.lisp",
+		"(defun old-fn (x) \"Deprecated: gone.\" x)\n"+
+			"(defmacro use-old (y) (quasiquote (old-fn (unquote y))))\n")
+	caller := writeTempLisp(t, dir, "main.lisp", "(use-old 1)\n(use-old 2)\n")
+
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerDeprecated}}
+
+	// The deprecated use lives in lib.lisp's macro template, not in the
+	// calling file: calling a live macro is not itself a deprecated use.
+	env, err := newLintEnv()
+	require.NoError(t, err)
+	diags, err := l.LintFiles(&LintConfig{Workspace: dir, Env: env}, []string{caller})
+	require.NoError(t, err)
+	for _, d := range diags {
+		assert.Equal(t, caller, d.Pos.File, "diagnostic must point at the linted file")
+	}
+	assertNoDiags(t, diags)
+
+	// Linting the template's own file reports the use there, exactly once.
+	env2, err := newLintEnv()
+	require.NoError(t, err)
+	diags, err = l.LintFiles(&LintConfig{Workspace: dir, Env: env2}, []string{lib})
+	require.NoError(t, err)
+	require.Len(t, diags, 1)
+	assertDiagOnLine(t, diags, 2, "use of deprecated function 'old-fn'")
+}
+
+// TestDeprecated_ExpanderDeprecatedMacroCallSites guards the boundary of the
+// foreign-reference filter: when the macro itself is deprecated, the use is
+// the call site, and analysis records that head reference in the linted file
+// before expansion runs. The filter must drop only the expansion's foreign
+// nodes, never the call-site references.
+func TestDeprecated_ExpanderDeprecatedMacroCallSites(t *testing.T) {
+	dir := t.TempDir()
+	writeTempLisp(t, dir, "lib.lisp",
+		"(defmacro old-mac (y) \"Deprecated: use new-mac.\" (quasiquote (list (unquote y))))\n")
+	caller := writeTempLisp(t, dir, "main.lisp", "(old-mac 1)\n(old-mac 2)\n")
+
+	env, err := newLintEnv()
+	require.NoError(t, err)
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerDeprecated}}
+	diags, err := l.LintFiles(&LintConfig{Workspace: dir, Env: env}, []string{caller})
+	require.NoError(t, err)
+	require.Len(t, diags, 2, "every call site of a deprecated macro is a use")
+	assertDiagOnLine(t, diags, 1, "use of deprecated macro 'old-mac'")
+	assertDiagOnLine(t, diags, 2, "use of deprecated macro 'old-mac'")
+	for _, d := range diags {
+		assert.Equal(t, caller, d.Pos.File)
+	}
+}
+
+// TestDeprecated_ExpanderSameFileDedup: when the macro is defined in the file
+// being linted, the template reference and the references the expander
+// re-derives at every call site are distinct nodes that all share the
+// template's byte offset. One use, one diagnostic — keyed by position, since
+// node identity cannot merge nodes from two parses.
+func TestDeprecated_ExpanderSameFileDedup(t *testing.T) {
+	dir := t.TempDir()
+	f := writeTempLisp(t, dir, "main.lisp",
+		"(defun old-fn (x) \"Deprecated: gone.\" x)\n"+
+			"(defmacro use-old (y) (quasiquote (old-fn (unquote y))))\n"+
+			"(use-old 1)\n(use-old 2)\n(use-old 3)\n")
+
+	env, err := newLintEnv()
+	require.NoError(t, err)
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerDeprecated}}
+	diags, err := l.LintFiles(&LintConfig{Workspace: dir, Env: env}, []string{f})
+	require.NoError(t, err)
+	require.Len(t, diags, 1)
+	assertDiagOnLine(t, diags, 2, "use of deprecated function 'old-fn'")
 }
 
 // TestDeprecated_RegistryBuiltin_NoDocstring guards the other half of the

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -2860,6 +2860,58 @@ func TestDeprecated_Positive_LaterParagraph(t *testing.T) {
 	assertHasDiag(t, diags, "use of deprecated function 'old-fn': use join-paths instead.")
 }
 
+// TestDeprecated_Positive_ParagraphStyle is the shape the language guide
+// teaches: ELPS strings hold no raw line break, so a second paragraph is
+// written as its own string literal. The runtime joins the run of leading
+// strings and analysis now does the same, so the marker is seen.
+func TestDeprecated_Positive_ParagraphStyle(t *testing.T) {
+	source := "(defun blend-paths (a b)\n" +
+		"  \"Combines two paths.\"\n" +
+		"  \"\"\n" +
+		"  \"Deprecated: use join-paths instead.\"\n" +
+		"  (join-paths a b))\n" +
+		"(blend-paths 1 2)\n"
+	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
+	require.Len(t, diags, 1)
+	assertHasDiag(t, diags, "use of deprecated function 'blend-paths': use join-paths instead.")
+	assertDiagOnLine(t, diags, 6, "use of deprecated function 'blend-paths'")
+}
+
+// TestDeprecated_Negative_ParagraphStyleInsideDeprecated exercises the
+// suppression walk against the same shape: isDeprecatedDefinition has to read
+// the whole string run, or a paragraph-style deprecated function would report
+// against its own body.
+func TestDeprecated_Negative_ParagraphStyleInsideDeprecated(t *testing.T) {
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" x)\n" +
+		"(defun blend-paths (a b)\n" +
+		"  \"Combines two paths.\"\n" +
+		"  \"\"\n" +
+		"  \"Deprecated: use join-paths instead.\"\n" +
+		"  (old-fn a))\n"
+	assertNoDiags(t, lintCheckSemantic(t, AnalyzerDeprecated, source))
+}
+
+// TestDeprecated_Positive_ParagraphStyleAcrossFiles runs the same definition
+// through the workspace scanner (LintFiles) rather than same-file analysis, so
+// the ExternalSymbol path is covered too.
+func TestDeprecated_Positive_ParagraphStyleAcrossFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeTempLisp(t, dir, "lib.lisp", "(defun blend-paths (a b)\n"+
+		"  \"Combines two paths.\"\n"+
+		"  \"\"\n"+
+		"  \"Deprecated: use join-paths instead.\"\n"+
+		"  (list a b))\n"+
+		"(export 'blend-paths)\n")
+	caller := writeTempLisp(t, dir, "main.lisp", "(blend-paths 1 2)\n")
+
+	l := &Linter{Analyzers: []*Analyzer{AnalyzerDeprecated}}
+	diags, err := l.LintFiles(&LintConfig{Workspace: dir}, []string{caller})
+	require.NoError(t, err)
+	require.Len(t, diags, 1)
+	assertDiagOnLine(t, diags, 1,
+		"use of deprecated function 'blend-paths': use join-paths instead.")
+}
+
 func TestDeprecated_Positive_NoticeOmittedWhenEmpty(t *testing.T) {
 	source := "(defun old-fn (x) \"Deprecated:\" x)\n(old-fn 1)\n"
 	diags := lintCheckSemantic(t, AnalyzerDeprecated, source)
@@ -2905,6 +2957,13 @@ func TestDeprecated_Negative_StringBodyIsNotADocstring(t *testing.T) {
 	// A string in the docstring position with no body after it is the body,
 	// exactly as analysis.prescanDefun reads it.
 	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\")\n(old-fn 1)\n"
+	assertNoDiags(t, lintCheckSemantic(t, AnalyzerDeprecated, source))
+}
+
+func TestDeprecated_Negative_AllStringBodyIsNotADocstring(t *testing.T) {
+	// Several strings and no executable form is still a constant function, so
+	// the marker is a return value, not documentation.
+	source := "(defun old-fn (x) \"Deprecated: use new-fn instead.\" \"result\")\n(old-fn 1)\n"
 	assertNoDiags(t, lintCheckSemantic(t, AnalyzerDeprecated, source))
 }
 

--- a/lisp/deprecated.go
+++ b/lisp/deprecated.go
@@ -1,0 +1,51 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import "strings"
+
+// DeprecationNotice reports whether a docstring marks its symbol as
+// deprecated and returns the notice text.
+//
+// The convention mirrors Go's: a docstring paragraph beginning with
+// "Deprecated:" (or "DEPRECATED:") marks the symbol deprecated, and the
+// rest of that paragraph tells callers what to use instead. Paragraphs
+// are separated by blank lines. Leading and trailing whitespace on each
+// line is ignored, so tab-indented builtin docstrings written as Go raw
+// string literals work unchanged.
+//
+// The returned notice is the marker paragraph's text with the marker
+// removed and its lines joined by single spaces. A marker paragraph with
+// no text after the marker returns ("", true).
+func DeprecationNotice(doc string) (string, bool) {
+	lines := strings.Split(doc, "\n")
+	paraStart := true
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			paraStart = true
+			continue
+		}
+		if !paraStart {
+			continue
+		}
+		paraStart = false
+		rest, ok := strings.CutPrefix(trimmed, "Deprecated:")
+		if !ok {
+			rest, ok = strings.CutPrefix(trimmed, "DEPRECATED:")
+		}
+		if !ok {
+			continue
+		}
+		parts := []string{strings.TrimSpace(rest)}
+		for _, cont := range lines[i+1:] {
+			cont = strings.TrimSpace(cont)
+			if cont == "" {
+				break
+			}
+			parts = append(parts, cont)
+		}
+		return strings.TrimSpace(strings.Join(parts, " ")), true
+	}
+	return "", false
+}

--- a/lisp/deprecated_test.go
+++ b/lisp/deprecated_test.go
@@ -1,0 +1,131 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDeprecationNotice covers the shapes real docstrings arrive in: the
+// hand-written one-liner a lisp defun carries, the tab-indented Go raw string
+// literal every builtin in this repository is written as, and the multi-line
+// paragraph a real deprecation notice runs to.
+func TestDeprecationNotice(t *testing.T) {
+	tests := []struct {
+		name   string
+		doc    string
+		notice string
+		ok     bool
+	}{{
+		name:   "first line marker",
+		doc:    "Deprecated: use new-fn instead.",
+		notice: "use new-fn instead.",
+		ok:     true,
+	}, {
+		name:   "later paragraph",
+		doc:    "Blend two paths.\n\nDeprecated: use join-paths instead.",
+		notice: "use join-paths instead.",
+		ok:     true,
+	}, {
+		name: "tab indented raw string literal",
+		doc: `Blend two paths.
+
+	Deprecated: use join-paths instead.`,
+		notice: "use join-paths instead.",
+		ok:     true,
+	}, {
+		name:   "shouting marker",
+		doc:    "DEPRECATED: use new-fn instead.",
+		notice: "use new-fn instead.",
+		ok:     true,
+	}, {
+		name:   "marker with no text",
+		doc:    "Blend two paths.\n\nDeprecated:",
+		notice: "",
+		ok:     true,
+	}, {
+		name:   "marker with trailing space only",
+		doc:    "Deprecated:   ",
+		notice: "",
+		ok:     true,
+	}, {
+		name:   "mid paragraph mention is not a marker",
+		doc:    "Blend two paths.\nDeprecated: not at a paragraph start.",
+		notice: "",
+		ok:     false,
+	}, {
+		name:   "mid line mention is not a marker",
+		doc:    "This is Deprecated: honest.",
+		notice: "",
+		ok:     false,
+	}, {
+		name:   "empty doc",
+		doc:    "",
+		notice: "",
+		ok:     false,
+	}, {
+		name:   "ordinary doc",
+		doc:    "Blend two paths.\n\nThe result is a new path.",
+		notice: "",
+		ok:     false,
+	}, {
+		name:   "continuation lines joined with spaces",
+		doc:    "Blend two paths.\n\nDeprecated: use join-paths instead.\nIt handles the empty case,\nwhich this does not.\n\nSee also: split-path.",
+		notice: "use join-paths instead. It handles the empty case, which this does not.",
+		ok:     true,
+	}, {
+		name:   "notice stops at the paragraph break",
+		doc:    "Deprecated: use join-paths.\n\nThis paragraph is not part of the notice.",
+		notice: "use join-paths.",
+		ok:     true,
+	}, {
+		name:   "leading blank lines do not hide the marker",
+		doc:    "\n\n\nDeprecated: use new-fn instead.",
+		notice: "use new-fn instead.",
+		ok:     true,
+	}, {
+		name:   "lowercase marker is not recognized",
+		doc:    "deprecated: use new-fn instead.",
+		notice: "",
+		ok:     false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notice, ok := lisp.DeprecationNotice(tt.doc)
+			assert.Equal(t, tt.ok, ok, "deprecation detection")
+			assert.Equal(t, tt.notice, notice, "notice text")
+		})
+	}
+}
+
+// TestDeprecationNotice_BuiltinDocstrings guards against a stdlib docstring
+// accidentally reading as a deprecation. No builtin, special operator or macro
+// compiled into the interpreter is deprecated today, and the deprecated lint
+// check reports every use of one that is — so a false positive here would fire
+// on every file in the repository.
+func TestDeprecationNotice_BuiltinDocstrings(t *testing.T) {
+	type documented interface {
+		Name() string
+		Docstring() string
+	}
+	check := func(kind string, defs []lisp.LBuiltinDef) {
+		t.Helper()
+		for _, def := range defs {
+			doc, ok := def.(documented)
+			if !ok {
+				continue
+			}
+			notice, deprecated := lisp.DeprecationNotice(doc.Docstring())
+			assert.False(t, deprecated,
+				"%s %q reads as deprecated (%q); if that is intended, the deprecated"+
+					" lint check will now fire on every use of it", kind, doc.Name(), notice)
+		}
+	}
+	check("builtin", lisp.DefaultBuiltins())
+	check("special operator", lisp.DefaultSpecialOps())
+	check("macro", lisp.DefaultMacros())
+}

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/luthersystems/elps/analysis"
+	"github.com/luthersystems/elps/lisp"
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
@@ -97,6 +98,9 @@ func (s *Server) packageCompletions(doc *Document, pkgName, partial string) []pr
 					Value: ext.DocString,
 				}
 			}
+			if _, deprecated := lisp.DeprecationNotice(ext.DocString); deprecated {
+				item.Tags = []protocol.CompletionItemTag{protocol.CompletionItemTagDeprecated}
+			}
 			items = append(items, item)
 		}
 	}
@@ -137,6 +141,9 @@ func (s *Server) scopeCompletions(doc *Document, line, col int, prefix string) [
 				Kind:  protocol.MarkupKindMarkdown,
 				Value: sym.DocString,
 			}
+		}
+		if _, deprecated := lisp.DeprecationNotice(sym.DocString); deprecated {
+			item.Tags = []protocol.CompletionItemTag{protocol.CompletionItemTagDeprecated}
 		}
 		items = append(items, item)
 	}

--- a/lsp/deprecated_test.go
+++ b/lsp/deprecated_test.go
@@ -1,0 +1,231 @@
+// Copyright © 2026 The ELPS authors
+
+package lsp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/analysis"
+	"github.com/luthersystems/elps/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Deprecation is spelled the same way everywhere: a docstring paragraph that
+// begins "Deprecated:" (lisp.DeprecationNotice is the detector). These tests
+// cover the three surfaces the editor sees it through -- the hover banner, the
+// completion item tag, and the diagnostic tag.
+//
+// Analysis reads a definition's docstring from the leading string literal of
+// the form, so the marker has to live in that one string; the sources below
+// use "\n\n" to open the second paragraph inside it.
+
+const deprecatedDefun = `(defun old-fn (x)
+  "Adds one to x.\n\nDeprecated: use new-fn instead."
+  (+ x 1))`
+
+func TestHoverOnDeprecatedDefun(t *testing.T) {
+	s := testServer()
+	openDoc(s, "file:///test.lisp", deprecatedDefun)
+
+	hover, err := s.textDocumentHover(mockContext(), &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 0, Character: 7}, // on "old-fn"
+		},
+	})
+	require.NoError(t, err)
+	assertHoverContains(t, hover, "old-fn", "**Deprecated.** use new-fn instead.")
+
+	mc := hover.Contents.(protocol.MarkupContent)
+	assert.Contains(t, mc.Value, "Adds one to x.",
+		"the banner must not replace the docstring")
+	assert.Less(t, strings.Index(mc.Value, "**Deprecated.**"), strings.Index(mc.Value, "Adds one to x."),
+		"the banner belongs above the docstring")
+}
+
+func TestHoverOnDeprecatedQualifiedSymbol(t *testing.T) {
+	s := testServer()
+	setTestAnalysisCfg(s, &analysis.Config{
+		PackageExports: map[string][]analysis.ExternalSymbol{
+			"substrate": {
+				{
+					Name:      "blend-paths",
+					Kind:      analysis.SymFunction,
+					Package:   "substrate",
+					DocString: "Combines two paths.\n\nDeprecated: use join-paths instead.",
+				},
+			},
+		},
+	})
+	openDoc(s, "file:///test.lisp", `(substrate:blend-paths "a" "b")`)
+
+	hover, err := s.textDocumentHover(mockContext(), &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 0, Character: 2}, // on "substrate:blend-paths"
+		},
+	})
+	require.NoError(t, err)
+	assertHoverContains(t, hover, "blend-paths", "**Deprecated.** use join-paths instead.")
+}
+
+func TestHoverBannerWithoutNotice(t *testing.T) {
+	// A marker paragraph with nothing after it still marks the symbol; the
+	// banner then stands alone, with no trailing space.
+	content := buildHoverContent(&analysis.Symbol{
+		Name:      "old-fn",
+		Kind:      analysis.SymFunction,
+		DocString: "Adds one to x.\n\nDeprecated:",
+	})
+	assert.Contains(t, content, "\n\n**Deprecated.**\n\n")
+	assert.NotContains(t, content, "**Deprecated.** \n")
+}
+
+func TestHoverNoBannerForPlainDocString(t *testing.T) {
+	content := buildHoverContent(&analysis.Symbol{
+		Name:      "new-fn",
+		Kind:      analysis.SymFunction,
+		DocString: "Adds one to x. Not deprecated: still supported.",
+	})
+	assert.NotContains(t, content, "**Deprecated.**")
+}
+
+func TestCompletionTagsDeprecatedPackageSymbol(t *testing.T) {
+	s := testServer()
+	setTestAnalysisCfg(s, &analysis.Config{
+		PackageExports: map[string][]analysis.ExternalSymbol{
+			"substrate": {
+				{
+					Name:      "blend-paths",
+					Kind:      analysis.SymFunction,
+					Package:   "substrate",
+					DocString: "Combines two paths.\n\nDeprecated: use join-paths instead.",
+				},
+				{
+					Name:      "join-paths",
+					Kind:      analysis.SymFunction,
+					Package:   "substrate",
+					DocString: "Joins two paths.",
+				},
+			},
+		},
+	})
+	openDoc(s, "file:///test.lisp", "(substrate:")
+
+	result, err := s.textDocumentCompletion(mockContext(), &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 0, Character: 11},
+		},
+	})
+	require.NoError(t, err)
+	items, ok := result.([]protocol.CompletionItem)
+	require.True(t, ok)
+
+	byLabel := make(map[string]protocol.CompletionItem, len(items))
+	for _, item := range items {
+		byLabel[item.Label] = item
+	}
+	deprecated, ok := byLabel["substrate:blend-paths"]
+	require.True(t, ok, "deprecated export should still be offered")
+	assert.Equal(t, []protocol.CompletionItemTag{protocol.CompletionItemTagDeprecated}, deprecated.Tags)
+	assert.Nil(t, deprecated.Deprecated, "the legacy Deprecated field stays unset")
+
+	live, ok := byLabel["substrate:join-paths"]
+	require.True(t, ok)
+	assert.Empty(t, live.Tags, "a live symbol carries no tags")
+}
+
+func TestCompletionTagsDeprecatedScopeSymbol(t *testing.T) {
+	s := testServer()
+	openDoc(s, "file:///test.lisp", deprecatedDefun+"\n(old-")
+
+	result, err := s.textDocumentCompletion(mockContext(), &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 3, Character: 5}, // after "(old-"
+		},
+	})
+	require.NoError(t, err)
+	items, ok := result.([]protocol.CompletionItem)
+	require.True(t, ok)
+
+	var found bool
+	for _, item := range items {
+		if item.Label != "old-fn" {
+			continue
+		}
+		found = true
+		assert.Equal(t, []protocol.CompletionItemTag{protocol.CompletionItemTagDeprecated}, item.Tags)
+		assert.Nil(t, item.Deprecated, "the legacy Deprecated field stays unset")
+	}
+	assert.True(t, found, "the deprecated function should still be completed")
+}
+
+func TestConvertLintDiagnosticDeprecatedTag(t *testing.T) {
+	d := convertLintDiagnostic(lint.Diagnostic{
+		Pos:        lint.Position{File: "test.lisp", Line: 2, Col: 3},
+		Message:    "use of deprecated function 'old-fn': use new-fn instead.",
+		Analyzer:   "deprecated",
+		Severity:   lint.SeverityWarning,
+		Deprecated: true,
+	})
+	assert.Equal(t, []protocol.DiagnosticTag{protocol.DiagnosticTagDeprecated}, d.Tags)
+}
+
+func TestConvertLintDiagnosticBothTags(t *testing.T) {
+	// Nothing produces both today, but the conversion must not drop one.
+	d := convertLintDiagnostic(lint.Diagnostic{
+		Pos:         lint.Position{File: "test.lisp", Line: 1, Col: 1},
+		Message:     "dead call to a deprecated function",
+		Analyzer:    "deprecated",
+		Unnecessary: true,
+		Deprecated:  true,
+	})
+	assert.Equal(t, []protocol.DiagnosticTag{
+		protocol.DiagnosticTagUnnecessary,
+		protocol.DiagnosticTagDeprecated,
+	}, d.Tags)
+}
+
+func TestConvertLintDiagnosticNoTags(t *testing.T) {
+	d := convertLintDiagnostic(lint.Diagnostic{
+		Pos:      lint.Position{File: "test.lisp", Line: 1, Col: 1},
+		Message:  "plain warning",
+		Analyzer: "test-check",
+	})
+	assert.Empty(t, d.Tags)
+}
+
+// TestDiagnosticsPublishDeprecatedTag is the end-to-end path: opening a
+// document runs the semantic `deprecated` analyzer and the published
+// diagnostic carries the tag editors strike the call site out with.
+func TestDiagnosticsPublishDeprecatedTag(t *testing.T) {
+	s := testServer()
+	ctx, captured := capturingContext()
+
+	err := s.textDocumentDidOpen(ctx, &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{
+			URI:     "file:///test.lisp",
+			Version: 1,
+			Text:    "(defun old-fn (x) \"Deprecated: use new-fn.\" x)\n(old-fn 1)\n",
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, *captured, 1)
+
+	var found bool
+	for _, d := range (*captured)[0].Diagnostics {
+		if d.Code == nil || d.Code.Value != "deprecated" {
+			continue
+		}
+		found = true
+		assert.Contains(t, d.Message, "use of deprecated function 'old-fn'")
+		assert.Contains(t, d.Tags, protocol.DiagnosticTagDeprecated)
+		assert.Equal(t, protocol.UInteger(1), d.Range.Start.Line, "the use, not the definition")
+	}
+	assert.True(t, found, "opening the document should publish a deprecated diagnostic")
+}

--- a/lsp/deprecated_test.go
+++ b/lsp/deprecated_test.go
@@ -18,13 +18,21 @@ import (
 // cover the three surfaces the editor sees it through -- the hover banner, the
 // completion item tag, and the diagnostic tag.
 //
-// Analysis reads a definition's docstring from the leading string literal of
-// the form, so the marker has to live in that one string; the sources below
-// use "\n\n" to open the second paragraph inside it.
+// Analysis reads a definition's docstring the way the runtime does: the whole
+// run of leading string literals, joined by lisp.JoinDocStrings. Either
+// spelling of the paragraph break therefore works -- "\n\n" inside one string,
+// as deprecatedDefun writes it, or an empty string between two literals, as
+// deprecatedParagraphDefun does.
 
 const deprecatedDefun = `(defun old-fn (x)
   "Adds one to x.\n\nDeprecated: use new-fn instead."
   (+ x 1))`
+
+const deprecatedParagraphDefun = `(defun blend-paths (a b)
+  "Combines two paths."
+  ""
+  "Deprecated: use join-paths instead."
+  (join-paths a b))`
 
 func TestHoverOnDeprecatedDefun(t *testing.T) {
 	s := testServer()
@@ -44,6 +52,26 @@ func TestHoverOnDeprecatedDefun(t *testing.T) {
 		"the banner must not replace the docstring")
 	assert.Less(t, strings.Index(mc.Value, "**Deprecated.**"), strings.Index(mc.Value, "Adds one to x."),
 		"the banner belongs above the docstring")
+}
+
+// TestHoverOnParagraphStyleDeprecatedDefun is the guide's own example: the
+// marker lives in a later string literal rather than after a "\n\n" escape.
+func TestHoverOnParagraphStyleDeprecatedDefun(t *testing.T) {
+	s := testServer()
+	openDoc(s, "file:///test.lisp", deprecatedParagraphDefun)
+
+	hover, err := s.textDocumentHover(mockContext(), &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///test.lisp"},
+			Position:     protocol.Position{Line: 0, Character: 8}, // on "blend-paths"
+		},
+	})
+	require.NoError(t, err)
+	assertHoverContains(t, hover, "blend-paths", "**Deprecated.** use join-paths instead.")
+
+	mc := hover.Contents.(protocol.MarkupContent)
+	assert.Contains(t, mc.Value, "Combines two paths.",
+		"the first paragraph must survive the join")
 }
 
 func TestHoverOnDeprecatedQualifiedSymbol(t *testing.T) {

--- a/lsp/diagnostics.go
+++ b/lsp/diagnostics.go
@@ -244,8 +244,13 @@ func convertLintDiagnostic(d lint.Diagnostic) protocol.Diagnostic {
 			Message: related.Message,
 		})
 	}
+	// A diagnostic could in principle carry both tags, so append rather than
+	// assign: editors fade unnecessary code and strike deprecated uses out.
 	if d.Unnecessary {
-		diag.Tags = []protocol.DiagnosticTag{protocol.DiagnosticTagUnnecessary}
+		diag.Tags = append(diag.Tags, protocol.DiagnosticTagUnnecessary)
+	}
+	if d.Deprecated {
+		diag.Tags = append(diag.Tags, protocol.DiagnosticTagDeprecated)
 	}
 	return diag
 }

--- a/lsp/hover.go
+++ b/lsp/hover.go
@@ -208,6 +208,16 @@ func buildHoverContent(sym *analysis.Symbol) string {
 		}
 	}
 
+	// Deprecation banner, between the signature and the docstring so it is
+	// the first thing read. lisp.DeprecationNotice is the canonical detector.
+	if notice, ok := lisp.DeprecationNotice(sym.DocString); ok {
+		if notice != "" {
+			fmt.Fprintf(&sb, "\n\n**Deprecated.** %s", notice)
+		} else {
+			sb.WriteString("\n\n**Deprecated.**")
+		}
+	}
+
 	// Docstring.
 	if sym.DocString != "" {
 		fmt.Fprintf(&sb, "\n\n%s", sym.DocString)

--- a/mcpserver/server_test.go
+++ b/mcpserver/server_test.go
@@ -1773,6 +1773,43 @@ func TestHover_UndefinedSymbol(t *testing.T) {
 	assert.False(t, resp.Found, "hover on undefined symbol should return found=false")
 }
 
+// TestHover_DeprecatedBanner covers the deprecation banner the hover markdown
+// carries, mirroring the language server. Analysis reads a definition's
+// docstring from the leading string literal of the form, so the "Deprecated:"
+// paragraph opens with "\n\n" inside that one string.
+func TestHover_DeprecatedBanner(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "test.lisp")
+	content := `(defun old-fn (x) "Adds one to x.\n\nDeprecated: use new-fn instead." (+ x 1))`
+	writeTestFile(t, path, content)
+
+	srv := New(WithWorkspaceRoot(tmp))
+	_, resp, err := srv.service.hoverTool(context.Background(), nil, FileQueryInput{
+		Path:      path,
+		Line:      0,
+		Character: strings.Index(content, "old-fn") + 1,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Found)
+	assert.Equal(t, "old-fn", resp.SymbolName)
+	assert.Contains(t, resp.Markdown, "**Deprecated.** use new-fn instead.")
+	assert.Contains(t, resp.Markdown, "Adds one to x.",
+		"the banner must not replace the docstring")
+	assert.Less(t,
+		strings.Index(resp.Markdown, "**Deprecated.**"),
+		strings.Index(resp.Markdown, "Adds one to x."),
+		"the banner belongs above the docstring")
+}
+
+func TestHover_NoDeprecatedBannerForPlainDocString(t *testing.T) {
+	content := buildHoverContent(&analysis.Symbol{
+		Name:      "new-fn",
+		Kind:      analysis.SymFunction,
+		DocString: "Adds one to x.",
+	})
+	assert.NotContains(t, content, "**Deprecated.**")
+}
+
 func TestHotspots_TopZeroErrors(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "test.lisp")

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -1303,6 +1303,16 @@ func buildHoverContent(sym *analysis.Symbol) string {
 		}
 		b.WriteString(")\n```")
 	}
+	// Deprecation banner, between the signature and the docstring, mirroring
+	// the language server's hover. lisp.DeprecationNotice is the canonical
+	// detector.
+	if notice, ok := lisp.DeprecationNotice(sym.DocString); ok {
+		b.WriteString("\n\n**Deprecated.**")
+		if notice != "" {
+			b.WriteString(" ")
+			b.WriteString(notice)
+		}
+	}
 	if sym.DocString != "" {
 		b.WriteString("\n\n")
 		b.WriteString(sym.DocString)


### PR DESCRIPTION
## Summary

- Adds a Go-style deprecation convention: a docstring paragraph beginning with `Deprecated:` (or `DEPRECATED:`) marks a function/macro/symbol deprecated. Works for lisp `defun`/`defmacro` docstrings and Go-registered builtins alike — no new syntax.
- `lisp.DeprecationNotice(doc)` is the canonical detector, exported so embedders can use it from Go too.
- New `deprecated` lint analyzer (`Semantic: true`, warning): flags every reference to a deprecated symbol — same-file defuns, workspace defuns, stdlib builtins, and embedder/registry builtins. References inside the body of a deprecated definition are suppressed (Go's rule: deprecated code may use deprecated code). Suppress per-site with `; nolint:deprecated`.
- `elpsutil.FunctionDoc(name, formals, fun, docs)` + `(*elpsutil.Builtin).Docstring()`: embedders can finally attach docstrings to registered builtins — previously `elpsutil.Function` had no way to carry one, so embedder builtins could not be documented or deprecated at all.
- `analysis` now reads a defun's whole docstring (the run of consecutive leading strings, joined the way the runtime joins them) instead of only the first string, so the idiomatic paragraph style `"doc" "" "Deprecated: ..."` is detected; all-string bodies are correctly treated as constant functions, not docstrings.
- Editor surfacing: LSP diagnostics carry `DiagnosticTag.Deprecated` (strikethrough in editors), hover shows a `**Deprecated.**` banner with the notice, completion items get the deprecated tag; the MCP server hover mirrors the banner.
- Docs: `docs/lang.md` (Deprecating functions), `docs/lint-checks.md` (`### deprecated`), `docs/lsp-guide.md`, and `docs/embed.md` (deprecating embedder builtins).

Embedder adoption (e.g. tagging `blend-paths` in substrate): register the builtin with a docstring ending in a `Deprecated: use X instead.` paragraph — via `elpsutil.FunctionDoc` or any def type with a `Docstring() string` method — and run the linter with `lint.LintConfig{Workspace: dir, Registry: env.Runtime.Registry}`; call sites in embedded lisp sources are then flagged. The LSP picks it up through `lsp.WithRegistry`/`WithEnv` with no extra wiring.

Notes:
- The check is a semantic analyzer (like `undefined-symbol`), so the CLI runs it under `--workspace`; the LSP and MCP paths always have semantics.
- An adversarial review pass over the full diff found and fixed one real bug before opening for review: with a macro expander configured, references from macro expansions carry positions from the macro's defining file, which misattributed diagnostics and could silently drop findings; the analyzer now scopes references to the linted file and dedups by byte offset (regression tests confirmed failing pre-fix).

## Test Plan

- [x] `make test` passes
- [x] `make static-checks` passes (0 issues)
- [x] `./elps doc -m` passes
- [x] Zero `deprecated` findings self-linting the repo's own `.lisp` sources (no false positives)
- [x] Regression tests confirmed failing before each bug fix (multi-string docstrings, expander scoping/dedup)
- [x] Unit tests: `lisp.DeprecationNotice` edge cases, analyzer positive/negative/nolint/suppression/registry/expander tests, elpsutil docstring round-trip, LSP hover/completion/diagnostic-tag tests (incl. didOpen end-to-end), MCP hover tests
- [x] Targeted fuzzing: `FuzzLintSource`, `FuzzAnalyzeSource`, `FuzzLSPSession` runs found no new crashers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdJPPUcKKqCbJZK1oFoboE