### PR TITLE
Stamp macro expansions onto private copies of spliced values, never the values

### DIFF
--- a/cmd/synthesized_location_test.go
+++ b/cmd/synthesized_location_test.go
@@ -1,0 +1,177 @@
+// Copyright © 2026 The ELPS authors
+
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/elps/diagnostic"
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+)
+
+// genFunName normalizes the generated name of an anonymous function
+// (_fun4) so a golden below does not pin how many lambdas the standard
+// library happens to construct before the program runs.
+var genFunName = regexp.MustCompile(`_fun\d+`)
+
+// renderRunError writes src to a file in its own directory, loads it exactly
+// as `elps run` does, and returns what `elps run` would have printed for the
+// resulting error.  It renders through the command's own converter and
+// renderer rather than reimplementing them, so the goldens below are the
+// text a user sees.
+func renderRunError(t *testing.T, name, src string) string {
+	t.Helper()
+	dir := t.TempDir()
+	// The renderer reads the source line for the snippet from the physical
+	// path, which the loader records relative to the library root.
+	t.Chdir(dir)
+	file := name + ".lisp"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, file), []byte(src), 0o600))
+
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	env.Runtime.Library = &lisp.FSLibrary{FS: os.DirFS(dir)}
+	for _, rc := range []*lisp.LVal{
+		lisp.InitializeUserEnv(env),
+		lisplib.LoadLibrary(env),
+		env.InPackage(lisp.String(lisp.DefaultUserPackage)),
+	} {
+		require.True(t, rc.IsNil(), "environment setup failed: %v", rc)
+	}
+
+	res := env.LoadFile(file)
+	require.Equal(t, lisp.LError, res.Type, "the program was expected to fail: %v", res)
+	d := lispErrorToDiagnostic(res)
+	d.Notes = append(d.Notes, "try: elps lint "+file)
+	var buf bytes.Buffer
+	require.NoError(t, (&diagnostic.Renderer{Color: diagnostic.ColorNever}).Render(&buf, d))
+	return genFunName.ReplaceAllString(buf.String(), "_funN")
+}
+
+// TestSynthesizedFunctionsReportTheirConstructionSite pins the location a
+// stack names for a function that Go code BUILT rather than the reader
+// parsed: compose, flip and the `expr` operator synthesize the body and call
+// forms of the function they return, and those nodes come out of
+// SExpr/Symbol with no location at all.
+//
+// Until stampMacroExpansion stopped writing into values, a macro that
+// returned such a function papered over that: the stamp walked INTO the
+// returned function value and wrote the macro CALL site onto its body.  That
+// was a write into a live binding (the bug this branch closes) AND the wrong
+// location -- the function was built where compose ran, not where the macro
+// was called.  Removing the write without locating the nodes left the stack
+// saying "at unknown", which is why setSynthesizedSource (lisp/lisp.go)
+// exists.
+//
+// EVERY case below differs from the behaviour before this branch, and the
+// direction is the point:
+//
+//   - macro-root, macro-child, flip: previously the MACRO CALL SITE (a write
+//     into the function value); now the construction site inside the macro
+//     body, which is where the function was actually built.
+//   - global: a compose'd function bound to a global and merely NAMED by a
+//     macro previously had the macro call site written into it -- the
+//     corruption in its purest form, since the function long predates the
+//     macro.  It now keeps its own definition site.
+//   - plain: no macro is involved at all, so nothing ever stamped it and the
+//     stack said "at unknown".  It now names the compose call, which is a
+//     strict improvement the previous behaviour could not reach.
+func TestSynthesizedFunctionsReportTheirConstructionSite(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{{
+		name: "macro-root",
+		src: "(defmacro m () (compose car car))\n" +
+			"(set 'f (m))\n" +
+			"(f 1)\n",
+		want: "error: lisp:car: argument is not a list int\n" +
+			"  --> macro-root.lisp:1:16\n" +
+			"   |\n" +
+			" 1 |  (defmacro m () (compose car car))\n" +
+			"   |                 ^\n" +
+			"   |\n" +
+			"   = note: in lisp:car at macro-root.lisp:1:16\n" +
+			"   = note: in lisp:apply at macro-root.lisp:1:16\n" +
+			"   = note: in f at macro-root.lisp:3:1\n" +
+			"   = note: try: elps lint macro-root.lisp\n",
+	}, {
+		name: "macro-child",
+		src: "(defmacro m () (quasiquote (funcall (unquote (compose car car)) 1)))\n" +
+			"(m)\n",
+		want: "error: lisp:car: argument is not a list int\n" +
+			"  --> macro-child.lisp:1:46\n" +
+			"   |\n" +
+			" 1 |  (defmacro m () (quasiquote (funcall (unquote (compose car car)) 1)))\n" +
+			"   |                                               ^\n" +
+			"   |\n" +
+			"   = note: in lisp:car at macro-child.lisp:1:46\n" +
+			"   = note: in lisp:apply at macro-child.lisp:1:46\n" +
+			"   = note: in _funN at macro-child.lisp:1:28\n" +
+			"   = note: in lisp:funcall at macro-child.lisp:1:28\n" +
+			"   = note: try: elps lint macro-child.lisp\n",
+	}, {
+		name: "global",
+		src: "(set 'gf (compose car car))\n" +
+			"(defmacro m () gf)\n" +
+			"(set 'f (m))\n" +
+			"(f 1)\n",
+		want: "error: lisp:car: argument is not a list int\n" +
+			"  --> global.lisp:1:10\n" +
+			"   |\n" +
+			" 1 |  (set 'gf (compose car car))\n" +
+			"   |           ^\n" +
+			"   |\n" +
+			"   = note: in lisp:car at global.lisp:1:10\n" +
+			"   = note: in lisp:apply at global.lisp:1:10\n" +
+			"   = note: in f at global.lisp:4:1\n" +
+			"   = note: try: elps lint global.lisp\n",
+	}, {
+		name: "plain",
+		src: "(set 'g (compose car car))\n" +
+			"(g 1)\n",
+		want: "error: lisp:car: argument is not a list int\n" +
+			"  --> plain.lisp:1:9\n" +
+			"   |\n" +
+			" 1 |  (set 'g (compose car car))\n" +
+			"   |          ^\n" +
+			"   |\n" +
+			"   = note: in lisp:car at plain.lisp:1:9\n" +
+			"   = note: in lisp:apply at plain.lisp:1:9\n" +
+			"   = note: in g at plain.lisp:2:1\n" +
+			"   = note: try: elps lint plain.lisp\n",
+	}, {
+		name: "flip",
+		src: "(defmacro m () (flip nth))\n" +
+			"(set 'f (m))\n" +
+			"(f 1 2)\n",
+		want: "error: lisp:nth: first argument is not a proper sequence: int\n" +
+			"  --> flip.lisp:1:16\n" +
+			"   |\n" +
+			" 1 |  (defmacro m () (flip nth))\n" +
+			"   |                 ^\n" +
+			"   |\n" +
+			"   = note: in lisp:nth at flip.lisp:1:16\n" +
+			"   = note: in f at flip.lisp:3:1\n" +
+			"   = note: try: elps lint flip.lisp\n",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := renderRunError(t, test.name, test.src)
+			assert.Equal(t, test.want, got)
+			assert.NotContains(t, got, "at unknown",
+				"a synthesized function's frames must name a location")
+		})
+	}
+}

--- a/docs/sealed-ast.md
+++ b/docs/sealed-ast.md
@@ -792,6 +792,72 @@ still be aliased by another binding, a container, or a closure. Code that
 intends to mutate data it did not construct copies unconditionally.
 `IsSealed()` stays a Go-side tool, where refuse-or-copy is a real choice.
 
+### 4.5 The macro-expansion stamp writes into storage it may not own
+
+`stampMacroExpansion` (`lisp/macro.go`) is the one place the evaluator
+writes debug metadata (a source location and, under a debugger, expansion
+info) onto nodes it did not construct: whatever a macro body returned.  It
+cannot tell fresh expansion output from storage that also belongs to
+someone else, and it has bitten six times, each found in production or by
+fuzzing rather than review.  The table is the history of the shared storage
+this stamp has written into; *where each was fixed* varies, and only three
+are guarded inside the function:
+
+| Issue | Storage the stamp wrote into | Where it was fixed |
+|---|---|---|
+| #274 | the singletons `Nil`/`true`/`false` (every reader corrupted for the process lifetime) | here: `isSingleton`, in `stampGuarded` |
+| #396 (fixed in #406) | the form being expanded, aliased into the macro's `&rest` list | upstream: `macroArgList` builds that list over a fresh array |
+| #370 | reader nodes emitted with synthetic locations | here: the `v.sealed` check in `stampGuarded` |
+| #517 | sealed parse-tree subtrees (cross-environment write, data race) | here: the same `v.sealed` check |
+| #431 | the caller's `env.loc`, shared by pointer, stored on every node the walk claimed | at the call site: `LEnv.macroCall` passes `env.loc.Copy()` |
+| the value fix | values yielded by the expansion: a builtin reached through `Get`, a global sorted map (`lisp:car` acquired a macro call site as its definition, and the profiler reported it) | here: the ownership rule below |
+
+So the function's own exclusions are three -- `isSingleton`, `sealed`, and
+the nil-`callSite` early return.  The rule below **replaces** adding more of
+them; it is not a fourth:
+
+- The stamp writes **in place only to syntax** -- the node types the reader
+  produces (`sealableNodeType`) that are unsealed and not singletons.
+- **Any other node type is a value.** A value is never written to.  At the
+  root it is returned as a stamped private header copy; inside an
+  expansion-owned list it is replaced by one.  The copy shares the value's
+  storage, so it is the same value to every reader.
+- Pinned by `TestMacroExpansionStampsValuesOnPrivateHeaders` (root and
+  child, for the value types a macro body can hand back: `LFun`, `LNative`,
+  `LSortMap`, `LArray`, `LBytes`, `LTaggedVal` -- `LError` is returned before
+  the stamp runs and the rest are evaluator-internal marks) and
+  `TestMacroExpansionDoesNotStampFunctionValues` (the `lisp:car` case).
+
+**Behaviour change, confined to error-location attribution.** Results are
+unchanged.  What changes is that a value a macro yields keeps its **own**
+location instead of acquiring the macro call site.  Where the value had no
+location of its own, the stack note previously read `at unknown` -- so the
+nodes `compose`, `flip` and the `expr` operator synthesize for the function
+they return are now located at their **construction site**
+(`setSynthesizedSource`, `lisp/lisp.go`) instead of relying on the stamp to
+reach inside a function value and locate its body.  A function built by
+`compose` and never passed through a macro at all previously reported
+`at unknown` in every frame and now names the `compose` call, which is a
+strict improvement.  Pinned by
+`TestSynthesizedFunctionsReportTheirConstructionSite` (`cmd/`), which holds
+the rendered `elps run` output for five shapes.
+
+**Identity across the header copy.** The copy is a new `*LVal`, so anything
+keyed on the header pointer must key on the shared storage instead or it
+will read the copy as a different value.  The runtime ownership checker does
+this (`ownershipKey`, `lisp/ownership_check_elpscheck.go`): an `LFun` is
+keyed on its `*funData` and an `LSortMap` on its `*MapData`, so a closure
+crossing runtimes through a macro expansion is still caught.  The same key
+also closes a hole that predates the stamp change -- `LEnv.Get` returns a
+`FunRef` header copy for **every** unqualified function lookup.
+
+Residual, tracked in #582: an unsealed *syntax* container that is itself a
+binding (a runtime list from `(list ...)` returned by a macro body) is
+indistinguishable from expansion output and is still stamped in place.
+
+When you touch this code: do not add an identity exclusion; extend the
+ownership rule, and add the new shape to the sweep test.
+
 ## 5. Embedder checklist
 
 1. **Parse through a sealing path.** `Reader.Read`, `LoadString`,

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -1205,6 +1205,19 @@ func builtinCompose(env *LEnv, args *LVal) *LVal {
 	} else {
 		gcall.Cells = append(gcall.Cells, Nil())
 	}
+	// The nodes above are synthesized: SExpr/Symbol produce them with no
+	// location, which renders as "unknown" in a stack note.  Give them the
+	// location of the (compose f g) form that built them, one Location
+	// object owned by this function (never env.loc itself -- issue #431).
+	//
+	// f, g and the formals' own head symbols are the only nodes here compose
+	// did not construct; f and g are deliberately absent from the list
+	// because a builtin reached through Get carries no location and writing
+	// one onto it corrupts a live global binding.  formals is a Copy, so its
+	// cells are compose's to locate.
+	loc := env.loc.Copy()
+	setSynthesizedSource(loc, formals, gcall, gcall.Cells[0], body, body.Cells[0])
+	setSynthesizedSource(loc, formals.Cells...)
 	newfun := env.Lambda(formals, []*LVal{body})
 	return newfun
 }
@@ -1230,7 +1243,14 @@ func builtinFlip(env *LEnv, args *LVal) *LVal {
 		return env.Errorf("argument is not a function of two arguments: %s", formals)
 	}
 	call := SExpr([]*LVal{fun, Symbol("y"), Symbol("x")})
-	return env.Lambda(Formals("x", "y"), []*LVal{call})
+	newFormals := Formals("x", "y")
+	// Locate the synthesized nodes at the (flip fun) form -- see the same
+	// step in builtinCompose.  call.Cells[0] is fun, a value flip was handed,
+	// and is deliberately not in the list.
+	loc := env.loc.Copy()
+	setSynthesizedSource(loc, call, call.Cells[1], call.Cells[2], newFormals)
+	setSynthesizedSource(loc, newFormals.Cells...)
+	return env.Lambda(newFormals, []*LVal{call})
 }
 
 func builtinAssoc(env *LEnv, args *LVal) *LVal {

--- a/lisp/cycle_test.go
+++ b/lisp/cycle_test.go
@@ -137,9 +137,14 @@ func TestGoValueOfCyclicValue(t *testing.T) {
 
 func TestStampMacroExpansionOfCyclicValue(t *testing.T) {
 	env := initSafetyTestEnv(t)
-	v := cyclicVector(1)
-	// Mirror a macro that built its expansion with append!: every node carries
-	// the synthetic source location stampMacroExpansion is there to replace.
+	// A list that contains itself, the shape a macro that built its
+	// expansion with append! hands back: every node carries the synthetic
+	// source location stampMacroExpansion is there to replace.  (A cyclic
+	// VECTOR would no longer exercise the walk: vectors are values, which
+	// the stamp diverts to a header copy without descending -- see the
+	// warning above stampMacroExpansion.)
+	v := SExpr([]*LVal{Int(1)})
+	v.Cells = append(v.Cells, v)
 	//
 	// The call site is built explicitly rather than taken from
 	// Symbol("x").source.  #362 deleted the process-wide native-source
@@ -147,9 +152,11 @@ func TestStampMacroExpansionOfCyclicValue(t *testing.T) {
 	// stampMacroExpansion returns immediately on a nil callSite, which would
 	// leave this test asserting nil == nil and cover nothing.
 	callSite := &token.Location{File: "test.lisp", Line: 5, Col: 1}
-	stampMacroExpansion(v, callSite, nil, env.Runtime)
+	got := stampMacroExpansion(v, callSite, nil, env.Runtime)
+	assert.Same(t, v, got, "a syntax root is stamped in place")
 	assert.Equal(t, callSite, v.source, "the root must be stamped")
-	assert.Equal(t, callSite, v.Cells[1].source, "the storage list must be stamped")
+	assert.Equal(t, callSite, v.Cells[0].source, "the element must be stamped")
+	assert.Same(t, v, v.Cells[1], "the cycle is preserved")
 }
 
 // TestAcyclicRenderingIsUnchangedBelowAndAboveTheGuard pins the property the
@@ -340,7 +347,13 @@ func TestCyclicWalkHelper(t *testing.T) {
 		}
 	case "stamp":
 		env := initSafetyTestEnv(t)
-		v := cyclicVector(1)
+		// A list that contains itself, NOT a cyclic vector.  A vector is a
+		// VALUE: the stamp diverts it to a header copy and never descends,
+		// so a vector fixture would report "stamped" without the walk having
+		// run at all -- the subtest would pass with the cycle guard removed.
+		// The same shape as TestStampMacroExpansionOfCyclicValue.
+		v := SExpr([]*LVal{Int(1)})
+		v.Cells = append(v.Cells, v)
 		// A real call site, for the reason given in
 		// TestStampMacroExpansionOfCyclicValue: a nil one makes the walk
 		// return before it starts, so this subprocess would report "stamped"

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -1470,8 +1470,17 @@ func (env *LEnv) macroCall(ctx context.Context, fun, args *LVal) *LVal {
 			Args:     args.Cells,
 		}
 	}
-	stampMacroExpansion(r, callSite, mctx, env.Runtime)
+	r = stampMacroExpansion(r, callSite, mctx, env.Runtime)
 
+	// ORDER: stamp first, unquote second.  shallowUnquote also mints a
+	// private header, so stamping after it would let a VALUE root be stamped
+	// in place and save one allocation on that path -- but only by telling
+	// stampMacroExpansion "this root is yours to write", which is the kind of
+	// per-call-site ownership assertion the ownership rule above it exists to
+	// remove.  The saving applies solely to a root that is an unlocated value
+	// (a rare shape; most expansion roots are syntax), so the order stays as
+	// it is.
+	//
 	// This is a lazy unquote.  Unquoting in this way appears to allow the
 	// upcoming evaluation to produce the correct value for user defined
 	// macros, which are typically using quasiquote.  Builtin macros can be

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -446,6 +446,42 @@ func (v *LVal) SetSource(loc *token.Location) {
 	v.source = loc //elps:mutates the audited setter for source metadata; sealed (shared) nodes are skipped above
 }
 
+// setSynthesizedSource gives every node in nodes that carries no location of
+// its own the location loc.
+//
+// It is for the nodes a builtin SYNTHESIZES -- the formals, call and body
+// forms that compose, flip and the `expr` operator build for the function
+// they return.  Those come out of SExpr/Symbol/Formals with source == nil,
+// and a nil source renders as "unknown" in a stack note, so a stack running
+// through a composed function named no location at all.
+//
+// The macro stamp used to hide that for the composed functions a macro
+// returned: stampMacroExpansion walked INTO the returned function value and
+// wrote the macro CALL site onto its body.  That was the wrong location (the
+// function was built where compose ran, not where the macro was called) and
+// a write into storage the expansion did not own; the stamp no longer
+// descends into a value, so the location has to be established here, where
+// the node is constructed.  See the warning above stampMacroExpansion.
+//
+// loc must be a Location the constructed function may own -- env.loc.Copy(),
+// ONE copy shared by the nodes of one constructed function, never env.loc
+// itself (issue #431), whose pointee moves with the evaluator.
+//
+// Nodes that already carry a location are skipped, but that is a
+// convenience, not a safety net: the caller must pass only nodes it
+// constructed.  A function value the caller was HANDED (compose's f and g,
+// flip's fun) has no location when it is a builtin, so passing one would
+// stamp a live global binding -- exactly the corruption the ownership rule
+// above stampMacroExpansion exists to prevent.
+func setSynthesizedSource(loc *token.Location, nodes ...*LVal) {
+	for _, v := range nodes {
+		if v == nil || v.source != nil {
+			continue
+		}
+		v.SetSource(loc)
+	}
+}
+
 // IsQuoted reports whether v carries a single level of quoting — the flag
 // behind the LQuote wrapper and the ['(...)/[...]] display forms.  The
 // underlying field is unexported (issue #382): quoting is established at

--- a/lisp/macro.go
+++ b/lisp/macro.go
@@ -270,7 +270,77 @@ func macroDeftype(env *LEnv, args *LVal) *LVal {
 // holds.  macroCall takes env.loc.Copy() for exactly this reason; passing
 // env.loc itself put the caller's node and the whole expansion on one mutable
 // object (issue #431).
-func stampMacroExpansion(v *LVal, callSite *token.Location, ctx *macroExpansionContext, rt *Runtime) {
+//
+// ---------------------------------------------------------------------------
+// DANGER: THIS STAMP WRITES INTO STORAGE IT MAY NOT OWN.  READ BEFORE EDITING.
+//
+// stampMacroExpansion is handed whatever the macro body returned, and it has
+// no way to tell fresh expansion output from storage that also belongs to
+// someone else.  The table below is the history of the shared storage this
+// stamp has written into; each was found in production or by fuzzing, not by
+// review.  Where each was FIXED varies -- three are guarded here, the other
+// two were closed at the site that handed the stamp the shared storage:
+//
+//	#274  (May 2026)  the singletons Nil/true/false: one write corrupted
+//	                  every reader for the rest of the process.  Guarded
+//	                  here: isSingleton, in stampGuarded.
+//	#396  (Aug 2026)  the form being expanded, aliased into the macro's
+//	                  &rest list.  NOT guarded here -- fixed upstream in
+//	                  macroArgList (lisp/builtins.go), which builds that
+//	                  list over a fresh array.
+//	#370  (Aug 2026)  reader nodes emitted with synthetic locations.
+//	#517  (Aug 2026)  sealed parse-tree subtrees: a cross-environment write
+//	                  and a data race under concurrent environments.
+//	                  Both guarded here: the v.sealed check in stampGuarded.
+//	#431  (Aug 2026)  the caller's env.loc, shared by pointer and then
+//	                  stored on every node the walk claimed.  NOT guarded
+//	                  here -- fixed at the call site, which passes
+//	                  env.loc.Copy() (LEnv.macroCall).  callSite is still
+//	                  stored BY POINTER, so the caller must keep passing a
+//	                  Location the expansion may own.
+//	(this fix)        VALUES yielded by the expansion -- a builtin reached
+//	                  through Get, a global sorted map -- are live bindings;
+//	                  stamping them in place moved lisp:car's definition
+//	                  site onto a macro call site for the rest of the
+//	                  process, and the profiler reported it as such.
+//
+// This function's own exclusions are therefore three: isSingleton (#274),
+// sealed (#370/#517), and the nil-callSite early return.  The rule below
+// REPLACES adding more of them; it is not a fourth.
+//
+// The rule, enforced by stampGuarded and pinned by
+// TestMacroExpansionStampsValuesOnPrivateHeaders: the stamp writes IN PLACE
+// only to SYNTAX nodes (the node types the reader produces, sealableNodeType)
+// that are unsealed and not singletons.  A node of any other type is a
+// VALUE.  A value is never written to; it is replaced, in its expansion-owned
+// parent (or at the root, by the return value), with a private header copy
+// that carries the stamp and shares the value's storage.  If a new kind of
+// shared storage turns up, extend the ownership rule rather than adding
+// another identity exclusion.
+//
+// BEHAVIOUR CHANGE, confined to error-location attribution -- results are
+// unchanged.  A value a macro yields now keeps its OWN location instead of
+// acquiring the macro call site.  Where that location was previously NONE the
+// stack note reads "unknown", so the nodes compose, flip and the `expr`
+// operator synthesize for the function they return are now located at their
+// construction site (setSynthesizedSource, lisp/lisp.go) rather than relying
+// on this stamp reaching inside a function value to locate its body.
+//
+// Known residual (issue #582): an UNSEALED syntax container that is itself a
+// binding -- a global list built at runtime by (list ...) and returned by a
+// macro body -- is indistinguishable from expansion output and is still
+// stamped in place, on every release since the stamp existed.
+// ---------------------------------------------------------------------------
+//
+// stampMacroExpansion returns the expansion the caller must evaluate: v
+// itself, or, when v is a value, its stamped private header copy.
+func stampMacroExpansion(v *LVal, callSite *token.Location, ctx *macroExpansionContext, rt *Runtime) *LVal {
+	if v == nil || callSite == nil {
+		return v
+	}
+	if isValueNode(v) {
+		return stampValueCopy(v, callSite, ctx, rt)
+	}
 	var st cycleState
 	stampGuarded(v, callSite, ctx, rt, cycleGuard{state: &st})
 	if st.cyclic {
@@ -280,6 +350,64 @@ func stampMacroExpansion(v *LVal, callSite *token.Location, ctx *macroExpansionC
 		// the rerun, which visits each node once, finishes the job.
 		stampGuarded(v, callSite, ctx, rt, strictCycleGuard())
 	}
+	return v
+}
+
+// isValueNode reports whether v is a runtime VALUE rather than SYNTAX: a
+// node of a type the reader never produces (a function, a native handle, a
+// sorted map, a vector, bytes).  Such a node inside a macro expansion is a
+// binding the macro body evaluated to or spliced in, not the expansion's
+// own output, so the stamp must not write to it.  See the warning above
+// stampMacroExpansion.
+func isValueNode(v *LVal) bool {
+	return !sealableNodeType(v.Type)
+}
+
+// stampValueCopy returns the node to put in a value's place in an
+// expansion: v itself when it already carries a real location, otherwise a
+// private header copy of v carrying the stamp.
+//
+// WHAT THE COPY SHARES AND WHAT IT PRIVATIZES, precisely.  Everything
+// reached through a POINTER is shared -- the *funData behind an LFun, the
+// *MapData behind an LSortMap, the []byte behind LBytes, and the Cells
+// BACKING ARRAY -- so the copy is the same value to every reader, and a
+// write through either header would be seen through the other.  What is
+// private is the copy's own struct: source and macroExpansion (the point of
+// the exercise), and alongside them the Cells slice HEADER, Str, Int, Float,
+// Type, FunType, quoted, spliced and sealed.  A write to one of those
+// through the copy would silently diverge from the binding rather than
+// corrupting it -- which would be a different bug, not a safe one.  No such
+// write is reachable through this path today: every `.Cells =`, `.Native =`,
+// `.Str =`, `.Int =` and `.Type =` assignment in lisp/ and lisp/lisplib/ was
+// audited, and the ones that land on a VALUE type write either a container
+// the builtin itself constructed (the vector rebuilds in select/reject) or a
+// shared INNER cell (append!'s `vec.Cells[1].Cells`, which is the same
+// storage through either header and so behaves identically).  The
+// checker that keeps the shared half honest across runtimes keys an LFun on
+// its *funData for exactly this reason (ownershipKey,
+// lisp/ownership_check_elpscheck.go): a private header must not read as a
+// different function.
+//
+// The arrangement is not new, but the cover it gave was accidental and
+// partial.  LEnv.Get returns a FunRef HEADER COPY for an LFun, so a function
+// the macro body reached through an UNQUALIFIED symbol arrived here as a
+// copy already and the stamp's write landed harmlessly on it.  A QUALIFIED
+// symbol -- lisp:car -- resolves through pkg.Get instead and returns the raw
+// binding, which is why the bug above exists at all.  Here the copy is
+// deliberate, unconditional, and extended to every value type.
+func stampValueCopy(v *LVal, callSite *token.Location, ctx *macroExpansionContext, rt *Runtime) *LVal {
+	if v.source != nil && v.source.Pos >= 0 {
+		return v
+	}
+	cp := *v
+	cp.source = callSite
+	if ctx != nil {
+		cp.macroExpansion = &macroExpansionInfo{
+			macroExpansionContext: ctx,
+			ID:                    rt.nextMacroExpID(),
+		}
+	}
+	return &cp
 }
 
 func stampGuarded(v *LVal, callSite *token.Location, ctx *macroExpansionContext, rt *Runtime, g cycleGuard) {
@@ -309,6 +437,12 @@ func stampGuarded(v *LVal, callSite *token.Location, ctx *macroExpansionContext,
 	if v.sealed {
 		return
 	}
+	// Values never reach this walk: the root is diverted by
+	// stampMacroExpansion and children by the loop below.  Keep the guard
+	// anyway -- it is the ownership rule's last line of defence.
+	if isValueNode(v) {
+		return
+	}
 	// Only a node with children is entered on the guard's path: a leaf stamps
 	// itself and reaches nothing, and stamping runs on every macro expansion.
 	nested := len(v.Cells) > 0
@@ -332,7 +466,18 @@ func stampGuarded(v *LVal, callSite *token.Location, ctx *macroExpansionContext,
 			}
 		}
 	}
-	for _, child := range v.Cells {
+	for i, child := range v.Cells {
+		if child == nil {
+			continue
+		}
+		if isValueNode(child) {
+			// v is expansion-owned unsealed syntax, so its cells are the
+			// expansion's to rewrite; the value itself is not.
+			if sc := stampValueCopy(child, callSite, ctx, rt); sc != child {
+				v.Cells[i] = sc //elps:mutates debug-metadata stamp on macro-expansion output: replaces a spliced value with its stamped private header copy; the value is never written
+			}
+			continue
+		}
 		stampGuarded(child, callSite, ctx, rt, g)
 	}
 	if nested && g.tracking() {

--- a/lisp/macro_stamp_fun_test.go
+++ b/lisp/macro_stamp_fun_test.go
@@ -1,0 +1,155 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// TestMacroExpansionDoesNotStampFunctionValues pins that a VALUE yielded
+// by a macro expansion keeps its own location.  stampGuarded walks the
+// expansion and writes the macro call site onto every unsealed node that
+// has no location; a builtin handed out by Get has no location by design
+// (it renders as "<native code>"), and it is a live binding, not syntax --
+// Package.Get returns the stored value, and LEnv.Get does too for a name
+// that matches.  Before the guard, (defmacro m () lisp:car) followed by
+// (m) moved lisp:car's definition site onto the call site for the rest of
+// the process, which the profiler then reported as the builtin's file.
+// The same holds for any non-syntax value a macro yields: the sorted map
+// bound to a global below must not gain a location either.
+func TestMacroExpansionDoesNotStampFunctionValues(t *testing.T) {
+	env := newForkTestEnv(t)
+	for i, form := range []*LVal{
+		SExpr([]*LVal{Symbol("defmacro"), Symbol("m"), SExpr(nil), Symbol("lisp:car")}),
+		SExpr([]*LVal{Symbol("m")}),
+		SExpr([]*LVal{Symbol("set"), SExpr([]*LVal{Symbol("quote"), Symbol("table")}), SExpr([]*LVal{Symbol("sorted-map")})}),
+		SExpr([]*LVal{Symbol("defmacro"), Symbol("mt"), SExpr(nil), Symbol("table")}),
+		SExpr([]*LVal{Symbol("mt")}),
+	} {
+		// The stamp is the macro CALL SITE, so the call form needs a real
+		// location, as every form read from a file has.
+		form.SetSource(&token.Location{File: "stamp.lisp", Pos: 20 * i, Line: i + 1, Col: 1})
+		form.SealAST()
+		if res := env.Eval(form); res.Type == LError {
+			t.Fatalf("eval %v: %v", form, res)
+		}
+	}
+	pkg := env.Runtime.Registry.packages["lisp"]
+	if pkg == nil {
+		t.Fatal("lisp package not in registry")
+	}
+	car, ok := pkg.Symbol("car")
+	if !ok || car == nil || car.Type != LFun {
+		t.Fatalf("lisp:car is not a bound function: %v", car)
+	}
+	if loc, ok := car.Source(); ok {
+		t.Errorf("lisp:car gained a source location from a macro expansion: %v", loc)
+	}
+	if car.macroExpansion != nil {
+		t.Errorf("lisp:car gained macro-expansion metadata")
+	}
+	table := env.Runtime.Package.Get(Symbol("table"))
+	if table.Type != LSortMap {
+		t.Fatalf("table is not a sorted map: %v", table)
+	}
+	if loc, ok := table.Source(); ok {
+		t.Errorf("a sorted-map value gained a source location from a macro expansion: %v", loc)
+	}
+}
+
+// TestMacroExpansionStampsValuesOnPrivateHeaders is the class-level guard
+// behind the warning above stampMacroExpansion: the stamp must never write to
+// a VALUE.  Placed at the root of an expansion the value is returned as a
+// stamped header copy; placed inside an expansion-owned list it is replaced
+// in that list by one.  In both cases the original keeps a nil source and no
+// macro-expansion metadata, and the copy shares the value's storage.  SYNTAX
+// nodes with no location (the reader's types) keep being stamped in place,
+// which is the stamp's job.
+//
+// COVERAGE, stated exactly rather than as "every value type": the fixtures
+// below are the value types a macro body can actually hand back -- LFun,
+// LNative, LSortMap, LArray, LBytes and LTaggedVal (a deftype/new value).
+// The remaining non-syntax types are unreachable here and are deliberately
+// not fixtures: LError is returned before the stamp (macroCall bails on
+// r.Type == LError), and LInvalid, LMarkTerminal, LMarkTailRec,
+// LMarkMacExpand and LTypeMax are evaluator-internal marks that no macro body
+// can produce -- macroCall wraps its own result in the last of them AFTER
+// stamping.  If a new LType is added, add it here or record why it cannot
+// reach this walk.
+func TestMacroExpansionStampsValuesOnPrivateHeaders(t *testing.T) {
+	env := newForkTestEnv(t)
+	car, ok := env.Runtime.Registry.packages["lisp"].Symbol("car")
+	if !ok || car.Type != LFun {
+		t.Fatalf("lisp:car is not a bound function: %v", car)
+	}
+	callSite := &token.Location{File: "stamp.lisp", Pos: 40, Line: 3, Col: 1}
+	// A deftype/new value.  Its location is cleared because LEnv.TaggedValue
+	// constructs one at env.loc, and a value that already carries a location
+	// is returned unchanged -- the fixture has to be unlocated to exercise
+	// the copy, like every other value here.
+	tagged := env.TaggedValue(Symbol("user:point"), Int(1))
+	if tagged.Type != LTaggedVal {
+		t.Fatalf("TaggedValue did not produce a tagged value: %v", tagged)
+	}
+	tagged.SetSource(nil)
+	values := map[string]*LVal{
+		"builtin":      car,
+		"native":       Native(&struct{ n int }{n: 1}),
+		"sorted-map":   SortedMap(),
+		"vector":       Vector([]*LVal{Int(1), Int(2)}),
+		"bytes":        Bytes([]byte("b")),
+		"tagged-value": tagged,
+	}
+	for name, v := range values {
+		t.Run(name+"/root", func(t *testing.T) {
+			if sealableNodeType(v.Type) {
+				t.Fatalf("%v is a syntax type; the fixture is wrong", v.Type)
+			}
+			got := stampMacroExpansion(v, callSite, nil, env.Runtime)
+			if got == v {
+				t.Fatalf("a value root was returned as itself, not a private copy")
+			}
+			if got.source != callSite {
+				t.Errorf("the copy is not stamped: %v", got.source)
+			}
+			if v.source != nil || v.macroExpansion != nil {
+				t.Errorf("the value itself was written to: source %v, macroExpansion %v", v.source, v.macroExpansion)
+			}
+			if got.Type != v.Type || got.Native != v.Native || (len(v.Cells) > 0 && &got.Cells[0] != &v.Cells[0]) {
+				t.Errorf("the copy does not share the value's storage")
+			}
+		})
+		t.Run(name+"/child", func(t *testing.T) {
+			expansion := SExpr([]*LVal{Symbol("identity"), v})
+			got := stampMacroExpansion(expansion, callSite, nil, env.Runtime)
+			if got != expansion {
+				t.Fatalf("a syntax root must be stamped in place, not replaced")
+			}
+			if expansion.source != callSite || expansion.Cells[0].source != callSite {
+				t.Errorf("syntax nodes were not stamped in place")
+			}
+			if expansion.Cells[1] == v {
+				t.Fatalf("the value was left in the expansion instead of a private copy")
+			}
+			if expansion.Cells[1].source != callSite {
+				t.Errorf("the copy in the expansion is not stamped: %v", expansion.Cells[1].source)
+			}
+			if v.source != nil || v.macroExpansion != nil {
+				t.Errorf("the value itself was written to: source %v, macroExpansion %v", v.source, v.macroExpansion)
+			}
+		})
+	}
+	// With a debugger context every stamped node also gets expansion
+	// metadata; the value must not.
+	ctx := &macroExpansionContext{CallSite: callSite, Name: "m"}
+	v := SortedMap()
+	got := stampMacroExpansion(v, callSite, ctx, env.Runtime)
+	if got.macroExpansion == nil {
+		t.Errorf("the copy did not get macro-expansion metadata under a debugger context")
+	}
+	if v.macroExpansion != nil {
+		t.Errorf("the value got macro-expansion metadata")
+	}
+}

--- a/lisp/op.go
+++ b/lisp/op.go
@@ -323,6 +323,13 @@ func opExpr(env *LEnv, args *LVal) *LVal {
 	if vargs {
 		formals.Cells = append(formals.Cells, Symbol(VarArgSymbol), Symbol("%"+VarArgSymbol))
 	}
+	// The formals are synthesized from the placeholder names, so they carry
+	// no location; locate them at the #^ form -- see the same step in
+	// builtinCompose.  body is the operand the reader parsed and already has
+	// one of its own.
+	loc := env.loc.Copy()
+	setSynthesizedSource(loc, formals)
+	setSynthesizedSource(loc, formals.Cells...)
 	return env.Lambda(formals, []*LVal{body})
 }
 

--- a/lisp/ownership_check_elpscheck.go
+++ b/lisp/ownership_check_elpscheck.go
@@ -278,7 +278,7 @@ func checkOwnership(rt *Runtime, v *LVal) {
 		return
 	}
 	m := ownershipTable.m.Load()
-	owner, loaded := m.LoadOrStore(v, rt)
+	owner, loaded := m.LoadOrStore(ownershipKey(v), rt)
 	if !loaded {
 		if ownershipTable.count.Add(1) >= ownershipTableMaxEntries {
 			resetOwnershipTable()
@@ -289,6 +289,52 @@ func checkOwnership(rt *Runtime, v *LVal) {
 		return
 	}
 	panic(ownershipViolation{msg: ownershipViolationMessage(owner.(*Runtime), rt, v)})
+}
+
+// ownershipKey returns the identity checkOwnership tracks for v.
+//
+// For most types that is the *LVal itself.  Two are keyed on the pointer to
+// their SHARED STORAGE instead, because for those a distinct header is not a
+// distinct value: an LFun's *funData carries the whole function (the Go
+// builtin or the captured *LEnv), and an LSortMap's *MapData carries the
+// whole map, while the header around either can be duplicated freely.  Two
+// duplicators ship: LEnv.Get returns a FunRef header copy on the
+// unqualified-symbol path, and stampMacroExpansion stamps a value it splices
+// into an expansion by giving it a private header rather than writing the
+// binding's own.
+//
+// Keying on the header would therefore let a closure reach a second Runtime
+// through a copy without the table ever seeing one key twice -- the checker
+// would report clean on exactly the cross-runtime flow it exists to catch --
+// and would additionally add a table entry per copy, one per macro expansion.
+// Keying on the storage makes the identity survive the header copy, which is
+// what "the same function" means.
+//
+// LNative is deliberately NOT keyed on its payload.  A payload is an
+// arbitrary embedder value: it need not be a pointer and need not be
+// comparable, and a sync.Map key that is not comparable panics.  Native
+// payloads carry a stronger rule of their own anyway -- declared affinity
+// (checkNativeAffinity), enforced at use time here and at fork time in
+// forker.native.
+//
+// A malformed value (an LFun or LSortMap whose Native is not the expected
+// payload, or is nil) falls back to the header, for isClosureFreeBuiltin's
+// reason: a value that has not answered what its storage is gets the
+// stricter treatment, not an exemption.
+func ownershipKey(v *LVal) interface{} {
+	switch v.Type {
+	case LFun:
+		if fd, ok := v.Native.(*funData); ok && fd != nil {
+			return fd
+		}
+	case LSortMap:
+		if md, ok := v.Native.(*MapData); ok && md != nil {
+			return md
+		}
+	default:
+		// Every other type: the header is the value's identity.
+	}
+	return v
 }
 
 // checkNativeAffinity asserts a native payload's DECLARED runtime binding:

--- a/lisp/ownership_check_elpscheck_test.go
+++ b/lisp/ownership_check_elpscheck_test.go
@@ -7,6 +7,8 @@ package lisp
 import (
 	"strings"
 	"testing"
+
+	"github.com/luthersystems/elps/parser/token"
 )
 
 // newOwnershipTestEnv returns a root LEnv with its own private Runtime.
@@ -339,5 +341,78 @@ func TestOwnershipCheck_SealedASTExempt(t *testing.T) {
 	}
 	expectOwnershipPanic(t, func() {
 		envB.Eval(unsealed)
+	})
+}
+
+// TestOwnershipCheck_StampedValueHeaderKeepsIdentity pins the identity rule
+// ownershipKey establishes: a value the macro stamp gave a PRIVATE HEADER is
+// still the same value, and must still be caught crossing runtimes.
+//
+// stampMacroExpansion no longer writes a macro call site into a value the
+// expansion yielded; it hands back a header copy carrying the stamp and
+// sharing the value's storage.  The checker keys its adoption table on a
+// pointer, so keying it on the *LVal would have made that copy a NEW value:
+// a closure reaching two runtimes through a macro expansion would present a
+// distinct pointer to each, the table would never see one key twice, and the
+// gate would report clean on exactly the flow it exists to catch (it would
+// also grow one entry per expansion).  Keying an LFun on its *funData makes
+// the identity survive the copy.
+//
+// Red-proof: with ownershipKey's LFun arm removed (return v for every type)
+// the cross-runtime half of this test panics with no violation at all.
+//
+// The same hole predates the stamp change and is closed by the same key:
+// LEnv.Get returns a FunRef header copy for EVERY unqualified function
+// lookup, so a function that crossed runtimes by name was already invisible.
+// The second half of this test is that case.
+func TestOwnershipCheck_StampedValueHeaderKeepsIdentity(t *testing.T) {
+	envA := initSafetyTestEnv(t)
+	envB := initSafetyTestEnv(t)
+
+	// A closure -- it captured envA's environment, so it is not exempt as a
+	// closure-free builtin.  Its location is cleared because a value that
+	// already carries one is returned unchanged by the stamp; the header
+	// copy is minted only for a value with none, which is the case under
+	// test.
+	fn := envA.Lambda(Formals("x"), []*LVal{Symbol("x")})
+	if fn.Type != LFun {
+		t.Fatalf("Lambda did not produce a function: %v", fn)
+	}
+	fn.SetSource(nil)
+	if lerr := envA.Put(Symbol("f"), fn); lerr.Type == LError {
+		t.Fatalf("put in runtime A failed: %v", lerr)
+	}
+
+	callSite := &token.Location{File: "ownership.lisp", Line: 3, Col: 1}
+	stamped := stampMacroExpansion(fn, callSite, nil, envA.Runtime)
+	if stamped == fn {
+		t.Fatal("the stamp must hand back a private header for an unlocated value;" +
+			" without a copy this test would be checking the original pointer")
+	}
+	if stamped.Native != fn.Native {
+		t.Fatal("the private header must share the function's storage")
+	}
+
+	// Same runtime: the copy is the same function, so reusing it must not
+	// trip the gate.
+	if res := envA.Eval(stamped); res.Type == LError {
+		t.Fatalf("eval of the stamped header in its own runtime failed: %v", res)
+	}
+	// Second runtime: still the same function, and still a violation.
+	expectOwnershipPanic(t, func() {
+		envB.Eval(stamped)
+	})
+
+	// The FunRef header LEnv.Get mints on every unqualified lookup is the
+	// same shape, and the same key covers it.
+	ref := envA.Get(Symbol("f"))
+	if ref.Type != LFun {
+		t.Fatalf("get did not return the function: %v", ref)
+	}
+	if ref == fn {
+		t.Fatal("Get is expected to return a FunRef header copy")
+	}
+	expectOwnershipPanic(t, func() {
+		envB.Eval(ref)
 	})
 }


### PR DESCRIPTION
## Summary

`stampMacroExpansion` is handed whatever a macro body returned and cannot tell fresh expansion output from storage that also belongs to someone else. A **value** the body yielded (a builtin reached through `Get`, a global sorted map, a vector) is a live binding, and the stamp wrote the macro call site into it in place. After one `(m)` where `m` expands to `lisp:car`, `lisp:car`'s definition site was the macro call site for the rest of the process, and the profiler reported it as such.

This is the sixth aliasing bug in this one walk:

| Issue | Storage the stamp wrote into | Where it was fixed |
|---|---|---|
| #274 | the singletons `Nil`/`true`/`false` | here (`isSingleton`) |
| #396 (fixed in #406) | the form being expanded | upstream, `macroArgList` |
| #370 | reader nodes emitted with synthetic locations | here (`sealed`) and the reader |
| #431 | the caller's `env.loc`, shared by pointer | at the call site (`env.loc.Copy()`) |
| #517 | sealed parse-tree subtrees (cross-environment write, data race) | here (`sealed`) |
| this PR | values yielded by the expansion | here, by the ownership rule below |

## The fix

Close the class instead of adding a fourth exclusion to this function. The stamp now writes in place only to **syntax** (the node types the reader produces, unsealed, not singletons). Any other node type is a **value** and is never written to: at the root it is returned as a stamped private header copy, inside an expansion-owned list it is replaced by one. The copy shares everything behind a pointer (`*funData`, `*MapData`, bytes, the Cells backing array); the copy's own struct fields are private.

## Behaviour change, stated plainly

Evaluation results are unchanged. **Error-location attribution changes** for values a macro yields: the value keeps its own location instead of acquiring the macro call site. Functions built by `compose`, `flip` and the `expr` operator now carry their construction site (they were built with no location, and the stamp used to paper over that with the macro call site; in the plain non-macro case they used to report `at unknown` in every frame). All 37 repo `.lisp` programs plus a 14-program battery render byte-identical output before and after.

## Review follow-ups

- **Synthesized function bodies now carry a location (blocking).** `compose`, `flip` and `expr` build their function's body/call/formals nodes with `source == nil`. With the in-place write gone the stack said `at unknown`, so the nodes are located where they are constructed (`setSynthesizedSource`, one `env.loc.Copy()` per constructed function, never `env.loc` itself). `cmd/synthesized_location_test.go` holds the rendered `elps run` output for five shapes; each says `at unknown` without the fix.
- **Cycle test de-vacuumed (blocking).** The `"stamp"` subprocess case built a cyclic *vector*, which is a value and never enters the walk; it passed with the cycle guard removed. It now uses the self-referential list, and dies of stack overflow when the guard is reverted.
- **Ownership checker keys on shared storage.** The private header copy is a new `*LVal`, so the elpscheck ownership table (keyed on the pointer) stopped seeing a closure that crossed runtimes through a macro expansion. `ownershipKey` now keys `LFun` on its `*funData` and `LSortMap` on its `*MapData`. This also closes the same hole for the `FunRef` header copy `LEnv.Get` mints on every unqualified function lookup, which predates this branch. New elpscheck test reports no violation at all without the key.
- **Doc corrections.** The warning table says where each historical bug was fixed (this function's own exclusions are three, not six). The `LEnv.Get` claim is corrected (the `FunRef` copy covers only the unqualified-symbol path; a qualified `lisp:car` returns the raw binding, which is why the bug exists). The value-type sweep covers `LTaggedVal` and states its coverage exactly, with a note on why `LError` and the internal marks are unreachable. The sharing boundary is spelled out field by field.
- **Not done:** stamping after `shallowUnquote` to reuse its header. It would save one allocation only for an unlocated value root, and only by asserting root ownership at the call site, the pattern this change removes. Reasoning is commented in `macroCall`.

## Docs

- Warning block above `stampMacroExpansion` in `lisp/macro.go`: the history, the ownership rule, the behaviour change, the residual.
- `docs/sealed-ast.md` section 4.5 with the same table and the rule for future edits: do not add an identity exclusion, extend the ownership rule.
- Residual tracked in #582: an unsealed runtime list that is itself a binding is indistinguishable from expansion output and is still stamped in place.

## Test plan

- `TestMacroExpansionDoesNotStampFunctionValues`: fails on main (`lisp:car` carries `stamp.lisp:2:1` after `(m)`), passes here.
- `TestMacroExpansionStampsValuesOnPrivateHeaders`: LFun, LNative, LSortMap, LArray, LBytes, LTaggedVal at the root and as a child. Original untouched, copy stamped and sharing storage, debugger metadata only on the copy.
- `TestSynthesizedFunctionsReportTheirConstructionSite`: five `elps run` renderings, RED without `setSynthesizedSource`.
- `TestOwnershipCheck_StampedValueHeaderKeepsIdentity` (elpscheck): RED without `ownershipKey`.
- `TestStampMacroExpansionOfCyclicValue` and the `"stamp"` subprocess case on cyclic list fixtures, RED with the cycle guard reverted.
- Gates: build, `go test ./...`, `-race` on `lisp` and `x/debugger`, `elpscheck` tag (tests and lint), `make elpsvet`, golangci-lint (0 issues), `elps fmt -l`, `elps doc -m`, `FuzzEval` 60s (520k execs, no crashers).

Part of the perf stack: this PR sits at the bottom (bug fixes first), ahead of #572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX