### PR TITLE
Memoise sorted maps, bytes and native payloads per payload in Fork so aliased headers stay aliased

### DIFF
--- a/docs/fork.md
+++ b/docs/fork.md
@@ -281,9 +281,10 @@ r := &elpstest.Runner{
   mutable values pointer-distinct with identical content, template
   aliasing and cycles reproduced in the fork.
 - `lisp/fork_mapalias_test.go` pins aliasing one level below the `*LVal`:
-  two headers over one `*MapData` (the shape `(quasiquote (unquote a))`
-  makes) fork to two headers over one clone, and a map that reaches itself
-  through such a header terminates (issue #576).
+  two headers over one `*MapData`, one `*[]byte` or one native payload (the
+  shape `(quasiquote (unquote a))` makes) fork to two headers over ONE clone,
+  and a map that reaches itself through such a header closes onto its own
+  clone rather than nesting a fresh one per header (issue #576).
 - `lisp/lisplib/fork_test.go` proves bidirectional isolation over real
   parsed programs two ways: observable mutations (neither side sees the
   other's writes) and a full-state fingerprint (structure-only hash of

--- a/docs/fork.md
+++ b/docs/fork.md
@@ -280,6 +280,10 @@ r := &elpstest.Runner{
   template: sealed values pointer-shared (with an anti-vacuity floor),
   mutable values pointer-distinct with identical content, template
   aliasing and cycles reproduced in the fork.
+- `lisp/fork_mapalias_test.go` pins aliasing one level below the `*LVal`:
+  two headers over one `*MapData` (the shape `(quasiquote (unquote a))`
+  makes) fork to two headers over one clone, and a map that reaches itself
+  through such a header terminates (issue #576).
 - `lisp/lisplib/fork_test.go` proves bidirectional isolation over real
   parsed programs two ways: observable mutations (neither side sees the
   other's writes) and a full-state fingerprint (structure-only hash of

--- a/lisp/fork.go
+++ b/lisp/fork.go
@@ -228,6 +228,7 @@ func (env *LEnv) Fork(opts ...ForkOption) (*LEnv, error) {
 		rt:             newRT,
 		envs:           make(map[*LEnv]*LEnv, 256),
 		vals:           make(map[*LVal]*LVal, 4096),
+		maps:           make(map[*MapData]*MapData, 64),
 		nativeReplacer: config.nativeReplacer,
 	}
 	newRoot := f.env(env)
@@ -263,16 +264,26 @@ func checkQuiescent(rt *Runtime) error {
 	return nil
 }
 
-// forker performs one Fork call's graph walk.  The two memo tables are the
+// forker performs one Fork call's graph walk.  The three memo tables are the
 // heart of the algorithm: each maps a template object to its fork-side copy
 // and is seeded BEFORE descending into the object's children, so values
 // reachable along multiple paths map to one copy (aliasing is reproduced,
 // not multiplied) and reference cycles — labels mutual recursion,
 // closure↔environment cycles — terminate instead of recursing forever.
+//
+// maps is keyed on the *MapData, not the *LVal header over it, because the
+// two are not one-to-one: Quote, Splice, shallowUnquote and opQuasiquote copy
+// an LVal's struct and keep its Native, so `(quasiquote (unquote a))` is a
+// second header on a's map.  Memoising per header alone rebuilt such a map
+// once per header, and a write through the fork's `a` was invisible through
+// the fork's `b` (issue #576).  A map reaching itself through a second
+// header is the same bug at its sharpest: the *LVal memo never sees the
+// cycle, because every visit arrives through a header it has not met.
 type forker struct {
 	rt             *Runtime
 	envs           map[*LEnv]*LEnv
 	vals           map[*LVal]*LVal
+	maps           map[*MapData]*MapData
 	nativeReplacer func(payload interface{}) (interface{}, bool)
 }
 
@@ -513,14 +524,24 @@ func (f *forker) native(payload interface{}) interface{} {
 // mapData rebuilds md as a fresh sorted map whose keys and values are
 // remapped through the walker (unlike detachMapData, entries may legally
 // contain funs and natives — the walker applies fork policy to them).
+//
+// Memoised per *MapData, and seeded BEFORE the entries are walked, for the
+// same two reasons f.vals is: a map reachable through several headers maps
+// to one clone, and a map that reaches itself terminates (issue #576; see
+// the forker doc).
 func (f *forker) mapData(md *MapData) *MapData {
 	if md == nil {
 		return nil
 	}
+	if cp, ok := f.maps[md]; ok {
+		return cp
+	}
 	if md.mapBacking == nil {
 		// Degenerate MapData with no implementation (possible via
 		// SortedMapFromData(NewMapData(nil))): fresh struct, nil backing preserved.
-		return &MapData{}
+		cp := &MapData{}
+		f.maps[md] = cp
+		return cp
 	}
 	entries := sortedMapEntries(md)
 	if entries.Type == LError {
@@ -530,6 +551,7 @@ func (f *forker) mapData(md *MapData) *MapData {
 		panic(fmt.Sprintf("fork: sorted-map entries cannot be enumerated: %v", entries))
 	}
 	m := NewMapData(newmap())
+	f.maps[md] = m // memo before descending, as above
 	for _, pair := range entries.Cells {
 		if lerr := m.Set(f.val(pair.Cells[0]), f.val(pair.Cells[1])); lerr.Type == LError {
 			panic(fmt.Sprintf("fork: sorted-map key %s cannot be stored: %v", pair.Cells[0], lerr))

--- a/lisp/fork.go
+++ b/lisp/fork.go
@@ -292,6 +292,27 @@ func checkQuiescent(rt *Runtime) error {
 // bounded the walk (every header is memoised before its payload is
 // remapped, and there are finitely many headers) but not the number of
 // clones -- one per header, each containing the next.
+//
+// The shape, drawn.  A header is the *LVal a variable points at; the
+// payload is the storage it points at in turn.  Two headers over one
+// payload is the case the header memo alone cannot see:
+//
+//	template:    a ──header 1──┐
+//	                           ├──► [one map]
+//	             b ──header 2──┘
+//
+//	memo per header only (the #576 bug):
+//	             a ──header 1'──► [map copy A]
+//	             b ──header 2'──► [map copy B]   the alias came apart:
+//	                                             (assoc! a k v) is invisible
+//	                                             through b, on the fork only
+//
+//	memo per header AND per payload (this file):
+//	             a ──header 1'──┐
+//	                            ├──► [map copy]  still one map, as in the
+//	             b ──header 2'──┘                template
+//
+// The same picture holds for a bytes value and for a NativeCloner payload.
 type forker struct {
 	rt             *Runtime
 	envs           map[*LEnv]*LEnv

--- a/lisp/fork.go
+++ b/lisp/fork.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 )
 
 // Template-environment forking (issue #380).
@@ -82,6 +83,10 @@ import (
 // Under `copy` the duplicate stays inside one environment, so a payload
 // written for that path alone still has to meet the stricter bar to be
 // fork-safe.
+//
+// Fork calls it once per payload: a pointer payload reachable through
+// several headers is cloned once and the clone shared by all of them, as
+// the payload was on the template (issue #576).
 type NativeCloner interface {
 	CloneNative() interface{}
 }
@@ -122,9 +127,11 @@ func ForkWithStderr(w io.Writer) ForkOption {
 // This is the escape hatch for payload types the embedder cannot modify to
 // implement NativeCloner (third-party handles), and for rebinding
 // fork-specific instances (a per-fork storage handle, a per-test
-// accumulator).  fn may be called more than once for payloads reachable
-// through multiple values; it must be pure with respect to the template
-// (never mutate the payload it is given).
+// accumulator).  fn is called once per pointer payload, however many values
+// reach it (the replacement is shared by all of them, as the payload was on
+// the template -- issue #576); a non-pointer payload may be seen once per
+// value.  It must be pure with respect to the template (never mutate the
+// payload it is given).
 func ForkWithNativeReplacer(fn func(payload interface{}) (interface{}, bool)) ForkOption {
 	return func(c *forkConfig) { c.nativeReplacer = fn }
 }
@@ -229,6 +236,8 @@ func (env *LEnv) Fork(opts ...ForkOption) (*LEnv, error) {
 		envs:           make(map[*LEnv]*LEnv, 256),
 		vals:           make(map[*LVal]*LVal, 4096),
 		maps:           make(map[*MapData]*MapData, 64),
+		bytes:          make(map[*[]byte]*[]byte),
+		natives:        make(map[interface{}]interface{}),
 		nativeReplacer: config.nativeReplacer,
 	}
 	newRoot := f.env(env)
@@ -271,19 +280,25 @@ func checkQuiescent(rt *Runtime) error {
 // not multiplied) and reference cycles — labels mutual recursion,
 // closure↔environment cycles — terminate instead of recursing forever.
 //
-// maps is keyed on the *MapData, not the *LVal header over it, because the
-// two are not one-to-one: Quote, Splice, shallowUnquote and opQuasiquote copy
-// an LVal's struct and keep its Native, so `(quasiquote (unquote a))` is a
-// second header on a's map.  Memoising per header alone rebuilt such a map
-// once per header, and a write through the fork's `a` was invisible through
-// the fork's `b` (issue #576).  A map reaching itself through a second
-// header is the same bug at its sharpest: the *LVal memo never sees the
-// cycle, because every visit arrives through a header it has not met.
+// The three payload memos -- maps, bytes, natives -- are keyed on the
+// PAYLOAD, not the *LVal header over it, because the two are not
+// one-to-one: Quote (reached from quasiquote through doUnquoteValue),
+// Splice, shallowUnquote and FunRef copy an LVal's struct and keep its
+// Native, so `(quasiquote (unquote a))` is a second header on a's sorted
+// map, bytes or native handle.  Memoising per header alone rebuilt such a
+// payload once per header, and a write through the fork's `a` was invisible
+// through the fork's `b` (issue #576).  A map reaching itself through a
+// second header showed the same thing one level down: the *LVal memo
+// bounded the walk (every header is memoised before its payload is
+// remapped, and there are finitely many headers) but not the number of
+// clones -- one per header, each containing the next.
 type forker struct {
 	rt             *Runtime
 	envs           map[*LEnv]*LEnv
 	vals           map[*LVal]*LVal
 	maps           map[*MapData]*MapData
+	bytes          map[*[]byte]*[]byte
+	natives        map[interface{}]interface{}
 	nativeReplacer func(payload interface{}) (interface{}, bool)
 }
 
@@ -452,8 +467,7 @@ func (f *forker) val(v *LVal) *LVal {
 		case nil:
 		case *[]byte:
 			if native != nil {
-				b := append([]byte(nil), *native...)
-				cp.Native = &b
+				cp.Native = f.byteSlice(native)
 			}
 		case *MapData:
 			cp.Native = f.mapData(native)
@@ -502,9 +516,22 @@ func (f *forker) val(v *LVal) *LVal {
 // lisp/runtime_bound.go).  A replacer's return value is checked like any
 // other — an embedder's hook handing back a template-bound instance is
 // precisely the bug class, not an exception to it.
+//
+// Resolved ONCE per payload: a pointer payload reachable through several
+// headers (issue #576; see the forker doc) maps to one resolution, so two
+// headers over one NativeCloner accumulator do not become two independent
+// clones in the fork, and a replacer sees each such payload once.  Only
+// pointer payloads are memoised -- identity is what aliasing means, and a
+// non-pointer payload (an int, a struct value) has none to preserve.
 func (f *forker) native(payload interface{}) interface{} {
 	if payload == nil {
 		return nil
+	}
+	memo := reflect.TypeOf(payload).Kind() == reflect.Pointer
+	if memo {
+		if resolved, ok := f.natives[payload]; ok {
+			return resolved
+		}
 	}
 	resolved, replaced := payload, false
 	if f.nativeReplacer != nil {
@@ -518,17 +545,32 @@ func (f *forker) native(payload interface{}) interface{} {
 		}
 	}
 	checkNativeAffinity(f.rt, resolved)
+	if memo {
+		f.natives[payload] = resolved
+	}
 	return resolved
+}
+
+// byteSlice copies one LBytes backing array, once per template array however
+// many headers reach it (issue #576).  No cycle is possible through bytes,
+// so the memo is filled after the copy.
+func (f *forker) byteSlice(b *[]byte) *[]byte {
+	if cp, ok := f.bytes[b]; ok {
+		return cp
+	}
+	nb := append([]byte(nil), *b...)
+	f.bytes[b] = &nb
+	return &nb
 }
 
 // mapData rebuilds md as a fresh sorted map whose keys and values are
 // remapped through the walker (unlike detachMapData, entries may legally
 // contain funs and natives — the walker applies fork policy to them).
 //
-// Memoised per *MapData, and seeded BEFORE the entries are walked, for the
-// same two reasons f.vals is: a map reachable through several headers maps
-// to one clone, and a map that reaches itself terminates (issue #576; see
-// the forker doc).
+// Memoised per *MapData, and seeded BEFORE the entries are walked, so that
+// a map reachable through several headers maps to one clone, and a map
+// that reaches itself closes onto that clone instead of nesting a fresh
+// one per header (issue #576; see the forker doc).
 func (f *forker) mapData(md *MapData) *MapData {
 	if md == nil {
 		return nil

--- a/lisp/fork_mapalias_test.go
+++ b/lisp/fork_mapalias_test.go
@@ -1,0 +1,117 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+)
+
+// newForkAliasEnv returns a user-package environment with a reader attached,
+// so the fixtures below can be written in ELPS.
+func newForkAliasEnv(t *testing.T) *lisp.LEnv {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); rc.Type == lisp.LError {
+		t.Fatalf("initialize-user-env: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		t.Fatalf("in-package: %v", rc)
+	}
+	return env
+}
+
+// TestForkPreservesMapDataAliasAcrossHeaders pins issue #576: two distinct
+// LVal headers over ONE *MapData must map to one *MapData in the fork, the
+// same way two references to one *LVal map to one copy.
+//
+// The shape is reachable from pure ELPS.  Quote, Splice, shallowUnquote and
+// opQuasiquote all copy the struct (`*cp = *v`) and keep the Native, so
+// `(quasiquote (unquote a))` yields a second header on a's map.  Before the
+// fix Fork memoised per *LVal only, so the two headers were rebuilt as two
+// independent maps and a write through the fork's `a` was invisible through
+// the fork's `b` -- a program that behaved one way on the template and
+// another way in every fork of it.
+func TestForkPreservesMapDataAliasAcrossHeaders(t *testing.T) {
+	env := newForkAliasEnv(t)
+	src := `
+(set 'a (sorted-map "k" 1))
+(set 'b (quasiquote (unquote a)))
+(assoc! a "x" 99)
+`
+	if rc := env.LoadString("alias.lisp", src); rc.Type == lisp.LError {
+		t.Fatalf("fixture: %v", rc)
+	}
+	a := env.Runtime.Package.Get(lisp.Symbol("a"))
+	b := env.Runtime.Package.Get(lisp.Symbol("b"))
+	if a == b {
+		t.Fatalf("fixture: a and b are one header; the test needs two headers over one map")
+	}
+	if a.Native != b.Native {
+		t.Fatalf("fixture: a and b do not share a *MapData (%p vs %p)", a.Native, b.Native)
+	}
+	if got := env.LoadString("read.lisp", `(get b "x")`); got.Type != lisp.LInt || got.Int != 99 {
+		t.Fatalf("fixture: template write through a not visible through b: %v", got)
+	}
+
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	fa := fork.Runtime.Package.Get(lisp.Symbol("a"))
+	fb := fork.Runtime.Package.Get(lisp.Symbol("b"))
+	if fa.Native == a.Native || fb.Native == b.Native {
+		t.Fatalf("fork shares a *MapData with the template")
+	}
+	if fa.Native != fb.Native {
+		t.Errorf("fork de-aliased the shared map: a=%p b=%p", fa.Native, fb.Native)
+	}
+
+	// The observable half: a write through one name is read through the
+	// other, in the fork exactly as in the template.
+	if got := fork.LoadString("write.lisp", `(assoc! a "y" 7) (get b "y")`); got.Type != lisp.LInt || got.Int != 7 {
+		t.Errorf("fork write through a not visible through b: got %v, want 7", got)
+	}
+	// And the template did not see the fork's write.
+	if got := env.LoadString("read2.lisp", `(get b "y")`); got.Type != lisp.LSExpr || len(got.Cells) != 0 {
+		t.Errorf("template saw the fork's write: %v", got)
+	}
+}
+
+// TestForkSelfReferenceThroughAliasedHeaderTerminates pins the sharper edge
+// of the same bug: a map that contains ITSELF through a second header.  The
+// *LVal memo does not see the cycle -- the walk arrives at the map through a
+// header it has not visited -- so only a *MapData memo, seeded before the
+// entries are walked, closes it back onto the one clone.
+func TestForkSelfReferenceThroughAliasedHeaderTerminates(t *testing.T) {
+	env := newForkAliasEnv(t)
+	m := lisp.SortedMap()
+	alias := &lisp.LVal{}
+	*alias = *m // a second header, same *MapData, as quasiquote makes
+	if lerr := m.Map().Set(lisp.String("self"), alias); lerr.Type == lisp.LError {
+		t.Fatalf("map set: %v", lerr)
+	}
+	env.PutGlobal(lisp.Symbol("m"), m)
+
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	fm := fork.Runtime.Package.Get(lisp.Symbol("m"))
+	if fm.Native == m.Native {
+		t.Fatalf("fork shares the template's *MapData")
+	}
+	self, ok := fm.Map().Get(lisp.String("self"))
+	if !ok {
+		t.Fatalf("forked map lost its self entry")
+	}
+	if self.Type != lisp.LSortMap {
+		t.Fatalf("forked self entry: want sorted map, got %v", self)
+	}
+	if self.Native != fm.Native {
+		t.Errorf("forked self entry is a different map (%p) from its container (%p)", self.Native, fm.Native)
+	}
+}

--- a/lisp/fork_mapalias_test.go
+++ b/lisp/fork_mapalias_test.go
@@ -28,13 +28,13 @@ func newForkAliasEnv(t *testing.T) *lisp.LEnv {
 // LVal headers over ONE *MapData must map to one *MapData in the fork, the
 // same way two references to one *LVal map to one copy.
 //
-// The shape is reachable from pure ELPS.  Quote, Splice, shallowUnquote and
-// opQuasiquote all copy the struct (`*cp = *v`) and keep the Native, so
-// `(quasiquote (unquote a))` yields a second header on a's map.  Before the
-// fix Fork memoised per *LVal only, so the two headers were rebuilt as two
-// independent maps and a write through the fork's `a` was invisible through
-// the fork's `b` -- a program that behaved one way on the template and
-// another way in every fork of it.
+// The shape is reachable from pure ELPS.  Quote -- which quasiquote reaches
+// through doUnquoteValue -- copies an unquoted value's struct (`*cp = *v`)
+// and keeps the Native, so `(quasiquote (unquote a))` yields a second header
+// on a's map.  Before the fix Fork memoised per *LVal only, so the two
+// headers were rebuilt as two independent maps and a write through the
+// fork's `a` was invisible through the fork's `b` -- a program that behaved
+// one way on the template and another way in every fork of it.
 func TestForkPreservesMapDataAliasAcrossHeaders(t *testing.T) {
 	env := newForkAliasEnv(t)
 	src := `
@@ -81,12 +81,13 @@ func TestForkPreservesMapDataAliasAcrossHeaders(t *testing.T) {
 	}
 }
 
-// TestForkSelfReferenceThroughAliasedHeaderTerminates pins the sharper edge
-// of the same bug: a map that contains ITSELF through a second header.  The
-// *LVal memo does not see the cycle -- the walk arrives at the map through a
-// header it has not visited -- so only a *MapData memo, seeded before the
-// entries are walked, closes it back onto the one clone.
-func TestForkSelfReferenceThroughAliasedHeaderTerminates(t *testing.T) {
+// TestForkSelfReferenceThroughAliasedHeaderStaysAliased pins the same bug
+// one level down: a map that contains ITSELF through a second header.  The
+// *LVal memo bounds the walk (each header is memoised before its payload is
+// remapped) but not the clones: without a *MapData memo seeded before the
+// entries are walked, the fork's map held a second, distinct clone under
+// "self" instead of closing onto itself.
+func TestForkSelfReferenceThroughAliasedHeaderStaysAliased(t *testing.T) {
 	env := newForkAliasEnv(t)
 	m := lisp.SortedMap()
 	alias := &lisp.LVal{}
@@ -113,5 +114,87 @@ func TestForkSelfReferenceThroughAliasedHeaderTerminates(t *testing.T) {
 	}
 	if self.Native != fm.Native {
 		t.Errorf("forked self entry is a different map (%p) from its container (%p)", self.Native, fm.Native)
+	}
+}
+
+// TestForkPreservesBytesAliasAcrossHeaders is the LBytes face of #576: two
+// headers over one *[]byte were copied once per header.
+func TestForkPreservesBytesAliasAcrossHeaders(t *testing.T) {
+	env := newForkAliasEnv(t)
+	src := `
+(set 'a (to-bytes "ab"))
+(set 'b (quasiquote (unquote a)))
+(append! a 99)
+`
+	if rc := env.LoadString("bytes.lisp", src); rc.Type == lisp.LError {
+		t.Fatalf("fixture: %v", rc)
+	}
+	a := env.Runtime.Package.Get(lisp.Symbol("a"))
+	b := env.Runtime.Package.Get(lisp.Symbol("b"))
+	if a == b || a.Native != b.Native {
+		t.Fatalf("fixture: want two headers over one *[]byte, got a=%p b=%p natives %p %p", a, b, a.Native, b.Native)
+	}
+	if got := env.LoadString("read.lisp", `(length b)`); got.Type != lisp.LInt || got.Int != 3 {
+		t.Fatalf("fixture: template write through a not visible through b: %v", got)
+	}
+
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	fa := fork.Runtime.Package.Get(lisp.Symbol("a"))
+	fb := fork.Runtime.Package.Get(lisp.Symbol("b"))
+	if fa.Native == a.Native {
+		t.Fatalf("fork shares the template's bytes")
+	}
+	if fa.Native != fb.Native {
+		t.Errorf("fork de-aliased the shared bytes: a=%p b=%p", fa.Native, fb.Native)
+	}
+	if got := fork.LoadString("write.lisp", `(append! a 7) (length b)`); got.Type != lisp.LInt || got.Int != 4 {
+		t.Errorf("fork write through a not visible through b: got %v, want 4", got)
+	}
+	if got := env.LoadString("read2.lisp", `(length b)`); got.Type != lisp.LInt || got.Int != 3 {
+		t.Errorf("template saw the fork's write: %v", got)
+	}
+}
+
+// countingCloner is a NativeCloner that counts its clones.
+type countingCloner struct {
+	clones *int
+}
+
+func (c *countingCloner) CloneNative() interface{} {
+	*c.clones++
+	return &countingCloner{clones: c.clones}
+}
+
+// TestForkClonesANativePayloadOncePerPayload is the native face of #576:
+// two headers over one NativeCloner accumulator were cloned once per
+// header, so the fork held two independent accumulators where the template
+// held one.
+func TestForkClonesANativePayloadOncePerPayload(t *testing.T) {
+	env := newForkAliasEnv(t)
+	clones := 0
+	payload := &countingCloner{clones: &clones}
+	a := lisp.Native(payload)
+	b := &lisp.LVal{}
+	*b = *a // a second header, same payload, as quasiquote makes
+	env.PutGlobal(lisp.Symbol("a"), a)
+	env.PutGlobal(lisp.Symbol("b"), b)
+
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	fa := fork.Runtime.Package.Get(lisp.Symbol("a"))
+	fb := fork.Runtime.Package.Get(lisp.Symbol("b"))
+	if fa.Native == payload {
+		t.Fatalf("fork shares the template's payload")
+	}
+	if fa.Native != fb.Native {
+		t.Errorf("fork de-aliased the shared payload: a=%p b=%p", fa.Native, fb.Native)
+	}
+	if clones != 1 {
+		t.Errorf("payload cloned %d times, want 1", clones)
 	}
 }


### PR DESCRIPTION
Replaces #584, same branch and commits. GitHub marked #584 merged when its old base branch (#578's) was rebased to a head that already contained these two commits; a merged PR cannot be reopened or retargeted, so this PR carries the branch on its new base, #583.

## Summary

`Fork` memoised copies per `*LVal` only. Two headers over one payload -- the shape `Quote` (reached from quasiquote through `doUnquoteValue`), `Splice`, `shallowUnquote` and `FunRef` produce, since each copies the struct and keeps the `Native` -- were rebuilt once per header. After `(set 'b (quasiquote (unquote a)))`, a write through the fork's `a` was invisible through the fork's `b`: a program that behaved one way on the template and another way in every fork of it. Pre-existing on `main` (03b789a); found during the adversarial review of #572.

One commit per payload type:

1. **Sorted maps** (`*MapData`). `forker` gains a memo keyed on the `*MapData`, seeded before the entries are walked, on both `mapData` paths that exist here (generic enumerate-and-reinsert, degenerate no-backing); the structural clone #572 adds above this PR seeds the same memo. A map reaching itself through a second header showed the same thing one level down: the `*LVal` memo bounded the walk (finitely many headers) but not the clones, one per header, each nesting the next. Closes #576.
2. **Bytes and native payloads**, found by the adversarial review of commit 1. Two headers over one `*[]byte` were copied once per header; two headers over one `NativeCloner` payload were cloned once per header, so an accumulator the template held once became two independent accumulators in the fork. Both get a memo keyed on the payload. Bytes cannot form a cycle, so the memo is filled after the copy. Native payloads are memoised only when the payload is a pointer (identity is what aliasing means); a replacer now sees such a payload once per fork, which its documented contract allowed ("may be called more than once"), and the `NativeCloner` and `ForkWithNativeReplacer` docs say so.

The same de-aliasing exists in `copy`/`detach`, which memoise per `*LVal` too; tracked in #585 rather than widened into this PR.

Stacked directly on #583, ahead of the perf PRs: bug fixes land first. #586 sits on this; #572 and the rest of the perf stack sit on #586.

## Measurements

`BenchmarkForkSortedMap`, `-count=4 -cpu 1`, base vs commit 1:

| metric | base | change |
|---|---|---|
| allocs/op | 20833 | 20837 |
| B/op | 2.586 MB | 2.591 MB |
| sec/op | within noise | within noise |

Four allocations per fork for the memo tables. CI benchmark gate on commit 1 (as #584): 0 rows at or above the gate.

## Test Plan

`lisp/fork_mapalias_test.go`, all four **fail on the parent commit** and pass here:

```
--- FAIL: TestForkPreservesMapDataAliasAcrossHeaders
    fork de-aliased the shared map: a=0xc0000931c0 b=0xc0000931a0
    fork write through a not visible through b: got (), want 7
--- FAIL: TestForkSelfReferenceThroughAliasedHeaderStaysAliased
    forked self entry is a different map (0xc000440a00) from its container (0xc000440a20)
--- FAIL: TestForkPreservesBytesAliasAcrossHeaders
    fork de-aliased the shared bytes: a=0xc00028ae40 b=0xc00028ae28
    fork write through a not visible through b: got 3, want 4
--- FAIL: TestForkClonesANativePayloadOncePerPayload
    fork de-aliased the shared payload: a=0xc0000a46e0 b=0xc0000a46e8
    payload cloned 2 times, want 1
```

The first and third are the ELPS-level shapes (template write visible through the alias, fork write visible through the fork's alias, template untouched by the fork's write). The second is the self-reference through a second header; the fourth counts clones of a `NativeCloner` reached through two headers.

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -race ./lisp/`
- [x] `go test -tags=elpscheck ./lisp/`
- [x] `make elpsvet` (plain and `-tags=elpscheck`)
- [x] `golangci-lint run ./...` -- 0 issues
- [x] `./elps fmt -l ./...` -- no files listed
- [x] `./elps doc -m` -- all documented

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX

---
_Generated by [Claude Code](https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX)_