### PR TITLE
make: warn when the local golangci-lint disagrees with CI's

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ ELPS is an embedded Lisp interpreter implemented in Go. It is a Lisp-1 dialect d
 | `make fuzz-list` | List the discovered fuzz targets without running them |
 | `go test ./lisp/...` | Run tests for a specific package |
 | `go test -run TestName ./lisp/` | Run a single test |
-| `make static-checks` | Run golangci-lint with gosec |
+| `make static-checks` | Run golangci-lint with gosec (warns if your version differs from CI's) |
 | `make fieldalign-fix` | Reorder struct fields for the fieldalignment gate (uses betteralign — `fieldalignment -fix` deletes field comments) |
 | `make repl` | Build and launch the REPL |
 | `./elps run file.lisp` | Run a lisp file |
@@ -36,6 +36,23 @@ ELPS is an embedded Lisp interpreter implemented in Go. It is a Lisp-1 dialect d
 | `./elps mcp` | Start the ELPS MCP server over stdio |
 | `make release-notes` | Preview release notes (commits, PRs, CI status since last tag) |
 | `make release VERSION=v1.X.0` | Create a tagged GitHub release (must be on main, CI must pass) |
+
+
+### golangci-lint version skew
+
+`make static-checks` runs whatever `golangci-lint` is on PATH; CI pins a
+version in `.github/workflows/elps.yml`. When the two differ the results
+differ, **in both directions and silently**, so the target now prints a
+warning naming both versions. Trust CI over a local run.
+
+The trap worth knowing, because it invites you to break the build: two
+`//nolint:gosec` directives in `parser/token/token.go` (lines 113 and 115)
+are **load-bearing** under CI's golangci-lint, but an older gosec does not
+flag those array indexes, so `nolintlint` reports the directives as unused
+and a local run reads as "two issues to clean up". Deleting them turns CI
+red. `main` being green in CI is the authority on whether a `//nolint` is
+dead — not a local run on a different version.
+
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,36 @@ tree-sitter-test:
 	cd tree-sitter-elps && go test ./...
 
 .PHONY: static-checks
-static-checks:
+# The golangci-lint version CI actually runs, read from the workflow so there
+# is one source of truth. Kept as a warning rather than a hard gate: a local
+# run on a near-enough version is still useful, and failing the build over a
+# patch bump would just get the target avoided.
+GOLANGCI_CI_VERSION := $(shell sed -n 's/^[[:space:]]*version:[[:space:]]*\(v[0-9][0-9.]*\)[[:space:]]*$$/\1/p' .github/workflows/elps.yml | head -1)
+
+# Warn when the local golangci-lint disagrees with CI's on major.minor.
+#
+# This exists because the failure mode is SILENT and costs real time: a local
+# run on a different version produces findings CI does not have, or misses
+# findings CI does. Both directions have happened here. The sharp one is
+# nolintlint: parser/token/token.go carries two //nolint:gosec directives that
+# are load-bearing under CI's version but report as "unused" under an older
+# gosec -- so an older local golangci-lint invites you to delete the very
+# directives that keep CI green.
+.PHONY: check-golangci-version
+check-golangci-version:
+	@command -v golangci-lint >/dev/null 2>&1 || { \
+		echo "WARNING: golangci-lint not on PATH; CI runs $(GOLANGCI_CI_VERSION)"; exit 0; }
+	@have=$$(golangci-lint --version 2>/dev/null | sed -n 's/.*has version \([0-9][0-9.]*\).*/v\1/p'); \
+	want='$(GOLANGCI_CI_VERSION)'; \
+	hmm=$$(echo "$$have" | cut -d. -f1,2); wmm=$$(echo "$$want" | cut -d. -f1,2); \
+	if [ -n "$$have" ] && [ -n "$$wmm" ] && [ "$$hmm" != "$$wmm" ]; then \
+		echo "WARNING: local golangci-lint $$have, CI runs $$want."; \
+		echo "         Findings below may not match CI in EITHER direction."; \
+		echo "         In particular, do not delete a //nolint directive this"; \
+		echo "         run calls unused without checking CI is green without it."; \
+	fi
+
+static-checks: check-golangci-version
 	golangci-lint run ./...
 	# Second pass under the elpscheck build tag. golangci-lint analyses only
 	# the DEFAULT build, so a file guarded by a build tag is invisible to every


### PR DESCRIPTION
`make static-checks` runs whatever `golangci-lint` is on PATH; CI pins a version in `.github/workflows/elps.yml`. When they differ the results differ, **in both directions and silently** — and the silence is what costs time.

## This is not hypothetical — it is live in this tree

`parser/token/token.go` carries two `//nolint:gosec` directives on array indexes (lines 113, 115). Under CI's pinned **v2.6** they are **load-bearing**: gosec fires there and the directives suppress it, which is why `main` is green. Under an older gosec that does not flag those lines, `nolintlint` reports the directives as *unused*, so a local `make static-checks` prints:

```
parser/token/token.go:113:31: directive `//nolint:gosec // INVALID is 0, always valid` is unused for linter "gosec" (nolintlint)
parser/token/token.go:115:26: directive `//nolint:gosec // bounds checked above` is unused for linter "gosec" (nolintlint)
2 issues:
* nolintlint: 2
```

which reads as two obvious cleanups. **Deleting them turns CI red.**

I read that output as two pre-existing defects and reported it as such — twice, including in a PR body — before checking whether `main` was green in CI. That is precisely the mistake this warning exists to stop, and it is the reason I would rather spend thirty lines of Makefile than trust myself to remember.

## What it does

`static-checks` now depends on a `check-golangci-version` target that reads the pinned version straight out of the workflow — one source of truth, no second constant to drift — and warns when `major.minor` disagrees:

```
WARNING: local golangci-lint v2.5.0, CI runs v2.6.
         Findings below may not match CI in EITHER direction.
         In particular, do not delete a //nolint directive this
         run calls unused without checking CI is green without it.
```

**It warns rather than fails, deliberately.** A local run on a near-enough version is still useful, and a hard gate over a patch bump would just get the target avoided — which is worse than a noisy line.

## Verification

| Case | Result |
|---|---|
| Extraction from the workflow | `GOLANGCI_CI_VERSION := v2.6` |
| Versions match (workflow temporarily pinned to v2.5) | **silent** |
| Versions differ | warns, `exit=0` — does not fail the build |
| `golangci-lint` absent from PATH | warns, `exit=0` |
| `static-checks` after the guard | still runs both `golangci-lint` passes |

`go build ./...`, `go test ./lint/ ./analysis/` green. The workflow file is read but never modified (confirmed clean after the match test).

CLAUDE.md gets the same warning plus the `token.go` specifics, since a future session reading "2 issues" has no other way to know they are phantom. It also states the rule that settles it: **`main` being green in CI is the authority on whether a `//nolint` is dead — not a local run on a different version.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgShxM3EoPmeVnq1cmpcPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgShxM3EoPmeVnq1cmpcPK)_