### PR TITLE
Return the bound function from Get when its name already matches

### DIFF
--- a/lisp/env.go
+++ b/lisp/env.go
@@ -454,12 +454,37 @@ func (env *LEnv) Copy() *LEnv {
 }
 
 // Get takes an LSymbol k and returns the LVal it is bound to in env.
+//
+// For a function the result MAY BE THE STORED BINDING ITSELF, not a
+// private copy: callers must treat it as read-only.  Only when the binding
+// does not already carry the looked-up name does Get hand back a FunRef
+// header copy stamped with it.
 func (env *LEnv) Get(k *LVal) *LVal {
 	v := env.get(k)
 	if v.Type == LFun {
-		// Set the function's name here in case the same function is
-		// defined with multiple names.  We want to try and use the name
-		// the programmer used.
+		// The FunRef copy exists to stamp the name the programmer used
+		// into LVal.Str.  That name is GetFunName's FALLBACK: a function
+		// defined by defun or bound at top level by set is named through
+		// the package's funNames table (putName overwrites it on every
+		// rebind, so an alias (set 'g f) renames f globally), and Str is
+		// consulted only for functions funNames never saw -- lambdas bound
+		// locally by flet, labels and macrolet, which report the local
+		// name in error messages and stack traces through this stamp.
+		//
+		// When the binding already carries the exact spelling there is
+		// nothing to stamp, and the copy would be a 112-byte allocation
+		// producing a byte-identical header.  Skipping it matters because
+		// this runs once per evaluated s-expression (the head symbol),
+		// which makes it one of the interpreter's highest-frequency
+		// allocations.  Definitions stamp their own name at creation:
+		// defun/defmacro on the lambda they freshly allocate, and
+		// AddBuiltins/AddSpecialOps/AddMacros in registrationFunValue.
+		// Functions built any other way (FunInPackage, env.builtin, a
+		// lambda, an embedder's Put) have Str == "" and keep the copy
+		// path, as does an alias; both still report their local name.
+		if v.Str == k.Str {
+			return v
+		}
 		v = FunRef(k, v)
 	}
 	return v
@@ -926,10 +951,17 @@ func registrationBound(pkg *Package, name string) (*LVal, bool) {
 // with the docstring placed at construction — the public constructors
 // allocate an empty-string docstring cell the Add* methods immediately
 // replaced, one dropped allocation per definition per environment.
-func registrationFunValue(pkgName, fid string, funType LFunType, formals *LVal, fn LBuiltin, doc string) *LVal {
+//
+// The value is born carrying its own registered name in Str.  That is the
+// name LEnv.Get would otherwise stamp onto a per-lookup copy of the value
+// (see Get), so pre-stamping it here lets every unqualified lookup of a
+// builtin return the binding itself instead of a copy.  Str is written at
+// construction, never onto a value a caller already holds.
+func registrationFunValue(pkgName, name, fid string, funType LFunType, formals *LVal, fn LBuiltin, doc string) *LVal {
 	return &LVal{
 		Type:    LFun,
 		FunType: funType,
+		Str:     name,
 		Native: &funData{
 			fid:     fid,
 			builtin: fn,
@@ -977,7 +1009,7 @@ func (env *LEnv) AddMacros(external bool, macs ...LBuiltinDef) {
 			// embedder-facing half of that story is #351.
 			panic(fmt.Sprintf("macro already defined: %v (= %v)", name, exist))
 		}
-		fn := registrationFunValue(pkg.Name, "<builtin-macro ``"+name+"''>", LFunMacro,
+		fn := registrationFunValue(pkg.Name, name, "<builtin-macro ``"+name+"''>", LFunMacro,
 			registrationFormals(&formals, mac.Formals()), mac.Eval, builtinDocstring(mac))
 		pkg.putName(name, fn)
 		if external {
@@ -1005,7 +1037,7 @@ func (env *LEnv) AddSpecialOps(external bool, ops ...LBuiltinDef) {
 			// is Go API an embedder drives, never lisp source.
 			panic(fmt.Sprintf("macro already defined: %v (= %v)", name, exist))
 		}
-		fn := registrationFunValue(pkg.Name, "<special-op ``"+name+"''>", LFunSpecialOp,
+		fn := registrationFunValue(pkg.Name, name, "<special-op ``"+name+"''>", LFunSpecialOp,
 			registrationFormals(&formals, op.Formals()), op.Eval, builtinDocstring(op))
 		pkg.putName(name, fn)
 		if external {
@@ -1033,7 +1065,7 @@ func (env *LEnv) AddBuiltins(external bool, funs ...LBuiltinDef) {
 			// is Go API an embedder drives, never lisp source.
 			panic("symbol already defined: " + name)
 		}
-		v := registrationFunValue(pkg.Name, "<builtin-function ``"+name+"''>", LFunNone,
+		v := registrationFunValue(pkg.Name, name, "<builtin-function ``"+name+"''>", LFunNone,
 			registrationFormals(&formals, f.Formals()), f.Eval, builtinDocstring(f))
 		pkg.putName(name, v)
 		if external {

--- a/lisp/get_funref_test.go
+++ b/lisp/get_funref_test.go
@@ -1,0 +1,162 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// LEnv.Get used to hand back a FunRef copy of every function binding it
+// resolved -- a fresh 112-byte LVal header per lookup -- purely so the
+// caller's spelling of the name landed in LVal.Str, where GetFunName reads
+// it as a fallback for error messages and stack traces.  The head symbol of
+// every evaluated s-expression goes through that path, so it was one of the
+// interpreter's highest frequency allocations.
+//
+// These tests pin both halves of the fix: the binding itself comes back when
+// its name already matches (no copy), and an alias still gets the copy, so
+// the names rendered in diagnostics are unchanged.
+
+func funRefTestEnv(t *testing.T) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	require.True(t, lisp.InitializeUserEnv(env).IsNil())
+	require.True(t, lisplib.LoadLibrary(env).IsNil())
+	require.True(t, env.InPackage(lisp.String(lisp.DefaultUserPackage)).IsNil())
+	return env
+}
+
+func funRefLoad(t *testing.T, env *lisp.LEnv, src string) *lisp.LVal {
+	t.Helper()
+	v := env.LoadString("get_funref_test.lisp", src)
+	require.NotNil(t, v)
+	require.NotEqual(t, lisp.LError, v.Type, "eval %q: %v", src, v)
+	return v
+}
+
+// TestGetReturnsBoundFunctionWhenNameMatches: a lookup whose symbol matches
+// the name the binding was defined under returns the binding itself, not a
+// copy.  This is the allocation the change removes; it fails before it.
+func TestGetReturnsBoundFunctionWhenNameMatches(t *testing.T) {
+	env := funRefTestEnv(t)
+	funRefLoad(t, env, `(defun f (x) x)`)
+
+	stored, ok := env.Runtime.Package.Symbol("f")
+	require.True(t, ok, "f is not bound in the user package")
+	require.Equal(t, lisp.LFun, stored.Type)
+	require.Equal(t, "f", stored.Str, "defun must stamp the definition name onto the fresh lambda")
+
+	got := env.Get(lisp.Symbol("f"))
+	require.Equal(t, lisp.LFun, got.Type)
+	assert.Same(t, stored, got, "Get must return the binding itself when the name already matches")
+	assert.Equal(t, "f", got.Str)
+}
+
+// TestGetReturnsBoundBuiltinWhenNameMatches: the same holds for the builtins
+// registered by AddBuiltins, which are now born carrying their own name.
+func TestGetReturnsBoundBuiltinWhenNameMatches(t *testing.T) {
+	env := funRefTestEnv(t)
+
+	got := env.Get(lisp.Symbol("car"))
+	require.Equal(t, lisp.LFun, got.Type)
+	assert.Equal(t, "car", got.Str)
+
+	lispPkg := env.Runtime.Registry.Package(lisp.DefaultLangPackage)
+	require.NotNil(t, lispPkg, "the lisp package is not registered")
+	stored, ok := lispPkg.Symbol("car")
+	require.True(t, ok, "car is not bound in the lisp package")
+	assert.Same(t, stored, got, "Get must return the registered builtin itself")
+
+	// A qualified lookup spells the symbol differently from the binding, so
+	// it still takes the copy path and still reports the qualified name.
+	qualified := env.Get(lisp.Symbol("lisp:car"))
+	require.Equal(t, lisp.LFun, qualified.Type)
+	assert.Equal(t, "lisp:car", qualified.Str)
+	assert.NotSame(t, stored, qualified)
+}
+
+// TestGetCopiesFunctionForAlias: a second name for the same function still
+// gets a renamed copy, and the original binding is untouched.
+func TestGetCopiesFunctionForAlias(t *testing.T) {
+	env := funRefTestEnv(t)
+	funRefLoad(t, env, `(defun f (x) x)`)
+	funRefLoad(t, env, `(set 'g f)`)
+
+	stored, ok := env.Runtime.Package.Symbol("f")
+	require.True(t, ok)
+
+	alias := env.Get(lisp.Symbol("g"))
+	require.Equal(t, lisp.LFun, alias.Type)
+	assert.Equal(t, "g", alias.Str, "an alias lookup must still be renamed")
+	assert.NotSame(t, stored, alias, "an alias lookup must not hand back the binding")
+
+	// Renaming the alias must not have renamed the binding.
+	again := env.Get(lisp.Symbol("f"))
+	assert.Equal(t, "f", again.Str)
+	assert.Same(t, stored, again)
+
+	// The alias is callable and behaves like the original.
+	res := funRefLoad(t, env, `(g 1)`)
+	assert.Equal(t, "1", res.String())
+}
+
+// TestAliasErrorMessagesAreUnchanged: the rendered error for calling an
+// aliased user function, and an aliased builtin, with the wrong number of
+// arguments.  The expected strings were captured on the parent commit, so a
+// mismatch means the change altered a diagnostic.
+func TestAliasErrorMessagesAreUnchanged(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		setup []string
+		call  string
+		want  string
+	}{
+		{
+			name:  "user function alias",
+			setup: []string{`(defun f (x) x)`, `(set 'g f)`},
+			call:  `(g)`,
+			want:  aliasUserFunErrorText,
+		},
+		{
+			name:  "builtin alias",
+			setup: []string{`(set 'first car)`},
+			call:  `(first)`,
+			want:  aliasBuiltinErrorText,
+		},
+		{
+			// The case the FunRef copy actually decides: a lambda bound
+			// locally by flet never reaches the package's funNames table,
+			// so its name in the message comes from the Str the copy
+			// stamps.  The two cases above are decided by funNames and
+			// would render the same with the copy path deleted.
+			name: "flet-bound lambda",
+			call: `(flet ([myf (a b) a]) (myf 1))`,
+			want: aliasFletErrorText,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			env := funRefTestEnv(t)
+			for _, src := range test.setup {
+				funRefLoad(t, env, src)
+			}
+			v := env.LoadString("get_funref_test.lisp", test.call)
+			require.Equal(t, lisp.LError, v.Type, "expected an error from %s", test.call)
+			assert.Equal(t, test.want, v.String())
+		})
+	}
+}
+
+// The expected renderings above, captured verbatim on the parent commit --
+// they must not change.
+const (
+	aliasUserFunErrorText = "get_funref_test.lisp:1:1: g: invalid number of arguments: 0"
+	aliasBuiltinErrorText = "get_funref_test.lisp:1:1: lisp:car: invalid number of arguments: 0"
+	aliasFletErrorText    = "get_funref_test.lisp:1:23: myf: invalid number of arguments: 1"
+)

--- a/lisp/macro.go
+++ b/lisp/macro.go
@@ -103,6 +103,9 @@ func macroDefmacro(env *LEnv, args *LVal) *LVal {
 		return fun
 	}
 	fun.FunType = LFunMacro //elps:mutates evaluate as a macro: fun is the closure env.Lambda freshly allocated above
+	// Stamp the definition name so LEnv.Get can return the binding itself
+	// rather than a renamed copy on every lookup (see LEnv.Get).
+	fun.Str = sym.Str //elps:mutates records the definition name: fun is the closure env.Lambda freshly allocated above
 	return SExpr([]*LVal{
 		Symbol("lisp:progn"),
 		SExpr([]*LVal{
@@ -124,6 +127,9 @@ func macroDefun(env *LEnv, args *LVal) *LVal {
 		fun.SetCallStack(env.Runtime.Stack.Copy())
 		return fun
 	}
+	// Stamp the definition name so LEnv.Get can return the binding itself
+	// rather than a renamed copy on every lookup (see LEnv.Get).
+	fun.Str = sym.Str //elps:mutates records the definition name: fun is the closure env.Lambda freshly allocated above
 	return SExpr([]*LVal{
 		Symbol("lisp:progn"),
 		SExpr([]*LVal{


### PR DESCRIPTION
## Summary

- `LEnv.Get` copied every function binding it resolved. `FunRef` allocates a fresh 112-byte `LVal` and copies the whole header, purely so the caller's spelling of the name lands in `LVal.Str` — read in exactly one place, `GetFunName`'s fallback, for the name rendered in error messages and stack traces. When the binding already carries that spelling the copy produces a byte-identical header.
- The head symbol of every evaluated s-expression goes through `Get`, so this is one of the interpreter's highest frequency allocations: 5.4% of all objects allocated on a 72k-line production phylum's test suite.
- `Get` now returns the binding itself when `v.Str == k.Str`, and falls back to `FunRef` otherwise.
- Names are stamped at definition so the fast path covers the common cases: `macroDefun` / `macroDefmacro` stamp the lambda `env.Lambda` freshly allocated for them (`//elps:mutates`, matching the existing `fun.FunType = LFunMacro` precedent on the line above), and `registrationFunValue` builds `AddBuiltins` / `AddSpecialOps` / `AddMacros` values with `Str` already set in the composite literal.
- **Not** stamped in `Package.putName`: it binds values its callers own — `UsePackage`'s import loop re-binds another package's function values by reference — so a write there would land in caller-owned, potentially shared storage. Not stamped in `Lambda` either: an anonymous lambda has no name.
- Stacked on #573 (scanner peek); item 3 of the stack (#572 sorted-map clone → #573 scanner peek → this). Study: https://claude.ai/code/artifact/05b3209b-890d-4f35-8b1b-fef71f432b74

## Semantics audit

The copy insulated the stored binding from any later write to the returned header, so every write to an LFun header field after construction has to be a fresh-value write. Grepping `\.Str = `, `\.source = `, `\.quoted`, `\.FunType = ` over `lisp/*.go` (excluding tests):

| Site | Why it is safe |
|---|---|
| `lisp/lisp.go:467` `GetType` | fresh `Symbol` allocated one line above |
| `lisp/lisp.go:734` `FunRef` | the copy `FunRef` itself just made |
| `lisp/macro.go` `defun`/`defmacro` (new) | the `env.Lambda` result, freshly allocated |
| `lisp/env.go` `registrationFunValue` (new) | set in the composite literal, i.e. at construction |
| `lisp/lisp.go:446` `SetSource` | audited setter; skips sealed nodes, and its only in-repo callers are in `parser/rdparser`, on parse nodes they just built |
| `lisp/env.go:1163`, `lisp/loader.go:87`, `lisp/package.go:175`, `lisp/program.go:248`, `lisp/program.go:294` | all onto freshly built `LError` values |
| `lisp/detach.go:149`, `lisp/lisp.go:1583` | onto the copy being produced |
| `lisp/macro.go:470` quasiquote | onto the fresh expansion `SExpr` |
| `lisp/macro.go:326` `stampGuarded` | the one walker that writes values it did not construct — see below |
| `lisp/lisp.go:465` `GetType`, `:884` `Quote`, `:909` `shallowUnquote` | all onto a value allocated immediately above; `Quote`/`Splice`/`shallowUnquote` copy first precisely so the flag never lands on a caller's value. Every other mention of `quoted` in `lisp/` is a read |
| `lisp/macro.go:105` `defmacro`, `lisp/op.go:682` `macrolet` | onto the lambda freshly allocated on the preceding line |

`stampGuarded` stamps macro-expansion **output**, skipping singletons and sealed (shared parse-tree) subtrees, and only when the node has no real location yet. A function value reaches it only if a macro returns a bare `LFun` as its expansion; a `defun`'d function already carries a location from its own definition's expansion and is left alone. The field is debug metadata for the location shown in a diagnostic — it cannot affect binding or control flow.

Both `elpsvet` passes (default and `-tags=elpscheck`), whose freshness rule exists for exactly this class of write, are clean.

Two further properties keep the shared binding safe:

- **Fork** header-copies `LFun` values (`lisp/fork.go`, the `LFun` case, rebuilding `funData` per fork), so a stamped name can never be observed or written across forks.
- **Aliases are unchanged.** A function bound under a second name, `(set 'g f)`, still takes the `FunRef` path, so it is still renamed and `GetFunName` / error messages for it are identical. `./elps lint ./...` output is byte-identical to the base branch's.

## Measurements

`go test -run '^$' -bench 'BenchmarkEnvFunCall|BenchmarkEnvGet$|BenchmarkMacroDefun$' -benchmem -count=6 -cpu 1 ./lisp/`, compared with `benchstat`:

```
                    │      base       │             change              │
                    │     sec/op      │   sec/op     vs base            │
EnvGet                  14.21m ± 57%   12.51m ±  5%  -11.99% (p=0.004 n=6)
EnvFunCallBuiltin      1170.9µ ± 31%   994.6µ ±  6%  -15.05% (p=0.002 n=6)
EnvFunCallRecursion    12.065m ± 13%   9.285m ± 10%  -23.04% (p=0.002 n=6)
EnvFunCallTailRec       4.925m ± 39%   4.496m ±  7%   -8.71% (p=0.009 n=6)
EnvFunCallPos           2.403m ± 57%   2.091m ±  6%  -12.97% (p=0.002 n=6)
EnvFunCallKey           5.161m ± 37%   2.427m ±  5%  -52.98% (p=0.002 n=6)
EnvFunCallOpt           2.318m ± 18%   1.982m ±  4%  -14.48% (p=0.002 n=6)
EnvFunCallVar           3.181m ± 12%   2.561m ±  5%  -19.48% (p=0.002 n=6)
MacroDefun              44.05µ ±  3%   46.82µ ± 10%   +6.29% (p=0.041 n=6)
geomean                 2.512m         2.045m        -18.58%

                    │      B/op       │             change              │
EnvGet                 9.738Mi ±  0%   8.563Mi ±  0%  -12.07% (p=0.002 n=6)
EnvFunCallBuiltin      829.4Ki ±  0%   719.9Ki ±  0%  -13.20% (p=0.002 n=6)
EnvFunCallRecursion    3.768Mi ±  0%   3.020Mi ±  0%  -19.85% (p=0.002 n=6)
EnvFunCallTailRec      3.454Mi ±  0%   2.706Mi ±  0%  -21.66% (p=0.002 n=6)
EnvFunCallPos          1.698Mi ±  0%   1.484Mi ±  0%  -12.59% (p=0.002 n=6)
EnvFunCallKey          1.774Mi ±  0%   1.561Mi ±  0%  -12.05% (p=0.002 n=6)
EnvFunCallOpt          1.698Mi ±  0%   1.484Mi ±  0%  -12.59% (p=0.002 n=6)
EnvFunCallVar          2.270Mi ±  0%   1.950Mi ±  0%  -14.12% (p=0.002 n=6)
MacroDefun             33.64Ki ±  0%   32.44Ki ±  0%   -3.58% (p=0.002 n=6)
geomean                1.503Mi         1.298Mi        -13.66%

                    │    allocs/op    │             change              │
EnvGet                  118.0k ±  0%   107.0k ±  0%   -9.32% (p=0.002 n=6)
EnvFunCallBuiltin       8.014k ±  0%   7.013k ±  0%  -12.49% (p=0.002 n=6)
EnvFunCallRecursion     40.08k ±  0%   33.07k ±  0%  -17.47% (p=0.002 n=6)
EnvFunCallTailRec       44.07k ±  0%   37.06k ±  0%  -15.89% (p=0.002 n=6)
EnvFunCallPos           20.06k ±  0%   18.06k ±  0%   -9.98% (p=0.002 n=6)
EnvFunCallKey           21.06k ±  0%   19.06k ±  0%   -9.51% (p=0.002 n=6)
EnvFunCallOpt           20.06k ±  0%   18.06k ±  0%   -9.98% (p=0.002 n=6)
EnvFunCallVar           27.06k ±  0%   24.06k ±  0%  -11.09% (p=0.002 n=6)
MacroDefun               475.0 ±  0%    464.0 ±  0%   -2.32% (p=0.002 n=6)
geomean                 17.83k         15.87k        -10.99%
```

Allocation counts are exact (±0%); the sec/op column carries the base run's wide variance (up to ±57%), so read the -52.98% on `EnvFunCallKey` as noise around a real but smaller win. `MacroDefun`'s +6.29% sec/op is inside the spread of either arm, and its allocations went down.

## Test Plan

New tests in `lisp/get_funref_test.go`:

- `TestGetReturnsBoundFunctionWhenNameMatches` — after `(defun f (x) x)`, `env.Get(Symbol("f"))` is the same pointer as the package binding and has `Str == "f"`. **Fails on the base branch** (it returns a copy).
- `TestGetReturnsBoundBuiltinWhenNameMatches` — `env.Get(Symbol("car"))` is the registered builtin itself with `Str == "car"`; the qualified `lisp:car` still takes the copy path and reports `"lisp:car"`. **Fails on the base branch.**
- `TestGetCopiesFunctionForAlias` — after `(set 'g f)`, the `g` lookup is a distinct value with `Str == "g"`, the `f` binding is untouched, and `(g 1)` works. The alias half of this passes on the base branch; only the "`f` returns the binding" assertion is new behaviour.
- `TestAliasErrorMessagesAreUnchanged` — the rendered arity error for an aliased user function and an aliased builtin, with the strings captured verbatim from the base branch. **Passes unchanged on both trees.**

Verification (all clean):

- [x] `go build -o elps .`
- [x] `make test`
- [x] `go test -tags=elpscheck ./lisp/`
- [x] `go test -run Fuzz ./lisp/`
- [x] `golangci-lint run ./...` — `0 issues.`
- [x] `./elps fmt -l ./...` — no files listed
- [x] `./elps lint ./...` — byte-identical to the base branch (pre-existing diagnostics only)
- [x] `./elps doc -m` — `All functions and exports are documented.`
- [x] `make elpsvet` — both passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX

---
_Generated by [Claude Code](https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX)_