### PR TITLE
lint: separate argument refinement from hiding a builtin in `shadowing`

### DIFF
--- a/_examples/random/oop.lisp
+++ b/_examples/random/oop.lisp
@@ -91,7 +91,7 @@
 ;; m.
 (export 'method?)
 (defun method? (obj &rest m)
-  (let* ([m (map 'list method-name m)] ; nolint:shadowing
+  (let* ([m (map 'list method-name m)]
          [type-table (get method-table (type obj))])
     (all? #^(key? type-table %) m)))
 

--- a/_examples/sicp/sicp.lisp
+++ b/_examples/sicp/sicp.lisp
@@ -48,7 +48,7 @@
   (if (done? a)
     null-value
     (let [(curr    (term a))
-          (match?  (if (nil? match?) (lambda (_) true) match?))] ; nolint:shadowing
+          (match?  (if (nil? match?) (lambda (_) true) match?))]
       (accumulate-iter combiner
                        (if (match? curr)
                          (funcall combiner null-value curr)

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -771,6 +771,7 @@ func (a *analyzer) analyzeLet(node *lisp.LVal, scope *Scope, sequential bool, cu
 				Kind:   SymVariable,
 				Source: astutil.SourceLoc(nameVal),
 				Node:   nameVal,
+				Init:   valueVal,
 			}
 			letScope.Define(sym)
 			a.result.Symbols = append(a.result.Symbols, sym)

--- a/analysis/symbol.go
+++ b/analysis/symbol.go
@@ -43,11 +43,20 @@ func (k SymbolKind) String() string {
 
 // Symbol represents a defined name in a scope.
 type Symbol struct {
-	Name       string
-	Package    string
-	Kind       SymbolKind
-	Source     *token.Location // nil for builtins
-	Node       *lisp.LVal
+	Name    string
+	Package string
+	Kind    SymbolKind
+	Source  *token.Location // nil for builtins
+	Node    *lisp.LVal
+	// Init is the initialiser expression for a binding that has one --
+	// today the value half of a let/let* binding pair. It is nil for every
+	// other symbol kind (parameters, defun/defmacro names, builtins).
+	//
+	// It exists so a check can tell a binding that REFINES the thing it
+	// shadows -- (let* ([ctx (default ctx (sorted-map))]) -- from one that
+	// gives the name an unrelated meaning. Node is the name symbol alone,
+	// so the initialiser is otherwise unreachable from a Symbol (elps#559).
+	Init       *lisp.LVal
 	Scope      *Scope
 	Signature  *Signature // non-nil for callables
 	DocString  string

--- a/docs/lint-checks.md
+++ b/docs/lint-checks.md
@@ -411,23 +411,58 @@ with `_` to silence the warning, or `export` them.
 
 ### `shadowing`
 
-**Reports local bindings that shadow an outer binding.** (Severity: info)
+**Reports local bindings that shadow an outer binding.**
+(Severity: **warning** when the shadowed name is callable, **info** otherwise)
 
 Requires semantic analysis. Flags parameters, `let` bindings, and local
 functions (via `labels`/`flet`) that reuse a name from an enclosing scope
 or the global scope. Top-level `defun` redefinitions are excluded (they
 are intentional overrides, not shadowing).
 
+Severity follows what is hidden. Shadowing a **builtin, special operator,
+macro or function** is a warning: while that binding is in scope, a call to
+the name resolves to the local instead. Shadowing another local — a
+variable or parameter — is info.
+
 ```lisp
-;; INFO — parameter car shadows the builtin
-(defun foo (car) (+ car 1))
+;; WARNING — while this binding is live, (min ...) is an int, not the builtin
+(defun foo () (let ([min (compute-min)]) (bar min)))
 
 ;; INFO — local x shadows the parameter x
 (defun foo (x) (let ((x 2)) (+ x 1)))
 
 ;; OK — top-level defun overriding a builtin is not flagged
 (defun map (f l) (cons (f (car l)) ()))
+
+;; OK — a parameter shadowing a builtin or special-op is idiomatic in
+;; formals; the builtins themselves use names like car, map and expr
+(defun foo (car) (+ car 1))
 ```
+
+#### Refinement is not shadowing
+
+A binding whose initialiser references the name it shadows is **not**
+reported. It narrows one value rather than introducing a second meaning,
+and it is the only way to default an `&optional` argument:
+
+```lisp
+;; OK — one value, progressively narrowed
+(defun handle (&optional ctx)
+  (let* ([ctx (default ctx (sorted-map))])
+    ...))
+```
+
+This carve-out deliberately does **not** apply when the shadowed name is
+callable, because refinement is only coherent for a value:
+
+```lisp
+;; WARNING — reported despite mentioning `car`, because the body's
+;; (car xs) now applies an element as a function
+(defun foo (xs) (let ([car (car xs)]) (car xs)))
+```
+
+Quoted occurrences do not count as a reference — `(let ([keys 'keys]) ...)`
+rebinds `keys` to a symbol, which narrows nothing, so it is still reported.
 
 ### `user-arity`
 

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -943,7 +943,15 @@ var AnalyzerShadowing = &Analyzer{
 	Name:     "shadowing",
 	Severity: SeverityInfo,
 	Semantic: true,
-	Doc:      "Report when a local binding shadows a name from an enclosing scope.\n\nRequires semantic analysis (--workspace flag). Shadowing is valid but can cause confusion, especially when it hides a builtin or outer variable.",
+	Doc: "Report when a local binding shadows a name from an enclosing scope.\n\n" +
+		"Requires semantic analysis (--workspace flag). Severity follows what is being " +
+		"hidden: shadowing a builtin, special operator or macro is a WARNING, because a " +
+		"later call to that name silently means something else; shadowing another local " +
+		"is INFO.\n\n" +
+		"A binding whose initialiser references the name it shadows is NOT reported \u2014 " +
+		"(let* ([ctx (default ctx (sorted-map))]) refines one value rather than " +
+		"introducing a second meaning, and ELPS offers no other way to default an " +
+		"&optional argument (elps#559).",
 	Run: func(pass *Pass) error {
 		if pass.Semantics == nil {
 			return nil
@@ -972,15 +980,66 @@ var AnalyzerShadowing = &Analyzer{
 				(outer.Kind == analysis.SymSpecialOp || outer.Kind == analysis.SymBuiltin) {
 				continue
 			}
+			// Don't report a binding that REFINES the thing it shadows.
+			// (let* ([ctx (default ctx (sorted-map))]) narrows one value; it
+			// does not give the name a second meaning, and it is the only way
+			// to default an &optional argument. See elps#559.
+			if refinesShadowed(sym) {
+				continue
+			}
+			// Hiding a builtin, special-op or macro is a different category of
+			// problem from shadowing a local: a later (min a b) in that scope
+			// silently denotes the local instead of the builtin.
+			severity := SeverityInfo
+			note := fmt.Sprintf("rename '%s' to avoid confusion with the outer %s", sym.Name, outer.Kind)
+			if hidesCallable(outer.Kind) {
+				severity = SeverityWarning
+				note = fmt.Sprintf("rename '%s': while this binding is in scope, a call to %s "+
+					"resolves to it rather than to the %s", sym.Name, sym.Name, outer.Kind)
+			}
 			pass.Report(Diagnostic{
-				Message: fmt.Sprintf("%s '%s' shadows %s from enclosing scope", sym.Kind, sym.Name, outer.Kind),
-				Pos:     posFromSource(sym.Source),
-				EndPos:  endPosFromNode(sym.Node),
-				Notes:   []string{fmt.Sprintf("rename '%s' to avoid confusion with the outer %s", sym.Name, outer.Kind)},
+				Message:  fmt.Sprintf("%s '%s' shadows %s from enclosing scope", sym.Kind, sym.Name, outer.Kind),
+				Severity: severity,
+				Pos:      posFromSource(sym.Source),
+				EndPos:   endPosFromNode(sym.Node),
+				Notes:    []string{note},
 			})
 		}
 		return nil
 	},
+}
+
+// hidesCallable reports whether shadowing a symbol of this kind changes what a
+// CALL means. Hiding a builtin, special operator or macro is a different
+// category of problem from shadowing another local: while the binding is in
+// scope, (min a b) silently denotes the local instead of the builtin, so these
+// are reported at warning severity rather than info (elps#559).
+func hidesCallable(k analysis.SymbolKind) bool {
+	return k == analysis.SymBuiltin || k == analysis.SymSpecialOp || k == analysis.SymMacro
+}
+
+// refinesShadowed reports whether a binding's initialiser references the very
+// name the binding shadows — (let* ([ctx (default ctx (sorted-map))]).
+//
+// That shape narrows a single value rather than introducing a second meaning
+// for the name, and ELPS gives authors no other way to default an &optional
+// argument, so reporting it is noise that buries the shadows that matter
+// (elps#559). Only let/let* bindings carry an Init, so every other symbol kind
+// falls through to being reported exactly as before.
+func refinesShadowed(sym *analysis.Symbol) bool {
+	if sym == nil || sym.Init == nil {
+		return false
+	}
+	found := false
+	Walk([]*lisp.LVal{sym.Init}, func(n *lisp.LVal, _ *lisp.LVal, _ int) {
+		if found || n == nil || n.Type != lisp.LSymbol {
+			return
+		}
+		if n.Str == sym.Name {
+			found = true
+		}
+	})
+	return found
 }
 
 // AnalyzerUserArity checks argument counts for calls to user-defined functions

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -984,7 +984,13 @@ var AnalyzerShadowing = &Analyzer{
 			// (let* ([ctx (default ctx (sorted-map))]) narrows one value; it
 			// does not give the name a second meaning, and it is the only way
 			// to default an &optional argument. See elps#559.
-			if refinesShadowed(sym) {
+			//
+			// This does NOT apply when the shadowed name is callable. There,
+			// (let ([car (car xs)]) (car xs)) narrows nothing -- the body's
+			// (car xs) applies an element as a function and fails at runtime.
+			// Refinement is only coherent for a value; silencing it here would
+			// suppress exactly the hazard hidesCallable exists to promote.
+			if !hidesCallable(outer.Kind) && refinesShadowed(sym) {
 				continue
 			}
 			// Hiding a builtin, special-op or macro is a different category of
@@ -1010,12 +1016,23 @@ var AnalyzerShadowing = &Analyzer{
 }
 
 // hidesCallable reports whether shadowing a symbol of this kind changes what a
-// CALL means. Hiding a builtin, special operator or macro is a different
-// category of problem from shadowing another local: while the binding is in
-// scope, (min a b) silently denotes the local instead of the builtin, so these
-// are reported at warning severity rather than info (elps#559).
+// CALL means. While the binding is in scope, (min a b) silently denotes the
+// local instead of the builtin, so these are reported at warning severity
+// rather than info (elps#559).
+//
+// SymFunction counts for the same reason a builtin does, and leaving it out was
+// a real gap: after (defun helper (x) x), a (let ([helper 2])) makes the body's
+// (helper 1) apply the integer 2. Nothing about that is milder because the
+// callee happened to be user-defined.
 func hidesCallable(k analysis.SymbolKind) bool {
-	return k == analysis.SymBuiltin || k == analysis.SymSpecialOp || k == analysis.SymMacro
+	switch k {
+	case analysis.SymBuiltin, analysis.SymSpecialOp, analysis.SymMacro, analysis.SymFunction:
+		return true
+	case analysis.SymVariable, analysis.SymParameter, analysis.SymType:
+		return false
+	default:
+		return false
+	}
 }
 
 // refinesShadowed reports whether a binding's initialiser references the very
@@ -1030,16 +1047,35 @@ func refinesShadowed(sym *analysis.Symbol) bool {
 	if sym == nil || sym.Init == nil {
 		return false
 	}
-	found := false
-	Walk([]*lisp.LVal{sym.Init}, func(n *lisp.LVal, _ *lisp.LVal, _ int) {
-		if found || n == nil || n.Type != lisp.LSymbol {
-			return
+	return mentionsUnquoted(sym.Init, sym.Name)
+}
+
+// mentionsUnquoted reports whether name occurs in node as live code, refusing
+// to descend into quoted subtrees.
+//
+// A quoted occurrence is data, not a use: (let ([keys 'keys]) ...) rebinds keys
+// to the SYMBOL keys, which narrows nothing. Skipping the whole quoted subtree
+// rather than only a quoted leaf also covers '(keys foo), whose elements do not
+// individually carry the flag.
+//
+// Known limitation: an occurrence that a nested binding form inside the
+// initialiser rebinds -- (let ([v (lambda (v) ...)]) ...) -- still counts,
+// because this is a syntactic walk with no scope of its own. That can only
+// under-report an info-level shadow of a local; hidesCallable kinds never reach
+// here.
+func mentionsUnquoted(node *lisp.LVal, name string) bool {
+	if node == nil || node.IsQuoted() {
+		return false
+	}
+	if node.Type == lisp.LSymbol {
+		return node.Str == name
+	}
+	for _, c := range node.Cells {
+		if mentionsUnquoted(c, name) {
+			return true
 		}
-		if n.Str == sym.Name {
-			found = true
-		}
-	})
-	return found
+	}
+	return false
 }
 
 // AnalyzerUserArity checks argument counts for calls to user-defined functions

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -3893,3 +3893,62 @@ func TestWithCleanupForms_Nolint(t *testing.T) {
 	assertNoDiags(t, lintCheck(t, AnalyzerWithCleanupForms,
 		`(with-cleanup () (do-work)) ; nolint:with-cleanup-forms`))
 }
+
+// --- shadowing: refinement vs. a second meaning (elps#559) ---
+
+func TestShadowing_Negative_RefinesShadowedParam(t *testing.T) {
+	// The defaulting idiom: the local is computed FROM the parameter it
+	// shadows, so the name keeps one meaning, progressively narrowed. ELPS
+	// gives no other way to default an &optional argument.
+	source := `(defun foo (&optional ctx) (let* ([ctx (or ctx 1)]) ctx))`
+	diags := lintCheckSemantic(t, AnalyzerShadowing, source)
+	assertNoDiags(t, diags)
+}
+
+func TestShadowing_Negative_RefinesShadowedNested(t *testing.T) {
+	// Same shape one level deeper, and through a call rather than `or`.
+	source := `(defun foo (xs) (let ([xs (map 'list to-string xs)]) xs))`
+	diags := lintCheckSemantic(t, AnalyzerShadowing, source)
+	assertNoDiags(t, diags)
+}
+
+func TestShadowing_Positive_UnrelatedInitStillReported(t *testing.T) {
+	// The refinement carve-out must NOT swallow a binding that gives the
+	// name an unrelated value -- this is the shape that actually hides
+	// something, and it is what substrate's `[min (determine-min)]` looks
+	// like.
+	source := `(defun foo (&optional ctx) (let* ([ctx (sorted-map)]) ctx))`
+	diags := lintCheckSemantic(t, AnalyzerShadowing, source)
+	assert.Len(t, diags, 1)
+	assertHasDiag(t, diags, "ctx")
+}
+
+func TestShadowing_Positive_ParamIsNeverRefinement(t *testing.T) {
+	// Parameters carry no initialiser, so the carve-out cannot reach them:
+	// an inner lambda parameter shadowing an outer one is still reported.
+	source := `(defun foo (x) (lambda (x) x))`
+	diags := lintCheckSemantic(t, AnalyzerShadowing, source)
+	assert.Len(t, diags, 1)
+	assertHasDiag(t, diags, "x")
+}
+
+func TestShadowing_Severity_HidingABuiltinIsAWarning(t *testing.T) {
+	// While this binding is in scope a call to (car ...) resolves to the
+	// local, which is a different category of problem from shadowing a
+	// local name -- so it is a warning, not info.
+	source := `(defun foo () (let ([car 1]) car))`
+	diags := lintCheckSemantic(t, AnalyzerShadowing, source)
+	require.Len(t, diags, 1)
+	assert.Equal(t, SeverityWarning, diags[0].Severity,
+		"hiding a builtin should outrank shadowing a local")
+	require.NotEmpty(t, diags[0].Notes)
+	assert.Contains(t, diags[0].Notes[0], "resolves to it rather than to the builtin",
+		"the note should say what actually goes wrong, not just 'rename it'")
+}
+
+func TestShadowing_Severity_HidingALocalStaysInfo(t *testing.T) {
+	source := `(defun foo (x) (let ([x 2]) x))`
+	diags := lintCheckSemantic(t, AnalyzerShadowing, source)
+	require.Len(t, diags, 1)
+	assert.Equal(t, SeverityInfo, diags[0].Severity)
+}

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -3952,3 +3952,42 @@ func TestShadowing_Severity_HidingALocalStaysInfo(t *testing.T) {
 	require.Len(t, diags, 1)
 	assert.Equal(t, SeverityInfo, diags[0].Severity)
 }
+
+// --- shadowing: the carve-out must not reach the hazards (review of #560) ---
+
+func TestShadowing_Positive_RefinementDoesNotSilenceABuiltin(t *testing.T) {
+	// The refinement carve-out is only coherent for a VALUE. Here nothing is
+	// narrowed: the body's (car xs) applies an element as a function. An
+	// earlier revision of #560 ran the carve-out before the severity split
+	// and silenced exactly this.
+	source := `(defun foo (xs) (let ([car (car xs)]) (car xs)))`
+	diags := lintCheckSemantic(t, AnalyzerShadowing, source)
+	require.Len(t, diags, 1)
+	assert.Equal(t, SeverityWarning, diags[0].Severity)
+	assertHasDiag(t, diags, "car")
+}
+
+func TestShadowing_Positive_QuotedIsNotARefinement(t *testing.T) {
+	// 'x is data, not a narrowed value -- the binding gives the name a second
+	// meaning and must still be reported.
+	//
+	// The shadowed name here is a PARAMETER on purpose. With a callable the
+	// carve-out is skipped wholesale, so a builtin-shadowing case would pass
+	// this test without the quote logic ever running.
+	source := `(defun foo (x) (let ([x 'x]) x))`
+	diags := lintCheckSemantic(t, AnalyzerShadowing, source)
+	require.Len(t, diags, 1)
+	assert.Equal(t, SeverityInfo, diags[0].Severity)
+	assertHasDiag(t, diags, "x")
+}
+
+func TestShadowing_Severity_HidingAUserFunctionIsAWarning(t *testing.T) {
+	// (helper 1) applies the integer 2. Nothing about that is milder because
+	// the callee is user-defined rather than a builtin.
+	source := `(defun helper (x) x)
+(defun foo () (let ([helper 2]) (helper 1)))`
+	diags := lintCheckSemantic(t, AnalyzerShadowing, source)
+	require.Len(t, diags, 1)
+	assert.Equal(t, SeverityWarning, diags[0].Severity,
+		"hiding a user-defined function is the same hazard as hiding a builtin")
+}


### PR DESCRIPTION
Closes #559.

## The problem

`shadowing` treated every shadow alike, and the harmless shape so outnumbered the harmful one that the harmful one was invisible.

Measured on luthersystems/substrate's shirocore, where after luthersystems/substrate#465 **all 86** remaining advisory diagnostics were `shadowing`. **59 of them were one idiom:**

```lisp
(let* ([ctx (default ctx (sorted-map))]                  ; connector.lisp:78
(let* ([version-id (phylum-version-deref version-id)])   ; router.lisp:443
(let* ([method-name (or method-name "")])                ; router.lisp:367
```

The local is computed **from** the binding it shadows. There is no second meaning — one value, progressively narrowed — and ELPS gives authors no other way to default an `&optional` argument. Renaming to satisfy the check makes the code worse (`ctx` → `ctx-or-default` everywhere), so nobody does it, the count sits there, and the diagnostics that matter drown in it.

## Two rules

**1. A binding whose initialiser references the name it shadows is not reported** — *unless the shadowed name is callable.*

The initialiser was not reachable: `analyzeLet` sets `Symbol.Node` to the *name symbol* alone, discarding the value half of the pair. So this adds `Symbol.Init`, populated for `let`/`let*` bindings and nil everywhere else. That nil is load-bearing — the carve-out **cannot** reach parameters or `flet`/`labels` names by construction, rather than by a condition someone could later loosen.

The callable exception is the important half, and the first revision of this PR got it wrong (see below).

**2. Severity follows what is hidden.** Shadowing a builtin, special-op, macro **or function** is a **warning**: while that binding is in scope, `(min a b)` silently denotes the local. Shadowing another local stays **info**. The note says what actually goes wrong:

> rename 'car': while this binding is in scope, a call to car resolves to it rather than to the builtin

No exit codes change anywhere — `elps lint --fail-on` defaults to `error`.

## What code review caught

The first revision got the *scope* of both rules wrong. Each was verified by diffing real `elps lint` output against the parent commit, not by reading:

- **The carve-out ran before the severity split, silencing precisely the case the split had just promoted.** `(let ([car (car xs)]) (car xs))` and `(let ([list (list xs)]) (list 1 2))` were reported on the parent and went silent — even though the body applies an element as a function and fails at runtime. Refinement is only coherent for a *value*; now gated on `!hidesCallable(outer.Kind)`.
- **`hidesCallable` omitted `SymFunction`.** After `(defun helper (x) x)`, a `(let ([helper 2]))` makes `(helper 1)` apply the integer `2`. Nothing about that is milder because the callee is user-defined. The predicate now enumerates every kind so a new one cannot silently default.
- **Quoted occurrences counted as references.** `(let ([x 'x]) x)` rebinds `x` to a *symbol*, narrowing nothing. Replaced the flat `Walk` with a recursive walk that refuses to descend into quoted subtrees — the whole subtree, so `'(x foo)` is covered too. The one case it still gets wrong is documented on the function: an occurrence rebound by a nested binding *inside* the initialiser. That can only under-report an info-level shadow of a local, since callables no longer reach the carve-out at all.
- **Two in-tree `; nolint:shadowing` directives went dead**, adding fresh `unused-nolint` warnings to this repo's own lint run. Removed (`_examples/random/oop.lisp:94`, `_examples/sicp/sicp.lisp:51`).
- **`docs/lint-checks.md` was stale** — single info severity, no mention of the carve-out — and it is the page `lsp/diagnostics.go` links every shadowing diagnostic to via `CodeDescription.HRef`. Rewritten. It also carried a **pre-existing** error: `(defun foo (car) …)` was labelled INFO but has never been reported, since parameters shadowing builtins are exempt.

## Validated against real code, not fixtures

**86 → 30.** All six hazards from #559 still fire, now joined by five function-shadowing ones correctly raised to warning:

```
utils.lisp:1192  parameter 'default'   shadows macro     ← and the next line calls get-default
utils.lisp:1597  function  'get'       shadows builtin
utils.lisp:1941  variable  'min'       shadows builtin
utils.lisp:1942  variable  'max'       shadows builtin
utils.lisp:2187  variable  'min'       shadows builtin
utils.lisp:3020  variable  'keys'      shadows builtin
batch.lisp:60    variable  'handler'   shadows function
utils.lisp:133   parameter 'vals'      shadows function
utils.lisp:949   parameter 'count'     shadows function
utils.lisp:2264  variable  'peek-next' shadows function
utils.lisp:2311  variable  'next'      shadows function
```

**Nothing appears that `main` did not already report** — every one of the 30 is a subset of the original 86. The count moved 28 → 30 between revisions because two refinements *of a callable* should never have been suppressed.

## Tests

Nine. The ones that matter guard the edges that would make this wrong: an unrelated initialiser is still reported (`[ctx (sorted-map)]` — the `[min (determine-min)]` shape), a parameter is never treated as a refinement, and the three review regressions above.

**All red-proved.** Worth recording one miss: the quote test initially passed *for the wrong reason* — it shadowed a builtin, which the `hidesCallable` gate already covers, so the quote path never ran. Red-proofing caught it; it now shadows a parameter, and removing the `IsQuoted` check fails it.

## Verification

`go test ./...` green across the repo. `elps doc -m` clean.

Two caveats, checked rather than assumed:
- `make test` fails in my sandbox with `go: no such tool "covdata"` during `-cover` builds of unrelated packages — a broken toolchain install here; plain `go test ./...` passes.
- `make static-checks` reports 2 `nolintlint` issues in `parser/token/token.go`, both confirmed to reproduce **identically on unmodified `origin/main`** in a clean worktree, consistent with the golangci-lint version skew CLAUDE.md warns about. The one that *was* mine — an `exhaustive` failure on a `switch` over `SymbolKind` — is fixed.

## Follow-on

Once this releases, substrate bumps, drops its advisory baseline from 90 to ~35, and fixes the eleven above. Separate PR there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgShxM3EoPmeVnq1cmpcPK