### PR TITLE
Make the macro-expansion stamp copy-on-write so it never writes to a binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ fuzz-crashers/
 # empty-discovery control and deletes it again. Ignored so an interrupted run
 # cannot leave the tree looking dirty.
 internal/citest-emptyfuzz.*/
+
+# `go test -c` / -memprofile leave a compiled test binary beside the package
+*.test

--- a/docs/sealed-ast.md
+++ b/docs/sealed-ast.md
@@ -792,41 +792,95 @@ still be aliased by another binding, a container, or a closure. Code that
 intends to mutate data it did not construct copies unconditionally.
 `IsSealed()` stays a Go-side tool, where refuse-or-copy is a real choice.
 
-### 4.5 The macro-expansion stamp writes into storage it may not own
+### 4.5 The macro-expansion stamp is handed storage it does not own
 
 `stampMacroExpansion` (`lisp/macro.go`) is the one place the evaluator
-writes debug metadata (a source location and, under a debugger, expansion
-info) onto nodes it did not construct: whatever a macro body returned.  It
+attaches debug metadata (a source location and, under a debugger, expansion
+info) to nodes it did not construct: whatever a macro body returned.  It
 cannot tell fresh expansion output from storage that also belongs to
-someone else, and it has bitten six times, each found in production or by
-fuzzing rather than review.  The table is the history of the shared storage
-this stamp has written into; *where each was fixed* varies, and only three
-are guarded inside the function:
+someone else.  For most of its life it wrote the call site **in place**, and
+it bit seven times, each found in production or by fuzzing rather than
+review.  The table is the history of the shared storage this stamp wrote
+into; *where each was fixed* varies:
 
 | Issue | Storage the stamp wrote into | Where it was fixed |
 |---|---|---|
-| #274 | the singletons `Nil`/`true`/`false` (every reader corrupted for the process lifetime) | here: `isSingleton`, in `stampGuarded` |
+| #274 | the singletons `Nil`/`true`/`false` (every reader corrupted for the process lifetime) | here: `isSingleton` |
 | #396 (fixed in #406) | the form being expanded, aliased into the macro's `&rest` list | upstream: `macroArgList` builds that list over a fresh array |
-| #370 | reader nodes emitted with synthetic locations | here: the `v.sealed` check in `stampGuarded` |
+| #370 | reader nodes emitted with synthetic locations | here: the `v.sealed` check |
 | #517 | sealed parse-tree subtrees (cross-environment write, data race) | here: the same `v.sealed` check |
 | #431 | the caller's `env.loc`, shared by pointer, stored on every node the walk claimed | at the call site: `LEnv.macroCall` passes `env.loc.Copy()` |
-| the value fix | values yielded by the expansion: a builtin reached through `Get`, a global sorted map (`lisp:car` acquired a macro call site as its definition, and the profiler reported it) | here: the ownership rule below |
+| the value fix | values yielded by the expansion: a builtin reached through `Get`, a global sorted map (`lisp:car` acquired a macro call site as its definition, and the profiler reported it) | here: stamped a private header copy instead of the value |
+| #582 | unsealed *syntax* that is itself a binding: a runtime list from `(list ...)` returned by a lisp macro body, or a located list holding an unlocated value (the value fix still overwrote its cells with private copies, in place) | here: the whole stamp became copy-on-write |
 
-So the function's own exclusions are three -- `isSingleton`, `sealed`, and
-the nil-`callSite` early return.  The rule below **replaces** adding more of
-them; it is not a fourth:
+**The rule now: the stamp writes only to nodes it allocated.**
 
-- The stamp writes **in place only to syntax** -- the node types the reader
-  produces (`sealableNodeType`) that are unsealed and not singletons.
-- **Any other node type is a value.** A value is never written to.  At the
-  root it is returned as a stamped private header copy; inside an
-  expansion-owned list it is replaced by one.  The copy shares the value's
-  storage, so it is the same value to every reader.
-- Pinned by `TestMacroExpansionStampsValuesOnPrivateHeaders` (root and
-  child, for the value types a macro body can hand back: `LFun`, `LNative`,
-  `LSortMap`, `LArray`, `LBytes`, `LTaggedVal` -- `LError` is returned before
-  the stamp runs and the rest are evaluator-internal marks) and
-  `TestMacroExpansionDoesNotStampFunctionValues` (the `lisp:car` case).
+- The walk over the expansion is **copy-on-write**.  A node that needs a
+  stamp (no real location), or whose cells changed, is replaced *in the
+  returned tree* by a private copy; a node that needs neither is shared, as
+  are sealed subtrees, singletons and located values.  The value the macro
+  body returned, and everything reachable from it, is never written to.
+- The copy shares everything behind a pointer (the `*funData` behind an
+  `LFun`, the `*MapData` behind an `LSortMap`, the `[]byte` behind `LBytes`,
+  an unchanged `Cells` backing array); its own struct -- `source`,
+  `macroExpansion` and, when a cell changed, the cell slice -- is private.
+- There is no identity exclusion left to add.  The remaining guards --
+  `isSingleton`, `sealed`, the nil-`callSite` early return -- are about
+  *sharing*, not about writing: a singleton or a sealed subtree is shared
+  outright rather than walked.
+- Pinned by `TestMacroExpansionStampNeverWritesTheExpansion` (an unlocated
+  runtime list, a located list with an unlocated value cell, an unlocated
+  list nested in a located binding, sealed and located cells shared,
+  debugger metadata only on the copy),
+  `TestMacroReturningARuntimeListBindingLeavesItUnlocated` (the ELPS shape
+  from #582, plus the error from an expansion built with `(list ...)` still
+  naming the macro call site), and, for the value cases,
+  `TestMacroExpansionStampsValuesOnPrivateHeaders` and
+  `TestMacroExpansionDoesNotStampFunctionValues`.
+
+**Cost, and who pays it.** An expansion in which nothing needs a stamp is
+returned as is, with no allocation
+(`TestMacroExpansionStampAllocatesNothingWhenNothingNeedsAStamp`).  A node
+that needs a stamp costs one header, plus a header and a cell slice for each
+ancestor up to the root.  A cyclic expansion (constructible from Go only)
+additionally pays for the walk that discovers the cycle before the memoised
+rerun; the IDs that walk minted are discarded with it, so the kept walk's
+expansion IDs stay contiguous and in pre-order.
+
+Only a **lisp** macro pays.  Its body builds its expansion with quasiquote,
+whose output carries the template's locations, so the usual lisp expansion
+needs no stamp at all -- and an unlocated node it does return may be a
+binding (#582), which is exactly what the copy is for.  A **Go** macro
+synthesizes its expansion from fresh nodes, so the copies would cost it two
+allocations per node on every expansion: the first draft of the
+copy-on-write stamp measured +23% allocs/op and +18% sec/op on
+`BenchmarkPackage/get-nested-baseline` in `libjson`, which expands
+`libtesting`'s `assert-equal` 6000 times per iteration, and substrate's
+`cc:infof` family has the same shape on every phylum log line.  So
+`LEnv.macroCall`, when no debugger is attached, **locates a Go macro's
+expansion in place** before the stamp sees it (`locateExpansionTree`,
+`lisp/macro.go`): every unlocated unsealed syntax node reachable from the
+expansion gets the call site, **stopping at the macro's arguments**, and
+the stamp then shares the fresh nodes.  (An unlocated value or argument in
+the expansion, or a cycle, still costs the copies the stamp's rules give.)
+That is the in-place write the stamp gave up, confined to the one caller
+whose output is fresh *by contract*: a Go macro's expansion consists of
+nodes it constructed and its arguments (`LEnv.AddMacros` states the rule).
+The arguments are the caller's nodes and may be bindings -- a call form
+built at runtime, `(macroexpand-1 (list 'm l))` or a Go-side `Eval` of a
+runtime form, hands the macro the raw binding `l` -- which is why the
+locate stops at them: the stamp copies such an argument, exactly as it
+copies a binding a lisp macro returns.  A Go macro that returned a binding
+it looked up *itself* would have the binding located -- the #582 shape --
+and none in this repository or in substrate does.  Values are never
+written to on either path.  Under a debugger the hand-off is skipped and a
+Go macro's expansion is copied like a lisp macro's, since the copy is
+where the expansion metadata the debugger reads is attached.  Pinned by
+`TestGoMacroExpansionIsLocatedInPlace` (fresh nodes located in place, a
+sealed argument untouched, an unlocated runtime argument left to the
+stamp, nothing located under a debugger).  `BenchmarkMacroDefun` and
+`BenchmarkPackage` are unchanged to the allocation against the parent
+commit.
 
 **Behaviour change, confined to error-location attribution.** Results are
 unchanged.  What changes is that a value a macro yields keeps its **own**
@@ -840,7 +894,10 @@ reach inside a function value and locate its body.  A function built by
 `at unknown` in every frame and now names the `compose` call, which is a
 strict improvement.  Pinned by
 `TestSynthesizedFunctionsReportTheirConstructionSite` (`cmd/`), which holds
-the rendered `elps run` output for five shapes.
+the rendered `elps run` output for five shapes.  A binding a macro body
+returns keeps its own (absent) location too; the stamp lands on the copy
+the caller evaluates, so an error raised while evaluating the expansion
+still reports the macro call site.
 
 **Identity across the header copy.** The copy is a new `*LVal`, so anything
 keyed on the header pointer must key on the shared storage instead or it
@@ -851,12 +908,8 @@ crossing runtimes through a macro expansion is still caught.  The same key
 also closes a hole that predates the stamp change -- `LEnv.Get` returns a
 `FunRef` header copy for **every** unqualified function lookup.
 
-Residual, tracked in #582: an unsealed *syntax* container that is itself a
-binding (a runtime list from `(list ...)` returned by a macro body) is
-indistinguishable from expansion output and is still stamped in place.
-
-When you touch this code: do not add an identity exclusion; extend the
-ownership rule, and add the new shape to the sweep test.
+When you touch this code: do not write to the expansion, and do not add an
+identity exclusion; if a new shape turns up, add it to the sweep test.
 
 ## 5. Embedder checklist
 

--- a/internal/fuzzval/fuzzval.go
+++ b/internal/fuzzval/fuzzval.go
@@ -229,11 +229,12 @@ func (g *Gen) value(depth int) *lisp.LVal {
 // locate gives a generated value a REAL source location about half the time.
 //
 // WHY.  Before this, every generated value carried lisp.nativeSource's shared
-// synthetic Location (Pos < 0), and the only write the interpreter makes to
-// Source -- stampMacroExpansion -- is guarded by `Source == nil || Source.Pos
-// < 0`.  A corpus of exclusively synthetic values therefore never presents the
-// case that a corrupting builtin would have to be caught on, and
-// internal/fuzzfp's Source rule has nothing to bite on.
+// synthetic Location (Pos < 0), and the one place the interpreter attaches a
+// Source -- stampMacroExpansion, which now stamps a private copy rather than
+// the node (issue #582) -- selects nodes by `Source == nil || Source.Pos < 0`.
+// A corpus of exclusively synthetic values therefore never presents the case
+// that a corrupting builtin would have to be caught on, and internal/fuzzfp's
+// Source rule has nothing to bite on.
 //
 // It is also the more faithful model, not merely the more testable one.  Every
 // callable that receives an UNEVALUATED fragment -- every special operator,

--- a/lisp/cycle_test.go
+++ b/lisp/cycle_test.go
@@ -153,10 +153,12 @@ func TestStampMacroExpansionOfCyclicValue(t *testing.T) {
 	// leave this test asserting nil == nil and cover nothing.
 	callSite := &token.Location{File: "test.lisp", Line: 5, Col: 1}
 	got := stampMacroExpansion(v, callSite, nil, env.Runtime)
-	assert.Same(t, v, got, "a syntax root is stamped in place")
-	assert.Equal(t, callSite, v.source, "the root must be stamped")
-	assert.Equal(t, callSite, v.Cells[0].source, "the element must be stamped")
-	assert.Same(t, v, v.Cells[1], "the cycle is preserved")
+	assert.NotSame(t, v, got, "the stamp is copy-on-write; a root that needs a stamp is replaced (issue #582)")
+	assert.Equal(t, callSite, got.source, "the root must be stamped")
+	assert.Equal(t, callSite, got.Cells[0].source, "the element must be stamped")
+	assert.Same(t, got, got.Cells[1], "the cycle is preserved in the copy")
+	assert.Nil(t, v.source, "the input was written to")
+	assert.Same(t, v, v.Cells[1], "the input's cycle is untouched")
 }
 
 // TestAcyclicRenderingIsUnchangedBelowAndAboveTheGuard pins the property the

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -945,6 +945,21 @@ func registrationFunValue(pkgName, fid string, funType LFunType, formals *LVal, 
 // A macro's sealed formal argument list is shared with env by reference; an
 // unsealed one is copied so environments never share mutable formals.  See
 // registrationFormals and issues #363, #379, #514.
+//
+// CONTRACT FOR A GO MACRO'S EXPANSION.  The value a Go macro returns must
+// consist of nodes the macro constructed and its arguments (which it may
+// splice in as they are, unevaluated).  It must not embed a lisp value it
+// looked up -- an unlocated runtime list reached through Get -- because,
+// unless a debugger is attached, macroCall locates a Go macro's expansion IN
+// PLACE (locateExpansionTree): every unlocated unsealed syntax node
+// reachable from it, other than the arguments and what is under them, gets
+// the macro call site as its source location, and a binding among them
+// would keep that location for the rest of the process (the issue #582
+// shape, closed for lisp macros and for a Go macro's arguments by the
+// copy-on-write stamp).  Values -- functions, maps, vectors, bytes, natives
+// -- are exempt: they are never written to.  The in-place locate is what
+// keeps a Go macro's expansion free of per-node copies; see the warning
+// above stampMacroExpansion (lisp/macro.go), "who pays".
 func (env *LEnv) AddMacros(external bool, macs ...LBuiltinDef) {
 	if len(macs) == 0 {
 		macs = DefaultMacros()
@@ -1449,6 +1464,21 @@ func (env *LEnv) macroCall(ctx context.Context, fun, args *LVal) *LVal {
 		return r
 	}
 
+	// A Go macro's expansion is fresh nodes and its arguments, by contract
+	// (LEnv.AddMacros), so its fresh nodes are located IN PLACE here,
+	// stopping at the arguments, and the copy-on-write stamp below shares
+	// them: the copies would otherwise cost two allocations per node on
+	// every expansion, on substrate's logging macros among others.  The
+	// arguments may be bindings (a runtime-built call form), so they are
+	// left to the stamp, which copies them.  Not under a debugger, whose
+	// expansion metadata is attached to the stamp's copies.  Not for a lisp
+	// macro, whose unlocated output may be a binding (issue #582) -- that
+	// is what the copy is for.  See the warning above stampMacroExpansion,
+	// "who pays".
+	if fun.Builtin() != nil && env.Runtime.Debugger == nil {
+		locateExpansionTree(r, callSite, args.Cells)
+	}
+
 	// NOTE:  There should be no need to check for LMarkTailRec objects because
 	// we block all tail-recursion for macro calls.
 
@@ -1472,14 +1502,12 @@ func (env *LEnv) macroCall(ctx context.Context, fun, args *LVal) *LVal {
 	}
 	r = stampMacroExpansion(r, callSite, mctx, env.Runtime)
 
-	// ORDER: stamp first, unquote second.  shallowUnquote also mints a
-	// private header, so stamping after it would let a VALUE root be stamped
-	// in place and save one allocation on that path -- but only by telling
-	// stampMacroExpansion "this root is yours to write", which is the kind of
-	// per-call-site ownership assertion the ownership rule above it exists to
-	// remove.  The saving applies solely to a root that is an unlocated value
-	// (a rare shape; most expansion roots are syntax), so the order stays as
-	// it is.
+	// The stamp is copy-on-write (see the warning above it): r is never
+	// written to, and the stamped tree it returns is what is evaluated.
+	// shallowUnquote below mints its own private header when the root is
+	// quoted, copying the stamp along with the rest of the struct, so the
+	// two are order-independent; stamp first so that the metadata is on the
+	// node that shallowUnquote copies from.
 	//
 	// This is a lazy unquote.  Unquoting in this way appears to allow the
 	// upcoming evaluation to produce the correct value for user defined

--- a/lisp/macro.go
+++ b/lisp/macro.go
@@ -248,42 +248,45 @@ func macroDeftype(env *LEnv, args *LVal) *LVal {
 	})
 }
 
-// stampMacroExpansion walks the expanded AST and replaces synthetic source
-// locations (Pos < 0) with the macro call site. Nodes with valid source
-// locations (from parser or unquote) are left unchanged.
+// stampMacroExpansion returns the expansion the caller must evaluate, with
+// every node that has no real source location (Pos < 0) stamped with the
+// macro call site.  Nodes with a real location (from the parser or from
+// unquote) keep it.
 //
 // When ctx is non-nil (debugger attached), each stamped node also gets a
 // macroExpansionInfo with a unique, monotonically-increasing ID. The
 // runtime's sequence counter is used to generate IDs.
 //
-// Singleton values (Nil(), Bool(true), Bool(false)) are skipped via
-// identity check — they are shared, immutable, pre-allocated values
-// and mutating one corrupts every reader of that singleton for the
-// remainder of the process lifetime. See issue #274.
+// THE STAMP NEVER WRITES TO THE VALUE IT IS HANDED.  It is copy-on-write: a
+// node that needs a stamp, or whose cells changed, is replaced by a private
+// copy in the returned tree; everything else is shared.  See the warning
+// below for why, and what it cost to learn.
+//
 // A macro is free to build its expansion with assoc! or append!, so the value
 // handed to stampMacroExpansion can contain itself, and an unguarded walk over
 // one overflows the goroutine stack and kills the process.  The walk is
 // bounded the same way rendering is; see lisp/cycle.go and issue #390.
 //
-// callSite is stored by POINTER on every node the walk claims, so the caller
+// callSite is stored by POINTER on every node the walk stamps, so the caller
 // must pass a Location the expansion may own -- not one a live parse tree also
 // holds.  macroCall takes env.loc.Copy() for exactly this reason; passing
 // env.loc itself put the caller's node and the whole expansion on one mutable
 // object (issue #431).
 //
 // ---------------------------------------------------------------------------
-// DANGER: THIS STAMP WRITES INTO STORAGE IT MAY NOT OWN.  READ BEFORE EDITING.
+// DANGER: THIS STAMP IS HANDED STORAGE IT DOES NOT OWN.  READ BEFORE EDITING.
 //
 // stampMacroExpansion is handed whatever the macro body returned, and it has
 // no way to tell fresh expansion output from storage that also belongs to
-// someone else.  The table below is the history of the shared storage this
-// stamp has written into; each was found in production or by fuzzing, not by
-// review.  Where each was FIXED varies -- three are guarded here, the other
-// two were closed at the site that handed the stamp the shared storage:
+// someone else.  For most of its life it wrote the call site IN PLACE, and
+// the table below is the history of the shared storage it wrote into; each
+// was found in production or by fuzzing, not by review.  Where each was
+// FIXED varies -- three were guarded here, two were closed at the site that
+// handed the stamp the shared storage, and the last two closed the class:
 //
 //	#274  (May 2026)  the singletons Nil/true/false: one write corrupted
 //	                  every reader for the rest of the process.  Guarded
-//	                  here: isSingleton, in stampGuarded.
+//	                  here: isSingleton.
 //	#396  (Aug 2026)  the form being expanded, aliased into the macro's
 //	                  &rest list.  NOT guarded here -- fixed upstream in
 //	                  macroArgList (lisp/builtins.go), which builds that
@@ -291,81 +294,265 @@ func macroDeftype(env *LEnv, args *LVal) *LVal {
 //	#370  (Aug 2026)  reader nodes emitted with synthetic locations.
 //	#517  (Aug 2026)  sealed parse-tree subtrees: a cross-environment write
 //	                  and a data race under concurrent environments.
-//	                  Both guarded here: the v.sealed check in stampGuarded.
+//	                  Both guarded here: the v.sealed check.
 //	#431  (Aug 2026)  the caller's env.loc, shared by pointer and then
 //	                  stored on every node the walk claimed.  NOT guarded
 //	                  here -- fixed at the call site, which passes
 //	                  env.loc.Copy() (LEnv.macroCall).  callSite is still
 //	                  stored BY POINTER, so the caller must keep passing a
 //	                  Location the expansion may own.
-//	(this fix)        VALUES yielded by the expansion -- a builtin reached
+//	(value fix)       VALUES yielded by the expansion -- a builtin reached
 //	                  through Get, a global sorted map -- are live bindings;
 //	                  stamping them in place moved lisp:car's definition
 //	                  site onto a macro call site for the rest of the
 //	                  process, and the profiler reported it as such.
+//	                  Closed by stamping a private header copy instead.
+//	#582  (Sep 2026)  unsealed SYNTAX that is itself a binding -- a global
+//	                  list built by (list ...) and returned by a LISP macro
+//	                  body, or a located list holding an unlocated value --
+//	                  is indistinguishable from expansion output.  The value
+//	                  fix still wrote into it, in place: its cells were
+//	                  overwritten with private copies of their values.
+//	                  Closed by making the whole stamp copy-on-write.
 //
-// This function's own exclusions are therefore three: isSingleton (#274),
-// sealed (#370/#517), and the nil-callSite early return.  The rule below
-// REPLACES adding more of them; it is not a fourth.
+// The rule, enforced by macroStamper and pinned by
+// TestMacroExpansionStampNeverWritesTheExpansion: THE STAMP WRITES ONLY TO
+// NODES IT ALLOCATED.  A node that needs a stamp, or whose cells changed, is
+// replaced in the returned tree by a private copy; a node that needs neither
+// is shared, as are sealed subtrees, singletons and located values.  The copy
+// shares everything behind a pointer (the *funData behind an LFun, the
+// *MapData behind an LSortMap, the []byte behind LBytes, an unchanged Cells
+// backing array); its own struct -- source, macroExpansion and, when a cell
+// changed, the cell slice -- is private.  Nothing is stamped in place, so
+// there is no identity exclusion left to add: if a new kind of shared
+// storage turns up, it is already not written to.
 //
-// The rule, enforced by stampGuarded and pinned by
-// TestMacroExpansionStampsValuesOnPrivateHeaders: the stamp writes IN PLACE
-// only to SYNTAX nodes (the node types the reader produces, sealableNodeType)
-// that are unsealed and not singletons.  A node of any other type is a
-// VALUE.  A value is never written to; it is replaced, in its expansion-owned
-// parent (or at the root, by the return value), with a private header copy
-// that carries the stamp and shares the value's storage.  If a new kind of
-// shared storage turns up, extend the ownership rule rather than adding
-// another identity exclusion.
+// The function's remaining guards are three, and all are about SHARING, not
+// about writing: isSingleton (#274) and sealed (#370/#517) share the node
+// outright instead of walking it, and the nil-callSite early return stamps
+// nothing.
+//
+// COST, AND WHO PAYS IT.  An expansion in which nothing needs a stamp is
+// returned as is, with no allocation
+// (TestMacroExpansionStampAllocatesNothingWhenNothingNeedsAStamp).  A node
+// that needs a stamp costs one header, plus a header and a cell slice for
+// each ancestor up to the root, which is the storage the in-place stamp
+// used to take from whoever owned the node.  A CYCLIC expansion
+// (constructible from Go only) additionally pays for the walk that
+// discovers the cycle before the memoised rerun.
+//
+// Only a LISP macro pays.  Its body builds its expansion with quasiquote,
+// whose output carries the template's locations, so the usual lisp
+// expansion needs no stamp at all; and an unlocated node it does return may
+// be a binding (#582), which is exactly what the copy is for.  A GO macro
+// synthesizes its expansion from fresh nodes, so the copies would cost it
+// two allocations per node on every expansion -- measured at +23% allocs/op
+// on a benchmark that expands libtesting's assert-equal in a loop, and the
+// same shape is substrate's cc:infof on every phylum log line.  So
+// LEnv.macroCall, not under a debugger, LOCATES A GO MACRO'S EXPANSION IN
+// PLACE before the stamp sees it (locateExpansionTree, below): every
+// unlocated unsealed syntax node it reaches gets the call site, stopping
+// at the macro's arguments, and the stamp then shares the fresh nodes (an
+// unlocated value or argument in the expansion, or a cycle, still costs
+// the copies the stamp's rules give).  That is the in-place write this
+// stamp gave up, confined to the one caller whose output is fresh BY
+// CONTRACT: a Go macro's expansion consists of nodes it constructed and
+// its arguments (see LEnv.AddMacros).  The arguments are the caller's
+// nodes and may be bindings -- a runtime-built call form hands the macro
+// raw bindings, through macroexpand-1 or a Go-side Eval -- which is why
+// the locate stops at them.  A Go macro that returned a binding it looked
+// up ITSELF, an unlocated runtime list from env.Get, would have that
+// binding located, the #582 shape; none in this repository or in
+// substrate does, and the contract is the rule against it.  Under a
+// debugger the hand-off is skipped and the stamp copies a Go macro's
+// expansion too, since the copy is where the expansion metadata the
+// debugger reads is attached.
 //
 // BEHAVIOUR CHANGE, confined to error-location attribution -- results are
-// unchanged.  A value a macro yields now keeps its OWN location instead of
+// unchanged.  A value a macro yields keeps its OWN location instead of
 // acquiring the macro call site.  Where that location was previously NONE the
 // stack note reads "unknown", so the nodes compose, flip and the `expr`
-// operator synthesize for the function they return are now located at their
+// operator synthesize for the function they return are located at their
 // construction site (setSynthesizedSource, lisp/lisp.go) rather than relying
-// on this stamp reaching inside a function value to locate its body.
-//
-// Known residual (issue #582): an UNSEALED syntax container that is itself a
-// binding -- a global list built at runtime by (list ...) and returned by a
-// macro body -- is indistinguishable from expansion output and is still
-// stamped in place, on every release since the stamp existed.
+// on this stamp reaching inside a function value to locate its body.  A
+// binding a macro body returns keeps its own (absent) location too; the
+// stamp lands on the copy the caller evaluates, so an error raised while
+// evaluating the expansion still reports the macro call site.
 // ---------------------------------------------------------------------------
-//
-// stampMacroExpansion returns the expansion the caller must evaluate: v
-// itself, or, when v is a value, its stamped private header copy.
 func stampMacroExpansion(v *LVal, callSite *token.Location, ctx *macroExpansionContext, rt *Runtime) *LVal {
 	if v == nil || callSite == nil {
 		return v
 	}
+	s := macroStamper{callSite: callSite, ctx: ctx, rt: rt}
+	if ctx != nil {
+		s.nextID, s.firstID = rt.macroExpSeq, rt.macroExpSeq
+	}
 	if isValueNode(v) {
-		return stampValueCopy(v, callSite, ctx, rt)
+		got := s.value(v)
+		s.commitIDs()
+		return got
 	}
 	var st cycleState
-	stampGuarded(v, callSite, ctx, rt, cycleGuard{state: &st})
+	got := s.syntax(v, cycleGuard{state: &st})
 	if st.cyclic {
 		// The walk above stopped as soon as it knew the expansion contains
-		// itself, leaving part of it unstamped.  Stamping is idempotent -- a
-		// node that already has a real source location is left alone -- so
-		// the rerun, which visits each node once, finishes the job.
-		stampGuarded(v, callSite, ctx, rt, strictCycleGuard())
+		// itself, and whatever it built on the way is discarded -- copies
+		// and expansion IDs alike, which is why the IDs are minted on the
+		// stamper and only committed below.  The rerun visits each node
+		// once and memoises its copies, so a back-edge lands on the copy
+		// and the returned tree contains itself exactly where the
+		// expansion did.
+		s.copies = make(map[*LVal]*LVal)
+		s.nextID = s.firstID
+		got = s.syntax(v, strictCycleGuard())
 	}
-	return v
+	s.commitIDs()
+	return got
+}
+
+// locateExpansionTree writes callSite, in place, onto every unlocated
+// unsealed syntax node reachable from v -- the expansion a Go macro has
+// just returned, which is fresh by contract (see the warning above
+// stampMacroExpansion, "who pays", and LEnv.AddMacros) -- stopping at the
+// macro's arguments.  stampMacroExpansion then finds the fresh nodes
+// located and shares them, so the usual Go macro expansion costs no
+// copies; an unlocated value in it, an unlocated argument, or a cycle
+// still costs the copies the stamp's own rules give.
+//
+// What is NOT written to, and why:
+//
+//   - The macro's ARGUMENTS (args), and everything under them.  They are the
+//     caller's nodes, never the macro's: sealed reader nodes when the call
+//     form was parsed, located copies when it came out of an enclosing
+//     lisp macro's stamp -- and raw bindings when it was built at runtime
+//     ((macroexpand-1 (list 'm l)), or a Go-side Eval of a runtime form).
+//     That last one is the #582 shape arriving through an argument; the
+//     walk stops at the argument and the stamp copies it, exactly as it
+//     copies a binding a lisp macro returns.  The boundary is only built
+//     when some argument is unsealed and unlocated, so a parsed call form
+//     pays nothing for it.
+//   - VALUES: a value in a Go macro's expansion is a binding it spliced in;
+//     the stamp copies its header.
+//   - Sealed subtrees and singletons, for the reasons the stamp's own walk
+//     gives.  A node that already carries a real location keeps it.
+//
+// The walk is bounded like the stamp's (lisp/cycle.go): a Go macro can
+// return a tree that contains itself.  A node is located BEFORE its cells
+// are walked, and locating is idempotent, so the strict rerun over a cyclic
+// tree finishes what the abandoned walk started.
+func locateExpansionTree(v *LVal, callSite *token.Location, args []*LVal) {
+	if v == nil || callSite == nil || isValueNode(v) {
+		return
+	}
+	var boundary map[*LVal]struct{}
+	for _, a := range args {
+		if a == nil || a.sealed || isSingleton(a) || isValueNode(a) || !needsStamp(a) {
+			continue
+		}
+		if boundary == nil {
+			boundary = make(map[*LVal]struct{}, len(args))
+		}
+		boundary[a] = struct{}{}
+	}
+	var st cycleState
+	locateGuarded(v, callSite, boundary, cycleGuard{state: &st})
+	if st.cyclic {
+		locateGuarded(v, callSite, boundary, strictCycleGuard())
+	}
+}
+
+func locateGuarded(v *LVal, callSite *token.Location, boundary map[*LVal]struct{}, g cycleGuard) {
+	if v == nil || isSingleton(v) || v.sealed || isValueNode(v) {
+		return
+	}
+	if _, isArg := boundary[v]; isArg {
+		return
+	}
+	nested := len(v.Cells) > 0
+	if nested {
+		if g.abandoned() {
+			return
+		}
+		var cyclic bool
+		g, cyclic = g.descend(v)
+		if cyclic {
+			return
+		}
+	}
+	if needsStamp(v) {
+		v.source = callSite //elps:mutates locates a Go macro's fresh expansion node (fresh by contract, see LEnv.AddMacros); arguments, sealed and value nodes are skipped above
+	}
+	for _, c := range v.Cells {
+		locateGuarded(c, callSite, boundary, g)
+	}
+	if nested && g.tracking() {
+		g.ascend(v)
+	}
 }
 
 // isValueNode reports whether v is a runtime VALUE rather than SYNTAX: a
 // node of a type the reader never produces (a function, a native handle, a
 // sorted map, a vector, bytes).  Such a node inside a macro expansion is a
 // binding the macro body evaluated to or spliced in, not the expansion's
-// own output, so the stamp must not write to it.  See the warning above
-// stampMacroExpansion.
+// own output.  See the warning above stampMacroExpansion.
 func isValueNode(v *LVal) bool {
 	return !sealableNodeType(v.Type)
 }
 
-// stampValueCopy returns the node to put in a value's place in an
-// expansion: v itself when it already carries a real location, otherwise a
-// private header copy of v carrying the stamp.
+// needsStamp reports whether v carries no real source location.
+func needsStamp(v *LVal) bool {
+	return v.source == nil || v.source.Pos < 0
+}
+
+// macroStamper carries one stamp's parameters down the copy-on-write walk.
+type macroStamper struct {
+	callSite *token.Location
+	ctx      *macroExpansionContext
+	rt       *Runtime
+	// copies memoises the strict rerun over a cyclic expansion: a nested
+	// node maps to its copy BEFORE its cells are walked, so the walk's
+	// second arrival at it -- through the cycle -- lands on the copy.  It
+	// is nil on the ordinary walk, which never revisits a node.
+	copies map[*LVal]*LVal
+	// nextID is the expansion-ID counter for the walk in progress, seeded
+	// from and committed back to Runtime.macroExpSeq (commitIDs) only for
+	// the walk whose result is kept.  An abandoned walk over a cyclic
+	// expansion mints IDs for copies it throws away; minting them here
+	// rather than on the Runtime keeps the kept walk's IDs contiguous and
+	// in pre-order, as the in-place stamp assigned them.  firstID is the
+	// seed, so an abandoned walk can be rewound and a walk that minted
+	// nothing can leave the Runtime untouched.
+	nextID, firstID int64
+}
+
+// commitIDs publishes the IDs the kept walk minted to the Runtime.  A walk
+// that minted none -- a singleton or a fully located expansion -- writes
+// nothing: the stamp is documented as a no-op on those, and the singleton
+// race test exercises it from many goroutines on one Runtime.
+func (s *macroStamper) commitIDs() {
+	if s.ctx != nil && s.nextID != s.firstID {
+		s.rt.macroExpSeq = s.nextID
+	}
+}
+
+// stampedCopy returns a private header copy of v carrying the call site
+// and, under a debugger, the expansion metadata.  v is never written to.
+func (s *macroStamper) stampedCopy(v *LVal) *LVal {
+	cp := *v
+	cp.source = s.callSite //elps:aliases by design: callSite is the expansion-owned copy macroCall took (env.loc.Copy(), issue #431), shared by every node of one expansion
+	if s.ctx != nil {
+		s.nextID++
+		cp.macroExpansion = &macroExpansionInfo{
+			macroExpansionContext: s.ctx,
+			ID:                    s.nextID,
+		}
+	}
+	return &cp
+}
+
+// value returns the node to put in a value's place in an expansion: v itself
+// when it already carries a real location, otherwise a private header copy
+// of v carrying the stamp.
 //
 // WHAT THE COPY SHARES AND WHAT IT PRIVATIZES, precisely.  Everything
 // reached through a POINTER is shared -- the *funData behind an LFun, the
@@ -393,96 +580,132 @@ func isValueNode(v *LVal) bool {
 // the macro body reached through an UNQUALIFIED symbol arrived here as a
 // copy already and the stamp's write landed harmlessly on it.  A QUALIFIED
 // symbol -- lisp:car -- resolves through pkg.Get instead and returns the raw
-// binding, which is why the bug above exists at all.  Here the copy is
+// binding, which is why the value bug existed at all.  Here the copy is
 // deliberate, unconditional, and extended to every value type.
-func stampValueCopy(v *LVal, callSite *token.Location, ctx *macroExpansionContext, rt *Runtime) *LVal {
-	if v.source != nil && v.source.Pos >= 0 {
+func (s *macroStamper) value(v *LVal) *LVal {
+	if !needsStamp(v) {
 		return v
 	}
-	cp := *v
-	cp.source = callSite
-	if ctx != nil {
-		cp.macroExpansion = &macroExpansionInfo{
-			macroExpansionContext: ctx,
-			ID:                    rt.nextMacroExpID(),
-		}
-	}
-	return &cp
+	return s.stampedCopy(v)
 }
 
-func stampGuarded(v *LVal, callSite *token.Location, ctx *macroExpansionContext, rt *Runtime, g cycleGuard) {
-	if v == nil || callSite == nil {
-		return
+// syntax returns the stamped counterpart of the syntax node v: v itself when
+// neither v nor anything under it needs a stamp, otherwise a private copy of
+// v -- its own header and, when any cell changed, its own cell slice --
+// carrying the stamp and pointing at the stamped counterparts of v's cells.
+// It never writes to v or to anything reachable from v.
+func (s *macroStamper) syntax(v *LVal, g cycleGuard) *LVal {
+	if v == nil {
+		return nil
 	}
 	// Identity-based guard: a type-based check would catch only the empty-
 	// LSExpr singletonNil and miss singletonTrue/singletonFalse (which are
 	// LSymbol with Source.Pos == -1). See issue #274.
 	if isSingleton(v) {
-		return
+		return v
 	}
 	// Sealed subtrees are parsed program nodes spliced into the expansion
 	// (macros receive their arguments unevaluated, so argument expressions
-	// arrive as shared parse-tree nodes).  They must not be stamped: the
+	// arrive as shared parse-tree nodes).  They are shared, not copied: the
 	// same node may be under evaluation in every environment sharing the
-	// parse, so the write below would be cross-environment visible — and a
-	// data race under concurrent environments.  Most parser nodes carry a
-	// real location (Pos >= 0) and were never stamped, but the parser CAN
-	// emit synthetic Pos < 0 locations (a funref's lisp:function head
-	// symbol, a #^ head symbol mirroring a location-less operand), so
-	// without this guard the stamp is reachable on shared storage.  A
-	// sealed node's descendants are all sealed; skip the whole subtree.
-	//
-	// Checked before the cycle guard descends: a sealed subtree is skipped
-	// whole, so there is nothing below it to bound.
+	// parse, its location is the real one, and a sealed node's descendants
+	// are all sealed, so there is nothing below it to stamp.  Most parser
+	// nodes carry a real location (Pos >= 0), but the parser CAN emit
+	// synthetic Pos < 0 locations (a funref's lisp:function head symbol, a
+	// #^ head symbol mirroring a location-less operand), so without this
+	// guard such a node would be replaced by a stamped copy -- harmless
+	// now, but a pointless allocation on a shared tree.
 	if v.sealed {
-		return
+		return v
 	}
 	// Values never reach this walk: the root is diverted by
 	// stampMacroExpansion and children by the loop below.  Keep the guard
 	// anyway -- it is the ownership rule's last line of defence.
 	if isValueNode(v) {
-		return
+		return s.value(v)
 	}
-	// Only a node with children is entered on the guard's path: a leaf stamps
-	// itself and reaches nothing, and stamping runs on every macro expansion.
-	nested := len(v.Cells) > 0
-	if nested {
-		if g.abandoned() {
-			return
+	if len(v.Cells) == 0 {
+		// A leaf stamps itself and reaches nothing.
+		if !needsStamp(v) {
+			return v
 		}
-		var cyclic bool
-		g, cyclic = g.descend(v)
-		if cyclic {
-			return
-		}
+		return s.stampedCopy(v)
 	}
-	if v.source == nil || v.source.Pos < 0 {
-		v.source = callSite //elps:mutates debug-metadata stamp on macro-expansion output; sealed (shared) subtrees are skipped above
-		if ctx != nil {
-			//elps:mutates debug-metadata stamp on macro-expansion output; sealed (shared) subtrees are skipped above
-			v.macroExpansion = &macroExpansionInfo{
-				macroExpansionContext: ctx,
-				ID:                    rt.nextMacroExpID(),
-			}
+	// Only a node with children is entered on the guard's path: a leaf
+	// reaches nothing, and stamping runs on every macro expansion.
+	if g.abandoned() {
+		return v
+	}
+	if s.copies != nil {
+		if cp, ok := s.copies[v]; ok {
+			return cp
 		}
 	}
-	for i, child := range v.Cells {
-		if child == nil {
+	var cyclic bool
+	g, cyclic = g.descend(v)
+	if cyclic {
+		return v
+	}
+	var (
+		cp    *LVal
+		cells []*LVal
+	)
+	if needsStamp(v) {
+		// Stamped BEFORE the cells are walked, so expansion IDs are
+		// assigned in pre-order -- a parent before its children -- exactly
+		// as the in-place stamp assigned them.
+		cp = s.stampedCopy(v)
+	}
+	if s.copies != nil {
+		// The strict rerun over a cyclic expansion: copy unconditionally,
+		// and memo the copy before descending so a back-edge lands on it.
+		// The cell slice is filled below; the copy holds it from the start
+		// so the cycle closes onto the finished storage.
+		if cp == nil {
+			cp = new(LVal)
+			*cp = *v
+		}
+		cells = make([]*LVal, len(v.Cells))
+		cp.Cells = cells
+		s.copies[v] = cp
+	}
+	for i, c := range v.Cells {
+		var sc *LVal
+		switch {
+		case c == nil:
+		case isValueNode(c):
+			sc = s.value(c)
+		default:
+			sc = s.syntax(c, g)
+		}
+		if cells != nil {
+			cells[i] = sc
 			continue
 		}
-		if isValueNode(child) {
-			// v is expansion-owned unsealed syntax, so its cells are the
-			// expansion's to rewrite; the value itself is not.
-			if sc := stampValueCopy(child, callSite, ctx, rt); sc != child {
-				v.Cells[i] = sc //elps:mutates debug-metadata stamp on macro-expansion output: replaces a spliced value with its stamped private header copy; the value is never written
-			}
-			continue
+		if sc != c {
+			// The first cell to change: from here on the copy has its own
+			// cell slice, seeded with the unchanged cells before it.  v's
+			// backing array is never written.
+			cells = make([]*LVal, len(v.Cells))
+			copy(cells, v.Cells[:i])
+			cells[i] = sc
 		}
-		stampGuarded(child, callSite, ctx, rt, g)
 	}
-	if nested && g.tracking() {
+	if g.tracking() {
 		g.ascend(v)
 	}
+	if cp == nil {
+		if cells == nil {
+			// Nothing under v changed and v itself is located: shared.
+			return v
+		}
+		cp = new(LVal)
+		*cp = *v
+	}
+	if cells != nil {
+		cp.Cells = cells
+	}
+	return cp
 }
 
 type unquoteType int

--- a/lisp/macro_expansion_test.go
+++ b/lisp/macro_expansion_test.go
@@ -19,15 +19,19 @@ func TestStampMacroExpansion_NoContext(t *testing.T) {
 	expr := SExpr([]*LVal{inner, Int(1), Int(2)})
 	expr.source = nil
 
-	stampMacroExpansion(expr, callSite, nil, rt)
+	got := stampMacroExpansion(expr, callSite, nil, rt)
 
-	// Source should be stamped.
-	assert.Equal(t, callSite, expr.source)
-	assert.Equal(t, callSite, inner.source)
+	// The stamp is copy-on-write (issue #582): the returned tree is
+	// stamped, the input is untouched.
+	require.NotSame(t, expr, got)
+	assert.Equal(t, callSite, got.source)
+	assert.Equal(t, callSite, got.Cells[0].source)
+	assert.Nil(t, expr.source)
+	assert.Nil(t, inner.source)
 
 	// MacroExpansion should remain nil.
-	assert.Nil(t, expr.macroExpansion)
-	assert.Nil(t, inner.macroExpansion)
+	assert.Nil(t, got.macroExpansion)
+	assert.Nil(t, got.Cells[0].macroExpansion)
 }
 
 func TestStampMacroExpansion_WithContext(t *testing.T) {
@@ -50,7 +54,15 @@ func TestStampMacroExpansion_WithContext(t *testing.T) {
 	expr := SExpr([]*LVal{inner, arg1, arg2})
 	expr.source = nil
 
-	stampMacroExpansion(expr, callSite, ctx, rt)
+	got := stampMacroExpansion(expr, callSite, ctx, rt)
+
+	// Copy-on-write (issue #582): the metadata lands on the returned tree
+	// and the input is untouched.
+	for _, orig := range []*LVal{expr, inner, arg1, arg2} {
+		assert.Nil(t, orig.macroExpansion, "the input was written to")
+		assert.Nil(t, orig.source, "the input was written to")
+	}
+	expr, inner, arg1, arg2 = got, got.Cells[0], got.Cells[1], got.Cells[2]
 
 	// All nodes should have MacroExpansion set.
 	require.NotNil(t, expr.macroExpansion)
@@ -95,16 +107,23 @@ func TestStampMacroExpansion_PreservesRealSource(t *testing.T) {
 	expr := SExpr([]*LVal{synth, node})
 	expr.source = nil
 
-	stampMacroExpansion(expr, callSite, ctx, rt)
+	got := stampMacroExpansion(expr, callSite, ctx, rt)
 
-	// Real source node should keep its source and have NO MacroExpansion.
+	// Real source node is shared, keeps its source and has NO
+	// MacroExpansion.
+	assert.Same(t, node, got.Cells[1])
 	assert.Equal(t, realSource, node.source)
 	assert.Nil(t, node.macroExpansion)
 
-	// Synthetic nodes should be stamped.
-	assert.Equal(t, callSite, synth.source)
-	require.NotNil(t, synth.macroExpansion)
-	assert.Equal(t, "lisp:defun", synth.macroExpansion.Name)
+	// Synthetic nodes are stamped on the copy; the input is untouched
+	// (issue #582).
+	stamped := got.Cells[0]
+	require.NotSame(t, synth, stamped)
+	assert.Equal(t, callSite, stamped.source)
+	require.NotNil(t, stamped.macroExpansion)
+	assert.Equal(t, "lisp:defun", stamped.macroExpansion.Name)
+	assert.Nil(t, synth.source)
+	assert.Nil(t, synth.macroExpansion)
 }
 
 func TestStampMacroExpansion_SkipsSingletonNil(t *testing.T) {
@@ -202,7 +221,7 @@ func TestMacroExpansionAccessor(t *testing.T) {
 	ctx := &macroExpansionContext{CallSite: callSite, Name: "lisp:defun", Args: args}
 	expr := SExpr([]*LVal{Symbol("+")})
 	expr.source = nil
-	stampMacroExpansion(expr, callSite, ctx, rt)
+	expr = stampMacroExpansion(expr, callSite, ctx, rt)
 
 	m, ok := expr.MacroExpansion()
 	require.True(t, ok)

--- a/lisp/macro_stamp_binding_test.go
+++ b/lisp/macro_stamp_binding_test.go
@@ -1,0 +1,67 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// TestMacroReturningARuntimeListBindingLeavesItUnlocated is the ELPS-level
+// shape of issue #582.  A global list built by (list ...) is unsealed
+// syntax with no location; a macro whose body returns it hands the stamp a
+// binding.  The stamp used to write the macro call site onto the binding
+// and its cells, for the rest of the process.
+func TestMacroReturningARuntimeListBindingLeavesItUnlocated(t *testing.T) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); rc.Type == lisp.LError {
+		t.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		t.Fatalf("in-package: %v", rc)
+	}
+	// Only the list header is unlocated: (list 1 2) builds a fresh SExpr
+	// over the reader's own (sealed, located) literal nodes.
+	if rc := env.LoadString("binding.lisp", "(set 'l (list 1 2))\n(defmacro m () l)\n"); rc.Type == lisp.LError {
+		t.Fatalf("fixture: %v", rc)
+	}
+	l := env.Runtime.Package.Get(lisp.Symbol("l"))
+	if lisp.SourceRefForTest(l) != nil {
+		t.Fatalf("fixture: the runtime list is located before the expansion: %v", lisp.SourceRefForTest(l))
+	}
+	cellSources := make([]*token.Location, len(l.Cells))
+	for i, c := range l.Cells {
+		cellSources[i] = lisp.SourceRefForTest(c)
+	}
+
+	// (1 2) is not callable, so the expansion errors -- after the stamp
+	// has run over it, which is all this test needs.
+	rc := env.LoadString("call.lisp", "\n\n(m)\n")
+	if rc.Type != lisp.LError {
+		t.Fatalf("expected (m) to fail evaluating (1 2), got %v", rc)
+	}
+	if got := lisp.SourceRefForTest(l); got != nil {
+		t.Errorf("the binding acquired a location from the macro expansion (issue #582): %v", got)
+	}
+	for i, c := range l.Cells {
+		if got := lisp.SourceRefForTest(c); got != cellSources[i] {
+			t.Errorf("cell %d of the binding changed location: %v -> %v", i, cellSources[i], got)
+		}
+	}
+
+	// The stamp still does its job on the tree that IS evaluated: an
+	// unlocated head built at runtime -- (gensym) yields a symbol with no
+	// location -- is stamped on the copy, so the unbound-symbol error
+	// reports the macro CALL site, not <native code>.
+	rc = env.LoadString("broken.lisp", "(defmacro broken () (list (gensym) 1))\n\n(broken)\n")
+	if rc.Type != lisp.LError {
+		t.Fatalf("expected an error from the broken expansion, got %v", rc)
+	}
+	if loc, ok := rc.Source(); !ok || loc.File != "broken.lisp" || loc.Line != 3 {
+		t.Errorf("error from an expansion built with (list ...) is located at %v (ok=%v), want broken.lisp:3\n%v", loc, ok, rc)
+	}
+}

--- a/lisp/macro_stamp_cow_test.go
+++ b/lisp/macro_stamp_cow_test.go
@@ -1,0 +1,183 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// TestMacroExpansionStampNeverWritesTheExpansion pins the copy-on-write
+// contract of stampMacroExpansion (issue #582): the value a macro body
+// returns is never written to.  A node that needs a stamp, or whose cells
+// changed, is replaced in the RETURNED tree by a private copy; everything
+// else -- located syntax, sealed subtrees, located values -- is shared.
+//
+// The shapes are the ones the in-place stamp got wrong.  A runtime list that
+// is itself a binding, `(set 'l (list 1 2))` returned by a macro, acquired
+// the macro call site as its location.  A LOCATED unsealed list holding an
+// unlocated value had that cell overwritten with the value's private header
+// copy, so a later `append!` through the binding and through the expansion
+// could diverge.
+func TestMacroExpansionStampNeverWritesTheExpansion(t *testing.T) {
+	env := initSafetyTestEnv(t)
+	callSite := &token.Location{File: "stamp.lisp", Line: 5, Col: 1}
+	realLoc := &token.Location{File: "real.lisp", Line: 1, Col: 1, Pos: 10}
+	unlocatedFun := func() *LVal {
+		fn := env.Lambda(Formals("x"), []*LVal{Symbol("x")})
+		fn.SetSource(nil)
+		return fn
+	}
+
+	t.Run("unlocated list root", func(t *testing.T) {
+		head, arg := Symbol("+"), Int(1)
+		v := SExpr([]*LVal{head, arg})
+		got := stampMacroExpansion(v, callSite, nil, env.Runtime)
+		if got == v {
+			t.Fatalf("a root that needs a stamp was returned as itself")
+		}
+		if got.source != callSite || got.Cells[0].source != callSite || got.Cells[1].source != callSite {
+			t.Errorf("the returned tree is not stamped throughout")
+		}
+		if got.Cells[0] == head || got.Cells[1] == arg {
+			t.Errorf("an unlocated cell was shared instead of copied")
+		}
+		if &got.Cells[0] == &v.Cells[0] {
+			t.Errorf("the copy shares the input's cell slice, so a cell write would land in the input")
+		}
+		if v.source != nil || head.source != nil || arg.source != nil || v.Cells[0] != head || v.Cells[1] != arg {
+			t.Errorf("the input was written to")
+		}
+	})
+
+	t.Run("located list with an unlocated value cell", func(t *testing.T) {
+		fn := unlocatedFun()
+		head := Symbol("call")
+		head.SetSource(realLoc)
+		v := SExpr([]*LVal{head, fn})
+		v.SetSource(realLoc)
+		got := stampMacroExpansion(v, callSite, nil, env.Runtime)
+		if got == v {
+			t.Fatalf("a root whose cell changed was returned as itself")
+		}
+		if got.source != realLoc {
+			t.Errorf("a located root lost its location on the copy: %v", got.source)
+		}
+		if got.Cells[0] != head {
+			t.Errorf("a located cell was copied needlessly")
+		}
+		if got.Cells[1] == fn || got.Cells[1].source != callSite || got.Cells[1].Native != fn.Native {
+			t.Errorf("the value cell is not a stamped private header of the same function")
+		}
+		if v.Cells[1] != fn || fn.source != nil {
+			t.Errorf("the input's value cell was written to (issue #582)")
+		}
+	})
+
+	t.Run("unlocated list nested in a located binding", func(t *testing.T) {
+		inner := SExpr([]*LVal{Symbol("inner")})
+		head := Symbol("outer")
+		head.SetSource(realLoc)
+		v := SExpr([]*LVal{head, inner})
+		v.SetSource(realLoc)
+		got := stampMacroExpansion(v, callSite, nil, env.Runtime)
+		if got == v || got.Cells[1] == inner {
+			t.Fatalf("the nested unlocated list was not replaced on the copy")
+		}
+		if got.Cells[1].source != callSite || got.Cells[1].Cells[0].source != callSite {
+			t.Errorf("the nested copy is not stamped")
+		}
+		if v.Cells[1] != inner || inner.source != nil || inner.Cells[0].source != nil {
+			t.Errorf("the input's nested list was written to (issue #582)")
+		}
+	})
+
+	t.Run("sealed subtree and located cells are shared", func(t *testing.T) {
+		sealed := SExpr([]*LVal{Symbol("sealed"), Int(2)})
+		sealed.SealAST()
+		located := Symbol("located")
+		located.SetSource(realLoc)
+		v := SExpr([]*LVal{Symbol("head"), sealed, located})
+		got := stampMacroExpansion(v, callSite, nil, env.Runtime)
+		if got == v {
+			t.Fatalf("a root that needs a stamp was returned as itself")
+		}
+		if got.Cells[1] != sealed || got.Cells[2] != located {
+			t.Errorf("a sealed subtree or a located cell was copied instead of shared")
+		}
+		if _, ok := sealed.Source(); ok {
+			t.Errorf("the sealed subtree was stamped")
+		}
+	})
+
+	t.Run("debugger metadata lands on the copy only", func(t *testing.T) {
+		ctx := &macroExpansionContext{CallSite: callSite, Name: "m"}
+		v := SExpr([]*LVal{Symbol("+"), Int(1)})
+		got := stampMacroExpansion(v, callSite, ctx, env.Runtime)
+		if got.macroExpansion == nil || got.Cells[0].macroExpansion == nil {
+			t.Errorf("the copy did not get macro-expansion metadata")
+		}
+		if v.macroExpansion != nil || v.Cells[0].macroExpansion != nil {
+			t.Errorf("the input got macro-expansion metadata")
+		}
+	})
+}
+
+// TestMacroExpansionStampAllocatesNothingWhenNothingNeedsAStamp pins the
+// cost of the copy-on-write stamp on the usual expansion shape: quasiquote
+// output, whose every node carries its template's location.  Nothing needs a
+// stamp, so the expansion is returned as is and the walk allocates nothing.
+func TestMacroExpansionStampAllocatesNothingWhenNothingNeedsAStamp(t *testing.T) {
+	env := initSafetyTestEnv(t)
+	callSite := &token.Location{File: "stamp.lisp", Line: 5, Col: 1}
+	realLoc := &token.Location{File: "real.lisp", Line: 1, Col: 1, Pos: 10}
+	locate := func(v *LVal) *LVal { v.SetSource(realLoc); return v }
+	sealed := SExpr([]*LVal{Symbol("arg"), Int(2)})
+	sealed.SealAST()
+	fn := env.Lambda(Formals("x"), []*LVal{Symbol("x")})
+	fn.SetSource(realLoc)
+	v := locate(SExpr([]*LVal{
+		locate(Symbol("progn")),
+		locate(SExpr([]*LVal{locate(Symbol("f")), sealed, fn})),
+		locate(Int(3)),
+	}))
+
+	if got := stampMacroExpansion(v, callSite, nil, env.Runtime); got != v {
+		t.Fatalf("an expansion with nothing to stamp was copied")
+	}
+	if allocs := testing.AllocsPerRun(100, func() {
+		stampMacroExpansion(v, callSite, nil, env.Runtime)
+	}); allocs != 0 {
+		t.Errorf("stamping an expansion with nothing to stamp allocated %v times per run, want 0", allocs)
+	}
+}
+
+// TestMacroExpansionStampMintsExpansionIDsOnlyForTheKeptWalk pins that a
+// cyclic expansion consumes exactly as many expansion IDs as it has stamped
+// nodes.  The walk that discovers the cycle is abandoned along with the
+// copies it built; the IDs it minted go with it, so the rerun's IDs are
+// contiguous and in pre-order, as they were when the stamp wrote in place.
+func TestMacroExpansionStampMintsExpansionIDsOnlyForTheKeptWalk(t *testing.T) {
+	env := initSafetyTestEnv(t)
+	callSite := &token.Location{File: "stamp.lisp", Line: 5, Col: 1}
+	ctx := &macroExpansionContext{CallSite: callSite, Name: "m"}
+	v := SExpr([]*LVal{Symbol("x")})
+	v.Cells = append(v.Cells, v) // (x . <self>)
+
+	before := env.Runtime.macroExpSeq
+	got := stampMacroExpansion(v, callSite, ctx, env.Runtime)
+	if got == v || got.Cells[1] != got {
+		t.Fatalf("the copy does not contain itself where the expansion did")
+	}
+	if got.macroExpansion == nil || got.Cells[0].macroExpansion == nil {
+		t.Fatalf("the copy is missing expansion metadata")
+	}
+	root, child := got.macroExpansion.ID, got.Cells[0].macroExpansion.ID
+	if root != before+1 || child != before+2 {
+		t.Errorf("expansion IDs root=%d child=%d, want %d and %d (pre-order, contiguous)", root, child, before+1, before+2)
+	}
+	if env.Runtime.macroExpSeq != before+2 {
+		t.Errorf("the runtime consumed %d IDs for a two-node cycle, want 2", env.Runtime.macroExpSeq-before)
+	}
+}

--- a/lisp/macro_stamp_fun_test.go
+++ b/lisp/macro_stamp_fun_test.go
@@ -65,8 +65,9 @@ func TestMacroExpansionDoesNotStampFunctionValues(t *testing.T) {
 // stamped header copy; placed inside an expansion-owned list it is replaced
 // in that list by one.  In both cases the original keeps a nil source and no
 // macro-expansion metadata, and the copy shares the value's storage.  SYNTAX
-// nodes with no location (the reader's types) keep being stamped in place,
-// which is the stamp's job.
+// nodes with no location (the reader's types) are likewise replaced by
+// stamped copies in the returned tree (issue #582); the stamp writes to
+// nothing it was handed.
 //
 // COVERAGE, stated exactly rather than as "every value type": the fixtures
 // below are the value types a macro body can actually hand back -- LFun,
@@ -124,17 +125,20 @@ func TestMacroExpansionStampsValuesOnPrivateHeaders(t *testing.T) {
 		t.Run(name+"/child", func(t *testing.T) {
 			expansion := SExpr([]*LVal{Symbol("identity"), v})
 			got := stampMacroExpansion(expansion, callSite, nil, env.Runtime)
-			if got != expansion {
-				t.Fatalf("a syntax root must be stamped in place, not replaced")
+			if got == expansion {
+				t.Fatalf("a syntax root that needs a stamp must be replaced by a stamped copy, not written (issue #582)")
 			}
-			if expansion.source != callSite || expansion.Cells[0].source != callSite {
-				t.Errorf("syntax nodes were not stamped in place")
+			if got.source != callSite || got.Cells[0].source != callSite {
+				t.Errorf("syntax nodes of the returned tree were not stamped")
 			}
-			if expansion.Cells[1] == v {
+			if expansion.source != nil || expansion.Cells[0].source != nil || expansion.Cells[1] != v {
+				t.Errorf("the input expansion was written to")
+			}
+			if got.Cells[1] == v {
 				t.Fatalf("the value was left in the expansion instead of a private copy")
 			}
-			if expansion.Cells[1].source != callSite {
-				t.Errorf("the copy in the expansion is not stamped: %v", expansion.Cells[1].source)
+			if got.Cells[1].source != callSite {
+				t.Errorf("the copy in the expansion is not stamped: %v", got.Cells[1].source)
 			}
 			if v.source != nil || v.macroExpansion != nil {
 				t.Errorf("the value itself was written to: source %v, macroExpansion %v", v.source, v.macroExpansion)

--- a/lisp/macro_stamp_gomacro_test.go
+++ b/lisp/macro_stamp_gomacro_test.go
@@ -1,0 +1,171 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+)
+
+// goMacroDef is a Go macro registered for the tests below.  Its expansion
+// is captured on the way out so the test can inspect the very nodes the
+// macro constructed.
+type goMacroDef struct {
+	name    string
+	formals *lisp.LVal
+	fun     lisp.LBuiltin
+}
+
+func (d *goMacroDef) Name() string                                    { return d.name }
+func (d *goMacroDef) Formals() *lisp.LVal                             { return d.formals }
+func (d *goMacroDef) Eval(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal { return d.fun(env, args) }
+
+func newGoMacroEnv(t *testing.T) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); rc.Type == lisp.LError {
+		t.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		t.Fatalf("in-package: %v", rc)
+	}
+	return env
+}
+
+// TestGoMacroExpansionIsLocatedInPlace pins the "who pays" half of the
+// copy-on-write stamp (see the warning above stampMacroExpansion): a Go
+// macro's expansion is fresh nodes and its arguments, by contract, so
+// macroCall locates it IN PLACE and the stamp shares it instead of copying
+// two allocations per node on every expansion -- the cost that regressed
+// libjson's get-nested-baseline benchmark by 23% allocs/op on the first
+// draft, and that substrate's logging macros would pay on every log line.
+//
+// Under a debugger the hand-off is skipped: the stamp copies the expansion
+// and attaches the expansion metadata to the copies, and the macro's own
+// nodes stay unlocated.
+func TestGoMacroExpansionIsLocatedInPlace(t *testing.T) {
+	run := func(t *testing.T, debugger lisp.Debugger) (fresh []*lisp.LVal, arg *lisp.LVal, result *lisp.LVal) {
+		env := newGoMacroEnv(t)
+		env.Runtime.Debugger = debugger
+		// (m X) expands to (lisp:+ X (lisp:* 2 3)): four fresh nodes and
+		// two fresh leaves around the caller's argument.
+		def := &goMacroDef{name: "m", formals: lisp.Formals("x"), fun: func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+			arg = args.Cells[0]
+			plus, times := lisp.Symbol("lisp:+"), lisp.Symbol("lisp:*")
+			two, three := lisp.Int(2), lisp.Int(3)
+			inner := lisp.SExpr([]*lisp.LVal{times, two, three})
+			outer := lisp.SExpr([]*lisp.LVal{plus, arg, inner})
+			fresh = []*lisp.LVal{outer, plus, inner, times, two, three}
+			return outer
+		}}
+		env.AddMacros(true, def)
+		result = env.LoadString("go-macro.lisp", "(m 10)")
+		return fresh, arg, result
+	}
+
+	t.Run("no debugger: fresh nodes located in place, the argument untouched", func(t *testing.T) {
+		fresh, arg, result := run(t, nil)
+		if result.Type != lisp.LInt || result.Int != 16 {
+			t.Fatalf("(m 10) = %v, want 16", result)
+		}
+		for i, n := range fresh {
+			loc, ok := n.Source()
+			if !ok {
+				t.Errorf("fresh node %d (%v) was not located", i, n)
+				continue
+			}
+			if loc.File != "go-macro.lisp" || loc.Line != 1 || loc.Col != 1 {
+				t.Errorf("fresh node %d (%v) located at %s:%d:%d, want the macro call site go-macro.lisp:1:1", i, n, loc.File, loc.Line, loc.Col)
+			}
+		}
+		// The argument is the reader's own node: sealed, located at its
+		// real position, and shared with the expansion as it is.
+		loc, ok := arg.Source()
+		if !ok || loc.Col != 4 {
+			t.Errorf("the argument's location was rewritten: %v", loc)
+		}
+	})
+
+	t.Run("an unlocated runtime argument is a binding and is not located", func(t *testing.T) {
+		// The call form is built at runtime, so the argument the macro
+		// splices in is the raw binding l, not a sealed reader node.  That
+		// is the #582 shape reaching a Go macro through its ARGUMENT --
+		// from lisp via macroexpand-1, from Go via Eval of a runtime form
+		// -- and the in-place locate must stop at it: the stamp copies it
+		// instead, as it does for a binding a lisp macro returns.
+		env := newGoMacroEnv(t)
+		var fresh []*lisp.LVal
+		def := &goMacroDef{name: "m", formals: lisp.Formals("x"), fun: func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+			plus := lisp.Symbol("lisp:+")
+			outer := lisp.SExpr([]*lisp.LVal{plus, args.Cells[0], lisp.Int(1)})
+			fresh = []*lisp.LVal{outer, plus, outer.Cells[2]}
+			return outer
+		}}
+		env.AddMacros(true, def)
+		if rc := env.LoadString("binding.lisp", "(set 'l (list 1 2))"); rc.Type == lisp.LError {
+			t.Fatalf("fixture: %v", rc)
+		}
+		l := env.Runtime.Package.Get(lisp.Symbol("l"))
+		if _, ok := l.Source(); ok || l.Type != lisp.LSExpr {
+			t.Fatalf("fixture: want an unlocated runtime list, got %v", l)
+		}
+		got := env.LoadString("expand.lisp", "(macroexpand-1 (list 'm l))")
+		if got.Type == lisp.LError {
+			t.Fatalf("macroexpand-1: %v", got)
+		}
+		if _, ok := l.Source(); ok {
+			t.Errorf("the binding passed as the macro's argument was located in place (issue #582): %v", l)
+		}
+		for i, n := range fresh {
+			if _, ok := n.Source(); !ok {
+				t.Errorf("fresh node %d (%v) was not located", i, n)
+			}
+		}
+		// And the expansion the caller gets still carries the call site on
+		// the binding's stand-in, so an error raised there is attributed.
+		if got.Type != lisp.LSExpr || len(got.Cells) != 3 || got.Cells[1] == l {
+			t.Fatalf("expansion %v: want (lisp:+ <copy of l> 1) with a private copy in the binding's place", got)
+		}
+		if loc, ok := got.Cells[1].Source(); !ok || loc.File != "expand.lisp" {
+			t.Errorf("the binding's stand-in in the expansion is not stamped with the call site: %v", got.Cells[1])
+		}
+	})
+
+	t.Run("debugger attached: the macro's nodes stay unlocated", func(t *testing.T) {
+		fresh, _, result := run(t, dormantDebugger{})
+		if result.Type != lisp.LInt || result.Int != 16 {
+			t.Fatalf("(m 10) = %v, want 16", result)
+		}
+		for i, n := range fresh {
+			if _, ok := n.Source(); ok {
+				t.Errorf("fresh node %d (%v) was located in place under a debugger; the stamp's copy is where the debugger's metadata goes", i, n)
+			}
+		}
+	})
+}
+
+// TestGoMacroExpansionValueIsNotLocatedInPlace pins that the in-place
+// locate stops at a VALUE the Go macro spliced in: a function reached
+// through the environment is a binding, and the stamp gives the expansion
+// a private header copy of it instead (the value fix).
+func TestGoMacroExpansionValueIsNotLocatedInPlace(t *testing.T) {
+	env := newGoMacroEnv(t)
+	if rc := env.LoadString("def.lisp", "(defun f (x) (lisp:* x 2))"); rc.Type == lisp.LError {
+		t.Fatalf("fixture: %v", rc)
+	}
+	f := env.Runtime.Package.Get(lisp.Symbol("f"))
+	f.SetSource(nil)
+	def := &goMacroDef{name: "m", formals: lisp.Formals("x"), fun: func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+		return lisp.SExpr([]*lisp.LVal{f, args.Cells[0]})
+	}}
+	env.AddMacros(true, def)
+	if result := env.LoadString("go-macro.lisp", "(m 21)"); result.Type != lisp.LInt || result.Int != 42 {
+		t.Fatalf("(m 21) = %v, want 42", result)
+	}
+	if _, ok := f.Source(); ok {
+		t.Errorf("the function value the Go macro spliced in was located in place")
+	}
+}

--- a/lisp/seal_watchdog_guard_test.go
+++ b/lisp/seal_watchdog_guard_test.go
@@ -47,15 +47,16 @@ func TestSealWatchdogStampMacroExpansionGuard(t *testing.T) {
 		t.Fatal("anti-vacuity: constructors must not stamp source; the stamp below would have nothing to write")
 	}
 
-	// Anti-vacuity for the write path itself: the same stamp against an
-	// UNSEALED clone must write, proving the only thing standing between
-	// stampMacroExpansion and the sealed tree is the sealed-skip guard.
+	// Anti-vacuity for the stamp itself: the same stamp against an
+	// UNSEALED clone must stamp (on its copy-on-write result; issue #582),
+	// proving the only thing standing between stampMacroExpansion and the
+	// sealed tree is the sealed-skip guard.
 	callSite := &token.Location{File: "stamp.lisp", Pos: 7, Line: 1, Col: 1}
 	rt := StandardRuntime()
 	unsealed := SExpr([]*LVal{Symbol("guarded"), Int(1)})
-	stampMacroExpansion(unsealed, callSite, nil, rt)
-	if loc, ok := unsealed.Source(); !ok || loc.Pos != callSite.Pos {
-		t.Fatalf("anti-vacuity: stamp did not write the unsealed clone (source=%v ok=%v)", loc, ok)
+	stamped := stampMacroExpansion(unsealed, callSite, nil, rt)
+	if loc, ok := stamped.Source(); !ok || loc.Pos != callSite.Pos {
+		t.Fatalf("anti-vacuity: stamp did not stamp the unsealed clone (source=%v ok=%v)", loc, ok)
 	}
 
 	unregister := registerSealWatch(expr)

--- a/parser/rdparser/parser.go
+++ b/parser/rdparser/parser.go
@@ -473,9 +473,10 @@ func (p *Parser) ParseFunRef() *lisp.LVal {
 // lisp.nativeSource(), the shared "<native code>" location whose Pos is -1,
 // and the head symbols behind #' and #^ were left carrying it.  That put a
 // PARSER-PRODUCED node into the population that lisp.stampMacroExpansion
-// treats as its own to rewrite: the stamp walk replaces any Source that is nil
-// or has Pos < 0 with the macro call site (and, with a debugger attached,
-// attaches a MacroExpansionInfo).
+// treated as its own to rewrite: the stamp walk, then in place (it stamps a
+// private copy since issue #582), replaced any Source that is nil or has
+// Pos < 0 with the macro call site (and, with a debugger attached, attached
+// a MacroExpansionInfo).
 //
 // Macro arguments are not evaluated, so a form containing #' reaches the
 // macro's parameters as the caller's own parse-tree nodes and is spliced into


### PR DESCRIPTION
## Summary

`stampMacroExpansion` wrote the macro call site **in place** onto every unlocated node of an expansion, and it cannot tell expansion output from a binding the macro body returned. Two shapes survived the value fix in #583:

- a global list built by `(list ...)` and returned by a lisp macro body acquired the call site as its location, for the rest of the process;
- a located unsealed list holding an unlocated value had that cell **overwritten** with the value's private header copy, so a later `append!` through the binding and through the expansion could diverge.

Closes #582.

## The fix

The stamp is now **copy-on-write** and never writes to the value it is handed. A node that needs a stamp, or whose cells changed, is replaced in the returned tree by a private copy; sealed subtrees, singletons and located nodes are shared. The copy shares everything behind a pointer (`*funData`, `*MapData`, bytes, an unchanged `Cells` backing array); its own struct (`source`, `macroExpansion`, and a fresh cell slice when a cell changed) is private. Expansion IDs are still assigned in pre-order, and a cyclic expansion's copy contains itself where the expansion did (the walk that discovers the cycle is discarded along with the IDs it minted, so the kept walk's IDs are contiguous).

There is no identity exclusion left to add: the remaining guards (`isSingleton`, `sealed`, nil call site) are about sharing, not writing.

## Who pays: lisp macros only

A lisp macro builds its expansion with quasiquote, whose output carries the template's locations, so the usual lisp expansion needs no stamp at all; and an unlocated node it does return may be a binding, which is exactly what the copy is for.

A **Go** macro synthesizes its expansion from fresh nodes, so the copies would cost it two allocations per node on every expansion. The first draft of this PR paid that everywhere except the kernel, and the benchmark gate caught it: `libjson`'s `Package/get-nested-baseline`, which expands `libtesting`'s `assert-equal` 6000 times per iteration, went +23% allocs/op, +30% B/op, +18% sec/op. Substrate's `cc:infof` family has the same shape on every phylum log line.

So `macroCall`, when no debugger is attached, **locates a Go macro's expansion in place** before the stamp sees it (`locateExpansionTree`): every unlocated unsealed syntax node reachable from the expansion gets the call site, **stopping at the macro's arguments**, and the stamp then shares the fresh nodes. That is the in-place write the stamp gave up, confined to the one caller whose output is fresh by contract, now stated on `LEnv.AddMacros`: a Go macro's expansion consists of nodes it constructed and its arguments. The arguments are the caller's nodes and may be bindings (a call form built at runtime, `(macroexpand-1 (list 'm l))` or a Go-side `Eval`, hands the macro the raw binding), which is why the locate stops at them: the stamp copies such an argument, exactly as it copies a binding a lisp macro returns. Values are never written to on either path. Under a debugger the hand-off is skipped and a Go macro's expansion is copied too, since the copy is where the expansion metadata the debugger reads is attached. Every Go macro in this repository and substrate's four (`cc:debugf/infof/warnf/errorf`) were checked against the contract; none embeds a binding it looked up.

The first draft's mechanism (`Runtime.macroCallSite` + `LEnv.locateExpansion`, with the kernel macros naming each fresh node) is gone; the kernel macros are back to their original construction.

| benchmark (allocs/op) | parent | first draft | this PR |
|---|---|---|---|
| `lisp MacroDefun` | 442 | 442 | 442 |
| `libjson Package/$load` | 7613 | 7730 | 7613 |
| `libjson Package/get-nested-baseline` | 489k | 604k | 489k |

B/op matches the parent on all three as well. An expansion in which nothing needs a stamp allocates nothing (`TestMacroExpansionStampAllocatesNothingWhenNothingNeedsAStamp`).

## Semantics

Non-debugger evaluation is unchanged: all 16 repo `.lisp` programs (examples, fixtures, profiler inputs) render byte-identical stdout, stderr and exit status before and after. For a Go macro the locations land exactly where the in-place stamp put them before. Error attribution is unchanged for lisp macros too: an error raised while evaluating an expansion built with `(list ...)` still reports the macro call site, because the stamp lands on the copy that is evaluated (`TestMacroReturningARuntimeListBindingLeavesItUnlocated`). What changes is only what the bug was: a binding a lisp macro body returns keeps its own location.

## Review follow-ups (two adversarial reviews, all addressed)

- Expansion IDs minted on the stamper and committed only for the kept walk, so a cyclic expansion no longer burns up to 64 IDs on the abandoned pass (`TestMacroExpansionStampMintsExpansionIDsOnlyForTheKeptWalk`). A walk that minted nothing writes nothing to the `Runtime`, which the singleton race test (many goroutines, one `Runtime`) caught under `-race`.
- Cost wording corrected (a header **and** a cell slice per changed ancestor); stale comments in `macro_stamp_fun_test.go`, `internal/fuzzval`, `parser/rdparser` updated; `*.test` binaries gitignored.
- Second review, on the in-place locate: a Go macro's unsealed, unlocated *argument* is a binding when the call form was built at runtime (`(macroexpand-1 (list 'm l))`, or a Go-side `Eval`), and the first cut located it in place, the parent's residual. The walk now stops at the arguments; the boundary set is built only when some argument is unsealed and unlocated, so a parsed call form pays nothing (`TestGoMacroExpansionIsLocatedInPlace/an_unlocated_runtime_argument`, RED before the boundary).
- "Costs no copies" overstated: an unlocated value or argument in a Go macro's expansion, or a cycle, still takes the copies the stamp's rules give. Reworded in the code, the DANGER block and §4.5. A stray blank line in `Runtime` removed.

## Docs

- Warning block above `stampMacroExpansion` rewritten: the seven-entry history, the copy-on-write rule, the cost and who pays it, the behaviour change.
- `LEnv.AddMacros` states the Go-macro expansion contract.
- `docs/sealed-ast.md` §4.5 rewritten to match.

## Test plan

New tests, **RED on the parent commit**:

```
--- FAIL: TestMacroExpansionStampNeverWritesTheExpansion (5 shapes: unlocated list root, located list with an unlocated value cell, unlocated list nested in a located binding, sealed/located cells shared, debugger metadata on the copy only)
--- FAIL: TestMacroReturningARuntimeListBindingLeavesItUnlocated (the ELPS shape from #582: the binding acquired a location from the macro expansion: call.lisp:3:1)
--- FAIL: TestGoMacroExpansionIsLocatedInPlace/debugger_attached (the parent located a Go macro's nodes in place under a debugger too)
```

`TestGoMacroExpansionIsLocatedInPlace/no_debugger` is RED on the first draft of this PR (fresh nodes were left unlocated and copied); its `an_unlocated_runtime_argument` case is RED on the first cut of the in-place locate (the binding passed as an argument was located). `TestGoMacroExpansionValueIsNotLocatedInPlace` pins that the in-place locate stops at a value.

Updated tests re-point their assertions at the returned tree and add negative assertions on the input (`macro_expansion_test.go`, `cycle_test.go`, `seal_watchdog_guard_test.go`, `macro_stamp_fun_test.go`).

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -race ./lisp/ ./lisp/x/debugger/`
- [x] `go test -tags=elpscheck ./lisp/`
- [x] `make elpsvet` (plain and `-tags=elpscheck`)
- [x] `golangci-lint run ./...` -- 0 issues
- [x] `./elps fmt -l ./...` -- no files listed
- [x] `./elps doc -m` -- all documented
- [x] `FuzzEval` 45s, no crashers
- [x] 16-program differential battery byte-identical to base
- [x] `BenchmarkMacroDefun`, `BenchmarkPackage/$load`, `BenchmarkPackage/get-nested-baseline` at the parent's allocs/op and B/op

Stacked on #587 (the fork memo fix, formerly #584); #572 and the rest of the perf stack sit on this (bug fixes first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX