### PR TITLE
Key libschema's validator credential off the marker's type, and give each fork its own libtesting suite

### DIFF
--- a/docs/fork.md
+++ b/docs/fork.md
@@ -173,6 +173,34 @@ embedder's to handle, with three tools, in order of preference:
    before `NativeCloner`, for payload types the embedder cannot modify and
    for instance-specific rebinding (a per-fork storage handle).
 
+Note what the sharing policy covers and what it does not: the *payload*
+travels by reference, but the `LVal` header carrying it does not — every
+forked value gets a fresh header. Anything that treats an `LVal`'s ADDRESS as
+meaning (a credential compared by pointer, a value used as a map key, a
+sentinel recognized by identity) is therefore revoked in a fork, silently.
+Key such markers off something the walk preserves — the payload's Go type,
+for instance — as `libschema`'s validator marker now does (issue #579).
+
+Two classes of value are the exception, and they keep their address: the
+three singletons (`isSingleton` — nil, true, false) and a node that is both
+`sealed` and of a sealable type are returned by `forker.val` unchanged rather
+than rebuilt. A sentinel that is one of those *is* stable across a fork —
+but that is a property of the seal, not of the marker, and a marker that is
+neither gets a fresh header.
+
+One channel neither this note nor the tooling can see: a Go closure inside a
+builtin captures `*lisp.LVal`s directly, and the fork walk never looks inside
+a `func`. `libschema`'s `builtinHasKey` / `builtinCheckAny` /
+`builtinAllowedValues` each close over template-side `*lisp.LVal`s — a
+slice of sub-constraints for the first two, the allowed-values list for the
+third — so a forked composite validator still reaches the *template's*
+values. That is benign today — they are read-only at call time, and
+`NewValidator`'s RUNTIME SCOPE contract sanctions a validator being shared
+by any number of runtimes — but neither the ownership checker nor the
+native-affinity check (`RuntimeBound`) can observe it, so a payload that
+became stateful behind such a closure would leak between template and forks
+undetected.
+
 A shared stateful native is the one way to leak state between template and
 forks that no isolation test in this repository can see from the outside —
 audit your template's native census when adopting Fork.

--- a/docs/fork.md
+++ b/docs/fork.md
@@ -155,10 +155,16 @@ embedder's to handle, with three tools, in order of preference:
    the hooks that open stateful handles, and run those hooks on each fork —
    exactly where a per-fresh-environment design already runs them. This is
    the pattern for accumulators whose ops/macros are Go closures over the
-   instance (e.g. the lisp testing suite: `elpstest`'s fork-served runner
-   test builds the template without `libtesting` and loads it per fork,
-   because a closure captured at template-load time can only ever see the
-   template's instance).
+   instance (e.g. `elpstest`'s fork-served runner test builds the template
+   without `libtesting` and loads it per fork). A closure captured at
+   template-load time can only ever see the template's instance, so an
+   accumulator reached that way needs BOTH halves fixed to survive a fork —
+   `libtesting` now has them (`TestSuite.CloneNative`, plus ops that resolve
+   the suite from the calling environment rather than from the captured
+   receiver) — and keeping the suite out of the template is still the
+   simpler answer where you can, and the necessary one if a fork must RUN
+   definitions the template made: an inherited `Test.Fun` is a lambda over
+   the template's environment.
 2. **`NativeCloner`.** A payload type that implements
    `CloneNative() interface{}` is duplicated at fork time; the clone must
    be independent of the original and must not retain references into the

--- a/lisp/lisplib/libschema/fork_test.go
+++ b/lisp/lisplib/libschema/fork_test.go
@@ -1,0 +1,228 @@
+// Copyright © 2026 The ELPS authors
+
+package libschema_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// This file covers issue #579: a schema validator lost its credential when
+// the environment holding it was forked.
+//
+// libschema recognizes a constraint by a marker cell every validator LFun
+// carries (isValidator, libschema.go).  LEnv.Fork shares a native payload by
+// reference but gives every forked value a FRESH *LVal header, so a
+// credential compared by HEADER identity is revoked in every fork: the
+// template validates, the fork raises "Value is not a schema constraint".
+// The credential therefore has to key off something the fork preserves --
+// the marker's payload TYPE, which no code outside libschema can name.
+//
+// The security property the marker exists for is unchanged and is pinned
+// separately by TestForgedValidatorCellIsRejected below: the fix widens the
+// credential from one pointer to one unexported, uninstantiable-from-outside
+// Go type, and the "the value must be a Go builtin" half of isValidator is
+// untouched.
+
+func mustLoad(t *testing.T, env *lisp.LEnv, name, src string) {
+	t.Helper()
+	if res := env.LoadString(name, src); res.Type == lisp.LError {
+		t.Fatalf("%s: %v", name, res)
+	}
+}
+
+func mustForkEnv(t *testing.T, env *lisp.LEnv) *lisp.LEnv {
+	t.Helper()
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	return fork
+}
+
+// assertValidates evaluates src and requires that it produce nil -- the
+// libschema convention for "the value satisfies the constraint".
+func assertValidates(t *testing.T, env *lisp.LEnv, name, src string) {
+	t.Helper()
+	res := env.LoadString(name, src)
+	if res.Type == lisp.LError {
+		t.Fatalf("%s: %v", name, res)
+	}
+	if !res.IsNil() {
+		t.Fatalf("%s: expected nil (valid), got %v", name, res)
+	}
+}
+
+// TestForkPreservesValidatorCredential is the catch for issue #579.
+//
+// A validator minted on the template -- by s:deftype, and by
+// s:make-validator wrapping an s: constructor -- must still be a validator in
+// a fork of that template, and a fork must still be able to mint its own.
+func TestForkPreservesValidatorCredential(t *testing.T) {
+	env := newSchemaEnv(t)
+	mustLoad(t, env, "template.lisp", `(s:deftype "T" s:int)
+(set 'anon (s:make-validator "Anon" s:int (s:gt 1)))`)
+	// The template itself validates: this is the non-fork behaviour, and it
+	// must be unchanged by the fix.
+	assertValidates(t, env, "template-validate.lisp", `(s:validate T 3)`)
+
+	fork := mustForkEnv(t, env)
+	// A validator defined on the template, reached from the fork.
+	assertValidates(t, fork, "fork-validate.lisp", `(s:validate T 3)`)
+	// An anonymous validator (s:make-validator, wrapping an s: constructor)
+	// minted on the template, reached from the fork.
+	assertValidates(t, fork, "fork-anon.lisp", `(s:validate anon 3)`)
+	// A validator minted inside the fork, from the fork's own s: package.
+	assertValidates(t, fork, "fork-deftype.lisp", `(s:deftype "U" s:string) (s:validate U "x")`)
+	assertValidates(t, fork, "fork-anon-new.lisp", `(s:validate (s:make-validator "Fresh" s:string) "x")`)
+	// A failing validation must still FAIL as a constraint failure, not as a
+	// "not a constraint" credential error.  Pinning the POSITIVE text, not
+	// just the absence of the credential message: a credential regression
+	// also produces an LError here, so "is an error and does not say
+	// 'not a schema constraint'" would be satisfied by several wrong
+	// answers.  This is the message the template produces for the same
+	// input, verbatim.
+	res := fork.LoadString("fork-invalid.lisp", `(s:validate T "nope")`)
+	if res.Type != lisp.LError {
+		t.Fatalf("expected a validation error, got %v", res)
+	}
+	const wantConstraintFailure = "wrong-type: Input was not an integer for type T"
+	if !strings.Contains(res.String(), wantConstraintFailure) {
+		t.Fatalf("expected %q, got %v", wantConstraintFailure, res)
+	}
+
+	// The template keeps working after being forked.
+	assertValidates(t, env, "template-after-fork.lisp", `(s:validate T 3)`)
+}
+
+// TestForkOfForkPreservesValidatorCredential checks that the credential does
+// not decay along a chain of forks (each fork re-walks the values it
+// inherited, so a fix that only survived one hop would fail here).
+func TestForkOfForkPreservesValidatorCredential(t *testing.T) {
+	env := newSchemaEnv(t)
+	mustLoad(t, env, "template.lisp", `(s:deftype "T" s:int)
+(set 'anon (s:make-validator "Anon" s:int))`)
+
+	fork := mustForkEnv(t, env)
+	grandchild := mustForkEnv(t, fork)
+	assertValidates(t, grandchild, "grandchild.lisp", `(s:validate T 3)`)
+	assertValidates(t, grandchild, "grandchild-anon.lisp", `(s:validate anon 3)`)
+
+	// And a fork taken from the grandchild, for good measure.
+	greatGrandchild := mustForkEnv(t, grandchild)
+	assertValidates(t, greatGrandchild, "great-grandchild.lisp", `(s:validate T 3)`)
+}
+
+// TestForkValidatorIsolation is the reverse direction: a type defined only in
+// a fork must not appear in the template, and the two environments must not
+// share the binding.
+func TestForkValidatorIsolation(t *testing.T) {
+	env := newSchemaEnv(t)
+	fork := mustForkEnv(t, env)
+
+	mustLoad(t, fork, "fork-only.lisp", `(s:deftype "ForkOnly" s:int)`)
+	assertValidates(t, fork, "fork-only-validate.lisp", `(s:validate ForkOnly 3)`)
+
+	// The error has to be an UNBOUND SYMBOL, not merely an error.  A
+	// credential regression fails this expression too -- with "Value is not
+	// a schema constraint" -- so a bare Type != LError check is vacuous
+	// here: it passed on the parent commit, where the symbol resolved fine
+	// and only the credential was gone.  Naming the message is what makes
+	// this an isolation assertion.
+	if res := env.LoadString("template-sees.lisp", `(s:validate ForkOnly 3)`); res.Type != lisp.LError {
+		t.Fatalf("template saw a fork-only validator: %v", res)
+	} else if !strings.Contains(res.String(), "unbound symbol") {
+		t.Fatalf("expected an unbound-symbol error in the template, got %v", res)
+	}
+
+	// ... and the same in the other direction.
+	mustLoad(t, env, "template-only.lisp", `(s:deftype "TemplateOnly" s:int)`)
+	if res := fork.LoadString("fork-sees.lisp", `(s:validate TemplateOnly 3)`); res.Type != lisp.LError {
+		t.Fatalf("fork saw a template-only validator defined after the fork: %v", res)
+	} else if !strings.Contains(res.String(), "unbound symbol") {
+		t.Fatalf("expected an unbound-symbol error in the fork, got %v", res)
+	}
+}
+
+// TestCopyOfForkedValidatorKeepsCredential checks the sibling duplication
+// paths, which are correct as they stand and need no change: the lisp `copy`
+// builtin (deepCopy, lisp/copy.go) returns an LFun BY REFERENCE, so a copied
+// validator is the very same value, and `detach` (lisp/detach.go) REFUSES an
+// LFun outright rather than handing back a credential-less duplicate -- a
+// loud refusal, not a silent revocation.  Fork was the one duplication
+// primitive that rebuilt the value, which is why it was the one that lost the
+// credential.
+//
+// Only the SECOND half is a regression test.  `copy` on the template
+// (copy.lisp) passed on the parent commit and is a control -- it pins that
+// this fix did not disturb the working path.  `copy` in a FORK
+// (fork-copy.lisp) failed there, and for the fork's reason rather than for a
+// reason of copy's own: the value copy hands back by reference is the fork's
+// re-headered validator, so it inherited the revoked credential.
+func TestCopyOfForkedValidatorKeepsCredential(t *testing.T) {
+	env := newSchemaEnv(t)
+	mustLoad(t, env, "template.lisp", `(s:deftype "T" s:int)`)
+	// Control: unchanged behaviour on the template, passed before the fix.
+	assertValidates(t, env, "copy.lisp", `(s:validate (copy T) 3)`)
+
+	// The regression: this is the half that failed on the parent commit.
+	fork := mustForkEnv(t, env)
+	assertValidates(t, fork, "fork-copy.lisp", `(s:validate (copy T) 3)`)
+}
+
+// lookalikeValidatorTag is what an outside Go caller can build: a private
+// zero-size type of its own, indistinguishable in shape from libschema's
+// marker tag and equally cheap to allocate.
+type lookalikeValidatorTag struct{}
+
+// TestForgedValidatorCellIsRejected pins the security property the marker
+// exists for (issue #325's crash class, restated in isValidator's comment):
+// the credential must not be forgeable from outside libschema.
+//
+// The forgery attempts here are the strongest an outside caller has: a real
+// Go builtin (so the Builtin() half of the check passes) carrying a third
+// cell that is a native of a lookalike zero-size type, an empty struct, and
+// a plain value.  None of them is a *libschema validator tag, and none may be
+// accepted -- before or after a fork.
+func TestForgedValidatorCellIsRejected(t *testing.T) {
+	forgeries := map[string]*lisp.LVal{
+		"lookalike-tag": lisp.Native(&lookalikeValidatorTag{}),
+		"empty-struct":  lisp.Native(&struct{}{}),
+		"nil-native":    lisp.Native(nil),
+		"string-cell":   lisp.String("marker"),
+	}
+	for name, marker := range forgeries {
+		t.Run(name, func(t *testing.T) {
+			env := newSchemaEnv(t)
+			forged := lisp.FunInPackage("user", "forged", lisp.Formals("input"),
+				func(_ *lisp.LEnv, _ *lisp.LVal) *lisp.LVal { return lisp.Nil() })
+			if forged.Type == lisp.LError {
+				t.Fatalf("build forged fun: %v", forged)
+			}
+			// Exactly the shape markValidator produces: three cells, the
+			// third being the "credential".
+			forged.Cells = append(forged.Cells, marker)
+			env.PutGlobal(lisp.Symbol("forged"), forged)
+
+			res := env.LoadString("forged.lisp", `(s:validate forged 3)`)
+			if res.Type != lisp.LError {
+				t.Fatalf("forged constraint accepted: %v", res)
+			}
+			if !strings.Contains(res.String(), "not a schema constraint") {
+				t.Fatalf("expected a credential rejection, got %v", res)
+			}
+
+			// The same forgery must not become valid by riding through a fork.
+			fork := mustForkEnv(t, env)
+			res = fork.LoadString("forged-fork.lisp", `(s:validate forged 3)`)
+			if res.Type != lisp.LError {
+				t.Fatalf("forged constraint accepted in fork: %v", res)
+			}
+			if !strings.Contains(res.String(), "not a schema constraint") {
+				t.Fatalf("expected a credential rejection in fork, got %v", res)
+			}
+		})
+	}
+}

--- a/lisp/lisplib/libschema/libschema.go
+++ b/lisp/lisplib/libschema/libschema.go
@@ -382,22 +382,50 @@ func GenSymbol() string {
 	return fmt.Sprintf("_validation_fun_%d", symcounter.Add(1))
 }
 
-// validatorTag is a private zero-size type whose ADDRESS identifies a schema
-// validator.  Nothing outside this package can obtain the pointer, and
-// lisp.Native of an identical struct value is a different pointer, so the
-// marker cannot be forged -- not from ELPS source, and not from a Go caller
-// that has not gone through NewValidator.
+// validatorTag is a private zero-size type whose TYPE identifies a schema
+// validator.  It is unexported and has no exported constructor, so no code
+// outside this package can name it, let alone instantiate one: not ELPS
+// source (which cannot build a native payload at all) and not a Go caller
+// that has not gone through NewValidator.  A lookalike zero-size struct
+// declared elsewhere is a DIFFERENT type and fails the assertion in
+// isValidator, so the marker still cannot be forged.
+//
+// The type assertion is also immune to zero-size address coalescing: Go may
+// give two distinct zero-size allocations the same address, so a credential
+// compared by PAYLOAD address would be a credential a lookalike could match
+// by accident.  That was never the old check -- it compared 112-byte *LVal
+// headers, which are distinct -- so this is a hazard the type assertion
+// forecloses, not a bug it fixes.
+//
+// What the old check did break is forking.  Keying off the type rather than
+// the marker cell's HEADER identity is what makes the credential survive
+// LEnv.Fork (issue #579): Fork shares a native payload by reference but
+// gives every forked value a fresh *LVal header, so a credential compared by
+// header identity is revoked in every fork.  (s:deftype "T" s:int) on the
+// template, (s:validate T 3) in the fork, and the fork raised "Value is not
+// a schema constraint".  The payload pointer travels intact, and so does its
+// type -- unless the embedder installs a ForkWithNativeReplacer (lisp/fork.go)
+// that rewrites this payload, which is the one way to revoke the credential
+// from outside this package.
 type validatorTag struct{}
 
-// validatorMarker is the single marker cell every validator LFun carries in
-// Cells[validatorMarkerIndex].  Its identity is the credential.
-//
-// Deliberately process-wide (hence elpsvet:allow): the marker is an
-// identity-only credential — compared by pointer in isValidator, never
-// evaluated, never bound into a scope, and never written after init.  A
-// per-runtime marker would break nothing but would also credential nothing:
-// its whole value is that every runtime recognizes the same pointer.
-var validatorMarker = lisp.Native(&validatorTag{}) //elpsvet:allow identity-only credential; read-only after init
+// validatorTagPayload is the credential itself: the value whose TYPE
+// isValidator asserts.  It is shared process-wide because it carries no
+// state whatsoever -- a zero-size struct, never read, never written -- so
+// one payload credentials every validator in the process exactly as well as
+// a fresh one per validator would.
+var validatorTagPayload = &validatorTag{}
+
+// validatorMarkerCell mints the marker cell markValidator stamps into
+// Cells[validatorMarkerIndex].  The HEADER is FRESH per validator: nothing
+// compares it by identity any more, so there is no reason to keep a
+// package-level *lisp.LVal reachable from every Runtime in the process --
+// which is exactly what cmd/elpsvet's rule against package-level LVals asks
+// for, and why this no longer carries an //elpsvet:allow.  Only the payload
+// is shared, and that is the credential.
+func validatorMarkerCell() *lisp.LVal {
+	return lisp.Native(validatorTagPayload)
+}
 
 // A validator LFun's cells are [formals, docstring, marker].  The first two
 // come from lisp.FunInPackage; newValidator appends the third.  For a builtin
@@ -428,12 +456,22 @@ const (
 // The Builtin check is not redundant with the marker check: it is what makes
 // the credential unforgeable even if the marker value ever leaked into a
 // user's hands, since a user lambda always has a nil Builtin.
+//
+// The marker is recognized by its payload TYPE, not by the address of the
+// marker cell: see validatorTag above for why (LEnv.Fork gives the marker
+// cell a fresh header in every fork, issue #579).
 func isValidator(v *lisp.LVal) bool {
-	return v != nil &&
-		v.Type == lisp.LFun &&
-		len(v.Cells) == validatorCellCount &&
-		v.Cells[validatorMarkerIndex] == validatorMarker &&
-		v.Builtin() != nil
+	if v == nil || v.Type != lisp.LFun || len(v.Cells) != validatorCellCount {
+		return false
+	}
+	marker := v.Cells[validatorMarkerIndex]
+	if marker == nil || marker.Type != lisp.LNative {
+		return false
+	}
+	if _, ok := marker.Native.(*validatorTag); !ok {
+		return false
+	}
+	return v.Builtin() != nil
 }
 
 // applyConstraint is the ONE place a schema constraint is invoked.
@@ -493,7 +531,7 @@ func newNamedValidator(name string, formals *lisp.LVal, fn lisp.LBuiltin) *lisp.
 func markValidator(fun *lisp.LVal) *lisp.LVal {
 	cells := make([]*lisp.LVal, 0, len(fun.Cells)+1)
 	cells = append(cells, fun.Cells...)
-	cells = append(cells, validatorMarker)
+	cells = append(cells, validatorMarkerCell())
 	fun.Cells = cells //elps:mutates construction-time tagging of a function value, over backing this call just allocated
 	return fun
 }

--- a/lisp/lisplib/libtesting/fork_test.go
+++ b/lisp/lisplib/libtesting/fork_test.go
@@ -1,0 +1,197 @@
+// Copyright © 2026 The ELPS authors
+
+package libtesting_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libtesting"
+	"github.com/luthersystems/elps/parser"
+)
+
+// This file covers the fork half of the suite-sharing question issue #420
+// opened. That issue asked whether one suite reached from several runtimes is
+// SAFE (it is now: the suite's own bookkeeping is locked). This one asks
+// whether a fork should be reaching the template's suite at all. It should
+// not: a `(test ...)` evaluated in a fork used to land in the TEMPLATE's
+// registry, carrying a lambda closed over the FORK's environment -- so the
+// template ended up owning a definition it never made and could not correctly
+// run, and a fork-served test runner accumulated every fork's definitions in
+// one place.
+//
+// Two mechanisms had to meet for that:
+//
+//   - The suite is an LVal.Native payload, and the fork walk's default policy
+//     for a native payload is share-by-reference (docs/fork.md). TestSuite now
+//     implements lisp.NativeCloner, so the fork gets its own.
+//
+//   - OpTest and OpBenchmark are METHODS, and the receiver is captured in the
+//     op closure registered with AddSpecialOps. A fork copies that function
+//     value without being able to rewrite the *TestSuite inside it, so the
+//     clone alone changes nothing: the ops keep writing to the template's
+//     suite. They now resolve the suite from the calling environment first.
+//
+// Neither elpsvet nor the checked-mode ownership gate sees this: the suite
+// crosses runtimes by a direct field read out of a Go closure, never through
+// Put or eval, and a *TestSuite is not an *LVal so the static rule about
+// package-level LVals does not apply either.
+
+// forkTestEnv builds a template environment with the testing package loaded,
+// which is the configuration under test: docs/fork.md's standing advice is to
+// keep the suite OUT of the template and load it per fork, and that advice
+// exists precisely because of the defect below.
+func forkTestEnv(t *testing.T) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); !rc.IsNil() {
+		t.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := libtesting.LoadPackage(env); !rc.IsNil() {
+		t.Fatalf("load-package: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); !rc.IsNil() {
+		t.Fatalf("in-package: %v", rc)
+	}
+	return env
+}
+
+func mustLoadTesting(t *testing.T, env *lisp.LEnv, name, src string) {
+	t.Helper()
+	if res := env.LoadString(name, src); res.Type == lisp.LError {
+		t.Fatalf("%s: %v", name, res)
+	}
+}
+
+// TestForkGetsItsOwnSuite is the catch.
+//
+// On the pre-fix tree the two environments report the SAME *TestSuite pointer
+// and the template holds the fork's test.
+func TestForkGetsItsOwnSuite(t *testing.T) {
+	env := forkTestEnv(t)
+	templateSuite := libtesting.EnvTestSuite(env)
+	if templateSuite == nil {
+		t.Fatal("premise: template has no suite")
+	}
+
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	forkSuite := libtesting.EnvTestSuite(fork)
+	if forkSuite == nil {
+		t.Fatal("fork has no suite")
+	}
+	// Errorf, not Fatalf: on the pre-fix tree this is the first symptom, and
+	// letting the test continue past it is what shows the second one -- the
+	// fork's definition landing in the template's registry below.
+	if forkSuite == templateSuite {
+		t.Errorf("shared=true: fork and template hold the same suite %p", forkSuite)
+	}
+
+	mustLoadTesting(t, fork, "fork-only.lisp",
+		`(use-package 'testing) (test "fork-only" (assert-equal 1 1))`)
+
+	if names := templateSuite.Tests(); len(names) != 0 {
+		t.Errorf("template suite holds the fork's test: %v", names)
+	}
+	if names := forkSuite.Tests(); len(names) != 1 || names[0] != "fork-only" {
+		t.Errorf("fork suite holds %v, want [fork-only]", names)
+	}
+
+	// The reverse direction: a definition made on the template AFTER the
+	// fork must not appear in the fork.
+	mustLoadTesting(t, env, "template-later.lisp",
+		`(use-package 'testing) (test "template-later" (assert-equal 1 1))`)
+	if names := forkSuite.Tests(); len(names) != 1 {
+		t.Errorf("fork suite saw a later template definition: %v", names)
+	}
+}
+
+// TestForkInheritsTemplateDefinitions is the other half of the clone's
+// contract: separating the registries must not LOSE the definitions the
+// template had already made. A fork-served runner that loads its test file
+// into the template and then forks per case depends on this.
+//
+// This one PASSES on the pre-fix tree, trivially -- sharing one suite gives
+// inheritance for free. It is the control: it fails a "fix" that hands the
+// fork an empty suite instead of a seeded clone.
+func TestForkInheritsTemplateDefinitions(t *testing.T) {
+	env := forkTestEnv(t)
+	mustLoadTesting(t, env, "template.lisp", `(use-package 'testing)
+(test "first" (assert-equal 1 1))
+(test "second" (assert-equal 2 2))
+(benchmark "bench" (n) (dotimes (_ n) ()))`)
+
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	forkSuite := libtesting.EnvTestSuite(fork)
+	if forkSuite == nil {
+		t.Fatal("fork has no suite")
+	}
+
+	names := forkSuite.Tests()
+	if len(names) != 2 || names[0] != "first" || names[1] != "second" {
+		t.Errorf("fork suite holds %v, want [first second] in template order", names)
+	}
+	if got := forkSuite.Len(); got != 2 {
+		t.Errorf("fork suite Len = %d, want 2", got)
+	}
+	if benches := forkSuite.Benchmarks(); len(benches) != 1 || benches[0] != "bench" {
+		t.Errorf("fork suite benchmarks = %v, want [bench]", benches)
+	}
+	if bench := forkSuite.Benchmark(0); bench == nil || bench.Name != "bench" {
+		t.Errorf("fork suite Benchmark(0) = %v, want the inherited benchmark", bench)
+	}
+
+	// Inherited names are real registrations, so redefining one in the fork
+	// must still be the duplicate-name error -- the clone copied the
+	// bookkeeping, not just the name list.
+	if res := fork.LoadString("dup.lisp", `(use-package 'testing) (test "first" ())`); res.Type != lisp.LError {
+		t.Errorf("redefining an inherited test in the fork was accepted: %v", res)
+	}
+
+	// And a fork of the fork keeps them.
+	grandchild, err := fork.Fork()
+	if err != nil {
+		t.Fatalf("fork of fork: %v", err)
+	}
+	if names := libtesting.EnvTestSuite(grandchild).Tests(); len(names) != 2 {
+		t.Errorf("grandchild suite holds %v, want the two inherited tests", names)
+	}
+}
+
+// TestForkedSuiteRunsItsOwnTest checks that the test a fork registers is
+// runnable through the fork's suite -- separating the registries would be a
+// poor trade if the entry it files were unusable. Another control: it passes
+// on the pre-fix tree too, because there the lambda is equally runnable; it
+// was just filed in the wrong registry.
+func TestForkedSuiteRunsItsOwnTest(t *testing.T) {
+	env := forkTestEnv(t)
+	mustLoadTesting(t, env, "template.lisp", `(use-package 'testing)
+(set 'shared-value 41)`)
+
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	mustLoadTesting(t, fork, "fork.lisp", `(use-package 'testing)
+(set 'shared-value 42)
+(test "reads-fork-state" (assert-equal 42 shared-value))`)
+
+	suite := libtesting.EnvTestSuite(fork)
+	if suite.Len() != 1 {
+		t.Fatalf("fork suite holds %d tests, want 1", suite.Len())
+	}
+	test := suite.Test(0)
+	if res := fork.FunCall(test.Fun, lisp.SExpr(nil)); res.Type == lisp.LError {
+		t.Errorf("running the fork's own test failed: %v", res)
+	}
+	// The template's binding is untouched, which is the point of forking.
+	if res := env.LoadString("check.lisp", `shared-value`); res.Type == lisp.LError || res.Int != 41 {
+		t.Errorf("template state changed: %v", res)
+	}
+}

--- a/lisp/lisplib/libtesting/libtesting.go
+++ b/lisp/lisplib/libtesting/libtesting.go
@@ -58,6 +58,10 @@ func LoadPackage(env *lisp.LEnv) *lisp.LVal {
 // Test's Fun is a lambda closed over the environment that defined it, so
 // evaluating it from a different runtime is environment sharing, which is a
 // separate question from whether the suite is a safe container.
+//
+// Forking an environment that holds a suite gives the fork its OWN suite,
+// seeded from the template's: see CloneNative, and suiteFor for the half of
+// that which CloneNative cannot do by itself.
 type TestSuite struct {
 	tests      map[string]*Test
 	benchmarks map[string]*Test
@@ -73,6 +77,12 @@ type TestSuite struct {
 	mu sync.RWMutex
 }
 
+// A suite duplicates rather than shares when the value holding it is forked,
+// copied or detached.  Stated as a compile-time assertion because the whole
+// mechanism is a satisfied interface: drop the method and every one of those
+// silently reverts to sharing the template's registry.
+var _ lisp.NativeCloner = (*TestSuite)(nil)
+
 // NewTestSuite returns an empty suite. The result may be installed into any
 // number of environments and used from all of them concurrently.
 func NewTestSuite() *TestSuite {
@@ -80,6 +90,64 @@ func NewTestSuite() *TestSuite {
 		tests:      make(map[string]*Test),
 		benchmarks: make(map[string]*Test),
 	}
+}
+
+// CloneNative implements lisp.NativeCloner, the kernel's opt-in duplication
+// protocol for native payloads (lisp/fork.go, docs/fork.md).
+//
+// Without it a fork SHARES this suite with its template — the default policy
+// for a native payload is share-by-reference — and the suite is an
+// accumulator, so a `(test ...)` evaluated in the fork lands in the
+// template's registry. The clone gives every fork (and every `copy` /
+// `detach` of the suite value, which route through the same protocol) its own
+// registry, seeded with whatever the template had already defined.
+//
+// The seeding is a shallow copy of the bookkeeping: an inherited *Test is
+// carried by pointer, so its Fun is still the lambda the TEMPLATE built, over
+// the template's environment. That is the same reference the fork would have
+// held before this method existed and is not something CloneNative can fix —
+// it sees a payload, not the forker — so a fork that means to RUN inherited
+// tests still wants the template built without them (docs/fork.md, "Keep
+// state out of the template"). What the clone does fix is the write side:
+// definitions made in the fork stay in the fork.
+func (s *TestSuite) CloneNative() interface{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cp := NewTestSuite()
+	cp.torder = make([]string, len(s.torder))
+	copy(cp.torder, s.torder)
+	cp.border = make([]string, len(s.border))
+	copy(cp.border, s.border)
+	for name, t := range s.tests {
+		cp.tests[name] = t
+	}
+	for name, b := range s.benchmarks {
+		cp.benchmarks[name] = b
+	}
+	return cp
+}
+
+// suiteFor resolves the suite a definition form must register into.
+//
+// CloneNative alone does not fix forking, because the op is a METHOD: the
+// receiver is baked into the closure libutil.FunctionDoc registers, and a
+// fork copies that function value without being able to see, let alone
+// rewrite, the *TestSuite captured inside it. So every op in a fork would
+// still write through to the template's suite even though the fork holds a
+// clone of its own. Resolving from the calling environment first is what
+// makes the two halves meet: the env's `testing:test-suite` binding is a
+// value the fork walk DOES rewrite, so it names the fork's clone.
+//
+// The receiver is the fallback, for an embedder that registered a suite's ops
+// into an environment without also binding the suite there (EnvTestSuite
+// returns nil for that shape). Where both exist they are the same suite --
+// LoadPackage and the documented embedder shape both install one suite as
+// both -- so this changes nothing outside a fork.
+func suiteFor(env *lisp.LEnv, receiver *TestSuite) *TestSuite {
+	if es := EnvTestSuite(env); es != nil {
+		return es
+	}
+	return receiver
 }
 
 func (s *TestSuite) Add(t *Test) error {
@@ -395,12 +463,17 @@ func (s *TestSuite) OpTest(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	if name.Type != lisp.LString {
 		return env.Errorf("first argument is not a string: %v", name.Type)
 	}
+	// Register into the suite the CALLING environment holds, not the one
+	// captured in this method value: see suiteFor.  The lambda below closes
+	// over env, so the two have to agree or the fork files its own test,
+	// closed over its own environment, in the template's registry.
+	suite := suiteFor(env, s)
 	fun := env.Lambda(lisp.Nil(), exprs)
 	test := &Test{
 		Name: name.Str,
 		Fun:  fun,
 	}
-	err := s.Add(test)
+	err := suite.Add(test)
 	if err != nil {
 		return env.Error(err)
 	}
@@ -425,12 +498,14 @@ func (s *TestSuite) OpBenchmark(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	if bargs.Len() != 1 {
 		return env.Errorf("benchmark doesn't take one argument: %v", bargs.Len())
 	}
+	// See OpTest: the benchmark belongs to the calling environment's suite.
+	suite := suiteFor(env, s)
 	fun := env.Lambda(bargs, exprs)
 	test := &Test{
 		Name: name.Str,
 		Fun:  fun,
 	}
-	err := s.AddBenchmark(test)
+	err := suite.AddBenchmark(test)
 	if err != nil {
 		return env.Error(err)
 	}

--- a/lisp/ownership_check_elpscheck.go
+++ b/lisp/ownership_check_elpscheck.go
@@ -48,9 +48,9 @@ import (
 //     registrationFormals in env.go); this checker covers the values that
 //     actually flow.
 //   - It only sees the instrumented points.  A value that crosses runtimes
-//     purely through direct field reads (e.g. libschema's validatorMarker,
-//     compared by pointer identity only) never hits Put or eval and is not
-//     checked.  Again: cmd/elpsvet flags the producer pattern statically.
+//     purely through direct field reads (e.g. libschema's validator marker
+//     cell, read straight out of a validator's cells) never hits Put or eval
+//     and is not checked.  Again: cmd/elpsvet flags the producer pattern statically.
 //   - Adoption order is first-touch, so a value CREATED for runtime B but
 //     touched first by runtime A is blamed backwards.  The panic reports
 //     both runtimes; which one is the rightful owner is for the reader to


### PR DESCRIPTION
## Summary

Two stdlib packages kept Go-side state that did not survive `LEnv.Fork` correctly. One commit each.

### Commit 1: libschema validators lose their credential in a fork

**Root cause.** `libschema.isValidator` recognized a schema constraint by requiring the validator `LFun`'s third cell to be the package-level `validatorMarker` value **compared by pointer**. `LEnv.Fork` shares a native payload by reference but gives every forked value a **fresh `*LVal` header** (`forker.val`, `lisp/fork.go`), so in a fork the marker cell is a different pointer and every validator the template minted is silently stripped of its credential:

```lisp
(s:deftype "T" s:int)   ; on the template
(s:validate T 3)        ; template => ()
                        ; fork     => bad-arguments: Value is not a schema constraint: #
```

Every constraint entry point routes through `applyConstraint` and the `deftype` choke point, so the whole `s` package is unusable in a forked environment — including the fork-served test-runner and pool-refill topologies `docs/fork.md` recommends.

**Fix.** `isValidator` asserts the marker cell's native payload **type** (`*validatorTag`) instead of comparing the cell's address. The payload pointer travels intact through a fork, and so does its type, so the credential survives forking to any depth. With identity no longer what is checked, the process-wide shared marker `*LVal` has no reason to exist: a zero-size payload is shared and a fresh header is minted per validator, which lets the `//elpsvet:allow` on the old package-level `*LVal` go away rather than be reworded.

**Why this option.** It is the only one of the three candidates that is both correct and local:

- *Seal the marker so the fork walk shares it by pointer* — not available. `sealableNodeType` (`lisp/seal.go`) covers only parser-producible types and deliberately excludes `LNative`.
- *Teach the fork walker to preserve identity for this marker* — puts `libschema` knowledge inside `lisp/` and fixes one marker rather than the class.
- *Key off the payload type* — one line of `libschema`, no kernel change, and it generalizes: the property it relies on (payloads travel by reference) is the documented fork contract.

**Security reasoning — the credential is not weakened.** `validatorTag` is unexported, has no fields and no methods, and has no exported constructor, so no code outside `libschema` can name the type, let alone instantiate one: not ELPS source (which cannot construct a native payload at all, and cannot read a function's cells: every accessor errors), and not a Go caller that has not gone through `NewValidator`. A lookalike zero-size struct declared elsewhere is a *different* type and fails the assertion. The type assertion is also immune to zero-size address coalescing, which a payload-address comparison would not have been (the old check compared 112-byte `*LVal` headers, which are never coalesced; header identity is exactly what the fork broke). The independent "the value must be a Go builtin" half of the check, which is what defeats a user lambda, is untouched. `TestForgedValidatorCellIsRejected` pins all of this, before and after a fork, with four forgery shapes each carried by a real Go builtin so the `Builtin()` half of the check passes.

**`detach` and `copy` do not have this bug** and are unchanged: `deepCopy` returns an `LFun` **by reference** (the copy *is* the validator) and strict `detach` **refuses** an `LFun` outright. Fork was the one duplication primitive that rebuilt the value.

`docs/fork.md` gains a note on the general hazard (the payload travels by reference but the header does not, so address-as-meaning is revoked in a fork, except for the three singletons and sealed nodes of a sealable type, which `forker.val` shares outright) and on the blind spot that Go closures inside builtins are invisible to the fork walk.

### Commit 2: the same bug class in libtesting

`libschema`'s marker was not the only Go-side value a fork kept sharing with its template. `TestSuite` is an `LVal.Native` payload, and the fork walk shares native payloads by reference — but this one is an accumulator, and it is *written* by evaluation.

- `OpTest` / `OpBenchmark` are methods, so the receiver is captured in the op closure `AddSpecialOps` registers. The fork walk cannot see inside a `func`, so cloning the payload alone fixes nothing.
- Result: `(test "x" ...)` evaluated in a **fork** registered into the **template's** suite, carrying a `Test.Fun` lambda closed over the fork's environment.
- Fix, both halves: `TestSuite` implements `lisp.NativeCloner` (seeded clone per fork/`copy`/`detach`), and the ops resolve the suite from the calling environment (`EnvTestSuite`) before falling back to the captured receiver.
- Scope limit (documented): an inherited `Test.Fun` is still the template's lambda, since `CloneNative` gets a payload, not the forker. "Keep the suite out of the template" remains the advice for forks that must *run* inherited tests.
- Neither `elpsvet` nor the checked-mode ownership gate catches this: a `*TestSuite` is not an `*LVal`, and it crosses runtimes by a direct field read out of a Go closure, never at `Put` or eval.

## Test Plan

Commit 1, `lisp/lisplib/libschema/fork_test.go`. Three tests **fail on `main`** and pass with the fix; two are controls that pass on both:

```
--- FAIL: TestForkPreservesValidatorCredential      (fork-validate.lisp: bad-arguments: Value is not a schema constraint)
--- FAIL: TestForkOfForkPreservesValidatorCredential (grandchild.lisp)
--- FAIL: TestCopyOfForkedValidatorKeepsCredential   (fork-copy.lisp; the copy half is the control)
--- PASS: TestForkValidatorIsolation                 (control; asserts "unbound symbol" in both directions)
--- PASS: TestForgedValidatorCellIsRejected          (control; 4 forgery shapes)
```

Commit 2, `lisp/lisplib/libtesting/fork_test.go`, **fails on the pre-fix tree**:

```
--- FAIL: TestForkGetsItsOwnSuite
    shared=true: fork and template hold the same suite
    template suite holds the fork's test: [fork-only]
--- PASS: TestForkInheritsTemplateDefinitions   (control)
--- PASS: TestForkedSuiteRunsItsOwnTest         (control)
```

Full gate, all green on the final head:

- [x] `go build ./...`, `make`
- [x] `go test ./...`
- [x] `go test -race ./lisp/...`
- [x] `go test -tags=elpscheck ./lisp/... ./lisp/lisplib/...`
- [x] `make elpsvet` (plain and `-tags=elpscheck` passes; no `//elpsvet:allow` left in libschema, and the rule was confirmed live by temporarily reintroducing a package-level `lisp.Native(...)`)
- [x] `golangci-lint run ./...` — v2.6.2, `0 issues.`
- [x] `./elps fmt -l ./...` — no files listed
- [x] `./elps doc -m` — `All functions and exports are documented.`
- [x] `go test -run Fuzz ./lisp/...` — seed corpora replay clean

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX