### PR TITLE
Run golangci-lint's config schema check offline so a network timeout cannot red the CI job

### DIFF
--- a/.github/golangci.v2.6.jsonschema.json
+++ b/.github/golangci.v2.6.jsonschema.json
@@ -1,0 +1,5136 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/golangci-lint.json",
+  "definitions": {
+    "gocritic-checks": {
+      "enum": [
+        "appendAssign",
+        "appendCombine",
+        "argOrder",
+        "assignOp",
+        "badCall",
+        "badCond",
+        "badLock",
+        "badRegexp",
+        "badSorting",
+        "badSyncOnceFunc",
+        "boolExprSimplify",
+        "builtinShadow",
+        "builtinShadowDecl",
+        "captLocal",
+        "caseOrder",
+        "codegenComment",
+        "commentFormatting",
+        "commentedOutCode",
+        "commentedOutImport",
+        "defaultCaseOrder",
+        "deferInLoop",
+        "deferUnlambda",
+        "deprecatedComment",
+        "docStub",
+        "dupArg",
+        "dupBranchBody",
+        "dupCase",
+        "dupImport",
+        "dupOption",
+        "dupSubExpr",
+        "dynamicFmtString",
+        "elseif",
+        "emptyDecl",
+        "emptyFallthrough",
+        "emptyStringTest",
+        "equalFold",
+        "evalOrder",
+        "exitAfterDefer",
+        "exposedSyncMutex",
+        "externalErrorReassign",
+        "filepathJoin",
+        "flagDeref",
+        "flagName",
+        "hexLiteral",
+        "httpNoBody",
+        "hugeParam",
+        "ifElseChain",
+        "importShadow",
+        "indexAlloc",
+        "initClause",
+        "mapKey",
+        "methodExprCall",
+        "nestingReduce",
+        "newDeref",
+        "nilValReturn",
+        "octalLiteral",
+        "offBy1",
+        "paramTypeCombine",
+        "preferDecodeRune",
+        "preferFilepathJoin",
+        "preferFprint",
+        "preferStringWriter",
+        "preferWriteByte",
+        "ptrToRefParam",
+        "rangeAppendAll",
+        "rangeExprCopy",
+        "rangeValCopy",
+        "redundantSprint",
+        "regexpMust",
+        "regexpPattern",
+        "regexpSimplify",
+        "returnAfterHttpError",
+        "ruleguard",
+        "singleCaseSwitch",
+        "sliceClear",
+        "sloppyLen",
+        "sloppyReassign",
+        "sloppyTypeAssert",
+        "sortSlice",
+        "sprintfQuotedString",
+        "sqlQuery",
+        "stringConcatSimplify",
+        "stringXbytes",
+        "stringsCompare",
+        "switchTrue",
+        "syncMapLoadAndDelete",
+        "timeExprSimplify",
+        "todoCommentWithoutDetail",
+        "tooManyResultsChecker",
+        "truncateCmp",
+        "typeAssertChain",
+        "typeDefFirst",
+        "typeSwitchVar",
+        "typeUnparen",
+        "uncheckedInlineErr",
+        "underef",
+        "unlabelStmt",
+        "unlambda",
+        "unnamedResult",
+        "unnecessaryBlock",
+        "unnecessaryDefer",
+        "unslice",
+        "valSwap",
+        "weakCond",
+        "whyNoLint",
+        "wrapperFunc",
+        "yodaStyleExpr",
+        "zeroByteRepeat"
+      ]
+    },
+    "gocritic-tags": {
+      "enum": [
+        "diagnostic",
+        "style",
+        "performance",
+        "experimental",
+        "opinionated",
+        "security"
+      ]
+    },
+    "staticcheck-checks": {
+      "enum": [
+        "*",
+        "all",
+        "SA*",
+        "-SA*",
+        "SA1*",
+        "-SA1*",
+        "SA1000",
+        "-SA1000",
+        "SA1001",
+        "-SA1001",
+        "SA1002",
+        "-SA1002",
+        "SA1003",
+        "-SA1003",
+        "SA1004",
+        "-SA1004",
+        "SA1005",
+        "-SA1005",
+        "SA1006",
+        "-SA1006",
+        "SA1007",
+        "-SA1007",
+        "SA1008",
+        "-SA1008",
+        "SA1010",
+        "-SA1010",
+        "SA1011",
+        "-SA1011",
+        "SA1012",
+        "-SA1012",
+        "SA1013",
+        "-SA1013",
+        "SA1014",
+        "-SA1014",
+        "SA1015",
+        "-SA1015",
+        "SA1016",
+        "-SA1016",
+        "SA1017",
+        "-SA1017",
+        "SA1018",
+        "-SA1018",
+        "SA1019",
+        "-SA1019",
+        "SA1020",
+        "-SA1020",
+        "SA1021",
+        "-SA1021",
+        "SA1023",
+        "-SA1023",
+        "SA1024",
+        "-SA1024",
+        "SA1025",
+        "-SA1025",
+        "SA1026",
+        "-SA1026",
+        "SA1027",
+        "-SA1027",
+        "SA1028",
+        "-SA1028",
+        "SA1029",
+        "-SA1029",
+        "SA1030",
+        "-SA1030",
+        "SA1031",
+        "-SA1031",
+        "SA1032",
+        "-SA1032",
+        "SA2*",
+        "-SA2*",
+        "SA2000",
+        "-SA2000",
+        "SA2001",
+        "-SA2001",
+        "SA2002",
+        "-SA2002",
+        "SA2003",
+        "-SA2003",
+        "SA3*",
+        "-SA3*",
+        "SA3000",
+        "-SA3000",
+        "SA3001",
+        "-SA3001",
+        "SA4*",
+        "-SA4*",
+        "SA4000",
+        "-SA4000",
+        "SA4001",
+        "-SA4001",
+        "SA4003",
+        "-SA4003",
+        "SA4004",
+        "-SA4004",
+        "SA4005",
+        "-SA4005",
+        "SA4006",
+        "-SA4006",
+        "SA4008",
+        "-SA4008",
+        "SA4009",
+        "-SA4009",
+        "SA4010",
+        "-SA4010",
+        "SA4011",
+        "-SA4011",
+        "SA4012",
+        "-SA4012",
+        "SA4013",
+        "-SA4013",
+        "SA4014",
+        "-SA4014",
+        "SA4015",
+        "-SA4015",
+        "SA4016",
+        "-SA4016",
+        "SA4017",
+        "-SA4017",
+        "SA4018",
+        "-SA4018",
+        "SA4019",
+        "-SA4019",
+        "SA4020",
+        "-SA4020",
+        "SA4021",
+        "-SA4021",
+        "SA4022",
+        "-SA4022",
+        "SA4023",
+        "-SA4023",
+        "SA4024",
+        "-SA4024",
+        "SA4025",
+        "-SA4025",
+        "SA4026",
+        "-SA4026",
+        "SA4027",
+        "-SA4027",
+        "SA4028",
+        "-SA4028",
+        "SA4029",
+        "-SA4029",
+        "SA4030",
+        "-SA4030",
+        "SA4031",
+        "-SA4031",
+        "SA4032",
+        "-SA4032",
+        "SA5*",
+        "-SA5*",
+        "SA5000",
+        "-SA5000",
+        "SA5001",
+        "-SA5001",
+        "SA5002",
+        "-SA5002",
+        "SA5003",
+        "-SA5003",
+        "SA5004",
+        "-SA5004",
+        "SA5005",
+        "-SA5005",
+        "SA5007",
+        "-SA5007",
+        "SA5008",
+        "-SA5008",
+        "SA5009",
+        "-SA5009",
+        "SA5010",
+        "-SA5010",
+        "SA5011",
+        "-SA5011",
+        "SA5012",
+        "-SA5012",
+        "SA6*",
+        "-SA6*",
+        "SA6000",
+        "-SA6000",
+        "SA6001",
+        "-SA6001",
+        "SA6002",
+        "-SA6002",
+        "SA6003",
+        "-SA6003",
+        "SA6005",
+        "-SA6005",
+        "SA6006",
+        "-SA6006",
+        "SA9*",
+        "-SA9*",
+        "SA9001",
+        "-SA9001",
+        "SA9002",
+        "-SA9002",
+        "SA9003",
+        "-SA9003",
+        "SA9004",
+        "-SA9004",
+        "SA9005",
+        "-SA9005",
+        "SA9006",
+        "-SA9006",
+        "SA9007",
+        "-SA9007",
+        "SA9008",
+        "-SA9008",
+        "SA9009",
+        "-SA9009",
+        "ST*",
+        "-ST*",
+        "ST1*",
+        "-ST1*",
+        "ST1000",
+        "-ST1000",
+        "ST1001",
+        "-ST1001",
+        "ST1003",
+        "-ST1003",
+        "ST1005",
+        "-ST1005",
+        "ST1006",
+        "-ST1006",
+        "ST1008",
+        "-ST1008",
+        "ST1011",
+        "-ST1011",
+        "ST1012",
+        "-ST1012",
+        "ST1013",
+        "-ST1013",
+        "ST1015",
+        "-ST1015",
+        "ST1016",
+        "-ST1016",
+        "ST1017",
+        "-ST1017",
+        "ST1018",
+        "-ST1018",
+        "ST1019",
+        "-ST1019",
+        "ST1020",
+        "-ST1020",
+        "ST1021",
+        "-ST1021",
+        "ST1022",
+        "-ST1022",
+        "ST1023",
+        "-ST1023",
+        "S*",
+        "-S*",
+        "S1*",
+        "-S1*",
+        "S1000",
+        "-S1000",
+        "S1001",
+        "-S1001",
+        "S1002",
+        "-S1002",
+        "S1003",
+        "-S1003",
+        "S1004",
+        "-S1004",
+        "S1005",
+        "-S1005",
+        "S1006",
+        "-S1006",
+        "S1007",
+        "-S1007",
+        "S1008",
+        "-S1008",
+        "S1009",
+        "-S1009",
+        "S1010",
+        "-S1010",
+        "S1011",
+        "-S1011",
+        "S1012",
+        "-S1012",
+        "S1016",
+        "-S1016",
+        "S1017",
+        "-S1017",
+        "S1018",
+        "-S1018",
+        "S1019",
+        "-S1019",
+        "S1020",
+        "-S1020",
+        "S1021",
+        "-S1021",
+        "S1023",
+        "-S1023",
+        "S1024",
+        "-S1024",
+        "S1025",
+        "-S1025",
+        "S1028",
+        "-S1028",
+        "S1029",
+        "-S1029",
+        "S1030",
+        "-S1030",
+        "S1031",
+        "-S1031",
+        "S1032",
+        "-S1032",
+        "S1033",
+        "-S1033",
+        "S1034",
+        "-S1034",
+        "S1035",
+        "-S1035",
+        "S1036",
+        "-S1036",
+        "S1037",
+        "-S1037",
+        "S1038",
+        "-S1038",
+        "S1039",
+        "-S1039",
+        "S1040",
+        "-S1040",
+        "QF*",
+        "-QF*",
+        "QF1*",
+        "-QF1*",
+        "QF1001",
+        "-QF1001",
+        "QF1002",
+        "-QF1002",
+        "QF1003",
+        "-QF1003",
+        "QF1004",
+        "-QF1004",
+        "QF1005",
+        "-QF1005",
+        "QF1006",
+        "-QF1006",
+        "QF1007",
+        "-QF1007",
+        "QF1008",
+        "-QF1008",
+        "QF1009",
+        "-QF1009",
+        "QF1010",
+        "-QF1010",
+        "QF1011",
+        "-QF1011",
+        "QF1012",
+        "-QF1012"
+      ]
+    },
+    "godoclint-rules": {
+      "enum": [
+        "pkg-doc",
+        "single-pkg-doc",
+        "require-pkg-doc",
+        "start-with-name",
+        "require-doc",
+        "deprecated",
+        "max-len",
+        "no-unused-link"
+      ]
+    },
+    "gosec-rules": {
+      "enum": [
+        "G101",
+        "G102",
+        "G103",
+        "G104",
+        "G106",
+        "G107",
+        "G108",
+        "G109",
+        "G110",
+        "G111",
+        "G112",
+        "G114",
+        "G115",
+        "G201",
+        "G202",
+        "G203",
+        "G204",
+        "G301",
+        "G302",
+        "G303",
+        "G304",
+        "G305",
+        "G306",
+        "G307",
+        "G401",
+        "G402",
+        "G403",
+        "G404",
+        "G405",
+        "G406",
+        "G501",
+        "G502",
+        "G503",
+        "G504",
+        "G505",
+        "G506",
+        "G507",
+        "G601",
+        "G602"
+      ]
+    },
+    "govet-analyzers": {
+      "enum": [
+        "appends",
+        "asmdecl",
+        "assign",
+        "atomic",
+        "atomicalign",
+        "bools",
+        "buildtag",
+        "cgocall",
+        "composites",
+        "copylocks",
+        "deepequalerrors",
+        "defers",
+        "directive",
+        "errorsas",
+        "fieldalignment",
+        "findcall",
+        "framepointer",
+        "hostport",
+        "httpmux",
+        "httpresponse",
+        "ifaceassert",
+        "loopclosure",
+        "lostcancel",
+        "nilfunc",
+        "nilness",
+        "printf",
+        "reflectvaluecompare",
+        "shadow",
+        "shift",
+        "sigchanyzer",
+        "slog",
+        "sortslice",
+        "stdmethods",
+        "stdversion",
+        "stringintconv",
+        "structtag",
+        "testinggoroutine",
+        "tests",
+        "timeformat",
+        "unmarshal",
+        "unreachable",
+        "unsafeptr",
+        "unusedresult",
+        "unusedwrite",
+        "waitgroup"
+      ]
+    },
+    "revive-rules": {
+      "enum": [
+        "add-constant",
+        "argument-limit",
+        "atomic",
+        "banned-characters",
+        "bare-return",
+        "blank-imports",
+        "bool-literal-in-expr",
+        "call-to-gc",
+        "cognitive-complexity",
+        "comment-spacings",
+        "comments-density",
+        "confusing-naming",
+        "confusing-results",
+        "constant-logical-expr",
+        "context-as-argument",
+        "context-keys-type",
+        "cyclomatic",
+        "datarace",
+        "deep-exit",
+        "defer",
+        "dot-imports",
+        "duplicated-imports",
+        "early-return",
+        "empty-block",
+        "empty-lines",
+        "enforce-map-style",
+        "enforce-repeated-arg-type-style",
+        "enforce-slice-style",
+        "enforce-switch-style",
+        "error-naming",
+        "error-return",
+        "error-strings",
+        "errorf",
+        "exported",
+        "file-header",
+        "file-length-limit",
+        "filename-format",
+        "flag-parameter",
+        "function-length",
+        "function-result-limit",
+        "get-return",
+        "identical-branches",
+        "identical-ifelseif-branches",
+        "identical-ifelseif-conditions",
+        "identical-switch-branches",
+        "identical-switch-conditions",
+        "if-return",
+        "import-alias-naming",
+        "import-shadowing",
+        "imports-blocklist",
+        "increment-decrement",
+        "indent-error-flow",
+        "line-length-limit",
+        "max-control-nesting",
+        "max-public-structs",
+        "modifies-parameter",
+        "modifies-value-receiver",
+        "nested-structs",
+        "optimize-operands-order",
+        "package-comments",
+        "package-directory-mismatch",
+        "range-val-address",
+        "range-val-in-closure",
+        "range",
+        "receiver-naming",
+        "redefines-builtin-id",
+        "redundant-build-tag",
+        "redundant-import-alias",
+        "redundant-test-main-exit",
+        "string-format",
+        "string-of-int",
+        "struct-tag",
+        "superfluous-else",
+        "time-date",
+        "time-equal",
+        "time-naming",
+        "unchecked-type-assertion",
+        "unconditional-recursion",
+        "unexported-naming",
+        "unexported-return",
+        "unhandled-error",
+        "unnecessary-format",
+        "unnecessary-stmt",
+        "unreachable-code",
+        "unsecure-url-scheme",
+        "unused-parameter",
+        "unused-receiver",
+        "use-any",
+        "use-errors-new",
+        "use-fmt-print",
+        "use-waitgroup-go",
+        "useless-break",
+        "useless-fallthrough",
+        "var-declaration",
+        "var-naming",
+        "waitgroup-by-value"
+      ]
+    },
+    "iface-analyzers": {
+      "enum": [
+        "identical",
+        "unused",
+        "opaque",
+        "unexported"
+      ]
+    },
+    "tagliatelle-cases": {
+      "enum": [
+        "",
+        "camel",
+        "pascal",
+        "kebab",
+        "snake",
+        "goCamel",
+        "goPascal",
+        "goKebab",
+        "goSnake",
+        "upper",
+        "upperSnake",
+        "lower",
+        "header"
+      ]
+    },
+    "modernize-analyzers": {
+      "enum": [
+        "any",
+        "bloop",
+        "fmtappendf",
+        "forvar",
+        "mapsloop",
+        "minmax",
+        "newexpr",
+        "omitzero",
+        "rangeint",
+        "reflecttypefor",
+        "slicescontains",
+        "slicessort",
+        "stditerators",
+        "stringscutprefix",
+        "stringsseq",
+        "stringsbuilder",
+        "testingcontext",
+        "waitgroup"
+      ]
+    },
+    "wsl-checks": {
+      "enum": [
+        "assign",
+        "branch",
+        "decl",
+        "defer",
+        "expr",
+        "for",
+        "go",
+        "if",
+        "inc-dec",
+        "label",
+        "range",
+        "return",
+        "select",
+        "send",
+        "switch",
+        "type-switch",
+        "append",
+        "assign-exclusive",
+        "assign-expr",
+        "err",
+        "leading-whitespace",
+        "trailing-whitespace"
+      ]
+    },
+    "relative-path-modes": {
+      "enum": [
+        "gomod",
+        "gitroot",
+        "cfg",
+        "wd"
+      ]
+    },
+    "simple-format": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "$ref": "#/definitions/formats-path",
+          "default": "stdout"
+        }
+      }
+    },
+    "formats-path" : {
+      "anyOf": [
+        {
+          "enum": [
+            "stdout",
+            "stderr"
+          ]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "linter-names": {
+      "$comment": "anyOf with enum is used to allow auto-completion of non-custom linters",
+      "description": "Usable linter names.",
+      "anyOf": [
+        {
+          "enum": [
+            "arangolint",
+            "asasalint",
+            "asciicheck",
+            "bidichk",
+            "bodyclose",
+            "canonicalheader",
+            "containedctx",
+            "contextcheck",
+            "copyloopvar",
+            "cyclop",
+            "decorder",
+            "depguard",
+            "dogsled",
+            "dupl",
+            "dupword",
+            "durationcheck",
+            "embeddedstructfieldcheck",
+            "errcheck",
+            "errchkjson",
+            "errname",
+            "errorlint",
+            "exhaustive",
+            "exhaustruct",
+            "exptostd",
+            "fatcontext",
+            "forbidigo",
+            "forcetypeassert",
+            "funcorder",
+            "funlen",
+            "ginkgolinter",
+            "gocheckcompilerdirectives",
+            "gochecknoglobals",
+            "gochecknoinits",
+            "gochecksumtype",
+            "gocognit",
+            "goconst",
+            "gocritic",
+            "gocyclo",
+            "godoclint",
+            "godot",
+            "godox",
+            "err113",
+            "goheader",
+            "gomoddirectives",
+            "gomodguard",
+            "goprintffuncname",
+            "gosec",
+            "gosimple",
+            "gosmopolitan",
+            "govet",
+            "grouper",
+            "iface",
+            "importas",
+            "inamedparam",
+            "ineffassign",
+            "interfacebloat",
+            "intrange",
+            "iotamixing",
+            "ireturn",
+            "lll",
+            "loggercheck",
+            "maintidx",
+            "makezero",
+            "mirror",
+            "misspell",
+            "mnd",
+            "modernize",
+            "musttag",
+            "nakedret",
+            "nestif",
+            "nilerr",
+            "nilnesserr",
+            "nilnil",
+            "nlreturn",
+            "noctx",
+            "noinlineerr",
+            "nolintlint",
+            "nonamedreturns",
+            "nosprintfhostport",
+            "paralleltest",
+            "perfsprint",
+            "prealloc",
+            "predeclared",
+            "promlinter",
+            "protogetter",
+            "reassign",
+            "recvcheck",
+            "revive",
+            "rowserrcheck",
+            "sloglint",
+            "sqlclosecheck",
+            "staticcheck",
+            "stylecheck",
+            "tagalign",
+            "tagliatelle",
+            "testableexamples",
+            "testifylint",
+            "testpackage",
+            "thelper",
+            "tparallel",
+            "unconvert",
+            "unparam",
+            "unused",
+            "usestdlibvars",
+            "usetesting",
+            "varnamelen",
+            "wastedassign",
+            "whitespace",
+            "wrapcheck",
+            "wsl",
+            "wsl_v5",
+            "zerologlint"
+          ]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "formatter-names": {
+      "description": "Usable formatter names.",
+      "enum": [
+        "gci",
+        "gofmt",
+        "gofumpt",
+        "goimports",
+        "golines",
+        "swaggo"
+      ]
+    },
+    "settings": {
+      "definitions": {
+        "dupwordSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keywords": {
+              "description": "Keywords for detecting duplicate words. If this list is not empty, only the words defined in this list will be detected.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "examples": ["the", "and", "a"]
+              }
+            },
+            "ignore": {
+              "description": "Keywords used to ignore detection.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "examples": ["0C0C"]
+              }
+            },
+            "comments-only": {
+              "description": "Checks only comments, skip strings.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "asasalintSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "exclude": {
+              "description": "To specify a set of function names to exclude.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "examples": ["\\.Wrapf"]
+              }
+            },
+            "use-builtin-exclusions": {
+              "description": "To enable/disable the asasalint builtin exclusions of function names.",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "bidichkSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "left-to-right-embedding": {
+              "description": "Disallow: LEFT-TO-RIGHT-EMBEDDING",
+              "type": "boolean",
+              "default": false
+            },
+            "right-to-left-embedding": {
+              "description": "Disallow: RIGHT-TO-LEFT-EMBEDDING",
+              "type": "boolean",
+              "default": false
+            },
+            "pop-directional-formatting": {
+              "description": "Disallow: POP-DIRECTIONAL-FORMATTING",
+              "type": "boolean",
+              "default": false
+            },
+            "left-to-right-override": {
+              "description": "Disallow: LEFT-TO-RIGHT-OVERRIDE",
+              "type": "boolean",
+              "default": false
+            },
+            "right-to-left-override": {
+              "description": "Disallow: RIGHT-TO-LEFT-OVERRIDE",
+              "type": "boolean",
+              "default": false
+            },
+            "left-to-right-isolate": {
+              "description": "Disallow: LEFT-TO-RIGHT-ISOLATE",
+              "type": "boolean",
+              "default": false
+            },
+            "right-to-left-isolate": {
+              "description": "Disallow: RIGHT-TO-LEFT-ISOLATE",
+              "type": "boolean",
+              "default": false
+            },
+            "first-strong-isolate": {
+              "description": "Disallow: FIRST-STRONG-ISOLATE",
+              "type": "boolean",
+              "default": false
+            },
+            "pop-directional-isolate": {
+              "description": "Disallow: POP-DIRECTIONAL-ISOLATE",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "cyclopSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "max-complexity": {
+              "description": "Max complexity the function can have",
+              "type": "integer",
+              "default": 10,
+              "minimum": 0
+            },
+            "package-average": {
+              "description": "Max average complexity in package",
+              "type": "number",
+              "default": 0,
+              "minimum": 0
+            }
+          }
+        },
+        "decorderSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "dec-order": {
+              "type": "array",
+              "default": [["type", "const", "var", "func"]],
+              "items": {
+                "enum": ["type", "const", "var", "func"]
+              }
+            },
+            "ignore-underscore-vars": {
+              "description": "Underscore vars (vars with \"_\" as the name) will be ignored at all checks",
+              "default": true,
+              "type": "boolean"
+            },
+            "disable-dec-order-check": {
+              "description": "Order of declarations is not checked",
+              "default": true,
+              "type": "boolean"
+            },
+            "disable-init-func-first-check": {
+              "description": "Allow init func to be anywhere in file",
+              "default": true,
+              "type": "boolean"
+            },
+            "disable-dec-num-check": {
+              "description": "Multiple global type, const and var declarations are allowed",
+              "default": true,
+              "type": "boolean"
+            },
+            "disable-type-dec-num-check": {
+              "description": "Type declarations will be ignored for dec num check",
+              "default": true,
+              "type": "boolean"
+            },
+            "disable-const-dec-num-check": {
+              "description": "Const declarations will be ignored for dec num check",
+              "default": true,
+              "type": "boolean"
+            },
+            "disable-var-dec-num-check": {
+              "description": "Var declarations will be ignored for dec num check",
+              "default": true,
+              "type": "boolean"
+            }
+          }
+        },
+        "depguardSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "rules": {
+              "description": "Rules to apply.",
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[^.]+$": {
+                  "description": "Name of a rule.",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "list-mode": {
+                      "description": "Used to determine the package matching priority.",
+                      "enum": ["original", "strict", "lax"],
+                      "default": "original"
+                    },
+                    "files": {
+                      "description": "List of file globs that will match this list of settings to compare against.",
+                      "additionalProperties": false,
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "allow": {
+                      "description": "List of allowed packages.",
+                      "additionalProperties": false,
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deny": {
+                      "description": "Packages that are not allowed where the value is a suggestion.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "desc": {
+                            "description": "Description",
+                            "type": "string"
+                          },
+                          "pkg": {
+                            "description": "Package",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "dogsledSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "max-blank-identifiers": {
+              "description": "Check assignments with too many blank identifiers.",
+              "type": "integer",
+              "default": 2,
+              "minimum": 0
+            }
+          }
+        },
+        "duplSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "threshold": {
+              "description": "Tokens count to trigger issue.",
+              "type": "integer",
+              "default": 150,
+              "minimum": 0
+            }
+          }
+        },
+        "embeddedstructfieldcheckSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "empty-line": {
+              "description": "Checks that there is an empty space between the embedded fields and regular fields.",
+              "type": "boolean",
+              "default": false
+            },
+            "forbid-mutex": {
+              "description": "Checks that sync.Mutex and sync.RWMutex are not used as embedded fields.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "errcheckSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "check-type-assertions": {
+              "description": "Report about not checking errors in type assertions, i.e.: `a := b.(MyStruct)`",
+              "type": "boolean",
+              "default": false
+            },
+            "check-blank": {
+              "description": "Report about assignment of errors to blank identifier",
+              "type": "boolean",
+              "default": false
+            },
+            "exclude-functions": {
+              "description": "List of functions to exclude from checking, where each entry is a single function to exclude",
+              "type": "array",
+              "examples": ["io/ioutil.ReadFile", "io.Copy(*bytes.Buffer)"],
+              "items": {
+                "type": "string"
+              }
+            },
+            "disable-default-exclusions": {
+              "description": "To disable the errcheck built-in exclude list",
+              "type": "boolean",
+              "default": false
+            },
+            "verbose": {
+              "description": "Display function signature instead of selector",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "errchkjsonSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "check-error-free-encoding": {
+              "type": "boolean",
+              "default": false
+            },
+            "report-no-exported": {
+              "description": "Issue on struct that doesn't have exported fields.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "errorlintSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "errorf": {
+              "description": "Check whether fmt.Errorf uses the %w verb for formatting errors",
+              "type": "boolean",
+              "default": true
+            },
+            "errorf-multi": {
+              "description": "Permit more than 1 %w verb, valid per Go 1.20",
+              "type": "boolean",
+              "default": true
+            },
+            "asserts": {
+              "description": "Check for plain type assertions and type switches.",
+              "type": "boolean",
+              "default": true
+            },
+            "comparison": {
+              "description": "Check for plain error comparisons",
+              "type": "boolean",
+              "default": true
+            },
+            "allowed-errors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  },
+                  "fun": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "allowed-errors-wildcard": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  },
+                  "fun": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "exhaustiveSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "check": {
+              "description": "Program elements to check for exhaustiveness.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "examples": ["switch", "map"]
+              }
+            },
+            "explicit-exhaustive-switch": {
+              "description": "Only run exhaustive check on switches with \"//exhaustive:enforce\" comment.",
+              "type": "boolean",
+              "default": false
+            },
+            "explicit-exhaustive-map": {
+              "description": "Only run exhaustive check on map literals with \"//exhaustive:enforce\" comment.",
+              "type": "boolean",
+              "default": false
+            },
+            "default-case-required": {
+              "description": "Switch statement requires default case even if exhaustive.",
+              "type": "boolean",
+              "default": false
+            },
+            "default-signifies-exhaustive": {
+              "description": "Presence of `default` case in switch statements satisfies exhaustiveness, even if all enum members are not listed.",
+              "type": "boolean",
+              "default": false
+            },
+            "ignore-enum-members": {
+              "description": "Enum members matching `regex` do not have to be listed in switch statements to satisfy exhaustiveness",
+              "type": "string"
+            },
+            "ignore-enum-types": {
+              "description": "Enum types matching the supplied regex do not have to be listed in switch statements to satisfy exhaustiveness.",
+              "type": "string"
+            },
+            "package-scope-only": {
+              "description": "Consider enums only in package scopes, not in inner scopes.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "exhaustructSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "include": {
+              "description": "List of regular expressions to match struct packages and names.",
+              "type": "array",
+              "examples": [".*\\.Test"],
+              "items": {
+                "type": "string"
+              }
+            },
+            "exclude": {
+              "description": "List of regular expressions to exclude struct packages and names from check.",
+              "type": "array",
+              "examples": ["cobra\\.Command$"],
+              "items": {
+                "type": "string"
+              }
+            },
+            "allow-empty": {
+              "description": "Allows empty structures, effectively excluding them from the check.",
+              "type": "boolean",
+              "default": false
+            },
+            "allow-empty-rx": {
+              "description": "List of regular expressions to match type names that should be allowed to be empty.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "allow-empty-returns": {
+              "description": "Allows empty structures in return statements.",
+              "type": "boolean",
+              "default": false
+            },
+            "allow-empty-declarations": {
+              "description": "Allows empty structures in variable declarations.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "fatcontextSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "check-struct-pointers": {
+              "description": "Check for potential fat contexts in struct pointers.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "forbidigoSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "exclude-godoc-examples": {
+              "description": "Exclude code in godoc examples.",
+              "type": "boolean",
+              "default": true
+            },
+            "analyze-types": {
+              "description": "Instead of matching the literal source code, use type information to replace expressions with strings that contain the package name and (for methods and fields) the type name.",
+              "type": "boolean",
+              "default": true
+            },
+            "forbid": {
+              "description": "List of identifiers to forbid (written using `regexp`)",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "pattern": {
+                    "description": "Pattern",
+                    "type": "string"
+                  },
+                  "pkg": {
+                    "description": "Package",
+                    "type": "string"
+                  },
+                  "msg": {
+                    "description": "Message",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "funcorderSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "constructor": {
+              "description": "Checks that constructors are placed after the structure declaration.",
+              "type": "boolean",
+              "default": true
+            },
+            "struct-method": {
+              "description": "Checks if the exported methods of a structure are placed before the non-exported ones.",
+              "type": "boolean",
+              "default": true
+            },
+            "alphabetical": {
+              "description": "Checks if the constructors and/or structure methods are sorted alphabetically.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "funlenSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "lines": {
+              "description": "Limit lines number per function.",
+              "type": "integer",
+              "default": 60
+            },
+            "statements": {
+              "description": "Limit statements number per function.",
+              "type": "integer",
+              "default": 40
+            },
+            "ignore-comments": {
+              "description": "Ignore comments when counting lines.",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "gciSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "sections": {
+              "description": "Section configuration to compare against.",
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "standard",
+                      "default",
+                      "blank",
+                      "dot",
+                      "alias",
+                      "localmodule"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "default": ["standard", "default"]
+            },
+            "no-inline-comments": {
+              "description": "Checks that no inline Comments are present.",
+              "type": "boolean",
+              "default": false
+            },
+            "no-prefix-comments": {
+              "description": "Checks that no prefix Comments(comment lines above an import) are present.",
+              "type": "boolean",
+              "default": false
+            },
+            "custom-order": {
+              "description": "Enable custom order of sections.",
+              "type": "boolean",
+              "default": false
+            },
+            "no-lex-order": {
+              "description": "Drops lexical ordering for custom sections.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "ginkgolinterSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "suppress-len-assertion": {
+              "description": "Suppress the wrong length assertion warning.",
+              "type": "boolean",
+              "default": false
+            },
+            "suppress-nil-assertion": {
+              "description": "Suppress the wrong nil assertion warning.",
+              "type": "boolean",
+              "default": false
+            },
+            "suppress-err-assertion": {
+              "description": "Suppress the wrong error assertion warning.",
+              "type": "boolean",
+              "default": false
+            },
+            "suppress-compare-assertion": {
+              "description": "Suppress the wrong comparison assertion warning.",
+              "type": "boolean",
+              "default": false
+            },
+            "suppress-async-assertion": {
+              "description": "Suppress the function all in async assertion warning.",
+              "type": "boolean",
+              "default": false
+            },
+            "suppress-type-compare-assertion": {
+              "description": "Suppress warning for comparing values from different types, like int32 and uint32.",
+              "type": "boolean",
+              "default": false
+            },
+            "forbid-focus-container": {
+              "description": "Trigger warning for ginkgo focus containers like FDescribe, FContext, FWhen or FIt.",
+              "type": "boolean",
+              "default": false
+            },
+            "allow-havelen-zero": {
+              "description": "Don't trigger warnings for HaveLen(0).",
+              "type": "boolean",
+              "default": false
+            },
+            "force-expect-to": {
+              "description": "Force using `Expect` with `To`, `ToNot` or `NotTo`",
+              "type": "boolean",
+              "default": false
+            },
+            "validate-async-intervals": {
+              "description": "Best effort validation of async intervals (timeout and polling).",
+              "type": "boolean",
+              "default": false
+            },
+            "forbid-spec-pollution": {
+              "description": "Trigger a warning for variable assignments in ginkgo containers like `Describe`, `Context` and `When`, instead of in `BeforeEach()`.",
+              "type": "boolean",
+              "default": false
+            },
+            "force-succeed": {
+              "description": "Force using the Succeed matcher for error functions, and the HaveOccurred matcher for non-function error values.",
+              "type": "boolean",
+              "default": false
+            },
+            "force-assertion-description": {
+              "description": "Force adding assertion descriptions to gomega matchers.",
+              "type": "boolean",
+              "default": false
+            },
+            "force-tonot": {
+              "description": "Force using `ToNot`, `ShouldNot` instead of `To(Not())`.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "gochecksumtypeSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "default-signifies-exhaustive": {
+              "description": "Presence of `default` case in switch statements satisfies exhaustiveness, if all members are not listed.",
+              "type": "boolean",
+              "default": true
+            },
+            "include-shared-interfaces": {
+              "description": "Include shared interfaces in the exhaustiviness check.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "gocognitSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "min-complexity": {
+              "description": "Minimal code complexity to report (we recommend 10-20).",
+              "type": "integer",
+              "default": 30
+            }
+          }
+        },
+        "goconstSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "match-constant": {
+              "description": "Look for existing constants matching the values",
+              "type": "boolean",
+              "default": true
+            },
+            "min-len": {
+              "description": "Minimum length of string constant.",
+              "type": "integer",
+              "default": 3
+            },
+            "min-occurrences": {
+              "description": "Minimum occurrences count to trigger.",
+              "type": "integer",
+              "default": 3
+            },
+            "ignore-calls": {
+              "description": "Ignore when constant is not used as function argument",
+              "type": "boolean",
+              "default": true
+            },
+            "ignore-string-values": {
+              "description": "Exclude strings matching the given regular expression",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "numbers": {
+              "description": "Search also for duplicated numbers.",
+              "type": "boolean",
+              "default": false
+            },
+            "min": {
+              "description": "Minimum value, only works with `numbers`",
+              "type": "integer",
+              "default": 3
+            },
+            "max": {
+              "description": "Maximum value, only works with `numbers`",
+              "type": "integer",
+              "default": 3
+            },
+            "find-duplicates": {
+              "description": "Detects constants with identical values",
+              "type": "boolean",
+              "default": false
+            },
+            "eval-const-expressions": {
+              "description": "Evaluates of constant expressions like Prefix + \"suffix\"",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "gocriticSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled-checks": {
+              "description": "Which checks should be enabled. By default, a list of stable checks is used. To see it, run `GL_DEBUG=gocritic golangci-lint run`.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/gocritic-checks"
+              }
+            },
+            "disabled-checks": {
+              "description": "Which checks should be disabled.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/gocritic-checks"
+              },
+              "default": []
+            },
+            "enabled-tags": {
+              "description": "Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint run` to see all tags and checks.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/gocritic-tags"
+              }
+            },
+            "disabled-tags": {
+              "description": "Disable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint run` to see all tags and checks.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/gocritic-tags"
+              }
+            },
+            "settings": {
+              "description": "Settings passed to gocritic. Properties must be valid and enabled check names.",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "captLocal": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "paramsOnly" : {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
+                },
+                "commentedOutCode": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "minLength" : {
+                      "type": "number",
+                      "default": 15
+                    }
+                  }
+                },
+                "elseif": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "skipBalanced" : {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
+                },
+                "hugeParam": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "sizeThreshold" : {
+                      "type": "number",
+                      "default": 80
+                    }
+                  }
+                },
+                "ifElseChain": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "minThreshold" : {
+                      "type": "number",
+                      "default": 2
+                    }
+                  }
+                },
+                "nestingReduce": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "bodyWidth" : {
+                      "type": "number",
+                      "default": 5
+                    }
+                  }
+                },
+                "rangeExprCopy": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "sizeThreshold" : {
+                      "type": "number",
+                      "default": 512
+                    },
+                    "skipTestFuncs" : {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
+                },
+                "rangeValCopy": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "sizeThreshold" : {
+                      "type": "number",
+                      "default": 128
+                    },
+                    "skipTestFuncs" : {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
+                },
+                "ruleguard": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "debug" : {
+                      "type": "string"
+                    },
+                    "enable" : {
+                      "type": "string"
+                    },
+                    "disable" : {
+                      "type": "string"
+                    },
+                    "failOn" : {
+                      "type": "string"
+                    },
+                    "rules" : {
+                      "type": "string"
+                    }
+                  }
+                },
+                "tooManyResultsChecker": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "maxResults" : {
+                      "type": "number",
+                      "default": 5
+                    }
+                  }
+                },
+                "truncateCmp": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "skipArchDependent" : {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
+                },
+                "underef": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "skipRecvDeref" : {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  }
+                },
+                "unnamedResult": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "checkExported" : {
+                      "type": "boolean",
+                      "default": false
+                    }
+                  }
+                }
+              }
+            },
+            "disable-all": {
+              "type": "boolean",
+              "default": false
+            },
+            "enable-all": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "gocycloSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "min-complexity": {
+              "description": "Minimum code complexity to report (we recommend 10-20).",
+              "type": "integer",
+              "default": 30
+            }
+          }
+        },
+        "godoclintSettings": {
+          "type": "object",
+          "properties": {
+            "default": {
+              "type": "string",
+              "enum": ["all", "basic", "none"],
+              "default": "basic",
+              "description": "Default set of rules to enable."
+            },
+            "enable": {
+              "description": "List of rules to enable in addition to the default set.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/definitions/godoclint-rules"
+              }
+            },
+            "disable": {
+              "description": "List of rules to disable.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/definitions/godoclint-rules"
+              }
+            },
+            "options": {
+              "type": "object",
+              "description": "A map for setting individual rule options.",
+              "properties": {
+                "max-len": {
+                  "type": "object",
+                  "properties": {
+                    "length": {
+                      "type": "integer",
+                      "description": "Maximum line length for godocs, not including the `// `, or `/*` or `*/` tokens.",
+                      "default": 77
+                    }
+                  }
+                },
+                "require-doc": {
+                  "type": "object",
+                  "properties": {
+                    "ignore-exported": {
+                      "type": "boolean",
+                      "description": "Ignore exported (public) symbols when applying the `require-doc` rule.",
+                      "default": false
+                    },
+                    "ignore-unexported": {
+                      "type": "boolean",
+                      "description": "Ignore unexported (private) symbols when applying the `require-doc` rule.",
+                      "default": true
+                    }
+                  }
+                },
+                "start-with-name": {
+                  "type": "object",
+                  "properties": {
+                    "include-unexported": {
+                      "type": "boolean",
+                      "description": "Include unexported symbols when applying the `start-with-name` rule.",
+                      "default": false
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "godotSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "scope": {
+              "description": "Comments to be checked.",
+              "enum": ["declarations", "toplevel", "all", "noinline"],
+              "default": "declarations"
+            },
+            "exclude": {
+              "description": "List of regexps for excluding particular comment lines from check.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "period": {
+              "description": "Check that each sentence ends with a period.",
+              "type": "boolean",
+              "default": true
+            },
+            "capital": {
+              "description": "Check that each sentence starts with a capital letter.",
+              "type": "boolean",
+              "default": false
+            },
+            "check-all": {
+              "description": "DEPRECATED: Check all top-level comments, not only declarations.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "godoxSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "keywords": {
+              "description": "Report any comments starting with one of these keywords. This is useful for TODO or FIXME comments that might be left in the code accidentally and should be resolved before merging.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": ["TODO", "BUG", "FIXME"]
+            }
+          }
+        },
+        "gofmtSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "simplify": {
+              "description": "Simplify code.",
+              "type": "boolean",
+              "default": true
+            },
+            "rewrite-rules": {
+              "description": "Apply the rewrite rules to the source before reformatting.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "pattern": {
+                    "type": "string"
+                  },
+                  "replacement": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "golinesSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "max-len": {
+              "type": "integer",
+              "default": 100
+            },
+            "tab-len": {
+              "type": "integer",
+              "default": 4
+            },
+            "shorten-comments": {
+              "type": "boolean",
+              "default": false
+            },
+            "reformat-tags": {
+              "type": "boolean",
+              "default": true
+            },
+            "chain-split-dots": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "interfacebloatSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "max": {
+              "description": "The maximum number of methods allowed for an interface.",
+              "type": "integer"
+            }
+          }
+        },
+        "gofumptSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "extra-rules": {
+              "description": "Choose whether or not to use the extra rules that are disabled by default.",
+              "type": "boolean",
+              "default": false
+            },
+            "module-path": {
+              "description": " Module path which contains the source code being formatted.",
+              "type": "string"
+            }
+          }
+        },
+        "goheaderSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "values": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "const": {
+                  "description": "Constants to use in the template.",
+                  "type": "object",
+                  "patternProperties": {
+                    "^.+$": {
+                      "description": "Value for the constant.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "examples": [
+                    {
+                      "YEAR": "2030",
+                      "COMPANY": "MY FUTURISTIC COMPANY"
+                    }
+                  ]
+                },
+                "regexp": {
+                  "description": "Regular expressions to use in your template.",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^.+$": {
+                      "type": "string"
+                    }
+                  },
+                  "examples": [
+                    {
+                      "AUTHOR": ".*@mycompany\\.com"
+                    }
+                  ]
+                }
+              }
+            },
+            "template": {
+              "description": "Template to put on top of every file.",
+              "type": "string",
+              "examples": [
+                "{{ MY COMPANY }}\nSPDX-License-Identifier: Apache-2.0\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at:\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License."
+              ]
+            },
+            "template-path": {
+              "description": "Path to the file containing the template source.",
+              "type": "string",
+              "examples": ["my_header_template.txt"]
+            }
+          },
+          "oneOf": [
+            { "required": ["template"] },
+            { "required": ["template-path"] }
+          ]
+        },
+        "goimportsSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "local-prefixes": {
+              "description": "Put imports beginning with prefix after 3rd-party packages. It is a list of prefixes.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "gomoddirectivesSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "replace-local": {
+              "description": "Allow local `replace` directives.",
+              "type": "boolean",
+              "default": true
+            },
+            "replace-allow-list": {
+              "description": "List of allowed `replace` directives.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "retract-allow-no-explanation": {
+              "description": "Allow to not explain why the version has been retracted in the `retract` directives.",
+              "type": "boolean",
+              "default": false
+            },
+            "exclude-forbidden": {
+              "description": "Forbid the use of the `exclude` directives.",
+              "type": "boolean",
+              "default": false
+            },
+            "ignore-forbidden": {
+              "description": "Forbid the use of the `ignore` directives. (>= go1.25)",
+              "type": "boolean",
+              "default": false
+            },
+            "toolchain-forbidden": {
+              "description": "Forbid the use of the `toolchain` directive.",
+              "type": "boolean",
+              "default": false
+            },
+            "toolchain-pattern": {
+              "description": "Defines a pattern to validate `toolchain` directive.",
+              "type": "string"
+            },
+            "tool-forbidden": {
+              "description": "Forbid the use of the `tool` directives.",
+              "type": "boolean",
+              "default": false
+            },
+            "go-debug-forbidden": {
+              "description": "Forbid the use of the `godebug` directive.",
+              "type": "boolean",
+              "default": false
+            },
+            "go-version-pattern": {
+              "description": "Defines a pattern to validate `go` minimum version directive.",
+              "type": "string",
+              "default": ""
+            }
+          }
+        },
+        "gomodguardSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allowed": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "modules": {
+                  "description": "List of allowed modules.",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "examples": ["gopkg.in/yaml.v2"]
+                  }
+                },
+                "domains": {
+                  "description": "List of allowed module domains.",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "examples": ["golang.org"]
+                  }
+                }
+              }
+            },
+            "blocked": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "modules": {
+                  "description": "List of blocked modules.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "patternProperties": {
+                      "^.+$": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "recommendations": {
+                            "description": "Recommended modules that should be used instead.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "reason": {
+                            "description": "Reason why the recommended module should be used.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "versions": {
+                  "description": "List of blocked module version constraints.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "patternProperties": {
+                      "^.*$": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "version": {
+                            "description": "Version constraint.",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "description": "Reason why the version constraint exists.",
+                            "type": "string"
+                          }
+                        },
+                        "required": ["reason"]
+                      }
+                    }
+                  }
+                },
+                "local-replace-directives": {
+                  "description": "Raise lint issues if loading local path with replace directive",
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          }
+        },
+        "gosecSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "includes": {
+              "type": "array",
+              "description": "To select a subset of rules to run",
+              "examples": [["G401"]],
+              "items": {
+                "$ref": "#/definitions/gosec-rules"
+              }
+            },
+            "excludes": {
+              "type": "array",
+              "description": "To specify a set of rules to explicitly exclude",
+              "examples": [["G401"]],
+              "items": {
+                "$ref": "#/definitions/gosec-rules"
+              }
+            },
+            "severity": {
+              "description": "Filter out the issues with a lower severity than the given value",
+              "type": "string",
+              "enum": ["low", "medium", "high"],
+              "default": "low"
+            },
+            "confidence": {
+              "description": "Filter out the issues with a lower confidence than the given value",
+              "type": "string",
+              "enum": ["low", "medium", "high"],
+              "default": "low"
+            },
+            "config": {
+              "description": "To specify the configuration of rules",
+              "type": "object"
+            },
+            "concurrency": {
+              "description": "Concurrency value",
+              "type": "integer"
+            }
+          }
+        },
+        "gosmopolitanSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow-time-local": {
+              "description": "Allow and ignore `time.Local` usages.",
+              "type": "boolean",
+              "default": false
+            },
+            "escape-hatches": {
+              "description": "List of fully qualified names in the `full/pkg/path.name` form, to act as \"i18n escape hatches\".",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "watch-for-scripts": {
+              "description": "List of Unicode scripts to watch for any usage in string literals.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "govetSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "settings": {
+              "description": "Settings per analyzer. Map of analyzer name to specific settings.\nRun `go tool vet help` to find out more.",
+              "type": "object",
+              "propertyNames": {
+                "$ref": "#/definitions/govet-analyzers"
+              },
+              "patternProperties": {
+                "^.*$": {
+                  "description": "Run `go tool vet help <analyzer>` to see all settings.",
+                  "type": "object"
+                }
+              }
+            },
+            "enable": {
+              "description": "Enable analyzers by name.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/govet-analyzers"
+              }
+            },
+            "disable": {
+              "description": "Disable analyzers by name.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/govet-analyzers"
+              }
+            },
+            "enable-all": {
+              "description": "Enable all analyzers.",
+              "type": "boolean",
+              "default": false
+            },
+            "disable-all": {
+              "description": "Disable all analyzers.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "grouperSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "const-require-single-const": {
+              "type": "boolean",
+              "default": false
+            },
+            "const-require-grouping": {
+              "type": "boolean",
+              "default": false
+            },
+            "import-require-single-import": {
+              "type": "boolean",
+              "default": false
+            },
+            "import-require-grouping": {
+              "type": "boolean",
+              "default": false
+            },
+            "type-require-single-type": {
+              "type": "boolean",
+              "default": false
+            },
+            "type-require-grouping": {
+              "type": "boolean",
+              "default": false
+            },
+            "var-require-single-var": {
+              "type": "boolean",
+              "default": false
+            },
+            "var-require-grouping": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "ifaceSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enable": {
+              "description": "Enable analyzers by name.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/iface-analyzers"
+              }
+            },
+            "settings": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "unused": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "exclude": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "importasSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "no-unaliased": {
+              "description": "Do not allow unaliased imports of aliased packages.",
+              "type": "boolean",
+              "default": false
+            },
+            "no-extra-aliases": {
+              "description": "Do not allow non-required aliases.",
+              "type": "boolean",
+              "default": false
+            },
+            "alias": {
+              "description": "List of aliases",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "pkg": {
+                    "description": "Package path e.g. knative.dev/serving/pkg/apis/autoscaling/v1alpha1",
+                    "type": "string"
+                  },
+                  "alias": {
+                    "description": "Package alias e.g. autoscalingv1alpha1",
+                    "type": "string"
+                  }
+                },
+                "required": ["pkg", "alias"]
+              }
+            }
+          }
+        },
+        "inamedparamSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "skip-single-param": {
+              "description": "Skips check for interface methods with only a single parameter.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "ineffassignSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "check-escaping-errors": {
+              "description": "Check escaping variables of type error, may cause false positives.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "iotamixingSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "report-individual": {
+              "description": "Whether to report individual consts rather than just the const block.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "ireturnSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Use either `reject` or `allow` properties for interfaces matching.",
+          "properties": {
+            "allow": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "enum": ["anon", "error", "empty", "stdlib"]
+                  }
+                ]
+              }
+            },
+            "reject": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "enum": ["anon", "error", "empty", "stdlib"]
+                  }
+                ]
+              }
+            }
+          },
+          "anyOf": [
+            {
+              "not": {
+                "properties": {
+                  "allow": {
+                    "const": "reject"
+                  }
+                }
+              },
+              "required": ["allow"]
+            },
+            {
+              "required": ["reject"]
+            }
+          ]
+        },
+        "lllSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "tab-width": {
+              "description": "Width of \"\\t\" in spaces.",
+              "type": "integer",
+              "minimum": 0,
+              "default": 1
+            },
+            "line-length": {
+              "description": "Maximum allowed line length, lines longer will be reported.",
+              "type": "integer",
+              "minimum": 1,
+              "default": 120
+            }
+          }
+        },
+        "maintidxSettings": {
+          "description": "Maintainability index https://docs.microsoft.com/en-us/visualstudio/code-quality/code-metrics-maintainability-index-range-and-meaning?view=vs-2022",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "under": {
+              "description": "Minimum accatpable maintainability index level (see https://docs.microsoft.com/en-us/visualstudio/code-quality/code-metrics-maintainability-index-range-and-meaning?view=vs-2022)",
+              "type": "number",
+              "default": 20
+            }
+          }
+        },
+        "makezeroSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "always": {
+              "description": "Allow only slices initialized with a length of zero.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "loggercheckSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "kitlog": {
+              "description": "Allow check for the github.com/go-kit/log library.",
+              "type": "boolean",
+              "default": true
+            },
+            "klog": {
+              "description": "Allow check for the k8s.io/klog/v2 library.",
+              "type": "boolean",
+              "default": true
+            },
+            "logr": {
+              "description": "Allow check for the github.com/go-logr/logr library.",
+              "type": "boolean",
+              "default": true
+            },
+            "slog": {
+              "description": "Allow check for the log/slog library.",
+              "type": "boolean",
+              "default": true
+            },
+            "zap": {
+              "description": "Allow check for the \"sugar logger\" from go.uber.org/zap library.",
+              "type": "boolean",
+              "default": true
+            },
+            "require-string-key": {
+              "description": "Require all logging keys to be inlined constant strings.",
+              "type": "boolean",
+              "default": false
+            },
+            "no-printf-like": {
+              "description": "Require printf-like format specifier (%s, %d for example) not present.",
+              "type": "boolean",
+              "default": false
+            },
+            "rules": {
+              "description": "List of custom rules to check against, where each rule is a single logger pattern, useful for wrapped loggers.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "misspellSettings": {
+          "description": "Correct spellings using locale preferences for US or UK. Default is to use a neutral variety of English.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "locale": {
+              "enum": ["US", "UK"]
+            },
+            "ignore-rules": {
+              "description": "List of rules to ignore.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "mode": {
+              "description": "Mode of the analysis.",
+              "enum": ["restricted", "", "default"],
+              "default": ""
+            },
+            "extra-words": {
+              "description": "Extra word corrections.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "correction": {
+                    "type": "string"
+                  },
+                  "typo": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "musttagSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "functions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "tag": {
+                    "type": "string"
+                  },
+                  "arg-pos": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nakedretSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "max-func-lines": {
+              "description": "Report if a function has more lines of code than this value and it has naked returns.",
+              "type": "integer",
+              "minimum": 0,
+              "default": 30
+            }
+          }
+        },
+        "nestifSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "min-complexity": {
+              "description": "Minimum complexity of \"if\" statements to report.",
+              "type": "integer",
+              "default": 5
+            }
+          }
+        },
+        "nilnilSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "only-two":  {
+              "type": "boolean",
+              "description": "To check functions with only two return values.",
+              "default": true
+            },
+            "detect-opposite": {
+              "type": "boolean",
+              "description": "In addition, detect opposite situation (simultaneous return of non-nil error and valid value).",
+              "default": false
+            },
+            "checked-types": {
+              "type": "array",
+              "description": "List of return types to check.",
+              "items": {
+                "enum": ["chan", "func", "iface", "map", "ptr", "uintptr", "unsafeptr"]
+              },
+              "default": ["chan", "func", "iface", "map", "ptr", "uintptr", "unsafeptr"]
+            }
+          }
+        },
+        "nlreturnSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "block-size": {
+              "description": "set block size that is still ok",
+              "type": "number",
+              "default": 0,
+              "minimum": 0
+            }
+          }
+        },
+        "mndSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ignored-files": {
+              "description": "List of file patterns to exclude from analysis.",
+              "examples": [["magic1_.*.go"]],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignored-functions": {
+              "description": "Comma-separated list of function patterns to exclude from the analysis.",
+              "examples": [["math.*", "http.StatusText", "make"]],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignored-numbers": {
+              "description": "List of numbers to exclude from analysis.",
+              "examples": [["1000", "1234_567_890", "3.14159264"]],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "checks": {
+              "description": "The list of enabled checks, see https://github.com/tommy-muehle/go-mnd/#checks for description.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "argument",
+                  "case",
+                  "condition",
+                  "operation",
+                  "return",
+                  "assign"
+                ]
+              }
+            }
+          }
+        },
+        "modernizeSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "disable": {
+              "description": "List of analyzers to disable.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/modernize-analyzers"
+              }
+            }
+          }
+        },
+        "nolintlintSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow-unused": {
+              "description": "Enable to ensure that nolint directives are all used.",
+              "type": "boolean",
+              "default": true
+            },
+            "allow-no-explanation": {
+              "description": "Exclude these linters from requiring an explanation.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/linter-names"
+              },
+              "default": []
+            },
+            "require-explanation": {
+              "description": "Enable to require an explanation of nonzero length after each nolint directive.",
+              "type": "boolean",
+              "default": false
+            },
+            "require-specific": {
+              "description": "Enable to require nolint directives to mention the specific linter being suppressed.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "reassignSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "patterns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "recvcheckSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "disable-builtin": {
+              "description": "Disables the built-in method exclusions.",
+              "type": "boolean",
+              "default": true
+            },
+            "exclusions": {
+              "description": "User-defined method exclusions.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "nonamedreturnsSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "report-error-in-defer": {
+              "description": "Report named error if it is assigned inside defer.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "paralleltestSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ignore-missing": {
+              "description": "Ignore missing calls to `t.Parallel()` and only report incorrect uses of it.",
+              "type": "boolean",
+              "default": false
+            },
+            "ignore-missing-subtests": {
+              "description": "Ignore missing calls to `t.Parallel()` in subtests. Top-level tests are still required to have `t.Parallel`, but subtests are allowed to skip it.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "perfsprintSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "integer-format": {
+              "description": "Enable/disable optimization of integer formatting.",
+              "type": "boolean",
+              "default": true
+            },
+            "int-conversion": {
+              "description": "Optimizes even if it requires an int or uint type cast.",
+              "type": "boolean",
+              "default": true
+            },
+            "error-format": {
+              "description": "Enable/disable optimization of error formatting.",
+              "type": "boolean",
+              "default": true
+            },
+            "err-error": {
+              "description": "Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.",
+              "type": "boolean",
+              "default": false
+            },
+            "errorf": {
+              "description": "Optimizes `fmt.Errorf`.",
+              "type": "boolean",
+              "default": true
+            },
+            "string-format": {
+              "description": "Enable/disable optimization of string formatting.",
+              "type": "boolean",
+              "default": true
+            },
+            "sprintf1": {
+              "description": "Optimizes `fmt.Sprintf` with only one argument.",
+              "type": "boolean",
+              "default": true
+            },
+            "strconcat": {
+              "description": "Optimizes into strings concatenation.",
+              "type": "boolean",
+              "default": true
+            },
+            "bool-format": {
+              "description": "Enable/disable optimization of bool formatting.",
+              "type": "boolean",
+              "default": true
+            },
+            "hex-format": {
+              "description": "Enable/disable optimization of hex formatting.",
+              "type": "boolean",
+              "default": true
+            },
+            "concat-loop": {
+              "description": "Enable/disable optimization of concat loop.",
+              "type": "boolean",
+              "default": true
+            },
+            "loop-other-ops": {
+              "description": "Optimization of `concat-loop` even with other operations.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "preallocSettings": {
+          "description": "We do not recommend using this linter before doing performance profiling.\nFor most programs usage of `prealloc` will be premature optimization.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "simple": {
+              "description": "Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.",
+              "type": "boolean",
+              "default": true
+            },
+            "range-loops": {
+              "description": "Report preallocation suggestions on range loops.",
+              "type": "boolean",
+              "default": true
+            },
+            "for-loops": {
+              "description": "Report preallocation suggestions on for loops.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "predeclaredSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ignore": {
+              "description": "List of predeclared identifiers to not report on.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "qualified-name": {
+              "description": "Include method names and field names in checks.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "promlinterSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "strict": {},
+            "disabled-linters": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Help",
+                  "MetricUnits",
+                  "Counter",
+                  "HistogramSummaryReserved",
+                  "MetricTypeInName",
+                  "ReservedChars",
+                  "CamelCase",
+                  "UnitAbbreviations"
+                ]
+              }
+            }
+          }
+        },
+        "protogetterSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "skip-generated-by": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "examples": ["protoc-gen-go-my-own-generator"]
+              }
+            },
+            "skip-files": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "examples": ["*.pb.go"]
+              }
+            },
+            "skip-any-generated": {
+              "description": "Skip any generated files from the checking.",
+              "type": "boolean",
+              "default": false
+            },
+            "replace-first-arg-in-append": {
+              "description": "Skip first argument of append function.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "reviveSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "examples": [
+            {
+              "ignore-generated-header": true,
+              "severity": "warning",
+              "rules": [
+                {
+                  "name": "indent-error-flow",
+                  "severity": "warning"
+                },
+                {
+                  "name": "add-constant",
+                  "severity": "warning",
+                  "arguments": [
+                    {
+                      "maxLitCount": "3",
+                      "allowStrs": "\"\"",
+                      "allowInts": "0,1,2",
+                      "allowFloats": "0.0,0.,1.0,1.,2.0,2."
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "properties": {
+            "max-open-files": {
+              "type": "integer"
+            },
+            "confidence": {
+              "type": "number"
+            },
+            "severity": {
+              "type": "string",
+              "enum": ["warning", "error"]
+            },
+            "enable-all-rules": {
+              "type": "boolean",
+              "default": false
+            },
+            "directives": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "enum": ["specify-disable-reason"]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": ["warning", "error"]
+                  },
+                  "exclude": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "arguments": {
+                    "type": "array"
+                  }
+                }
+              }
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "$ref": "#/definitions/revive-rules",
+                    "title": "The rule name"
+                  },
+                  "disabled": {
+                    "type": "boolean"
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": ["warning", "error"]
+                  },
+                  "exclude": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "arguments": {
+                    "type": "array"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "rowserrcheckSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "packages": {
+              "type": "array",
+              "items": {
+                "description": "",
+                "type": "string",
+                "examples": ["github.com/jmoiron/sqlx"]
+              }
+            }
+          }
+        },
+        "sloglintSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "kv-only": {
+              "description": "Enforce using key-value pairs only (incompatible with attr-only).",
+              "type": "boolean",
+              "default": false
+            },
+            "no-global": {
+              "description": "Enforce not using global loggers.",
+              "enum": ["", "all", "default"],
+              "default": ""
+            },
+            "no-mixed-args": {
+              "description": "Enforce not mixing key-value pairs and attributes.",
+              "type": "boolean",
+              "default": true
+            },
+            "context": {
+              "description": "Enforce using methods that accept a context.",
+              "enum": ["", "all", "scope"],
+              "default": ""
+            },
+            "static-msg": {
+              "description": "Enforce using static values for log messages.",
+              "type": "boolean",
+              "default": false
+            },
+            "msg-style": {
+              "description": "Enforce message style.",
+              "enum": ["", "lowercased", "capitalized"],
+              "default": ""
+            },
+            "key-naming-case": {
+              "description": "Enforce a single key naming convention.",
+              "enum": ["snake", "kebab", "camel", "pascal"]
+            },
+            "attr-only": {
+              "description": "Enforce using attributes only (incompatible with kv-only).",
+              "type": "boolean",
+              "default": false
+            },
+            "no-raw-keys": {
+              "description": "Enforce using constants instead of raw keys.",
+              "type": "boolean",
+              "default": false
+            },
+            "forbidden-keys": {
+              "description": "Enforce not using specific keys.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "args-on-sep-lines": {
+              "description": "Enforce putting arguments on separate lines.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "spancheckSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "checks": {
+              "description": "Checks to enable.",
+              "type": "array",
+              "items": {
+                "enum": ["end", "record-error", "set-status"]
+              }
+            },
+            "ignore-check-signatures": {
+              "description": "A list of regexes for function signatures that silence `record-error` and `set-status` reports if found in the call path to a returned error.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "extra-start-span-signatures": {
+              "description": "A list of regexes for additional function signatures that create spans.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "staticcheckSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "checks": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/staticcheck-checks"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "dot-import-whitelist": {
+              "description": "By default, ST1001 forbids all uses of dot imports in non-test packages. This setting allows setting a whitelist of import paths that can be dot-imported anywhere.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "http-status-code-whitelist": {
+              "description": "ST1013 recommends using constants from the net/http package instead of hard-coding numeric HTTP status codes. This setting specifies a list of numeric status codes that this check does not complain about.",
+              "default": ["200", "400", "404", "500"],
+              "type": "array",
+              "items": {
+                "enum": [
+                  "100",
+                  "101",
+                  "102",
+                  "103",
+                  "200",
+                  "201",
+                  "202",
+                  "203",
+                  "204",
+                  "205",
+                  "206",
+                  "207",
+                  "208",
+                  "226",
+                  "300",
+                  "301",
+                  "302",
+                  "303",
+                  "304",
+                  "305",
+                  "306",
+                  "307",
+                  "308",
+                  "400",
+                  "401",
+                  "402",
+                  "403",
+                  "404",
+                  "405",
+                  "406",
+                  "407",
+                  "408",
+                  "409",
+                  "410",
+                  "411",
+                  "412",
+                  "413",
+                  "414",
+                  "415",
+                  "416",
+                  "417",
+                  "418",
+                  "421",
+                  "422",
+                  "423",
+                  "424",
+                  "425",
+                  "426",
+                  "428",
+                  "429",
+                  "431",
+                  "451",
+                  "500",
+                  "501",
+                  "502",
+                  "503",
+                  "504",
+                  "505",
+                  "506",
+                  "507",
+                  "508",
+                  "510",
+                  "511"
+                ]
+              }
+            },
+            "initialisms": {
+              "description": "ST1003 check, among other things, for the correct capitalization of initialisms. The set of known initialisms can be configured with this option.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "default": [
+                  "ACL",
+                  "API",
+                  "ASCII",
+                  "CPU",
+                  "CSS",
+                  "DNS",
+                  "EOF",
+                  "GUID",
+                  "HTML",
+                  "HTTP",
+                  "HTTPS",
+                  "ID",
+                  "IP",
+                  "JSON",
+                  "QPS",
+                  "RAM",
+                  "RPC",
+                  "SLA",
+                  "SMTP",
+                  "SQL",
+                  "SSH",
+                  "TCP",
+                  "TLS",
+                  "TTL",
+                  "UDP",
+                  "UI",
+                  "GID",
+                  "UID",
+                  "UUID",
+                  "URI",
+                  "URL",
+                  "UTF8",
+                  "VM",
+                  "XML",
+                  "XMPP",
+                  "XSRF",
+                  "XSS",
+                  "SIP",
+                  "RTP",
+                  "AMQP",
+                  "DB",
+                  "TS"
+                ]
+              }
+            }
+          }
+        },
+        "tagalignSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "align": {
+              "description": "Align and sort can be used together or separately.",
+              "type": "boolean",
+              "default": true
+            },
+            "sort": {
+              "description": "Whether enable tags sort.",
+              "type": "boolean",
+              "default": true
+            },
+            "order": {
+              "description": "Specify the order of tags, the other tags will be sorted by name.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [],
+              "examples": [
+                [
+                  "json",
+                  "yaml",
+                  "yml",
+                  "toml",
+                  "mapstructure",
+                  "binding",
+                  "validate"
+                ]
+              ]
+            },
+            "strict": {
+              "description": "Whether enable strict style.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "tagliatelleSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "case": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "use-field-name": {
+                  "description": "Use the struct field name to check the name of the struct tag.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "ignored-fields": {
+                  "description": "The field names to ignore.",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "examples": ["example"]
+                  }
+                },
+                "rules": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^.+$": {
+                      "$ref": "#/definitions/tagliatelle-cases"
+                    }
+                  }
+                },
+                "extended-rules": {
+                  "description": "Defines the association between tag name and case.",
+                  "type": "object",
+                  "patternProperties": {
+                    "^.+$": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["case"],
+                      "properties": {
+                        "case": {
+                          "$ref": "#/definitions/tagliatelle-cases"
+                        },
+                        "extra-initialisms": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "initialism-overrides": {
+                          "type": "object",
+                          "patternProperties": {
+                            "^.+$": {
+                              "type": "boolean",
+                              "default": false
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "overrides": {
+                  "description": "Overrides the default/root configuration.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["pkg"],
+                    "properties": {
+                      "pkg": {
+                        "description": "A package path.",
+                        "type": "string"
+                      },
+                      "use-field-name": {
+                        "description": "Use the struct field name to check the name of the struct tag.",
+                        "type": "boolean",
+                        "default": false
+                      },
+                      "ignored-fields": {
+                        "description": "The field names to ignore.",
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "examples": ["example"]
+                        }
+                      },
+                      "ignore": {
+                        "description": "Ignore the package (takes precedence over all other configurations).",
+                        "type": "boolean",
+                        "default": false
+                      },
+                      "rules": {
+                        "type": "object",
+                        "patternProperties": {
+                          "^.+$": {
+                            "$ref": "#/definitions/tagliatelle-cases"
+                          }
+                        }
+                      },
+                      "extended-rules": {
+                        "description": "Defines the association between tag name and case.",
+                        "type": "object",
+                        "patternProperties": {
+                          "^.+$": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["case"],
+                            "properties": {
+                              "case": {
+                                "$ref": "#/definitions/tagliatelle-cases"
+                              },
+                              "extra-initialisms": {
+                                "type": "boolean",
+                                "default": false
+                              },
+                              "initialism-overrides": {
+                                "type": "object",
+                                "patternProperties": {
+                                  "^.+$": {
+                                    "type": "boolean",
+                                    "default": false
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "testifylintSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enable-all": {
+              "description": "Enable all checkers.",
+              "type": "boolean",
+              "default": false
+            },
+            "disable-all": {
+              "description": "Disable all checkers.",
+              "type": "boolean",
+              "default": false
+            },
+            "enable": {
+              "description": "Enable specific checkers.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "blank-import",
+                  "bool-compare",
+                  "compares",
+                  "contains",
+                  "empty",
+                  "encoded-compare",
+                  "equal-values",
+                  "error-is-as",
+                  "error-nil",
+                  "expected-actual",
+                  "float-compare",
+                  "formatter",
+                  "go-require",
+                  "len",
+                  "negative-positive",
+                  "nil-compare",
+                  "regexp",
+                  "require-error",
+                  "suite-broken-parallel",
+                  "suite-dont-use-pkg",
+                  "suite-extra-assert-call",
+                  "suite-method-signature",
+                  "suite-subtest-run",
+                  "suite-thelper",
+                  "useless-assert"
+                ]
+              },
+              "default": [
+                "blank-import",
+                "bool-compare",
+                "compares",
+                "contains",
+                "empty",
+                "encoded-compare",
+                "equal-values",
+                "error-is-as",
+                "error-nil",
+                "expected-actual",
+                "float-compare",
+                "formatter",
+                "go-require",
+                "len",
+                "negative-positive",
+                "nil-compare",
+                "regexp",
+                "require-error",
+                "suite-broken-parallel",
+                "suite-dont-use-pkg",
+                "suite-extra-assert-call",
+                "suite-method-signature",
+                "suite-subtest-run",
+                "useless-assert"
+              ]
+            },
+            "disable": {
+              "description": "Disable specific checkers.",
+              "type": "array",
+              "items": {
+                "enum": [
+                  "blank-import",
+                  "bool-compare",
+                  "compares",
+                  "contains",
+                  "empty",
+                  "encoded-compare",
+                  "equal-values",
+                  "error-is-as",
+                  "error-nil",
+                  "expected-actual",
+                  "float-compare",
+                  "formatter",
+                  "go-require",
+                  "len",
+                  "negative-positive",
+                  "nil-compare",
+                  "regexp",
+                  "require-error",
+                  "suite-broken-parallel",
+                  "suite-dont-use-pkg",
+                  "suite-extra-assert-call",
+                  "suite-method-signature",
+                  "suite-subtest-run",
+                  "suite-thelper",
+                  "useless-assert"
+                ],
+                "default": [
+                  "suite-thelper"
+                ]
+              }
+            },
+            "bool-compare": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignore-custom-types": {
+                  "description": "To ignore user defined types (over builtin bool).",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            },
+            "expected-actual": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "pattern": {
+                  "description": "Regexp for expected variable name.",
+                  "type": "string",
+                  "default": "(^(exp(ected)?|want(ed)?)([A-Z]\\w*)?$)|(^(\\w*[a-z])?(Exp(ected)?|Want(ed)?)$)"
+                }
+              }
+            },
+            "formatter": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "check-format-string": {
+                  "description": "To enable go vet's printf checks.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "require-f-funcs": {
+                  "description": "To require f-assertions (e.g. assert.Equalf) if format string is used, even if there are no variable-length variables.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "require-string-msg": {
+                  "description": "To require that the first element of msgAndArgs (msg) has a string type.",
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            },
+            "go-require": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignore-http-handlers": {
+                  "description": "To ignore HTTP handlers (like http.HandlerFunc).",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            },
+            "require-error": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "fn-pattern": {
+                  "description": "Regexp for assertions to analyze. If defined, then only matched error assertions will be reported.",
+                  "type": "string",
+                  "default": ""
+                }
+              }
+            },
+            "suite-extra-assert-call": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "mode": {
+                  "description": "To require or remove extra Assert() call?",
+                  "type": "string",
+                  "enum": ["remove", "require"],
+                  "default": "remove"
+                }
+              }
+            }
+          }
+        },
+        "testpackageSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "skip-regexp": {
+              "description": "Files with names matching this regular expression are skipped.",
+              "type": "string",
+              "examples": ["(export|internal)_test\\.go"]
+            },
+            "allow-packages": {
+              "description": "List of packages that don't end with _test that tests are allowed to be in.",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "examples": ["example"]
+              }
+            }
+          }
+        },
+        "thelperSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "test": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "begin": {
+                  "description": "Check if `t.Helper()` begins helper function.",
+                  "default": true,
+                  "type": "boolean"
+                },
+                "first": {
+                  "description": "Check if *testing.T is first param of helper function.",
+                  "default": true,
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "Check if *testing.T param has t name.",
+                  "default": true,
+                  "type": "boolean"
+                }
+              }
+            },
+            "benchmark": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "begin": {
+                  "description": "Check if `b.Helper()` begins helper function.",
+                  "default": true,
+                  "type": "boolean"
+                },
+                "first": {
+                  "description": "Check if *testing.B is first param of helper function.",
+                  "default": true,
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "Check if *testing.B param has b name.",
+                  "default": true,
+                  "type": "boolean"
+                }
+              }
+            },
+            "tb": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "begin": {
+                  "description": "Check if `tb.Helper()` begins helper function.",
+                  "default": true,
+                  "type": "boolean"
+                },
+                "first": {
+                  "description": "Check if *testing.TB is first param of helper function.",
+                  "default": true,
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "Check if *testing.TB param has tb name.",
+                  "default": true,
+                  "type": "boolean"
+                }
+              }
+            },
+            "fuzz": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "begin": {
+                  "description": "Check if `f.Helper()` begins helper function.",
+                  "default": true,
+                  "type": "boolean"
+                },
+                "first": {
+                  "description": "Check if *testing.F is first param of helper function.",
+                  "default": true,
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "Check if *testing.F param has f name.",
+                  "default": true,
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "usestdlibvarsSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "http-method": {
+              "description": "Suggest the use of http.MethodXX.",
+              "type": "boolean",
+              "default": true
+            },
+            "http-status-code": {
+              "description": "Suggest the use of http.StatusXX.",
+              "type": "boolean",
+              "default": true
+            },
+            "time-weekday": {
+              "description": "Suggest the use of time.Weekday.String().",
+              "type": "boolean",
+              "default": false
+            },
+            "time-month": {
+              "description": "Suggest the use of time.Month.String().",
+              "type": "boolean",
+              "default": false
+            },
+            "time-layout": {
+              "description": "Suggest the use of time.Layout.",
+              "type": "boolean",
+              "default": false
+            },
+            "time-date-month": {
+              "description": "Suggest the use of time.Month in time.Date.",
+              "type": "boolean",
+              "default": false
+            },
+            "crypto-hash": {
+              "description": "Suggest the use of crypto.Hash.String().",
+              "type": "boolean",
+              "default": false
+            },
+            "default-rpc-path": {
+              "description": "Suggest the use of rpc.DefaultXXPath.",
+              "type": "boolean",
+              "default": false
+            },
+            "sql-isolation-level": {
+              "description": "Suggest the use of sql.LevelXX.String().",
+              "type": "boolean",
+              "default": false
+            },
+            "tls-signature-scheme": {
+              "description": "Suggest the use of tls.SignatureScheme.String().",
+              "type": "boolean",
+              "default": false
+            },
+            "constant-kind": {
+              "description": "Suggest the use of constant.Kind.String().",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "usetestingSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "context-background": {
+              "type": "boolean",
+              "default": false
+            },
+            "context-todo": {
+              "type": "boolean",
+              "default": false
+            },
+            "os-chdir": {
+              "type": "boolean",
+              "default": true
+            },
+            "os-mkdir-temp": {
+              "type": "boolean",
+              "default": true
+            },
+            "os-setenv": {
+              "type": "boolean",
+              "default": true
+            },
+            "os-create-temp": {
+              "type": "boolean",
+              "default": true
+            },
+            "os-temp-dir": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "unconvertSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "fast-math": {
+              "type": "boolean",
+              "default": false
+            },
+            "safe": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "unparamSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "check-exported": {
+              "description": "Inspect exported functions. Set to true if no external program/library imports your code.\n\nWARNING: if you enable this setting, unparam will report a lot of false-positives in text editors:\nif it's called for subdir of a project it can't find external interfaces. All text editor integrations\nwith golangci-lint call it on a directory with the changed file.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "unqueryvetSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "check-sql-builders": {
+              "description": "Enable SQL builder checking.",
+              "type": "boolean",
+              "default": true
+            },
+            "allowed-patterns": {
+              "description": "Regex patterns for acceptable SELECT * usage.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "unusedSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "field-writes-are-uses": {
+              "description": "",
+              "type": "boolean",
+              "default": true
+            },
+            "post-statements-are-reads": {
+              "description": "",
+              "type": "boolean",
+              "default": false
+            },
+            "exported-fields-are-used": {
+              "description": "",
+              "type": "boolean",
+              "default": true
+            },
+            "parameters-are-used": {
+              "description": "",
+              "type": "boolean",
+              "default": true
+            },
+            "local-variables-are-used": {
+              "description": "",
+              "type": "boolean",
+              "default": true
+            },
+            "generated-is-used": {
+              "description": "",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "varnamelenSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "max-distance": {
+              "description": "Variables used in at most this N-many lines will be ignored.",
+              "type": "integer",
+              "default": 5
+            },
+            "min-name-length": {
+              "description": "The minimum length of a variable's name that is considered `long`.",
+              "type": "integer",
+              "default": 3
+            },
+            "check-receiver": {
+              "description": "Check method receiver names.",
+              "default": false,
+              "type": "boolean"
+            },
+            "check-return": {
+              "description": "Check named return values.",
+              "default": false,
+              "type": "boolean"
+            },
+            "check-type-param": {
+              "description": "Check type parameters.",
+              "default": false,
+              "type": "boolean"
+            },
+            "ignore-type-assert-ok": {
+              "description": "Ignore `ok` variables that hold the bool return value of a type assertion",
+              "default": false,
+              "type": "boolean"
+            },
+            "ignore-map-index-ok": {
+              "description": "Ignore `ok` variables that hold the bool return value of a map index.",
+              "default": false,
+              "type": "boolean"
+            },
+            "ignore-chan-recv-ok": {
+              "description": "Ignore `ok` variables that hold the bool return value of a channel receive.",
+              "default": false,
+              "type": "boolean"
+            },
+            "ignore-names": {
+              "description": "Optional list of variable names that should be ignored completely.",
+              "default": [[]],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignore-decls": {
+              "description": "Optional list of variable declarations that should be ignored completely.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "examples": [
+                ["c echo.Context", "t testing.T", "f *foo.Bar", "const C"]
+              ]
+            }
+          }
+        },
+        "whitespaceSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "multi-if": {
+              "description": "Enforces newlines (or comments) after every multi-line if statement",
+              "type": "boolean",
+              "default": false
+            },
+            "multi-func": {
+              "description": "Enforces newlines (or comments) after every multi-line function signature",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "wrapcheckSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "extra-ignore-sigs": {
+              "description": "An array of strings specifying additional substrings of signatures to ignore.",
+              "default": [
+                ".CustomError(",
+                ".SpecificWrap("
+              ],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignore-sigs": {
+              "description": "An array of strings which specify substrings of signatures to ignore.",
+              "default": [
+                ".Errorf(",
+                "errors.New(",
+                "errors.Unwrap(",
+                ".Wrap(",
+                ".Wrapf(",
+                ".WithMessage(",
+                ".WithMessagef(",
+                ".WithStack("
+              ],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignore-sig-regexps": {
+              "description": "An array of strings which specify regular expressions of signatures to ignore.",
+              "default": [""],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignore-package-globs": {
+              "description": "An array of glob patterns which, if any match the package of the function returning the error, will skip wrapcheck analysis for this error.",
+              "default": [""],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ignore-interface-regexps": {
+              "description": "An array of glob patterns which, if matched to an underlying interface name, will ignore unwrapped errors returned from a function whose call is defined on the given interface.",
+              "default": [""],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "report-internal-errors": {
+              "description": "Determines whether wrapcheck should report errors returned from inside the package.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "wslSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow-assign-and-anything": {
+              "description": "Controls if you may cuddle assignments and anything without needing an empty line between them.",
+              "type": "boolean",
+              "default": false
+            },
+            "allow-assign-and-call": {
+              "description": "Allow calls and assignments to be cuddled as long as the lines have any matching variables, fields or types.",
+              "type": "boolean",
+              "default": true
+            },
+            "allow-cuddle-declarations": {
+              "description": "Allow declarations (var) to be cuddled.",
+              "type": "boolean",
+              "default": false
+            },
+            "allow-cuddle-with-calls": {
+              "description": "A list of call idents that everything can be cuddled with.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "allow-cuddle-with-rhs": {
+              "description": "AllowCuddleWithRHS is a list of right hand side variables that is allowed to be cuddled with anything.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "allow-cuddle-used-in-block": {
+              "description": "Allow cuddling with any block as long as the variable is used somewhere in the block",
+              "type": "boolean",
+              "default": false
+            },
+            "allow-multiline-assign": {
+              "description": "Allow multiline assignments to be cuddled.",
+              "type": "boolean",
+              "default": true
+            },
+            "allow-separated-leading-comment": {
+              "description": "Allow leading comments to be separated with empty lines.",
+              "type": "boolean",
+              "default": false
+            },
+            "allow-trailing-comment": {
+              "description": "Allow trailing comments in ending of blocks.",
+              "type": "boolean",
+              "default": false
+            },
+            "error-variable-names": {
+              "description": "When force-err-cuddling is enabled this is a list of names used for error variables to check for in the conditional.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "force-case-trailing-whitespace": {
+              "description": "Force newlines in end of case at this limit (0 = never).",
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            },
+            "force-err-cuddling": {
+              "description": "Causes an error when an If statement that checks an error variable doesn't cuddle with the assignment of that variable.",
+              "type": "boolean",
+              "default": false
+            },
+            "force-short-decl-cuddling": {
+              "description": "Causes an error if a short declaration (:=) cuddles with anything other than another short declaration.",
+              "type": "boolean",
+              "default": false
+            },
+            "strict-append": {
+              "description": "If true, append is only allowed to be cuddled if appending value is matching variables, fields or types on line above.",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "wslSettingsV5": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow-first-in-block": {
+              "type": "boolean",
+              "default": true
+            },
+            "allow-whole-block": {
+              "type": "boolean",
+              "default": false
+            },
+            "branch-max-lines": {
+              "type": "integer",
+              "default": 2
+            },
+            "case-max-lines": {
+              "type": "integer",
+              "default": 0
+            },
+            "default": {
+              "enum": ["all", "none", "default", ""],
+              "default": "default"
+            },
+            "enable": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/wsl-checks"
+              }
+            },
+            "disable": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/wsl-checks"
+              }
+            }
+          }
+        },
+        "copyloopvarSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "check-alias": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "customSettings": {
+          "description": "The custom section can be used to define linter plugins to be loaded at runtime. See README of golangci-lint for more information.\nEach custom linter should have a unique name.",
+          "type": "object",
+          "patternProperties": {
+            "^.*$": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "description": "The plugin type.",
+                  "enum": ["module", "goplugin"],
+                  "default": "goplugin"
+                },
+                "path": {
+                  "description": "The path to the plugin *.so. Can be absolute or local.",
+                  "type": "string",
+                  "examples": ["/path/to/example.so"]
+                },
+                "description": {
+                  "description": "The description of the linter, for documentation purposes only.",
+                  "type": "string"
+                },
+                "original-url": {
+                  "description": "Intended to point to the repo location of the linter, for documentation purposes only.",
+                  "type": "string"
+                },
+                "settings": {
+                  "description": "Plugins settings/configuration. Only work with plugin based on `linterdb.PluginConstructor`.",
+                  "type": "object"
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "type": {"enum": ["module"] }
+                  },
+                  "required": ["type"]
+                },
+                {
+                  "required": ["path"]
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "default": "2"
+    },
+    "run": {
+      "description": "Options for analysis running,",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "concurrency": {
+          "description": "Number of concurrent runners. Defaults to the number of available CPU cores.",
+          "type": "integer",
+          "minimum": 0,
+          "examples": [4]
+        },
+        "timeout": {
+          "description": "Timeout for the analysis.",
+          "type": "string",
+          "pattern": "^((\\d+h)?(\\d+m)?(\\d+(?:\\.\\d)?s)?|0)$",
+          "default": "1m",
+          "examples": ["30s", "5m", "5m30s"]
+        },
+        "issues-exit-code": {
+          "description": "Exit code when at least one issue was found.",
+          "type": "integer",
+          "default": 1
+        },
+        "tests": {
+          "description": "Enable inclusion of test files.",
+          "type": "boolean",
+          "default": true
+        },
+        "build-tags": {
+          "description": "List of build tags to pass to all linters.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "examples": [["mytag"]]
+        },
+        "modules-download-mode": {
+          "description": "Option to pass to \"go list -mod={option}\".\nSee \"go help modules\" for more information.",
+          "enum": ["mod", "readonly", "vendor"]
+        },
+        "allow-parallel-runners": {
+          "description": "Allow multiple parallel golangci-lint instances running. If disabled, golangci-lint acquires file lock on start.",
+          "type": "boolean",
+          "default": false
+        },
+        "allow-serial-runners": {
+          "description": "Allow multiple golangci-lint instances running, but serialize them around a lock.",
+          "type": "boolean",
+          "default": false
+        },
+        "go": {
+          "description": "Targeted Go version.",
+          "type": "string",
+          "default": "1.17"
+        },
+        "relative-path-mode": {
+          "description": "The mode used to evaluate relative paths.",
+          "type": "string",
+          "$ref": "#/definitions/relative-path-modes",
+          "default": "wd"
+        }
+      }
+    },
+    "output": {
+      "description": "Output configuration options.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "formats": {
+          "description": "Output formats to use.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "path": {
+                  "$ref": "#/definitions/formats-path",
+                  "default": "stdout"
+                },
+                "print-linter-name": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "print-issued-lines": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "colors": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            },
+            "json": {
+              "$ref": "#/definitions/simple-format"
+            },
+            "tab": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "path": {
+                  "$ref": "#/definitions/formats-path",
+                  "default": "stdout"
+                },
+                "print-linter-name": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "colors": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            },
+            "html": {
+              "$ref": "#/definitions/simple-format"
+            },
+            "checkstyle": {
+              "$ref": "#/definitions/simple-format"
+            },
+            "code-climate": {
+              "$ref": "#/definitions/simple-format"
+            },
+            "junit-xml": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "path": {
+                  "$ref": "#/definitions/formats-path",
+                  "default": "stdout"
+                },
+                "extended": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            },
+            "teamcity": {
+              "$ref": "#/definitions/simple-format"
+            },
+            "sarif": {
+              "$ref": "#/definitions/simple-format"
+            }
+          }
+        },
+        "path-mode": {
+          "type": "string",
+          "default": "",
+          "examples": ["abs"]
+        },
+        "path-prefix": {
+          "description": "Add a prefix to the output file references.",
+          "type": "string",
+          "default": ""
+        },
+        "show-stats": {
+          "description": "Show statistics per linter.",
+          "type": "boolean",
+          "default": true
+        },
+        "sort-order": {
+          "type": "array",
+          "items": {
+            "enum": ["linter", "severity", "file"]
+          }
+        }
+      }
+    },
+    "linters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "enum": [
+            "standard",
+            "all",
+            "none",
+            "fast"
+          ]
+        },
+        "enable": {
+          "description": "List of enabled linters.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/linter-names"
+          }
+        },
+        "disable": {
+          "description": "List of disabled linters.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/linter-names"
+          }
+        },
+        "settings": {
+          "description": "All available settings of specific linters.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "dupword": {
+              "$ref": "#/definitions/settings/definitions/dupwordSettings"
+            },
+            "asasalint": {
+              "$ref": "#/definitions/settings/definitions/asasalintSettings"
+            },
+            "bidichk": {
+              "$ref": "#/definitions/settings/definitions/bidichkSettings"
+            },
+            "cyclop": {
+              "$ref": "#/definitions/settings/definitions/cyclopSettings"
+            },
+            "decorder": {
+              "$ref": "#/definitions/settings/definitions/decorderSettings"
+            },
+            "depguard":{
+              "$ref": "#/definitions/settings/definitions/depguardSettings"
+            },
+            "dogsled": {
+              "$ref": "#/definitions/settings/definitions/dogsledSettings"
+            },
+            "dupl": {
+              "$ref": "#/definitions/settings/definitions/duplSettings"
+            },
+            "embeddedstructfieldcheck": {
+              "$ref": "#/definitions/settings/definitions/embeddedstructfieldcheckSettings"
+            },
+            "errcheck": {
+              "$ref": "#/definitions/settings/definitions/errcheckSettings"
+            },
+            "errchkjson": {
+              "$ref": "#/definitions/settings/definitions/errchkjsonSettings"
+            },
+            "errorlint": {
+              "$ref": "#/definitions/settings/definitions/errorlintSettings"
+            },
+            "exhaustive": {
+              "$ref": "#/definitions/settings/definitions/exhaustiveSettings"
+            },
+            "exhaustruct": {
+              "$ref": "#/definitions/settings/definitions/exhaustructSettings"
+            },
+            "fatcontext": {
+              "$ref": "#/definitions/settings/definitions/fatcontextSettings"
+            },
+            "forbidigo": {
+              "$ref": "#/definitions/settings/definitions/forbidigoSettings"
+            },
+            "funcorder": {
+              "$ref": "#/definitions/settings/definitions/funcorderSettings"
+            },
+            "funlen": {
+              "$ref": "#/definitions/settings/definitions/funlenSettings"
+            },
+            "ginkgolinter": {
+              "$ref": "#/definitions/settings/definitions/ginkgolinterSettings"
+            },
+            "gochecksumtype": {
+              "$ref": "#/definitions/settings/definitions/gochecksumtypeSettings"
+            },
+            "gocognit": {
+              "$ref": "#/definitions/settings/definitions/gocognitSettings"
+            },
+            "goconst": {
+              "$ref": "#/definitions/settings/definitions/goconstSettings"
+            },
+            "gocritic": {
+              "$ref": "#/definitions/settings/definitions/gocriticSettings"
+            },
+            "gocyclo": {
+              "$ref": "#/definitions/settings/definitions/gocycloSettings"
+            },
+            "godoclint": {
+              "$ref": "#/definitions/settings/definitions/godoclintSettings"
+            },
+            "godot": {
+              "$ref": "#/definitions/settings/definitions/godotSettings"
+            },
+            "godox": {
+              "$ref": "#/definitions/settings/definitions/godoxSettings"
+            },
+            "interfacebloat":{
+              "$ref": "#/definitions/settings/definitions/interfacebloatSettings"
+            },
+            "goheader": {
+              "$ref": "#/definitions/settings/definitions/goheaderSettings"
+            },
+            "gomoddirectives": {
+              "$ref": "#/definitions/settings/definitions/gomoddirectivesSettings"
+            },
+            "gomodguard": {
+              "$ref": "#/definitions/settings/definitions/gomodguardSettings"
+            },
+            "gosec": {
+              "$ref": "#/definitions/settings/definitions/gosecSettings"
+            },
+            "gosmopolitan": {
+              "$ref": "#/definitions/settings/definitions/gosmopolitanSettings"
+            },
+            "govet": {
+              "$ref": "#/definitions/settings/definitions/govetSettings"
+            },
+            "grouper": {
+              "$ref": "#/definitions/settings/definitions/grouperSettings"
+            },
+            "iface": {
+              "$ref": "#/definitions/settings/definitions/ifaceSettings"
+            },
+            "importas": {
+              "$ref": "#/definitions/settings/definitions/importasSettings"
+            },
+            "inamedparam": {
+              "$ref": "#/definitions/settings/definitions/inamedparamSettings"
+            },
+            "ineffassign": {
+              "$ref": "#/definitions/settings/definitions/ineffassignSettings"
+            },
+            "iotamixing": {
+              "$ref": "#/definitions/settings/definitions/iotamixingSettings"
+            },
+            "ireturn": {
+              "$ref": "#/definitions/settings/definitions/ireturnSettings"
+            },
+            "lll": {
+              "$ref": "#/definitions/settings/definitions/lllSettings"
+            },
+            "maintidx": {
+              "$ref": "#/definitions/settings/definitions/maintidxSettings"
+            },
+            "makezero":{
+              "$ref": "#/definitions/settings/definitions/makezeroSettings"
+            },
+            "loggercheck": {
+              "$ref": "#/definitions/settings/definitions/loggercheckSettings"
+            },
+            "misspell": {
+              "$ref": "#/definitions/settings/definitions/misspellSettings"
+            },
+            "musttag": {
+              "$ref": "#/definitions/settings/definitions/musttagSettings"
+            },
+            "nakedret": {
+              "$ref": "#/definitions/settings/definitions/nakedretSettings"
+            },
+            "nestif": {
+              "$ref": "#/definitions/settings/definitions/nestifSettings"
+            },
+            "nilnil": {
+              "$ref": "#/definitions/settings/definitions/nilnilSettings"
+            },
+            "nlreturn": {
+              "$ref": "#/definitions/settings/definitions/nlreturnSettings"
+            },
+            "mnd": {
+              "$ref": "#/definitions/settings/definitions/mndSettings"
+            },
+            "modernize": {
+              "$ref": "#/definitions/settings/definitions/modernizeSettings"
+            },
+            "nolintlint":{
+              "$ref": "#/definitions/settings/definitions/nolintlintSettings"
+            },
+            "reassign": {
+              "$ref": "#/definitions/settings/definitions/reassignSettings"
+            },
+            "recvcheck": {
+              "$ref": "#/definitions/settings/definitions/recvcheckSettings"
+            },
+            "nonamedreturns": {
+              "$ref": "#/definitions/settings/definitions/nonamedreturnsSettings"
+            },
+            "paralleltest": {
+              "$ref": "#/definitions/settings/definitions/paralleltestSettings"
+            },
+            "perfsprint": {
+              "$ref": "#/definitions/settings/definitions/perfsprintSettings"
+            },
+            "prealloc": {
+              "$ref": "#/definitions/settings/definitions/preallocSettings"
+            },
+            "predeclared": {
+              "$ref": "#/definitions/settings/definitions/predeclaredSettings"
+            },
+            "promlinter": {
+              "$ref": "#/definitions/settings/definitions/promlinterSettings"
+            },
+            "protogetter": {
+              "$ref": "#/definitions/settings/definitions/protogetterSettings"
+            },
+            "revive": {
+              "$ref": "#/definitions/settings/definitions/reviveSettings"
+            },
+            "rowserrcheck": {
+              "$ref": "#/definitions/settings/definitions/rowserrcheckSettings"
+            },
+            "sloglint": {
+              "$ref": "#/definitions/settings/definitions/sloglintSettings"
+            },
+            "spancheck": {
+              "$ref": "#/definitions/settings/definitions/spancheckSettings"
+            },
+            "staticcheck":{
+              "$ref": "#/definitions/settings/definitions/staticcheckSettings"
+            },
+            "tagalign": {
+              "$ref": "#/definitions/settings/definitions/tagalignSettings"
+            },
+            "tagliatelle": {
+              "$ref": "#/definitions/settings/definitions/tagliatelleSettings"
+            },
+            "testifylint": {
+              "$ref": "#/definitions/settings/definitions/testifylintSettings"
+            },
+            "testpackage": {
+              "$ref": "#/definitions/settings/definitions/testpackageSettings"
+            },
+            "thelper": {
+              "$ref": "#/definitions/settings/definitions/thelperSettings"
+            },
+            "usestdlibvars": {
+              "$ref": "#/definitions/settings/definitions/usestdlibvarsSettings"
+            },
+            "usetesting": {
+              "$ref": "#/definitions/settings/definitions/usetestingSettings"
+            },
+            "unconvert": {
+              "$ref": "#/definitions/settings/definitions/unconvertSettings"
+            },
+            "unparam": {
+              "$ref": "#/definitions/settings/definitions/unparamSettings"
+            },
+            "unqueryvet": {
+              "$ref": "#/definitions/settings/definitions/unqueryvetSettings"
+            },
+            "unused": {
+              "$ref": "#/definitions/settings/definitions/unusedSettings"
+            },
+            "varnamelen": {
+              "$ref": "#/definitions/settings/definitions/varnamelenSettings"
+            },
+            "whitespace": {
+              "$ref": "#/definitions/settings/definitions/whitespaceSettings"
+            },
+            "wrapcheck": {
+              "$ref": "#/definitions/settings/definitions/wrapcheckSettings"
+            },
+            "wsl": {
+              "$ref": "#/definitions/settings/definitions/wslSettings"
+            },
+            "wsl_v5": {
+              "$ref": "#/definitions/settings/definitions/wslSettingsV5"
+            },
+            "copyloopvar": {
+              "$ref": "#/definitions/settings/definitions/copyloopvarSettings"
+            },
+            "custom":{
+              "$ref": "#/definitions/settings/definitions/customSettings"
+            }
+          }
+        },
+        "exclusions":{
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "generated": {
+              "enum": ["strict", "lax", "disable"],
+              "default": "strict"
+            },
+            "warn-unused": {
+              "type": "boolean",
+              "default": false
+            },
+            "presets": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "comments",
+                  "std-error-handling",
+                  "common-false-positives",
+                  "legacy"
+                ]
+              }
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "path-except": {
+                    "type": "string"
+                  },
+                  "linters": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/linter-names"
+                    }
+                  },
+                  "text": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "anyOf": [
+                  { "required": ["path"] },
+                  { "required": ["path-except"] },
+                  { "required": ["linters"] },
+                  { "required": ["text"] },
+                  { "required": ["source"] }
+                ]
+              }
+            },
+            "paths":  {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "paths-except":  {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "formatters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "description": "List of enabled formatters.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/formatter-names"
+          }
+        },
+        "settings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "gci": {
+              "$ref": "#/definitions/settings/definitions/gciSettings"
+            },
+            "gofmt": {
+              "$ref": "#/definitions/settings/definitions/gofmtSettings"
+            },
+            "gofumpt": {
+              "$ref": "#/definitions/settings/definitions/gofumptSettings"
+            },
+            "goimports": {
+              "$ref": "#/definitions/settings/definitions/goimportsSettings"
+            },
+            "golines": {
+              "$ref": "#/definitions/settings/definitions/golinesSettings"
+            }
+          }
+        },
+        "exclusions": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "generated": {
+              "enum": ["strict", "lax", "disable"],
+              "default": "strict"
+            },
+            "paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "warn-unused": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        }
+      }
+    },
+    "issues": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max-issues-per-linter": {
+          "description": "Maximum issues count per one linter. Set to 0 to disable.",
+          "type": "integer",
+          "default": 50,
+          "minimum": 0
+        },
+        "max-same-issues": {
+          "description": "Maximum count of issues with the same text. Set to 0 to disable.",
+          "type": "integer",
+          "default": 3,
+          "minimum": 0
+        },
+        "new": {
+          "description": "Show only new issues: if there are unstaged changes or untracked files, only those changes are analyzed, else only changes in HEAD~ are analyzed.",
+          "type": "boolean",
+          "default": false
+        },
+        "new-from-merge-base": {
+          "description": "Show only new issues created after the best common ancestor (merge-base against HEAD).",
+          "type": "string"
+        },
+        "new-from-rev": {
+          "description": "Show only new issues created after this git revision.",
+          "type": "string"
+        },
+        "new-from-patch": {
+          "description": "Show only new issues created in git patch with this file path.",
+          "type": "string",
+          "examples": ["path/to/patch/file"]
+        },
+        "fix": {
+          "description": "Apply the fixes detected by the linters and formatters (if it's supported by the linter).",
+          "type": "boolean",
+          "default": false
+        },
+        "uniq-by-line": {
+          "description": "Make issues output unique by line.",
+          "type": "boolean",
+          "default": true
+        },
+        "whole-files": {
+          "description": "Show issues in any part of update files (requires new-from-rev or new-from-patch).",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "severity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "description": "Set the default severity for issues. If severity rules are defined and the issues do not match or no severity is provided to the rule this will be the default severity applied. Severities should match the supported severity names of the selected out format.",
+          "type": "string",
+          "default": ""
+        },
+        "rules": {
+          "description": "When a list of severity rules are provided, severity information will be added to lint issues. Severity rules have the same filtering capability as exclude rules except you are allowed to specify one matcher per severity rule.\nOnly affects out formats that support setting severity information.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "severity": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "path-except": {
+                "type": "string"
+              },
+              "linters": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/linter-names"
+                }
+              },
+              "text": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              }
+            },
+            "required": ["severity"],
+            "anyOf": [
+              { "required": ["path"] },
+              { "required": ["path-except"] },
+              { "required": ["linters"] },
+              { "required": ["text"] },
+              { "required": ["source"] }
+            ]
+          },
+          "default": []
+        }
+      },
+      "required": ["default"]
+    }
+  }
+}

--- a/.github/workflows/elps.yml
+++ b/.github/workflows/elps.yml
@@ -80,6 +80,26 @@ jobs:
         with:
           version: v2.6
           args: --timeout=5m ./...
+          # `config verify` downloads the JSON schema from golangci-lint.run
+          # on every run and was the one step in this job that needed a host
+          # other than GitHub.  When that fetch timed out the job died here,
+          # before a single test had run, and the rollup went red for a
+          # reason no PR could fix (three PRs in one day: #586 twice, #573).
+          # The check itself is worth keeping: `golangci-lint run` does NOT
+          # reject an unknown key in .golangci.yml (a misspelled section runs
+          # to "0 issues"), only the schema check does.  So it runs in the
+          # next step against the schema vendored in .github/, offline.
+          verify: false
+
+      # The schema check `verify: true` used to run, against the checked-in
+      # copy of the schema so it needs no network.  The Makefile derives the
+      # schema filename from the `version:` above, so bumping golangci-lint
+      # without re-vendoring the schema fails here with a missing file, not
+      # silently validating against the old one.  golangci-lint is on PATH
+      # because the action above adds its install dir (core.addPath in
+      # src/run.ts, before the install-only branch).
+      - name: golangci-lint config schema
+        run: make check-golangci-config
 
       - name: Tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,28 @@ check-golangci-version:
 		echo "         run calls unused without checking CI is green without it."; \
 	fi
 
-static-checks: check-golangci-version
+# Validate .golangci.yml against the JSON schema for CI's golangci-lint
+# version, from the copy vendored in .github/ so it works offline.  This is
+# what golangci-lint-action's `verify: true` did before it was turned off
+# (its schema fetch from golangci-lint.run timed out and redded three PRs in
+# one day).  It is not redundant with `golangci-lint run`: run does NOT reject
+# an unknown key in the config -- a misspelled section or setting is silently
+# ignored and the lint reports "0 issues" -- only the schema check does.
+#
+# The schema filename carries CI's major.minor, derived from the workflow, so
+# bumping `version:` there without re-vendoring fails with a missing file:
+#   curl -sSo .github/golangci.<ver>.jsonschema.json \
+#     https://golangci-lint.run/jsonschema/golangci.<ver>.jsonschema.json
+GOLANGCI_SCHEMA := .github/golangci.$(GOLANGCI_CI_VERSION).jsonschema.json
+
+.PHONY: check-golangci-config
+check-golangci-config:
+	@test -f '$(GOLANGCI_SCHEMA)' || { \
+		echo "ERROR: $(GOLANGCI_SCHEMA) not found; CI runs golangci-lint $(GOLANGCI_CI_VERSION)."; \
+		echo "       Re-vendor the schema for that version (see the Makefile comment)."; exit 1; }
+	golangci-lint config verify --schema '$(GOLANGCI_SCHEMA)'
+
+static-checks: check-golangci-version check-golangci-config
 	golangci-lint run ./...
 	# Second pass under the elpscheck build tag. golangci-lint analyses only
 	# the DEFAULT build, so a file guarded by a build tag is invisible to every


### PR DESCRIPTION
## Summary

- golangci-lint-action runs `golangci-lint config verify` before linting, and that step downloads the config JSON schema from golangci-lint.run on every run. It is the only step in the Lint & Test job that needs a host other than GitHub. When the download times out the job fails before a single test has run, and the required rollup goes red for a reason no PR can fix. Three PR runs hit it in one day (#586 twice, #573), each recovered only by a manual re-run.
- The check is worth keeping. `golangci-lint run` does NOT reject an unknown key in `.golangci.yml`: a misspelled section or setting is silently ignored and the lint reports "0 issues" (measured on v2.6.2). Only the schema check catches that.
- So: `verify: false` on the action, the v2.6 schema vendored at `.github/golangci.v2.6.jsonschema.json`, and a new `make check-golangci-config` that runs `golangci-lint config verify --schema <vendored file>`. CI runs it as the step after the action (the action puts its install dir on PATH before the install-only branch). `make static-checks` depends on it locally.
- The Makefile derives the schema filename from the workflow's `version:`, so bumping golangci-lint without re-vendoring the schema fails with a missing-file message instead of validating against the old schema. The re-vendor command is in the Makefile comment.

## Test Plan

Local, with the proxy pointed at a dead port so no network is possible:

| Case | Result |
|---|---|
| real `.golangci.yml` | `make check-golangci-config` passes |
| config with an unknown top-level key | fails: `additional properties 'linter' not allowed` |
| simulated bump to v2.7 without re-vendoring | fails: `.github/golangci.v2.7.jsonschema.json not found; CI runs golangci-lint v2.7` |
| the same unknown key through `golangci-lint run` alone | "0 issues", rc 0 (why the check stays) |

- [x] workflow YAML parses
- [x] CI on this PR: the new "golangci-lint config schema" step runs green after the action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX