### PR TITLE
analysis,formatter: gate the perf mirror, and make the round-trip test real

### DIFF
--- a/analysis/perf/local_drift_test.go
+++ b/analysis/perf/local_drift_test.go
@@ -1,0 +1,206 @@
+// Copyright © 2024 The ELPS authors
+
+package perf
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/require"
+)
+
+// This file gates isCallable, one of the hand-maintained mirrors of
+// lisp.DefaultSpecialOps() inventoried in internal/formsync.  A special
+// operator that reaches isCallable unlisted is reported as an ordinary
+// function call, which inflates the caller's LocalCost (and, inside a loop,
+// inflates it by LoopMultiplier per level) and adds a bogus edge to the call
+// graph.
+//
+// WHAT AN AUDIT OF THIS MIRROR GETS WRONG, AND WHY THE EXEMPTIONS EXIST.
+// Reading isCallable against the op table shows lambda, quote and quasiquote
+// missing, and the obvious conclusion -- that the analyzer records a call edge
+// for (lambda ...) -- is false.  scanExpr resolves all three in its own switch
+// and RETURNS, several statements before isCallable is consulted, so their
+// isCallable value is unreachable.  Measured on
+// (defun f (xs) (map 'list (lambda (x) (+ x 1)) xs)): score 20 as the code
+// stands, and 60 with those switch cases deleted -- 20 for a spurious lambda
+// edge, 20 more for a spurious edge to the formal x, 20 for the real +.
+//
+// So the three are not drift to be tidied away by adding them to isCallable.
+// Each switch case does strictly MORE than suppress a call edge, and none of
+// the extra work is expressible in isCallable, which only chooses whether to
+// emit an edge and cannot stop the walk or redirect it:
+//
+//	quote, quasiquote  stop the walk descending, so quoted data is never
+//	                   costed as code
+//	lambda             skip the formals and scan the BODY at the caller's
+//	                   current loop depth, so an inline callback is costed as
+//	                   the caller's own work
+//
+// Adding them to isCallable would state the same fact in a second place while
+// leaving the switch load-bearing, and would invite a later reader to delete
+// the switch case that is actually doing the work.  They stay out, and the
+// exemptions below carry the reason.
+//
+// THE EXEMPTIONS ARE CHECKED, NOT PROMISED.  formsync's lesson is that
+// asserting only an absence turns the stated reason into a promise nothing
+// verifies: naming the rule that handles a form instead, and never checking
+// it, left its gates green while the named rules had been deleted.  Every
+// exemption here therefore carries a probe, and the probe pins the stronger
+// behaviour the exemption claims -- deleting the switch case fails this test
+// rather than silently widening the analyzer.
+//
+// A NEW special operator is not exempt.  Adding one without touching
+// isCallable fails TestIsCallableCoversTheOpTable until someone either lists
+// it or records here why it does not belong.
+
+// callableExemption records why a special operator is absent from
+// isCallable's non-callable list, together with a probe that demonstrates the
+// rule handling it instead is still doing its job.
+type callableExemption struct {
+	// reason is why the operator does not belong in isCallable.
+	reason string
+
+	// probe is a single body form, spliced into a defun and scanned.  The
+	// operator itself must never appear as a callee of that scan.
+	probe string
+
+	// absentCallees are callee names the probe must NOT produce.  They pin
+	// the part of the handling rule that isCallable could not replicate.
+	absentCallees []string
+
+	// presentCallees are callee names the probe MUST produce, so a rule that
+	// suppresses too much fails here instead of quietly under-reporting.
+	presentCallees []string
+}
+
+// isCallableExempt lists special operators deliberately absent from
+// isCallable because scanExpr resolves them earlier.  See the file comment
+// for why adding them to isCallable would be the wrong fix.
+var isCallableExempt = map[string]callableExemption{
+	"quote": {
+		reason: `scanExpr's "quote", "quasiquote" case returns first, and also stops the ` +
+			`walk descending, so quoted data is never costed as code`,
+		probe:         `(quote (quoted-marker 1 2))`,
+		absentCallees: []string{"quoted-marker"},
+	},
+	"quasiquote": {
+		reason: `scanExpr's "quote", "quasiquote" case returns first, and also stops the ` +
+			`walk descending, so quasiquoted template data is never costed as code`,
+		probe:         `(quasiquote (quoted-marker (unquote n)))`,
+		absentCallees: []string{"quoted-marker", "unquote"},
+	},
+	"lambda": {
+		reason: `scanExpr's "lambda" case returns first, and also skips the formals and ` +
+			`scans the body at the caller's current loop depth, so an inline callback ` +
+			`is costed as the caller's own work`,
+		probe:          `(lambda (formal-marker) (body-marker formal-marker))`,
+		absentCallees:  []string{"formal-marker"},
+		presentCallees: []string{"body-marker"},
+	},
+}
+
+// isCallableMacroExempt is the same idea for lisp.DefaultMacros().  It is
+// empty: no default macro is a call edge, and there is no known reason for
+// one not to be listed in isCallable.  It exists so that a future exception
+// is recorded with a reason instead of being made by deleting an assertion.
+var isCallableMacroExempt = map[string]callableExemption{}
+
+// probeCallees scans a defun whose body is the given form and returns the set
+// of callee names the scan recorded.
+func probeCallees(t *testing.T, body string) map[string]bool {
+	t.Helper()
+	src := "(defun probe-subject (n) " + body + ")"
+	exprs := parseSource(t, src)
+	summaries := ScanFile(exprs, "drift_probe.lisp", DefaultConfig())
+	require.Len(t, summaries, 1,
+		"probe %q did not scan to exactly one function summary", src)
+	out := map[string]bool{}
+	for _, edge := range summaries[0].Calls {
+		out[edge.Callee] = true
+	}
+	return out
+}
+
+// requireProbeHarnessWorks guards against the failure mode where every
+// per-operator assertion passes because the probe records nothing at all.
+func requireProbeHarnessWorks(t *testing.T) {
+	t.Helper()
+	require.True(t, probeCallees(t, "(ordinary-marker 1)")["ordinary-marker"],
+		"the probe harness recorded no call edge for an ordinary call, so the"+
+			" per-operator assertions would pass while measuring nothing")
+}
+
+// assertFormsAreNotCallEdges pins isCallable against a table of builtin
+// definitions.  kind names the table for failure messages.
+func assertFormsAreNotCallEdges(t *testing.T, kind string, defs []lisp.LBuiltinDef, exempt map[string]callableExemption) {
+	t.Helper()
+	require.NotEmpty(t, defs, "the %s table returned nothing", kind)
+
+	seen := make(map[string]bool, len(defs))
+	for _, def := range defs {
+		name := def.Name()
+		seen[name] = true
+
+		ex, isExempt := exempt[name]
+		if !isExempt {
+			require.False(t, isCallable(name),
+				"%s %q is missing from isCallable (analysis/perf/local.go), so the"+
+					" perf analyzer costs it as an ordinary function call and adds a"+
+					" bogus edge to the call graph; add it there, or add it to the"+
+					" exemption map with a reason and a probe", kind, name)
+			continue
+		}
+
+		require.NotEmpty(t, ex.reason, "exemption for %s %q must carry a reason", kind, name)
+		require.NotEmpty(t, ex.probe, "exemption for %s %q must carry a probe", kind, name)
+
+		// A live exemption means isCallable really does not list it.  Once it
+		// is listed the exemption is stale and must go, or the map starts
+		// describing a state of the code that no longer exists.
+		require.True(t, isCallable(name),
+			"%s %q is listed in the exemption map (%s) but isCallable now reports it"+
+				" as non-callable too; drop the exemption", kind, name, ex.reason)
+
+		callees := probeCallees(t, ex.probe)
+		require.False(t, callees[name],
+			"%s %q is exempt because %s, but probe %q recorded a call edge to it"+
+				" anyway -- the rule the exemption relies on is gone",
+			kind, name, ex.reason, ex.probe)
+		for _, callee := range ex.absentCallees {
+			require.False(t, callees[callee],
+				"%s %q is exempt because %s, but probe %q recorded a call edge to %q,"+
+					" which that rule is supposed to prevent",
+				kind, name, ex.reason, ex.probe, callee)
+		}
+		for _, callee := range ex.presentCallees {
+			require.True(t, callees[callee],
+				"%s %q is exempt because %s, but probe %q did NOT record the call edge"+
+					" to %q that rule is supposed to keep -- it now suppresses too much",
+				kind, name, ex.reason, ex.probe, callee)
+		}
+	}
+
+	for name, ex := range exempt {
+		require.True(t, seen[name],
+			"the exemption map lists %q (%s), which is no longer in the %s table;"+
+				" drop the entry", name, ex.reason, kind)
+	}
+}
+
+// TestIsCallableCoversTheOpTable pins isCallable against
+// lisp.DefaultSpecialOps().
+func TestIsCallableCoversTheOpTable(t *testing.T) {
+	t.Parallel()
+	requireProbeHarnessWorks(t)
+	assertFormsAreNotCallEdges(t, "special operator", lisp.DefaultSpecialOps(), isCallableExempt)
+}
+
+// TestIsCallableCoversTheMacroTable pins isCallable against
+// lisp.DefaultMacros(), which isCallable mirrors for the same reason and
+// which drifts the same way.
+func TestIsCallableCoversTheMacroTable(t *testing.T) {
+	t.Parallel()
+	requireProbeHarnessWorks(t)
+	assertFormsAreNotCallEdges(t, "macro", lisp.DefaultMacros(), isCallableMacroExempt)
+}

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -6,8 +6,11 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sort"
 	"strings"
 	"testing"
 
@@ -1836,32 +1839,114 @@ func TestInnerTrailingCommentBlankLine(t *testing.T) {
 }
 
 // --- Repository file round-trip tests ---
-// Format every .lisp file in the repo and verify AST preservation.
+// Format every real .lisp source in the repository and verify that formatting
+// preserves the AST and is idempotent.  This is TestASTPreservation's
+// assertion applied to whole real files instead of hand-written snippets.
+//
+// HOW THIS TEST USED TO PASS WHILE COVERING NOTHING.  It discovered files with
+//
+//	filepath.Glob("../../_examples/**/*.lisp")
+//
+// which is wrong twice over.  A test binary runs with its own package
+// directory as the working directory, so "../../" resolves to the PARENT of
+// the repository, not to its root -- both patterns matched outside the source
+// tree.  And filepath.Glob has no ** operator: ** is an ordinary wildcard
+// matching exactly one path element, so even a correctly rooted pattern would
+// only ever have found files exactly one directory deep.  filepath.Glob
+// reports no error for a pattern that matches nothing, so the loop body never
+// ran, zero subtests were registered, and the test reported success.
+//
+// Both halves of the fix matter, and so does the third assertion: paths are
+// derived from this file's own compiled-in location (repoRoot), the walk is a
+// real recursive filepath.WalkDir, and an empty result is a FAILURE rather
+// than a silent pass.  A round-trip test that covers nothing is worse than no
+// round-trip test, because it also reports that the property holds.
+
+// repoRoot returns the root of the elps source tree, located from this file's
+// own compile-time path rather than from the working directory.  Test binaries
+// run with their package directory as the working directory, which is what
+// made the relative paths this test used to use resolve outside the repo.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, self, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller could not locate this test file")
+	dir := filepath.Dir(self)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, parent, dir, "walked to the filesystem root without finding go.mod")
+		dir = parent
+	}
+}
+
+// repoLispDirs are the repository directories holding real ELPS source, walked
+// recursively for round-trip material.  They mirror internal/fuzzseed's
+// lispDirs, which is this repository's existing answer to "where is the real
+// .lisp source", so the two corpora cannot drift apart.
+//
+// The other .lisp files in the tree (analysis/perf/testdata,
+// lisp/x/debugger/dapserver/testdata, editors/vscode/test/grammar,
+// lisp/testfixtures, lisp/x/profiler) are fixtures owned by other packages,
+// free to hold deliberately odd or malformed source; they are deliberately not
+// walked here.  They all round-trip cleanly today, so this is a scope choice,
+// not an exemption hiding a failure.
+var repoLispDirs = []string{
+	"_examples",
+	filepath.Join("lisp", "lisplib"),
+}
+
+// lispFilesUnder returns every .lisp file under dir, recursively.  Unlike the
+// glob it replaces, a missing directory and an empty directory are both errors
+// -- this test's entire failure history is a discovery step that found nothing
+// and said nothing.
+func lispFilesUnder(t *testing.T, dir string) []string {
+	t.Helper()
+	var paths []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".lisp") {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	require.NoError(t, err, "walking %s", dir)
+	sort.Strings(paths)
+	return paths
+}
 
 func TestRepoFileRoundTrip(t *testing.T) {
-	patterns := []string{
-		"../../_examples/**/*.lisp",
-		"../../lisp/lisplib/**/*.lisp",
-	}
-	for _, pattern := range patterns {
-		matches, err := filepath.Glob(pattern)
-		if err != nil {
-			t.Fatalf("glob %s: %v", pattern, err)
-		}
-		for _, path := range matches {
-			t.Run(filepath.Base(path), func(t *testing.T) {
-				src, err := os.ReadFile(path) //nolint:gosec // test reads discovered files
-				require.NoError(t, err)
-				formatted, err := Format(src, nil)
-				require.NoError(t, err, "Format failed for %s", path)
-				roundTripEqual(t, string(src), string(formatted))
+	root := repoRoot(t)
 
-				// Also verify idempotency
-				formatted2, err := Format(formatted, nil)
-				require.NoError(t, err, "Idempotent format failed for %s", path)
-				assert.Equal(t, string(formatted), string(formatted2),
-					"not idempotent for %s", path)
-			})
-		}
+	var files []string
+	for _, dir := range repoLispDirs {
+		found := lispFilesUnder(t, filepath.Join(root, dir))
+		// Per-directory, not just in total: if one root is renamed or moved,
+		// a global count would stay non-zero and hide it.
+		require.NotEmpty(t, found, "no .lisp files found under %s -- this test covers nothing", dir)
+		files = append(files, found...)
+	}
+	require.NotEmpty(t, files, "no repository .lisp files discovered")
+	t.Logf("round-tripping %d repository .lisp files", len(files))
+
+	for _, path := range files {
+		rel, err := filepath.Rel(root, path)
+		require.NoError(t, err)
+		t.Run(rel, func(t *testing.T) {
+			src, err := os.ReadFile(path) //nolint:gosec // path derived from runtime.Caller, not input
+			require.NoError(t, err)
+			formatted, err := Format(src, nil)
+			require.NoError(t, err, "Format failed for %s", rel)
+			roundTripEqual(t, string(src), string(formatted))
+
+			// Also verify idempotency
+			formatted2, err := Format(formatted, nil)
+			require.NoError(t, err, "Idempotent format failed for %s", rel)
+			assert.Equal(t, string(formatted), string(formatted2),
+				"not idempotent for %s", rel)
+		})
 	}
 }


### PR DESCRIPTION
Two test-quality follow-ups from the review of #555. Independent of that PR — this branches from `main` and touches no production code.

Both were **investigated before being fixed**, and one turned out not to need fixing.

## Formatter: `TestRepoFileRoundTrip` was inert

It passed while testing nothing — 0 subtests, 0.00s. Two independent defects:

- **Wrong depth.** The globs were rooted at `../../` from the package directory, which resolves *outside* the repository. `filepath.Glob` returns no error for a pattern matching nothing, so the loop body never ran.
- **`**` is not recursion in Go.** Verified: `../_examples/**/*.lisp` and `../_examples/*/*.lisp` return the *identical* 11 matches. So even a correctly-rooted pattern would only ever have found files exactly one directory deep.

Discovery now locates the repo from `runtime.Caller` walked up to `go.mod` and walks it with `filepath.WalkDir`. It fails loudly **per-directory** on zero files rather than only in aggregate — a global count stays non-zero when one of the two roots is renamed. Both failure modes are red-proved: a missing root fails with `no such file or directory`, an existing-but-empty root with `covers nothing`.

**Coverage 0 → 21 files.** Every `.lisp` file in the repository — all 37, not just the 21 in scope — was probed against the three assertions and all pass, cross-checked by running `elps fmt` over each and diffing. So there are **no formatter defects behind this** and no exemptions were needed. The fix is purely to discovery.

## Perf: the reported drift is false, and `local.go` is deliberately unchanged

The claim was that `isCallable` is missing `lambda`, `quote` and `quasiquote` from the op table, so the analyzer records a call edge for `(lambda ...)`. It does not. `scanExpr` resolves all three in its own switch *before* `isCallable` is consulted.

Measured on `(defun f (xs) (map 'list (lambda (x) (+ x 1)) xs))`: **score 20** as the code stands, **60** with those switch cases deleted — 20 of that difference being exactly the spurious lambda edge that does not happen today.

What it gets instead is a drift test in the shape of `lsp/semantic_tokens_drift_test.go`, with one addition worth keeping: **each exemption carries a probe as well as a reason**, and the probe pins the behaviour the exemption claims. Deleting the switch case fails this test, rather than silently turning the exemption into a lie. A new special operator is not exempt and fails until someone classifies it.

## Why this is a separate PR

These landed on #555's branch by mistake and were pushed there, which buried two unrelated test fixes inside a feature PR. Split out here; #555 has been rewritten to drop them. The one hunk that could not come along is the `internal/formsync` header comment citing the formatter bug in the present tense — that package is new in #555, so the correction stays there.

## Verification

- `go test ./...` — 41 packages, all pass
- `golangci-lint run ./formatter/... ./analysis/...` — 0 issues
- `go test -run TestRepoFileRoundTrip -v ./formatter/` — 21 subtests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgShxM3EoPmeVnq1cmpcPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgShxM3EoPmeVnq1cmpcPK)_