### PR TITLE
Clone sorted maps structurally in Fork

### DIFF
--- a/lisp/fork.go
+++ b/lisp/fork.go
@@ -606,6 +606,51 @@ func (f *forker) mapData(md *MapData) *MapData {
 		f.maps[md] = cp
 		return cp
 	}
+	if sm, ok := md.mapBacking.(sortedmap); ok {
+		// The stock sorted map is a Go map plus a key-type map, so it can be
+		// cloned structurally: copy both maps and remap the values through
+		// the fork walk.  This is what Set would store for every entry, so
+		// the contents, key types, aliasing and cycles come out identical to
+		// the enumerate-and-reinsert path below, without the sorted entry
+		// list, the per-entry pair cells, or the incremental map growth.
+		//
+		// make(..., len(sm.m)) right-sizes the clone on purpose.  Go maps
+		// never shrink after deletes and maps.Clone copies the table at its
+		// high-water mark, so a load-time map filled to 100k entries and
+		// pruned to 3 would cost every fork 3.7MB instead of 0.2MB (pinned
+		// by TestForkSortedMapClonePrunedMapIsRightSized); the per-entry
+		// copy costs nothing measurable over maps.Clone.
+		//
+		// The key-type map is copied verbatim rather than rebuilt from the
+		// entries (as detach's mapData still does).  An entry in tm with no
+		// partner in m cannot exist today (Set and Del keep the two in
+		// step), so nothing is laundered here, and a future desync shows
+		// up in the fork instead of being hidden by the rebuild.
+		//
+		// Measured on a 72k-line production phylum whose template holds
+		// large load-time sorted maps (rating tables, templates): this one
+		// branch removed 28% of the bytes and 15% of the allocations of
+		// every fork, and 15% of the wall time of building a retained pool
+		// of forked VMs.  Embedder map implementations keep the generic
+		// path: their entry enumeration is the only contract they offer.
+		nm := sortedmap{
+			m:  make(map[interface{}]*LVal, len(sm.m)),
+			tm: make(typemap, len(sm.tm)),
+		}
+		// Memo before descending, as the generic path does (issue #576):
+		// an entry may reach back to md.  The Go maps inside nm are
+		// references, so filling them after the memo stores the *MapData
+		// is visible through it.
+		cp := NewMapData(nm)
+		f.maps[md] = cp
+		for k, v := range sm.m {
+			nm.m[k] = f.val(v)
+		}
+		for k, t := range sm.tm {
+			nm.tm[k] = t
+		}
+		return cp
+	}
 	entries := sortedMapEntries(md)
 	if entries.Type == LError {
 		// Unreachable for the stock sorted map (its entry enumeration

--- a/lisp/fork_sortedmap_test.go
+++ b/lisp/fork_sortedmap_test.go
@@ -1,0 +1,184 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+// TestForkSortedMapClone pins the structural clone forker.mapData takes for
+// the stock sorted map against the contract the enumerate-and-reinsert path
+// it replaced provided: same entries in the same order with the same key
+// types, values remapped through the fork walk (so a mutable value is copied
+// and an aliased map stays aliased), and no storage shared with the template
+// in either direction.
+func TestForkSortedMapClone(t *testing.T) {
+	env := newForkTestEnv(t)
+
+	m := SortedMap()
+	inner := Array(nil, []*LVal{Int(1), Int(2)})
+	for _, kv := range []struct {
+		k, v *LVal
+	}{
+		{String("b-string"), inner},
+		{Symbol("a-symbol"), String("sym-val")},
+		{String("c-string"), Int(3)},
+	} {
+		if lerr := m.Map().Set(kv.k, kv.v); lerr.Type == LError {
+			t.Fatalf("map set: %v", lerr)
+		}
+	}
+	// The map is reachable under two names AND from inside one of its own
+	// values: the clone must preserve both the alias and the cycle.
+	if lerr := m.Map().Set(String("self"), Array(nil, []*LVal{m})); lerr.Type == LError {
+		t.Fatalf("map set: %v", lerr)
+	}
+	env.PutGlobal(Symbol("cfg"), m)
+	env.PutGlobal(Symbol("cfg-alias"), m)
+
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	fm := fork.Runtime.Package.Get(Symbol("cfg"))
+	if fm.Type != LSortMap {
+		t.Fatalf("forked cfg: want sorted map, got %v", fm)
+	}
+	if fork.Runtime.Package.Get(Symbol("cfg-alias")).Native != fm.Native {
+		t.Errorf("aliased binding was not remapped to the same clone")
+	}
+	if fm.Native == m.Native {
+		t.Fatalf("forked map shares MapData with the template")
+	}
+
+	// Same entries, same order, same key types.
+	oe, ne := sortedMapEntries(m.Map()), sortedMapEntries(fm.Map())
+	if len(oe.Cells) != len(ne.Cells) {
+		t.Fatalf("entry count differs: template %d, fork %d", len(oe.Cells), len(ne.Cells))
+	}
+	for i := range oe.Cells {
+		ok, nk := oe.Cells[i].Cells[0], ne.Cells[i].Cells[0]
+		if ok.Type != nk.Type || ok.Str != nk.Str {
+			t.Errorf("entry %d key: template %v (%v), fork %v (%v)", i, ok, ok.Type, nk, nk.Type)
+		}
+	}
+
+	// A mutable value is copied, not shared; the cycle points at the clone.
+	fv, _ := fm.Map().Get(String("b-string"))
+	if fv == inner {
+		t.Errorf("mutable vector value shared with the template")
+	}
+	if eq := fv.Equal(inner); eq.Type != LSymbol || eq.Str != TrueSymbol {
+		t.Errorf("vector value differs: %v vs %v", fv, inner)
+	}
+	self, _ := fm.Map().Get(String("self"))
+	if got := self.Cells[1].Cells[0].Native; got != fm.Native { // Cells[1] holds an array's elements
+		t.Errorf("self-reference points at %p, want the clone %p", got, fm.Native)
+	}
+
+	// Independence in both directions.
+	if lerr := fm.Map().Set(String("fork-only"), Int(1)); lerr.Type == LError {
+		t.Fatalf("fork map set: %v", lerr)
+	}
+	if _, found := m.Map().Get(String("fork-only")); found {
+		t.Errorf("a key set in the fork appeared in the template")
+	}
+	if lerr := m.Map().Set(String("template-only"), Int(1)); lerr.Type == LError {
+		t.Fatalf("template map set: %v", lerr)
+	}
+	if _, found := fm.Map().Get(String("template-only")); found {
+		t.Errorf("a key set in the template appeared in the fork")
+	}
+	fv.Cells[1].Cells[0] = Int(99) //elps:mutates the fork's private copy, to prove the template's vector is untouched
+	if inner.Cells[1].Cells[0].Int != 1 {
+		t.Errorf("mutating the fork's vector value changed the template's")
+	}
+
+	// The key-type map is independent too.  Get and Len never consult it,
+	// so a shared typemap is invisible to the probes above; it shows when
+	// the fork stores a SYMBOL key and the template then stores a STRING
+	// key of the same name: a shared typemap makes the template enumerate
+	// its string key as a symbol (and a concurrent fork's Set would be a
+	// concurrent write to the template's map).
+	if lerr := fm.Map().Set(Symbol("k"), Int(1)); lerr.Type == LError {
+		t.Fatalf("fork map set: %v", lerr)
+	}
+	if lerr := m.Map().Set(String("k"), Int(2)); lerr.Type == LError {
+		t.Fatalf("template map set: %v", lerr)
+	}
+	for _, p := range sortedMapEntries(m.Map()).Cells {
+		if p.Cells[0].Str == "k" && p.Cells[0].Type != LString {
+			t.Errorf("template key %q enumerates as %v, want string: fork and template share a typemap", p.Cells[0].Str, p.Cells[0].Type)
+		}
+	}
+}
+
+// TestForkSortedMapClonePrunedMapIsRightSized pins that the clone is sized
+// to the map's live entries, not to the template table's high-water mark.
+// Go maps never shrink after deletes, and a maps.Clone-based clone copied
+// the abandoned table: a map filled to 100k entries and pruned to 3 cost
+// every fork 3.7MB and several times the wall time, instead of ~0.2MB.
+func TestForkSortedMapClonePrunedMapIsRightSized(t *testing.T) {
+	env := newForkTestEnv(t)
+	m := SortedMap()
+	const highWater = 100_000
+	for i := range highWater {
+		if lerr := m.Map().Set(String(strconv.Itoa(i)), Int(i)); lerr.Type == LError {
+			t.Fatalf("map set: %v", lerr)
+		}
+	}
+	for i := 3; i < highWater; i++ {
+		m.Map().Del(String(strconv.Itoa(i)))
+	}
+	if m.Map().Len() != 3 {
+		t.Fatalf("pruned map has %d entries, want 3", m.Map().Len())
+	}
+	env.PutGlobal(Symbol("staging"), m)
+
+	res := testing.Benchmark(func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := env.Fork(); err != nil {
+				b.Fatalf("fork: %v", err)
+			}
+		}
+	})
+	// The whole fork of this small env is ~0.25MB; the abandoned 100k-slot
+	// table alone is ~3.5MB.
+	const limit = 1 << 20
+	if got := res.AllocedBytesPerOp(); got > limit {
+		t.Errorf("fork of a pruned 3-entry map allocates %d B/op, want at most %d: the clone kept the template's %d-entry table", got, limit, highWater)
+	}
+}
+
+// BenchmarkForkSortedMap measures Fork on a template whose mutable state is
+// dominated by load-time sorted maps, the shape of a production phylum's
+// rating tables and templates.  It exists so the benchmark gate sees the
+// fork's map-cloning cost directly rather than diluted across an env-wide
+// fork; the structural clone in forker.mapData is what it pins.
+func BenchmarkForkSortedMap(b *testing.B) {
+	env := newForkTestEnv(b)
+	for i := range 20 {
+		m := SortedMap()
+		for j := range 200 {
+			var v *LVal
+			if j%2 == 0 {
+				v = String(fmt.Sprintf("value-%d-%d", i, j))
+			} else {
+				v = Array(nil, []*LVal{Int(j), String("x")})
+			}
+			if lerr := m.Map().Set(String(fmt.Sprintf("key-%03d", j)), v); lerr.Type == LError {
+				b.Fatalf("map set: %v", lerr)
+			}
+		}
+		env.PutGlobal(Symbol(fmt.Sprintf("table-%d", i)), m)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := env.Fork(); err != nil {
+			b.Fatalf("fork: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `forker.mapData` rebuilt every sorted map by enumerating its entries in sorted order and re-inserting them one by one: a sort, one pair list per entry, and incremental growth of the new map, for every map in every fork.
- The stock sorted map is a Go map plus a key-type map, so the fork now copies both maps directly and remaps the values through the fork walk (values must still go through `f.val` so mutable values are copied and aliases/cycles are preserved; the keys are immutable strings and copy as-is). `Set` stored exactly those two things per entry, so contents, key types, aliasing and cycles are unchanged. Embedder map implementations keep the generic entries path.
- The clone seeds the per-`*MapData` memo that #587 (fixes #576) added below this PR, before the entries are walked, exactly as the generic path does, so two headers over one map and a map that reaches itself come out the same through either path (`lisp/fork_mapalias_test.go` runs on this head too).
- The clone uses `make(..., len)` plus a copy loop, not `maps.Clone`, on purpose. Go maps never shrink after deletes and `maps.Clone` copies the table at its high-water mark, so a load-time map filled to 100k entries and pruned to 3 would cost every fork 3.7MB instead of 0.2MB. Found by adversarial review of an earlier revision; `TestForkSortedMapClonePrunedMapIsRightSized` now pins it.
- First of a stack of small, isolated fork/evaluator changes from a profiling study of the interpreter on a 72k-line production phylum running under substrate, where the per-VM fork dominates warm-VM cost. Study: https://claude.ai/code/artifact/05b3209b-890d-4f35-8b1b-fef71f432b74. This PR is the lowest-risk item: it touches one function in `lisp/fork.go` and has no language-semantic surface.

Stacked on #586: the bug-fix PRs (#580, #581, #583, #587, #586) land first, then this and the rest of the perf stack.

## Measurements

Production phylum forked under substrate (pinned CPU, 30 forks per sample, n=3):

| metric | base | this change |
|---|---|---|
| fork B/op | 5.78 MiB | 4.15 MiB (−28%) |
| fork allocs/op | 49.3k | 42.2k (−15%) |
| retained-fork pool wall time | 1.98 s | 1.68 s (−15%) |

New `BenchmarkForkSortedMap` (20 maps × 200 entries, `-cpu 1 -count 6`, interleaved): sec/op −44%, B/op −44%, allocs/op −29%. The allocation numbers are exact; the wall-time number needs a pinned CPU to reproduce. CI benchmark gate: 0 rows at or above the gate.

## Test Plan

- [x] `make test` passes
- [x] `golangci-lint run ./...` reports 0 issues (v2.6.2, matches CI's v2.6)
- [x] `./elps fmt -l ./...` reports no changes
- [x] `./elps lint ./...` reports only the pre-existing `editors/vscode/test/grammar/builtins.lisp` diagnostics, identical on `main`
- [x] `./elps doc -m` reports no missing docs
- [x] `make elpsvet` passes
- [x] `TestForkSortedMapClone` pins entry order, key types, value remapping (mutable value copied, aliased map stays aliased, self-reference points at the clone) and template/fork independence in both directions, including the key-type map (a shared typemap would be a concurrent write to the template under parallel forks)
- [x] `TestForkSortedMapClonePrunedMapIsRightSized` fails on a `maps.Clone` build (3.7MB/op) and passes here (0.25MB/op)
- [x] `lisp/fork_mapalias_test.go` (from #587) passes through the structural clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX