### PR TITLE
Keep the scanner's one-rune peek buffer instead of reallocating it

### DIFF
--- a/parser/token/scanner.go
+++ b/parser/token/scanner.go
@@ -148,7 +148,16 @@ func (s *Scanner) ScanRune() error {
 	}
 	if len(s.peek) > 0 {
 		s.scan(s.peek[0])
-		s.peek = s.peek[1:]
+		// Drop the consumed rune by shifting the tail down one slot and
+		// shortening the slice by one.  This keeps the backing array (and
+		// its capacity), so the next Peek's append does not allocate.
+		// Reslicing with s.peek[1:] instead would leave a one-element
+		// buffer with both length AND capacity zero, and every rune of
+		// source used to allocate a fresh backing array that way.  Unlike
+		// a bare s.peek[:0] this stays correct if the buffer ever holds
+		// more than one rune.
+		kept := copy(s.peek, s.peek[1:])
+		s.peek = s.peek[:kept]
 		return s.checkRuneError()
 	}
 	err = s.checkExtend()

--- a/parser/token/scanner_peek_test.go
+++ b/parser/token/scanner_peek_test.go
@@ -1,0 +1,62 @@
+// Copyright © 2026 The ELPS authors
+
+package token
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestScannerPeekBufferDoesNotReallocate pins the fix for the scanner's
+// one-rune peek buffer.  ScanRune used to consume the buffered rune with
+// s.peek = s.peek[1:], which on a one-element slice leaves length AND capacity
+// zero, so the append in Peek allocated a fresh backing array for every rune
+// of source.  ScanRune now shifts the buffer down in place, keeping the slot
+// the first Peek allocated.
+//
+// The lexer drives the scanner as an alternating Peek/ScanRune pair (see
+// Accept and friends), so the test drives it the same way over a few KB of
+// source and asserts that a full scan is allocation-free in steady state.
+//
+// Each measured run needs its own scanner -- a scanner that has reached the
+// end of its input cannot be rescanned -- so the scanners are built up front,
+// outside the measured closure, and the closure only scans.  The bound is 2
+// rather than 0 to leave slack for incidental allocation from the runtime or
+// from future scanner bookkeeping: the regression this pins costs one
+// allocation per rune (thousands per run), so anything in single digits
+// distinguishes it unambiguously.
+func TestScannerPeekBufferDoesNotReallocate(t *testing.T) {
+	const runs = 10
+
+	// ~4KB of ASCII source.  ASCII means the rune count equals the byte count.
+	src := strings.Repeat("(defun add-one (x) (+ x 1)) ; increment\n", 100)
+	nrune := len(src)
+
+	// testing.AllocsPerRun calls f once to warm up and then runs more times.
+	scanners := make([]*Scanner, runs+1)
+	for i := range scanners {
+		scanners[i] = NewScannerString("scanner_peek_test.lisp", src)
+	}
+	var next int
+
+	avg := testing.AllocsPerRun(runs, func() {
+		if next >= len(scanners) {
+			t.Fatalf("AllocsPerRun called the closure more than %d times", len(scanners))
+		}
+		s := scanners[next]
+		next++
+		for i := range nrune {
+			if _, ok := s.Peek(); !ok {
+				t.Fatalf("Peek failed at rune %d of %d", i, nrune)
+			}
+			if err := s.ScanRune(); err != nil {
+				t.Fatalf("ScanRune failed at rune %d of %d: %v", i, nrune, err)
+			}
+		}
+	})
+
+	if avg > 2 {
+		t.Errorf("scanning %d runes allocated %v times per run; want <= 2 "+
+			"(the peek buffer is being reallocated per rune)", nrune, avg)
+	}
+}


### PR DESCRIPTION
## Summary

- **The bug.** `Scanner.Peek` buffers a lookahead rune with `s.peek = append(s.peek, peek)`, and `ScanRune` consumed it with `s.peek = s.peek[1:]`. On a one-element slice, `[1:]` leaves length **and capacity** zero, so the next `Peek`'s append had no slot to reuse and allocated a fresh backing array — one allocation for every rune of source scanned.
- **The fix.** `ScanRune` shifts the buffer down in place, `s.peek = s.peek[:copy(s.peek, s.peek[1:])]`, which keeps the backing array the first `Peek` allocated. This form was chosen over a bare `s.peek[:0]` after adversarial review: today the buffer never holds more than one element (the sole append is inside `Peek` behind an early return on `len(s.peek) > 0`, and nothing else writes the field), but `[:0]` would silently drop runes if a multi-rune lookahead ever landed, with no test to catch it. No slot is pre-allocated in `newScannerBuf`: append to a nil slice allocates the one-element array on the first `Peek`, and a constructor-time `make` only added an allocation to scanners over empty input.
- **Scope.** One line of production code plus a regression test. No semantic surface: the scanner's observable behaviour is unchanged (differential harness of 1,260 inputs × 7 Peek/ScanRune interleave patterns across scanner, lexer, parser, fault-tolerant parser and formatter was byte-identical to base), and this is the lowest-risk item of the stack.
- Stacked on #572 — this PR targets `claude/elps-perf-optimization-jcgfd2`, not `main`.
- Background study: https://claude.ai/code/artifact/05b3209b-890d-4f35-8b1b-fef71f432b74

## Measurements

`go test -run '^$' -bench 'BenchmarkParse50KB$|BenchmarkParser' -benchmem -count=4 -cpu 1 ./lisp/ ./parser/rdparser/`, compared with `benchstat`. Machine: Intel Xeon @ 2.80GHz, linux/amd64.

### `lisp` — BenchmarkParse50KB

| metric | base | new | delta |
|---|---|---|---|
| sec/op | 10.163m | 7.210m | **-29.05%** (p=0.029 n=4) |
| B/s | 4.826Mi | 6.795Mi | +40.81% (p=0.029 n=4) |
| B/op | 4.449Mi | 3.665Mi | -17.62% (p=0.029 n=4) |
| allocs/op | 127.81k | 76.42k | **-40.21%** (p=0.029 n=4) |

### `parser/rdparser` — sec/op

| benchmark | base | new | delta |
|---|---|---|---|
| Parser/approx.lisp | 240.3µ | 168.2µ | -30.01% |
| Parser/complex.lisp | 683.9µ | 471.0µ | -31.14% |
| Parser/diff.lisp | 284.3µ | 213.8µ | -24.78% |
| Parser/scheme-math.lisp | 1.582m | 1.131m | -28.49% |
| Parser/sicp.lisp | 1098.4µ | 775.0µ | -29.44% |
| Parser/stream.lisp | 1012.2µ | 670.8µ | -33.73% |
| ParserFaultTolerant/approx.lisp | 249.5µ | 176.2µ | -29.38% |
| ParserFaultTolerant/complex.lisp | 692.5µ | 494.1µ | -28.65% |
| ParserFaultTolerant/diff.lisp | 281.3µ | 219.5µ | -21.98% |
| ParserFaultTolerant/scheme-math.lisp | 1.588m | 1.175m | -25.98% |
| ParserFaultTolerant/sicp.lisp | 1139.2µ | 783.7µ | -31.21% |
| ParserFaultTolerant/stream.lisp | 1075.8µ | 667.0µ | -38.01% |
| **geomean** | **667.1µ** | **470.3µ** | **-29.51%** |

All rows p=0.029, n=4.

### `parser/rdparser` — allocs/op

| benchmark | base | new | delta |
|---|---|---|---|
| Parser/approx.lisp | 3.577k | 1.836k | -48.67% |
| Parser/complex.lisp | 10.834k | 5.514k | -49.10% |
| Parser/diff.lisp | 4.245k | 2.473k | -41.74% |
| Parser/scheme-math.lisp | 24.94k | 12.86k | -48.44% |
| Parser/sicp.lisp | 16.706k | 9.475k | -43.28% |
| Parser/stream.lisp | 14.675k | 7.567k | -48.44% |
| ParserFaultTolerant/approx.lisp | 3.577k | 1.836k | -48.67% |
| ParserFaultTolerant/complex.lisp | 10.834k | 5.514k | -49.10% |
| ParserFaultTolerant/diff.lisp | 4.245k | 2.473k | -41.74% |
| ParserFaultTolerant/scheme-math.lisp | 24.94k | 12.86k | -48.44% |
| ParserFaultTolerant/sicp.lisp | 16.706k | 9.475k | -43.28% |
| ParserFaultTolerant/stream.lisp | 14.675k | 7.567k | -48.44% |
| **geomean** | **10.01k** | **5.336k** | **-46.69%** |

`B/op` geomean over the same corpora: 473.8Ki to 398.2Ki, -15.95%. `B/s` geomean: 6.661Mi to 9.450Mi, +41.86%. The `copy` form measures identically to the `[:0]` form on these benchmarks (same allocs/op and B/op to the digit).

Downstream, on a 72k-line production phylum the `shirotester` test suite's wall time went from 234s to 150s, and `Scanner.Peek` accounted for 62% of all objects allocated in that suite.

## Test Plan

- [x] `go build -o elps .` — passes
- [x] `make test` — passes (41 packages ok, no failures, plus the example lisp files)
- [x] `go test -race ./...` — passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `./elps fmt -l ./...` — no files listed
- [x] `./elps doc -m` — "All functions and exports are documented."
- [x] `make elpsvet` — passes
- [x] `./elps lint ./...` — only the pre-existing diagnostics in `editors/vscode/test/grammar/` (`builtins.lisp`, `special-ops.lisp`); no new diagnostics, and nothing in this diff touches `.lisp` sources
- [x] New regression test `parser/token/scanner_peek_test.go` drives a scanner over 4KB of source with the alternating `Peek`/`ScanRune` pair the lexer uses and asserts via `testing.AllocsPerRun` that a full scan is allocation-free (bound `<= 2` for slack, explained in the test comment)
- [x] Confirmed the regression test **fails on the base commit**: with the base `scanner.go` it reports `scanning 4000 runes allocated 4000 times per run` and fails; with the fix the scan allocates 0
- [x] Invariant fuzzing (review): base instrumented to panic if `Peek` ever appends to a non-empty buffer; 2.87M fuzz execs across the scanner, lexer and parser targets, none fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX