### PR TITLE
Capture the defining environment in Lambda

### DIFF
--- a/docs/fork.md
+++ b/docs/fork.md
@@ -246,6 +246,37 @@ per-call `EvalContext` context overrides it for that evaluation only, and
 neither the template nor any other fork can observe it.
 `lisp/fork_context_test.go` pins this contract.
 
+A call frame is a shallow copy of the environment the function captured,
+given a fresh scope. Two of its registers are worth naming, and they
+behave differently.
+
+The *location* register is a snapshot taken when the function was defined,
+carried on the function value itself. It is deliberately not the captured
+environment's live position, because the evaluator reads `env.loc` before
+it rebinds it: the nesting-depth guard and `checkLimits` both raise
+through `ErrorConditionf`, which stamps that register into the error's
+rendered text and `Source()`. An evaluation-budget error that trips
+exactly at a function-body entry -- a step limit, a nesting limit, a
+cancelled or expired context -- therefore reports the function's
+definition site, not its call site. `lisp/funloc_test.go` pins this.
+
+The *context* register is the live one: a call frame reads the captured
+environment's context at the moment of the call rather than a snapshot
+taken when the function was defined. Normal evaluation never sees the
+difference, because `call` bridges the per-call context onto the
+environment at every builtin and special-operator boundary before a body
+form runs. A debugger that evaluates in a paused frame without a context
+(conditional breakpoints, the inspector) observes the live register
+instead: a function defined on the template and called in a fork bound
+with `ForkWithContext` reports the fork's context, and a function defined
+under a since-cancelled `EvalContext` no longer carries that cancelled
+context into a later call.
+
+Neither register crosses a fork. `forker` drops the location register of
+every environment it remaps, and a function value's definition-site
+snapshot does not travel either -- exactly as before, when that snapshot
+lived in a per-function environment the fork remapped and blanked.
+
 ## Embedder patterns
 
 Pool refill:

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -255,10 +255,6 @@ func newEnvN(parent *LEnv, n int) *LEnv {
 	return env
 }
 
-func (env *LEnv) getFID() string {
-	return fmt.Sprintf("_fun%d", env.ID)
-}
-
 func (env *LEnv) GenSym() *LVal {
 	return Symbol(env.Runtime.GenSym())
 }
@@ -824,15 +820,23 @@ func (env *LEnv) Lambda(formals *LVal, body []*LVal) *LVal {
 	cells := make([]*LVal, 0, len(body)+1)
 	cells = append(cells, formals)
 	cells = append(cells, body...)
-	fenv := NewEnv(env)
 	fun := &LVal{
 		Type: LFun,
 		//elps:aliases deliberate in-runtime alias: a lambda's location is the defining form's parse location, already frozen before evaluation reaches this constructor, and the function value lives inside the same runtime as env.loc
 		source: env.loc,
 		Native: &funData{
-			fid: fenv.getFID(),
+			// The function captures its defining environment directly.  A
+			// call binds the formals in a fresh child of it (see bind), which
+			// is the same scope chain the former per-function child
+			// environment produced, minus one LEnv (and its scope map) per
+			// definition, per call-site Copy, and per fork remap.  The FID
+			// still consumes exactly one environment ID, so generated names
+			// are unchanged.
+			fid: fmt.Sprintf("_fun%d", env.Runtime.GenEnvID()),
 			pkg: env.Runtime.Package.Name,
-			env: fenv,
+			env: env,
+			//elps:aliases deliberate in-runtime alias: the definition-site snapshot of the environment's location register, the same pointer NewEnv(env) froze into the per-function child environment this replaces, and the function value lives inside the same runtime as env.loc
+			loc: env.loc,
 		},
 		Cells: cells,
 	}
@@ -846,7 +850,7 @@ func (env *LEnv) builtin(f LBuiltinDef) *LVal {
 	// The formals are copied for the same reason the Add* methods copy
 	// theirs: an LBuiltinDef's formals typically belong to a process-wide
 	// table.  See formalsCopier and issue #363.
-	return FunInPackage(env.Runtime.Package.Name, NewEnv(env).getFID(), f.Formals().Copy(), f.Eval)
+	return FunInPackage(env.Runtime.Package.Name, fmt.Sprintf("_fun%d", env.Runtime.GenEnvID()), f.Formals().Copy(), f.Eval)
 }
 
 func (env *LEnv) Terminal(expr *LVal) *LVal {
@@ -1935,7 +1939,24 @@ func (env *LEnv) bind(fun, args *LVal) (*LEnv, *LVal) {
 	formals := argParser{args: fun.Cells[0].Cells}
 	narg := len(args.Cells)
 
-	funenv := fun.funEnv().Copy()
+	// A lambda call gets a fresh scope whose parent is the captured
+	// environment: bindings made here are private to the call, and
+	// everything the closure can see stays live through the parent.
+	//
+	// The call environment starts as a shallow copy of the captured one so
+	// that a register added to LEnv later cannot silently arrive here
+	// zeroed; the three registers a call must not inherit are then
+	// overridden.  The location register is the definition-site snapshot
+	// taken in Lambda rather than the captured environment's live value,
+	// because eval reads env.loc before it rebinds it -- see funData.loc.
+	var funenv *LEnv
+	if fenv := fun.funEnv(); fenv != nil {
+		cp := *fenv
+		cp.parent = fenv
+		cp.loc = fun.funData().loc
+		cp.scope = make(map[string]*LVal, formals.Len())
+		funenv = &cp
+	}
 	putArg := func(k, v *LVal) {
 		funenv.Put(k, v)
 	}
@@ -1985,7 +2006,7 @@ func (env *LEnv) bind(fun, args *LVal) (*LEnv, *LVal) {
 	if funenv == nil {
 		return env, QExpr(builtinArgs)
 	}
-	return funenv, QExpr(fun.Cells[1:])
+	return funenv, QExpr(fun.Cells[1:]) //elps:aliases the call env's loc register deliberately aliases the function's definition-site location, which was frozen before evaluation reached Lambda, and its evalCtx register aliases the captured env's current context: LEnv is runtime-internal state and no consumer-facing value is built from either pointer
 }
 
 type bindfunc func(k, v *LVal)

--- a/lisp/fork.go
+++ b/lisp/fork.go
@@ -481,6 +481,11 @@ func (f *forker) val(v *LVal) *LVal {
 				fid:     fd.fid,
 				pkg:     fd.pkg,
 				env:     f.env(fd.env),
+				// loc is left nil deliberately, exactly as forker.env
+				// drops the location register of every environment it
+				// remaps: a function called in a fork before the fork has
+				// evaluated anything reports "<native code>" rather than a
+				// position inherited from the template.
 			}
 		}
 	case LNative:

--- a/lisp/fork_metadata_test.go
+++ b/lisp/fork_metadata_test.go
@@ -63,10 +63,16 @@ func forkedEnvs(root *LEnv) map[*LEnv]bool {
 func TestForkDropsEvaluatorLocation(t *testing.T) {
 	env := newForkTestEnv(t)
 
-	// A closure, so the forked tree is deeper than its root: its captured
-	// environment goes through forker.env too, and it is the environment
-	// whose register a template holds a *definition-site* location in.
-	lam := lambdaExpr()
+	// A closure defined inside a let, so the forked tree is deeper than its
+	// root: the captured environment (the let's scope) goes through
+	// forker.env too, and it is the environment whose register a template
+	// holds a *definition-site* location in.  A top-level lambda captures
+	// the root environment itself and would leave the walk with one env.
+	lam := SExpr([]*LVal{
+		Symbol("let"),
+		SExpr([]*LVal{SExpr([]*LVal{Symbol("y"), Int(1)})}),
+		lambdaExpr(),
+	})
 	templateLoc := &token.Location{File: "template.lisp", Path: "template.lisp", Line: 12, Col: 3, Pos: 40}
 	lam.SetSource(templateLoc)
 	fun := env.Eval(lam)

--- a/lisp/funloc_test.go
+++ b/lisp/funloc_test.go
@@ -1,0 +1,104 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// funLocProgram defines three functions whose bodies live at three different
+// places: a top-level defun, a lambda closed over a let scope, and a defun
+// that calls both.  Every function is therefore entered from a call site on a
+// different line than its own definition, which is what makes the location a
+// budget error reports observable.
+const funLocProgram = `(defun aa (n)
+  (+ n 1))
+(let ([k 2])
+  (set 'bb (lambda (m)
+     (* m k))))
+(defun cc (x)
+  (aa (bb x)))
+(cc 3)`
+
+// TestBudgetErrorReportsDefinitionSite pins the location an evaluation-budget
+// error reports when it trips at the exact moment a function body is entered.
+//
+// LEnv.eval READS env.loc before it rebinds it to the expression being
+// evaluated: the evalNesting guard and checkLimits both raise through
+// env.ErrorConditionf, which stamps env.loc into the error's rendered text
+// and into Source().  At a body entry the environment in hand is the call
+// environment bind just built, so what that error reports is whatever
+// location register bind put there.
+//
+// It must be the function's definition site.  Every step count below is a
+// trip point where the reported location differs from the call site, so a
+// call environment that inherited its captured environment's live register
+// (the environment's position at the moment of the call, i.e. the call site)
+// would fail here.
+func TestBudgetErrorReportsDefinitionSite(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		steps int64
+		want  string
+	}{
+		// Entering cc's body: cc is defined on line 6, called from line 8.
+		{"defun-body", 29, "s.lisp:6:1: step-limit-exceeded: step limit exceeded (29 steps)"},
+		// Entering bb's body: the lambda form starts at line 4 column 12.
+		{"closure-body", 34, "s.lisp:4:12: step-limit-exceeded: step limit exceeded (34 steps)"},
+		// Entering aa's body, from inside cc: aa is defined on line 1.
+		{"nested-defun-body", 38, "s.lisp:1:1: step-limit-exceeded: step limit exceeded (38 steps)"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			env := newLimitTestEnv(t, lisp.WithMaxSteps(test.steps))
+			res := env.LoadString("s.lisp", funLocProgram)
+			require.Equal(t, lisp.LError, res.Type, "expected the step limit to trip")
+			assert.Equal(t, test.want, res.String())
+			loc, ok := res.Source()
+			require.True(t, ok, "the error must carry a source location")
+			assert.Equal(t, "s.lisp", loc.File)
+		})
+	}
+}
+
+// countdownContext reports itself cancelled once Err has been probed more
+// than n times, which walks the cancellation point across the evaluation one
+// checkLimits call at a time.  A real cancelled context would trip at the
+// first check; this one trips at a chosen one.
+type countdownContext struct {
+	n int
+	i int
+}
+
+func (c *countdownContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c *countdownContext) Done() <-chan struct{}       { return nil }
+func (c *countdownContext) Value(any) any               { return nil }
+func (c *countdownContext) Err() error {
+	c.i++
+	if c.i > c.n {
+		return context.Canceled
+	}
+	return nil
+}
+
+// TestCancellationAtBodyEntryReportsDefinitionSite is the same invariant
+// reached through the other caller of checkLimits: cancellation rather than a
+// step limit.  It needs no step limit at all, so it also covers embedders who
+// run with cancellation as their only budget.
+func TestCancellationAtBodyEntryReportsDefinitionSite(t *testing.T) {
+	t.Parallel()
+	env := newLimitTestEnv(t)
+	res := env.LoadStringContext(&countdownContext{n: 38}, "s.lisp", funLocProgram)
+	require.Equal(t, lisp.LError, res.Type, "expected the cancellation to trip")
+	assert.Equal(t,
+		"s.lisp:1:1: context-cancelled: context cancelled: context canceled",
+		res.String())
+}

--- a/lisp/lambda_string_test.go
+++ b/lisp/lambda_string_test.go
@@ -1,0 +1,120 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import "testing"
+
+// TestLambdaStringRendersFormals pins the text (*LVal).str produces for a
+// function value.  Printing used to concatenate the formals with the
+// function's own environment scope and unquote the joined list; that scope
+// was always empty, so the concatenation was doing nothing but allocating a
+// list and creating the write that became issue #333.  The formals now
+// render directly, and every expected string below was captured from the
+// concatenating implementation -- they are what elps printed before, not
+// what this one happens to print.
+func TestLambdaStringRendersFormals(t *testing.T) {
+	env := NewEnv(nil)
+	if rc := InitializeUserEnv(env); rc.Type == LError {
+		t.Fatalf("InitializeUserEnv: %v", rc)
+	}
+	lambda := func(t *testing.T, formals *LVal, body ...*LVal) *LVal {
+		t.Helper()
+		fn := env.Lambda(formals, body)
+		if fn.Type == LError {
+			t.Fatalf("Lambda: %v", fn)
+		}
+		return fn
+	}
+	syms := func(names ...string) *LVal {
+		cells := make([]*LVal, len(names))
+		for i := range names {
+			cells[i] = Symbol(names[i])
+		}
+		return QExpr(cells)
+	}
+
+	tests := []struct {
+		name string
+		fn   func(t *testing.T) *LVal
+		want string
+	}{{
+		name: "no-formals",
+		fn:   func(t *testing.T) *LVal { return lambda(t, QExpr(nil), Int(1)) },
+		want: "(lambda () 1)",
+	}, {
+		name: "positional",
+		fn:   func(t *testing.T) *LVal { return lambda(t, syms("x", "y"), Symbol("x")) },
+		want: "(lambda (x y) x)",
+	}, {
+		name: "rest",
+		fn:   func(t *testing.T) *LVal { return lambda(t, syms("x", "&rest", "r"), Symbol("x")) },
+		want: "(lambda (x &rest r) x)",
+	}, {
+		name: "optional",
+		fn:   func(t *testing.T) *LVal { return lambda(t, syms("x", "&optional", "y"), Symbol("x")) },
+		want: "(lambda (x &optional y) x)",
+	}, {
+		name: "key",
+		fn:   func(t *testing.T) *LVal { return lambda(t, syms("&key", "k"), Symbol("k")) },
+		want: "(lambda (&key k) k)",
+	}, {
+		name: "multi-form-body",
+		fn:   func(t *testing.T) *LVal { return lambda(t, syms("x"), Symbol("x"), Int(2)) },
+		want: "(lambda (x) x 2)",
+	}, {
+		// The quote prefix belongs to the function value, not to its
+		// formals: exprString ignores the quoted flag on the list it
+		// renders, exactly as the concatenated-and-unquoted list did.
+		name: "quoted-function-value",
+		fn:   func(t *testing.T) *LVal { return Quote(lambda(t, syms("x"), Symbol("x"))) },
+		want: "'(lambda (x) x)",
+	}, {
+		// Formals() hands back a QExpr, i.e. a quoted list.  It must still
+		// print as (a b) and never as '(a b).
+		name: "go-built-formals",
+		fn: func(t *testing.T) *LVal {
+			return &LVal{
+				Type:   LFun,
+				Native: &funData{env: env, fid: "_funtest0", pkg: DefaultUserPackage},
+				Cells:  []*LVal{Formals("a", "b"), Symbol("a")},
+			}
+		},
+		want: "(lambda (a b) a)",
+	}, {
+		name: "go-built-formals-varargs",
+		fn: func(t *testing.T) *LVal {
+			return &LVal{
+				Type:   LFun,
+				Native: &funData{env: env, fid: "_funtest1", pkg: DefaultUserPackage},
+				Cells:  []*LVal{Formals("a", VarArgSymbol, "rest"), Symbol("a")},
+			}
+		},
+		want: "(lambda (a &rest rest) a)",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fn := test.fn(t)
+			if got := fn.String(); got != test.want {
+				t.Errorf("String() = %q, want %q", got, test.want)
+			}
+			// Printing is a pure read: the same value prints the same way
+			// twice, and nothing it touched changed underneath it.
+			if got := fn.String(); got != test.want {
+				t.Errorf("second String() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// TestBuiltinStringUnchanged pins the other arm of the LFun case, which
+// never reached the formals at all.
+func TestBuiltinStringUnchanged(t *testing.T) {
+	fn := FunInPackage(DefaultUserPackage, "_funtest2", Formals("a"), func(env *LEnv, args *LVal) *LVal { return Nil() })
+	if got, want := fn.String(), "#<builtin>"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+	if got, want := Quote(fn).String(), "'#<builtin>"; got != want {
+		t.Errorf("quoted String() = %q, want %q", got, want)
+	}
+}

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -1864,8 +1864,12 @@ func (v *LVal) strNested(onTheRecord bool, g cycleGuard) string {
 		if v.Builtin() != nil {
 			return quote + "#<builtin>"
 		}
-		vars := lambdaVars(v.Cells[0], boundVars(v))
-		return fmt.Sprintf("%s(lambda %s%s)", quote, vars.str(false, g), bodyStr(v.Cells[1:], g))
+		// The formals render directly.  There is no second list to
+		// concatenate them with: what used to follow them was the
+		// function's own environment scope, which was always empty (see
+		// the note on funData.env), so this prints exactly what the
+		// concatenation printed.
+		return fmt.Sprintf("%s(lambda %s%s)", quote, exprString(v.Cells[0], 0, "(", ")", g), bodyStr(v.Cells[1:], g))
 	case LQuote:
 		// TODO: make more efficient
 		return QUOTE + v.Cells[0].str(true, g)
@@ -1900,43 +1904,6 @@ func bodyStr(exprs []*LVal, g cycleGuard) string {
 		buf.WriteString(exprs[i].str(false, g))
 	}
 	return buf.String()
-}
-
-// lambdaVars renders a function's formals and closure bindings as a
-// single unquoted list, for (*LVal).str.
-//
-// builtinConcat does NOT always hand back a freshly allocated list --
-// the comment that used to sit on the unquote here claimed it did, and
-// that was the bug in issue #333. builtinConcatSeq short-circuits the
-// empty case with `return Nil()`, so a function with no formals AND no
-// bound vars made this write `Quoted = false` straight into the
-// process-wide singletonNil. It stored the value the field already
-// held, which made it invisible to SingletonSnapshot.Verify (see the
-// note on checkSingleton), but it was still a write to shared memory
-// and raced with every concurrent (*LEnv).eval reading `v.quoted` off a
-// Nil().
-//
-// shallowUnquote copies before clearing Quoted, so lambdaVars mutates
-// only a value it owns. It copies unconditionally rather than only when
-// builtinConcat happens to share, which makes the contract the simple
-// one -- lambdaVars returns a value the caller owns -- instead of the
-// fragile one, "the result is usually fresh, but don't write to it."
-// That contract is checkable without the race detector; see
-// TestLambdaVarsDoesNotReturnSingleton. The extra LVal is noise next to
-// the fmt.Sprintf this feeds, and only printing a function reaches it.
-func lambdaVars(formals *LVal, bound *LVal) *LVal {
-	s := SExpr([]*LVal{Quote(Symbol("list")), formals, bound})
-	return shallowUnquote(builtinConcat(nil, s))
-}
-
-func boundVars(v *LVal) *LVal {
-	// A function's captured environment is its defining scope; the
-	// per-function child scope this used to render from was always empty,
-	// so a lambda renders with its formals only, as before.
-	if v.funEnv() == nil {
-		return Nil()
-	}
-	return SExpr(nil)
 }
 
 func exprString(v *LVal, offset int, left string, right string, g cycleGuard) string {

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -5,7 +5,6 @@ package lisp
 import (
 	"bytes"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -186,15 +185,22 @@ func (ft LFunType) String() string {
 type funData struct {
 	builtin LBuiltin
 	env     *LEnv
-	fid     string
-	pkg     string
-}
 
-func (fd *funData) Copy() *funData {
-	cp := &funData{}
-	*cp = *fd
-	cp.env = fd.env.Copy()
-	return cp
+	// loc is the captured environment's location register as it stood when
+	// the function was defined.  bind gives the call environment this
+	// snapshot rather than the captured environment's live register,
+	// because eval READS env.loc before it rebinds it: the nesting-depth
+	// guard and checkLimits both raise through env.ErrorConditionf, which
+	// stamps env.loc into the error's rendered text and Source().  A
+	// step-limit, nesting-limit or context cancellation that trips exactly
+	// at a function-body entry therefore reports the definition site, which
+	// is what the per-function child environment reported before functions
+	// captured their defining environment directly.  Builtins leave it nil:
+	// they carry no environment, so bind never reads it.
+	loc *token.Location
+
+	fid string
+	pkg string
 }
 
 // macroExpansionContext is shared by all nodes in a single macro expansion.
@@ -1924,24 +1930,13 @@ func lambdaVars(formals *LVal, bound *LVal) *LVal {
 }
 
 func boundVars(v *LVal) *LVal {
-	env := v.funEnv()
-	if env == nil {
+	// A function's captured environment is its defining scope; the
+	// per-function child scope this used to render from was always empty,
+	// so a lambda renders with its formals only, as before.
+	if v.funEnv() == nil {
 		return Nil()
 	}
-	keys := make([]string, 0, len(env.scope))
-	for k := range env.scope {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	bound := SExpr(nil)
-	for i := range keys {
-		q := SExpr([]*LVal{
-			Symbol(keys[i]),
-			env.Get(Symbol(keys[i])),
-		})
-		bound.Cells = append(bound.Cells, q)
-	}
-	return bound
+	return SExpr(nil)
 }
 
 func exprString(v *LVal, offset int, left string, right string, g cycleGuard) string {

--- a/lisp/singleton_race_lambdavars_test.go
+++ b/lisp/singleton_race_lambdavars_test.go
@@ -2,7 +2,8 @@
 
 // Singleton mutation regression test for issue #333.
 //
-// Pre-fix, lambdaVars (lisp.go) did:
+// Pre-fix, printing a lambda concatenated its formals with its bound
+// variables and then unquoted the result in place:
 //
 //	s := SExpr([]*LVal{Quote(Symbol("list")), formals, bound})
 //	s = builtinConcat(nil, s)
@@ -18,11 +19,16 @@
 // invisible to SingletonSnapshot.Verify() / the elpscheck build, which
 // compare values rather than observing writes. Only -race caught it.
 //
-// Two tests here:
+// The mutation path no longer exists at all. A function's bound-variable
+// list was always empty -- the scope it rendered belonged to a
+// per-function environment nothing ever bound into -- so (*LVal).str
+// prints the formals directly and concatenates, copies and unquotes
+// nothing. These tests now pin that: printing a lambda writes nowhere.
 //
-//   - TestLambdaVarsDoesNotReturnSingleton is deterministic and needs no
-//     -race: it asserts the identity invariant directly.
-//   - TestSingletonRaceLambdaVars drives the real production path
+//   - TestPrintingZeroArgLambdaWritesNothing is deterministic and needs
+//     no -race: it asserts the rendered text and then that every shared
+//     singleton is untouched.
+//   - TestSingletonRacePrintingLambda drives the real production path
 //     ((*LVal).String() on a zero-formal lambda) against concurrent
 //     evaluation. Run with `go test -race` to observe the failure
 //     pre-fix.
@@ -50,34 +56,39 @@ func zeroArgLambda(t *testing.T) (*LEnv, *LVal) {
 	return env, fn
 }
 
-// TestLambdaVarsDoesNotReturnSingleton pins the identity invariant that
-// makes the mutation safe. lambdaVars writes to the value it returns, so
-// that value must never be one of the shared singletons -- regardless of
-// what builtinConcat decides to hand back for the empty case.
-func TestLambdaVarsDoesNotReturnSingleton(t *testing.T) {
+// TestPrintingZeroArgLambdaWritesNothing pins what replaced the identity
+// invariant. The empty-formals case is the one that reached the write, so
+// it is the one worth pinning: printing it renders the same text as ever
+// and leaves every shared singleton pristine.
+func TestPrintingZeroArgLambdaWritesNothing(t *testing.T) {
 	_, fn := zeroArgLambda(t)
 
-	vars := lambdaVars(fn.Cells[0], boundVars(fn))
-	if isSingleton(vars) {
-		t.Fatalf("lambdaVars returned a shared singleton (%v); mutating it races with every concurrent reader", vars.Type)
-	}
-	if vars.Len() != 0 {
-		t.Errorf("lambdaVars returned %d cells, want 0", vars.Len())
-	}
+	snap := TakeSingletonSnapshot()
 	if got, want := fn.String(), "(lambda () 1)"; got != want {
 		t.Errorf("String() = %q, want %q", got, want)
 	}
+	if bad := snap.Verify(); bad != "" {
+		t.Errorf("printing a lambda mutated the shared singleton %s", bad)
+	}
+	// Verify compares values and so cannot see a write that stores the
+	// value already there -- the shape #333 took.  The structural half of
+	// the invariant is that printing reaches no singleton at all: the only
+	// value it could reach is the formals list, and an empty formals list
+	// is a fresh QExpr, never a singleton.
+	if isSingleton(fn.Cells[0]) {
+		t.Error("a lambda's formals list is a shared singleton; printing must not be able to reach one")
+	}
 }
 
-// TestSingletonRaceLambdaVars reproduces issue #333 under `go test
-// -race`: printers stringify a zero-formal lambda (write side, via
-// lambdaVars) while evaluators evaluate Nil() (read side, `if v.quoted`
-// in (*LEnv).eval). Pre-fix both touch singletonNil and the race
-// detector fires.
+// TestSingletonRacePrintingLambda reproduces issue #333 under `go test
+// -race`: printers stringify a zero-formal lambda (the write side, back
+// when printing concatenated and unquoted) while evaluators evaluate
+// Nil() (read side, `if v.quoted` in (*LEnv).eval). Pre-fix both touch
+// singletonNil and the race detector fires.
 //
 // Each goroutine owns its LEnv -- LEnv is not safe for concurrent use.
 // The race is on the process-wide singleton, not on any env.
-func TestSingletonRaceLambdaVars(t *testing.T) {
+func TestSingletonRacePrintingLambda(t *testing.T) {
 	const (
 		printers   = 4
 		evaluators = 4
@@ -102,8 +113,9 @@ func TestSingletonRaceLambdaVars(t *testing.T) {
 			defer wg.Done()
 			<-start
 			for range iterations {
-				// Write side: str() -> lambdaVars -> builtinConcat
-				// returns Nil() for the empty case -> `s.quoted = false`.
+				// The former write side: str() -> lambdaVars ->
+				// builtinConcat returned Nil() for the empty case and
+				// the caller then set `s.quoted = false` on it.
 				_ = fn.String()
 			}
 		}(lambdas[i])


### PR DESCRIPTION
## Summary

- `Lambda` created a private child environment for every function and stored it in `funData.env`. That child never received a binding: `bind` copied it on every call, and `Fork` remapped it (one `LEnv` plus one scope map) for every function value in the template.
- A function now captures its defining environment directly, and `bind` makes a fresh child of it per call. The scope chain a call sees is unchanged (fresh scope → the defining environment → …), closures still see live bindings through the parent, and the FID still consumes exactly one environment ID per definition, so generated names are unchanged.
- The one thing that child carried besides the FID — its **location register**, frozen at definition time — now travels on the function value itself as `funData.loc`, and `bind` installs it on the call environment. See F1 below: this is load-bearing for error text.
- `bind` builds the call environment as a **shallow copy** of the captured one and then overrides only `parent`, `loc` and `scope`, so a register added to `LEnv` later cannot silently arrive here zeroed (F3).
- `funData.Copy` is deleted (no in-tree callers, and after this change it would have shared the captured environment). `env.builtin` no longer allocates an environment just to mint an FID.
- A second commit removes the bound-variable machinery from lambda printing entirely: `lambdaVars`/`boundVars` are gone and `(*LVal).str` renders the formals directly. Output is byte-identical; the write that became #333 is now impossible by construction rather than avoided by a copy-first helper.
- Last of the stack (#572 → #573 → #575 → this). Stacked on #575 because both touch `lisp/env.go`. This is the one PR in the stack with a language-visible surface, so it is deliberately last and carries the adversarial-review findings below.

## Semantics

**Non-debugger evaluation is byte-identical to base, including rendered error text.** Exactly one register is read live rather than snapshotted: a call frame reads the captured environment's `evalCtx` at call time instead of the value it held at definition time. Normal evaluation cannot observe this because `call` bridges the per-call context onto the environment at every builtin and special-operator boundary. The **location** register is *not* live — it is the definition-site snapshot, for the reason in F1.

**Debugger-attached evaluation can differ.** A debugger evaluating in a paused frame without a context (conditional breakpoints, the inspector) sees the live `evalCtx`: a template function called in a fork bound with `ForkWithContext` reports the fork's context, and a function defined under a since-cancelled `EvalContext` no longer drags that cancelled context into later calls. `docs/fork.md` records both registers under Context.

Adversarial review findings (all addressed or documented):

| Finding | Outcome |
|---|---|
| **F1 (blocking).** The call env's `loc` was the captured env's **live** register at call time; on base it was the definition-site snapshot `NewEnv(env)` froze inside `Lambda`. `LEnv.eval` **reads** `env.loc` before rebinding it — the eval-nesting guard and `checkLimits` both raise through `ErrorConditionf`, which stamps `env.loc` into the error's rendered text and `Source()` — so a step limit, nesting limit or context cancellation tripping exactly at a function-body entry reported a different `file:line`. Example: the 8-line closure program under `WithMaxSteps(38)` rendered `s.lisp:1:1: step-limit-exceeded: …` on base and `s.lisp:8:1: …` on the first draft (the call site, not `aa`'s definition site). | **Fixed.** `funData` gains `loc`, set in `Lambda` where `NewEnv(env)` used to snapshot it; `bind` installs it. Builtins carry no env and never read it; a fork does not carry it, exactly as `forker.env` drops every environment's register. `lisp/funloc_test.go` pins the defun, closure and nested-call trip points plus a cancellation case — all four fail on the pre-fix draft and pass on base. |
| **F3 (latent).** The call env was a partial struct literal enumerating every `LEnv` field by hand; a field added to `LEnv` later would silently arrive zeroed. | **Fixed.** `bind` now does `cp := *fenv` and overrides `parent`, `loc`, `scope`. `allocs/op` is unchanged on all seven `BenchmarkEnvFunCall*` (one `LEnv` + one map per call). |
| Live `evalCtx` register vs definition-time snapshot | Only observable through the debugger's no-context `Eval` path. Documented in the commit and `docs/fork.md`, which now names each register and says which is snapshotted and which is live. |
| `LEnv.ID` reuse between the captured env and the call env | No consumer needs uniqueness of `ID`; FIDs are minted separately and are identical to base. |
| **F5.** `funData.Copy` had no in-tree callers and, after this change, would have returned a value whose `env` aliases the defining scope. | **Deleted** rather than left as an alias hazard for a future caller. |
| `TestForkDropsEvaluatorLocation` counted the removed child env | Fixture now defines the lambda inside a `let`, so the test's real assertion (the location register does not travel) is unchanged and non-vacuous. |

## Differential verification

- **63-program battery** (closures in every shape, macros, `handler-bind`, `with-cleanup`, arity and package errors, lambda rendering, deep tail recursion): stdout, stderr and exit status byte-identical to base, and byte-identical to the reviewer's captured base artifacts.
- **Budget sweep**, two programs, 5984 observations, all identical to base: a step limit tripped at every reachable step (1…1400), a context cancelled at every reachable `checkLimits` call with no step limit at all, an eval-nesting cap swept 1…60, and the step sweep repeated inside a `Fork`. Each observation records the rendered error text, `Source()`, and every call-stack frame with its own location. The pre-fix draft diverged on 42 of them; the fix diverges on none.
- FIDs are identical; fork trees are consistent under `-race`; elpscheck, elpsvet and the fuzz corpora pass; substrate's suites and a 72k-line production phylum's 29 test files pass under both the shared and the isolated runner.

## Measurements

Production phylum forked under substrate (30 forks per sample, n=4):

| metric | delta |
|---|---|
| fork allocs/op | −17% |
| fork B/op | −12% |
| retained bytes per VM | −13% |
| retained-fork pool wall time | −7% |
| cold load allocs/op | −3.5% |
| `MacroDefun` sec/op | −12% |

## Test Plan

- [x] `go build ./...`
- [x] `go test ./...` (41 packages ok)
- [x] `go test -tags=elpscheck ./lisp/...`
- [x] `go test -race -run 'Fork|Lambda|Closure|Env|Limit|Step|Singleton|Print' ./lisp/`
- [x] `go test -run Fuzz ./lisp/` (corpora replay)
- [x] `make elpsvet` (plain and `-tags=elpscheck`)
- [x] `golangci-lint run ./...` (v2.6.2, the CI pin) — 0 issues
- [x] `./elps fmt -l ./...` reports nothing
- [x] `./elps doc -m` reports no missing docs
- [x] `BenchmarkEnvFunCall*` `allocs/op` unchanged
- [x] 63-program battery and 5984-observation budget sweep byte-identical against base
- [x] substrate suites and the production phylum's 29 test files pass under both runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX