### PR TITLE
docs: explain that `handler-bind` has CL's name but `handler-case`'s semantics

### DIFF
--- a/docs/lang.md
+++ b/docs/lang.md
@@ -1245,6 +1245,41 @@ In the above code double-not-number is handled by replacing the `(double x)`
 function call with the value 0, while any other error (like integer overflow)
 will be replaced with the string "ERROR DETECTED".
 
+#### A note on the name
+
+elps's `handler-bind` has Common Lisp's name but Common Lisp's `handler-case`
+semantics, and the difference explains a piece of this chapter that otherwise
+looks arbitrary.
+
+In Common Lisp the two forms are a deliberate pair. A `handler-bind` handler
+runs *at the signal point* with the stack still intact, and returning normally
+**declines** — the condition keeps searching for another handler. A
+`handler-case` handler runs *after* unwinding, and its value becomes the value
+of the whole form. (The same pairing exists for `restart-bind` and
+`restart-case`; the `-bind` suffix means the form binds handlers in dynamic
+scope, parallel to `let` binding variables.)
+
+elps has only the second behaviour:
+
+```lisp
+(handler-bind ((condition (lambda (c &rest _) 'handler-returned-this)))
+    (error 'boom "x"))
+; evaluates to 'handler-returned-this
+```
+
+In Common Lisp that would not return `'handler-returned-this` — the handler
+would decline and `'boom` would keep propagating. There is no `handler-case`
+in elps.
+
+**This is why `rethrow` exists.** With Common Lisp's `handler-bind` you never
+need it: a handler that returns normally already declines. Because elps's
+handler captures instead, declining has to be requested explicitly, which is
+what `rethrow` does and what the `rethrow-context` lint check polices. The
+three are one design decision, not three independent features.
+
+The name is kept for compatibility with existing code rather than because it
+is accurate.
+
 ### Rethrowing Errors
 
 Sometimes a handler needs to perform a side effect (such as logging or


### PR DESCRIPTION
Closes #556.

**Documentation only.** No behaviour changes, and deliberately not a rename — renaming `handler-bind` would break every phylum in luthersystems/substrate and every embedder, for a discrepancy that costs nothing at runtime.

Branches from `main` and is independent of #555 and #557.

## What it documents

In Common Lisp the two forms are a deliberate pair:

| form | handler runs | returning normally |
| --- | --- | --- |
| `handler-bind` | at the signal point, stack **not** unwound | *declines* — the condition keeps searching |
| `handler-case` | after unwinding | its value becomes the form's value |

elps has only the second behaviour. Verified rather than assumed:

```lisp
(handler-bind ((condition (lambda (c &rest _) 'handler-returned-this)))
    (error 'boom "x"))
; => 'handler-returned-this
```

In Common Lisp that declines and `'boom` keeps propagating. There is no `handler-case` in elps at all.

## Why it is worth writing down

**It explains `rethrow`.** With Common Lisp's `handler-bind` you never need it — a handler that returns normally already declines. Because elps's handler *captures* instead, declining has to be requested explicitly, which is what `rethrow` does and what the `rethrow-context` analyzer polices.

A reader meeting `handler-bind`, `rethrow` and `rethrow-context` today has no way to see that they are **one design decision, not three independent features**. That is the whole cost of the discrepancy, and a paragraph fixes it.

## Where it came from

Found while adding #554's cleanup form, and it is the reason that form shipped as `with-cleanup` rather than reusing Common Lisp's `unwind-protect` name for a changed argument shape. Making the same mistake a second time would have let CL code paste in, parse, run, and protect the wrong thing — a silent behaviour change rather than a loud one.

## Verification

- `./elps doc --guide` renders
- `./elps doc -m` — all documented
- The example in the new section was executed against the interpreter, not written from memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgShxM3EoPmeVnq1cmpcPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgShxM3EoPmeVnq1cmpcPK)_