### PR TITLE
Add elpstest.RunForkCheck, a template/fork oracle with a regression per fork bug that shipped

### DIFF
--- a/docs/fork.md
+++ b/docs/fork.md
@@ -293,6 +293,19 @@ r := &elpstest.Runner{
 - `lisp/fork_ownership_elpscheck_test.go` pins the checker model: sealed
   cross-runtime sharing sanctioned, mutable cross-runtime leaks still
   panic.
+- `elpstest.RunForkCheck` is the embedder-facing harness: give it a program
+  and the transactions a caller would run, and it holds the template/fork
+  model to three properties against a reference that never calls `Fork`.
+  Parity: each transaction's result, and the whole reachable state after
+  it, must match a cold environment that loaded the program itself.
+  Aliasing: "same object" must hold for the same pairs of reachable
+  mutable payloads in template and fork. Isolation: no per-fork payload
+  shared with the template, the template untouched after a fork's
+  transaction, a later fork pristine. Every check also runs one hop
+  deeper, on a fork of the fork. `elpstest/forkcheck_test.go` carries one
+  `ForkCheck` per fork bug that shipped (#576 for sorted maps, bytes and
+  native cloners; #579; #381), each verified to fail on the tree it
+  shipped in. New embedder shapes go there.
 - Correctness at production scale (POC, issue #380): transaction results
   byte-identical between forked and fresh-loaded environments; a full
   phylum unit-test suite fork-served with identical results.

--- a/docs/fork.md
+++ b/docs/fork.md
@@ -296,16 +296,23 @@ r := &elpstest.Runner{
 - `elpstest.RunForkCheck` is the embedder-facing harness: give it a program
   and the transactions a caller would run, and it holds the template/fork
   model to three properties against a reference that never calls `Fork`.
-  Parity: each transaction's result, and the whole reachable state after
-  it, must match a cold environment that loaded the program itself.
-  Aliasing: "same object" must hold for the same pairs of reachable
-  mutable payloads in template and fork. Isolation: no per-fork payload
-  shared with the template, the template untouched after a fork's
-  transaction, a later fork pristine. Every check also runs one hop
-  deeper, on a fork of the fork. `elpstest/forkcheck_test.go` carries one
-  `ForkCheck` per fork bug that shipped (#576 for sorted maps, bytes and
-  native cloners; #579; #381), each verified to fail on the tree it
-  shipped in. New embedder shapes go there.
+  Parity: each transaction's result, and the state reachable from the
+  package bindings after it (cells, sorted-map entries, bytes, and the
+  environments closures captured), must match a cold environment that
+  loaded the program itself. Aliasing: "same object" must hold for the
+  same pairs of reachable mutable payloads — cells, map storage, bytes
+  storage, pointer `NativeCloner`s, captured environments — in template
+  and fork. Isolation: no such payload shared with the template or with
+  another fork, the template untouched after a fork's transaction, a
+  later fork pristine. Every check also runs one hop deeper, on a fork of
+  the fork. Outside its sight, by the sharing policy above: a native's
+  contents (compared by Go type only; a non-cloner native is shared by
+  design and has no identity) and package metadata beside the symbol
+  table. `elpstest/forkcheck_test.go` carries one `ForkCheck` per fork bug
+  that shipped (#576 for sorted maps, bytes and native cloners; #579;
+  #381, which only parity sees, through a duplicate registration on the
+  shared suite), each verified to fail on the tree it shipped in. New
+  embedder shapes go there.
 - Correctness at production scale (POC, issue #380): transaction results
   byte-identical between forked and fresh-loaded environments; a full
   phylum unit-test suite fork-served with identical results.

--- a/elpstest/forkcheck.go
+++ b/elpstest/forkcheck.go
@@ -1,0 +1,504 @@
+// Copyright © 2026 The ELPS authors
+
+package elpstest
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib"
+	"github.com/luthersystems/elps/parser"
+)
+
+// ForkCheck is a minimal model of the template/fork pattern an embedder
+// such as substrate runs: a program is loaded ONCE into a template, and
+// every transaction runs on a fresh fork of it.  RunForkCheck holds that
+// model to three properties, each stated against a reference that does not
+// involve Fork at all, so a Fork bug cannot hide in the oracle:
+//
+//   - PARITY: a transaction run on a fork must produce the same result, and
+//     leave the same reachable state, as the same transaction run on a cold
+//     environment that loaded the program itself.  This is the whole
+//     contract in one line — "a fork is indistinguishable from a full
+//     load" — and it is what catches a fork that changes semantics without
+//     leaking (issue #576: two names for one sorted-map became two maps in
+//     the fork, so a write through one was invisible through the other).
+//   - ALIASING: for every pair of reachable mutable payloads, "same object"
+//     holds in the fork exactly when it holds in the template.  Parity
+//     only sees an alias the transaction exercises; this sees all of them.
+//   - ISOLATION: no mutable payload is shared between the template and a
+//     fork, a transaction on a fork leaves the template untouched, and a
+//     later fork is pristine.
+//
+// Every fork is also checked one level deeper (a fork of the fork), since
+// a fix that survived one hop and not two has happened (issue #579).
+type ForkCheck struct {
+	// NewEnv builds an environment with whatever library the program needs
+	// loaded and the user package selected.  It is called once for the
+	// template and once per cold arm.  Nil means NewForkCheckEnv.
+	NewEnv func() (*lisp.LEnv, error)
+	// Program is loaded into the template, and into each cold environment.
+	Program string
+	// Setup, when set, runs on every environment a transaction will use:
+	// each fork and each cold environment, after Program on the cold side.
+	// It is the per-environment hook an embedder runs at checkout — a
+	// stateful package the template must not carry, such as libtesting.
+	Setup func(*lisp.LEnv) error
+	// Tx are the transactions.  Each runs on its own fork, its own fork of
+	// a fork, and its own cold environment.
+	Tx []string
+}
+
+// NewForkCheckEnv is ForkCheck's default NewEnv: a user environment with
+// the standard library loaded.
+func NewForkCheckEnv() (*lisp.LEnv, error) {
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); rc.Type == lisp.LError {
+		return nil, lisp.GoError(rc)
+	}
+	if rc := lisplib.LoadLibrary(env); rc.Type == lisp.LError {
+		return nil, lisp.GoError(rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		return nil, lisp.GoError(rc)
+	}
+	return env, nil
+}
+
+// RunForkCheck runs every check described on ForkCheck and reports each
+// failure through t.  It never calls t.FailNow across a transaction, so one
+// run reports every transaction that diverges.
+func RunForkCheck(t testing.TB, c ForkCheck) {
+	t.Helper()
+	newEnv := c.NewEnv
+	if newEnv == nil {
+		newEnv = NewForkCheckEnv
+	}
+	build := func(what string) *lisp.LEnv {
+		t.Helper()
+		env, err := newEnv()
+		if err != nil {
+			t.Fatalf("%s: new env: %v", what, err)
+		}
+		if rc := env.LoadString("program.lisp", c.Program); rc.Type == lisp.LError {
+			t.Fatalf("%s: program: %v", what, rc)
+		}
+		return env
+	}
+	setup := func(what string, env *lisp.LEnv) {
+		t.Helper()
+		if c.Setup == nil {
+			return
+		}
+		if err := c.Setup(env); err != nil {
+			t.Fatalf("%s: setup: %v", what, err)
+		}
+	}
+	fork := func(what string, env *lisp.LEnv) *lisp.LEnv {
+		t.Helper()
+		f, err := env.Fork()
+		if err != nil {
+			t.Fatalf("%s: fork: %v", what, err)
+		}
+		return f
+	}
+
+	tmpl := build("template")
+	tmplState := envState(tmpl)
+	tmplAlias := aliasSignature(tmpl)
+	tmplIDs := payloadIDs(tmpl)
+
+	// A fresh fork before any transaction: same state, same alias
+	// structure, no shared mutable payload.
+	f0 := fork("fork", tmpl)
+	checkFork := func(what string, f *lisp.LEnv) {
+		t.Helper()
+		if got := envState(f); got != tmplState {
+			t.Errorf("%s: reachable state differs from the template\n%s", what, diffLines(tmplState, got))
+		}
+		if got := aliasSignature(f); got != tmplAlias {
+			t.Errorf("%s: alias structure differs from the template (a payload reachable under two names in one is reachable under one, or under different objects, in the other)\n%s", what, diffLines(tmplAlias, got))
+		}
+		if shared := sharedPayloads(tmplIDs, payloadIDs(f)); len(shared) > 0 {
+			t.Errorf("%s: %d mutable payload(s) shared with the template: %s", what, len(shared), strings.Join(shared, ", "))
+		}
+	}
+	checkFork("fresh fork", f0)
+	checkFork("fresh fork of a fork", fork("fork of fork", f0))
+
+	for i, tx := range c.Tx {
+		name := fmt.Sprintf("tx[%d]", i)
+
+		cold := build(name + " cold")
+		setup(name+" cold", cold)
+		wantRes := renderResult(cold.LoadString("tx.lisp", tx))
+		wantState := envState(cold)
+		wantAlias := aliasSignature(cold)
+
+		arms := []struct {
+			what string
+			env  *lisp.LEnv
+		}{
+			{name + " fork", fork(name, tmpl)},
+			{name + " fork of fork", fork(name, fork(name, tmpl))},
+		}
+		for _, arm := range arms {
+			setup(arm.what, arm.env)
+			if got := renderResult(arm.env.LoadString("tx.lisp", tx)); got != wantRes {
+				t.Errorf("%s: result differs from the cold run\n  cold: %s\n  fork: %s", arm.what, wantRes, got)
+			}
+			if got := envState(arm.env); got != wantState {
+				t.Errorf("%s: reachable state after the transaction differs from the cold run\n%s", arm.what, diffLines(wantState, got))
+			}
+			if got := aliasSignature(arm.env); got != wantAlias {
+				t.Errorf("%s: alias structure after the transaction differs from the cold run\n%s", arm.what, diffLines(wantAlias, got))
+			}
+		}
+
+		// The template is untouched by anything the forks did, and the
+		// next fork starts from the same place as the first.
+		if got := envState(tmpl); got != tmplState {
+			t.Errorf("%s: the template's reachable state changed\n%s", name, diffLines(tmplState, got))
+		}
+		checkFork(name+" fork taken afterwards", fork(name, tmpl))
+	}
+}
+
+// renderResult renders a transaction result for comparison: the value's
+// type and rendering, or the error text for an error.
+func renderResult(v *lisp.LVal) string {
+	if v.Type == lisp.LError {
+		return "error: " + normalizeFunIDs(v.String())
+	}
+	var b strings.Builder
+	w := &stateWalker{sb: &b, seen: map[*lisp.LVal]int{}}
+	w.value(v)
+	return v.Type.String() + " " + b.String()
+}
+
+// funIDPattern matches the environment-derived part of a lambda's name.
+// Cold and fork arms allocate environment IDs on independent counters, so
+// the IDs are not comparable; only that two mentions agree.
+var funIDPattern = regexp.MustCompile(`_fun\d+`)
+
+func normalizeFunIDs(s string) string {
+	return funIDPattern.ReplaceAllString(s, "_fun#")
+}
+
+// roots returns every package binding in a deterministic order: package
+// names sorted, symbol names sorted within each.
+func roots(env *lisp.LEnv, visit func(pkg, name string, v *lisp.LVal)) {
+	reg := env.Runtime.Registry
+	names := reg.PackageNames()
+	sort.Strings(names)
+	for _, pn := range names {
+		pkg := reg.Package(pn)
+		if pkg == nil {
+			continue
+		}
+		syms := pkg.SymbolNames()
+		sort.Strings(syms)
+		for _, sn := range syms {
+			v, ok := pkg.Symbol(sn)
+			if !ok || v == nil {
+				continue
+			}
+			visit(pn, sn, v)
+		}
+	}
+}
+
+// envState renders every reachable value from every package binding, one
+// line per binding, so two environments holding the same program state
+// render the same text.  Identity is not part of the rendering: a value
+// reached twice renders as a back-reference to its first rendering, which
+// is what keeps cyclic structures finite and what makes this an
+// alias-blind comparison (aliasSignature is the alias-aware one).
+func envState(env *lisp.LEnv) string {
+	var b strings.Builder
+	roots(env, func(pkg, name string, v *lisp.LVal) {
+		fmt.Fprintf(&b, "%s:%s = ", pkg, name)
+		w := &stateWalker{sb: &b, seen: map[*lisp.LVal]int{}}
+		w.value(v)
+		b.WriteByte('\n')
+	})
+	return b.String()
+}
+
+type stateWalker struct {
+	sb   *strings.Builder
+	seen map[*lisp.LVal]int
+}
+
+func (w *stateWalker) value(v *lisp.LVal) {
+	if v == nil {
+		w.sb.WriteString("<nil>")
+		return
+	}
+	if n, ok := w.seen[v]; ok {
+		fmt.Fprintf(w.sb, "@%d", n)
+		return
+	}
+	w.seen[v] = len(w.seen)
+	switch v.Type {
+	case lisp.LSortMap:
+		md := v.Map()
+		w.sb.WriteString("{")
+		if md != nil {
+			keys := md.Keys()
+			for i, k := range keys.Cells {
+				if i > 0 {
+					w.sb.WriteString(" ")
+				}
+				w.sb.WriteString(k.String())
+				w.sb.WriteString(":")
+				val, _ := md.Get(k)
+				w.value(val)
+			}
+		}
+		w.sb.WriteString("}")
+	case lisp.LBytes:
+		fmt.Fprintf(w.sb, "bytes(%q)", v.Bytes())
+	case lisp.LNative:
+		fmt.Fprintf(w.sb, "native(%T)", v.Native)
+	case lisp.LFun:
+		w.sb.WriteString(normalizeFunIDs(v.String()))
+	default:
+		if len(v.Cells) == 0 {
+			w.sb.WriteString(normalizeFunIDs(v.String()))
+			return
+		}
+		fmt.Fprintf(w.sb, "%s[", v.Type)
+		for i, c := range v.Cells {
+			if i > 0 {
+				w.sb.WriteString(" ")
+			}
+			w.value(c)
+		}
+		w.sb.WriteString("]")
+	}
+}
+
+// aliasSignature renders the alias structure of everything reachable from
+// the package bindings: every payload that can be mutated in place — a
+// list or vector's cells, a sorted-map's storage, a bytes value's storage,
+// a native payload held by pointer — is numbered on first visit and
+// rendered as that number on every visit.  Two environments have the same
+// signature exactly when, walking them in the same order, "same object" is
+// true for the same pairs of positions.  A fork that de-aliases (issue
+// #576) or over-aliases renders differently from its template here even
+// when envState cannot tell them apart.
+func aliasSignature(env *lisp.LEnv) string {
+	var b strings.Builder
+	w := &aliasWalker{sb: &b, ids: map[interface{}]int{}, path: map[*lisp.LVal]bool{}}
+	roots(env, func(pkg, name string, v *lisp.LVal) {
+		fmt.Fprintf(&b, "%s:%s = ", pkg, name)
+		w.value(v)
+		b.WriteByte('\n')
+	})
+	return b.String()
+}
+
+type aliasWalker struct {
+	sb   *strings.Builder
+	ids  map[interface{}]int
+	path map[*lisp.LVal]bool
+}
+
+// id numbers a payload identity on first sight.
+func (w *aliasWalker) id(key interface{}) int {
+	n, ok := w.ids[key]
+	if !ok {
+		n = len(w.ids)
+		w.ids[key] = n
+	}
+	return n
+}
+
+func (w *aliasWalker) value(v *lisp.LVal) {
+	if v == nil {
+		w.sb.WriteString("<nil>")
+		return
+	}
+	if p, ok := mutablePayload(v); ok {
+		fmt.Fprintf(w.sb, "#%d", w.id(p))
+	} else {
+		w.sb.WriteString("_")
+	}
+	// Recurse into children.  The walk is guarded by the path, not by
+	// "seen": a payload reached twice must be rendered twice for the
+	// aliasing to show, and only a cycle needs cutting.
+	if w.path[v] {
+		w.sb.WriteString("(cycle)")
+		return
+	}
+	w.path[v] = true
+	defer delete(w.path, v)
+	switch v.Type {
+	case lisp.LSortMap:
+		md := v.Map()
+		if md == nil {
+			return
+		}
+		w.sb.WriteString("{")
+		for i, k := range md.Keys().Cells {
+			if i > 0 {
+				w.sb.WriteString(" ")
+			}
+			val, _ := md.Get(k)
+			w.value(val)
+		}
+		w.sb.WriteString("}")
+	default:
+		if len(v.Cells) == 0 {
+			return
+		}
+		w.sb.WriteString("[")
+		for i, c := range v.Cells {
+			if i > 0 {
+				w.sb.WriteString(" ")
+			}
+			w.value(c)
+		}
+		w.sb.WriteString("]")
+	}
+}
+
+// mutablePayload returns the identity of the storage a value can be
+// mutated through, when it has one.  Sealed values are immutable by
+// contract and may legitimately be shared, so they carry no identity; so
+// does a native payload that is not a NativeCloner, which Fork shares by
+// reference by design.
+func mutablePayload(v *lisp.LVal) (interface{}, bool) {
+	if v.IsSealed() {
+		return nil, false
+	}
+	switch v.Type {
+	case lisp.LSortMap:
+		if md := v.Map(); md != nil {
+			return md, true
+		}
+	case lisp.LBytes:
+		if p, ok := v.Native.(*[]byte); ok && p != nil {
+			return p, true
+		}
+	case lisp.LNative:
+		// A native payload is shared between template and fork by
+		// reference unless it is a NativeCloner (docs/fork.md), so only a
+		// cloner is a per-fork payload with an identity to keep straight.
+		// A plain native still takes part in the alias signature through
+		// the header that holds it.
+		if _, ok := v.Native.(lisp.NativeCloner); !ok {
+			return nil, false
+		}
+		rv := reflect.ValueOf(v.Native)
+		switch rv.Kind() {
+		case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func, reflect.UnsafePointer:
+			if rv.IsNil() {
+				return nil, false
+			}
+			return pointerKey{rv.Type(), rv.Pointer()}, true
+		default:
+			// A cloner held by value has no identity to share.
+		}
+	default:
+		if len(v.Cells) > 0 {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+// pointerKey identifies a native payload by its type and address, so two
+// distinct types at one address (a struct and its first field) stay
+// distinct.
+type pointerKey struct {
+	t reflect.Type
+	p uintptr
+}
+
+// payloadIDs collects every mutable payload identity reachable from the
+// package bindings, labelled by the first path it was reached on.
+func payloadIDs(env *lisp.LEnv) map[interface{}]string {
+	out := map[interface{}]string{}
+	var walk func(v *lisp.LVal, path string, onPath map[*lisp.LVal]bool)
+	walk = func(v *lisp.LVal, path string, onPath map[*lisp.LVal]bool) {
+		if v == nil || onPath[v] {
+			return
+		}
+		if p, ok := mutablePayload(v); ok {
+			if _, seen := out[p]; !seen {
+				out[p] = path
+			}
+		}
+		onPath[v] = true
+		defer delete(onPath, v)
+		switch v.Type {
+		case lisp.LSortMap:
+			md := v.Map()
+			if md == nil {
+				return
+			}
+			for _, k := range md.Keys().Cells {
+				val, _ := md.Get(k)
+				walk(val, path+"/"+k.String(), onPath)
+			}
+		default:
+			for i, c := range v.Cells {
+				walk(c, fmt.Sprintf("%s/%d", path, i), onPath)
+			}
+		}
+	}
+	roots(env, func(pkg, name string, v *lisp.LVal) {
+		walk(v, pkg+":"+name, map[*lisp.LVal]bool{})
+	})
+	return out
+}
+
+// sharedPayloads lists the payload identities present in both maps, by the
+// path each was first reached on in a.
+func sharedPayloads(a, b map[interface{}]string) []string {
+	var out []string
+	for id, path := range a {
+		if _, ok := b[id]; ok {
+			out = append(out, path)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// diffLines renders the first differing line of two multi-line renderings,
+// with its line number, so a failure points at a binding rather than at a
+// wall of text.
+func diffLines(want, got string) string {
+	wl := strings.Split(want, "\n")
+	gl := strings.Split(got, "\n")
+	for i := 0; i < len(wl) || i < len(gl); i++ {
+		var w, g string
+		if i < len(wl) {
+			w = wl[i]
+		}
+		if i < len(gl) {
+			g = gl[i]
+		}
+		if w != g {
+			return fmt.Sprintf("  line %d\n    want: %s\n    got:  %s", i+1, clip(w), clip(g))
+		}
+	}
+	return "  (no differing line found)"
+}
+
+func clip(s string) string {
+	const maxLen = 400
+	if len(s) > maxLen {
+		return s[:maxLen] + "…"
+	}
+	return s
+}

--- a/elpstest/forkcheck.go
+++ b/elpstest/forkcheck.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/luthersystems/elps/internal/funraw"
 	"github.com/luthersystems/elps/lisp"
 	"github.com/luthersystems/elps/lisp/lisplib"
 	"github.com/luthersystems/elps/parser"
@@ -32,11 +33,20 @@ import (
 //     holds in the fork exactly when it holds in the template.  Parity
 //     only sees an alias the transaction exercises; this sees all of them.
 //   - ISOLATION: no mutable payload is shared between the template and a
-//     fork, a transaction on a fork leaves the template untouched, and a
-//     later fork is pristine.
+//     fork, or between two forks; a transaction on a fork leaves the
+//     template untouched; a later fork is pristine.
 //
 // Every fork is also checked one level deeper (a fork of the fork), since
 // a fix that survived one hop and not two has happened (issue #579).
+//
+// "Reachable" means everything reachable from the package bindings: list
+// and vector cells, sorted-map entries, bytes, and the environment a
+// closure captured (its bindings and its parents').  What is NOT compared,
+// because the oracles cannot see inside it: a native payload's contents
+// (rendered by Go type only, so a stateful native that is not a
+// NativeCloner is compared by the header that holds it, not by what it
+// holds), and package metadata outside the symbol table (exports,
+// docstrings, the function-name index).
 type ForkCheck struct {
 	// NewEnv builds an environment with whatever library the program needs
 	// loaded and the user package selected.  It is called once for the
@@ -49,6 +59,9 @@ type ForkCheck struct {
 	// It is the per-environment hook an embedder runs at checkout — a
 	// stateful package the template must not carry, such as libtesting.
 	Setup func(*lisp.LEnv) error
+	// ForkOptions are passed to every Fork call: the place to exercise
+	// ForkWithNativeReplacer or ForkWithContext the way the embedder does.
+	ForkOptions []lisp.ForkOption
 	// Tx are the transactions.  Each runs on its own fork, its own fork of
 	// a fork, and its own cold environment.
 	Tx []string
@@ -71,9 +84,11 @@ func NewForkCheckEnv() (*lisp.LEnv, error) {
 	return env, nil
 }
 
-// RunForkCheck runs every check described on ForkCheck and reports each
-// failure through t.  It never calls t.FailNow across a transaction, so one
-// run reports every transaction that diverges.
+// RunForkCheck runs every check described on ForkCheck.  A comparison that
+// fails is reported with t.Errorf, so one run reports every transaction
+// that diverges; a failure to build an environment, load the program, run
+// Setup or take a fork is fatal, since nothing after it would mean
+// anything.
 func RunForkCheck(t testing.TB, c ForkCheck) {
 	t.Helper()
 	newEnv := c.NewEnv
@@ -102,7 +117,7 @@ func RunForkCheck(t testing.TB, c ForkCheck) {
 	}
 	fork := func(what string, env *lisp.LEnv) *lisp.LEnv {
 		t.Helper()
-		f, err := env.Fork()
+		f, err := env.Fork(c.ForkOptions...)
 		if err != nil {
 			t.Fatalf("%s: fork: %v", what, err)
 		}
@@ -116,8 +131,7 @@ func RunForkCheck(t testing.TB, c ForkCheck) {
 
 	// A fresh fork before any transaction: same state, same alias
 	// structure, no shared mutable payload.
-	f0 := fork("fork", tmpl)
-	checkFork := func(what string, f *lisp.LEnv) {
+	checkFork := func(what string, f *lisp.LEnv) map[interface{}]string {
 		t.Helper()
 		if got := envState(f); got != tmplState {
 			t.Errorf("%s: reachable state differs from the template\n%s", what, diffLines(tmplState, got))
@@ -125,12 +139,21 @@ func RunForkCheck(t testing.TB, c ForkCheck) {
 		if got := aliasSignature(f); got != tmplAlias {
 			t.Errorf("%s: alias structure differs from the template (a payload reachable under two names in one is reachable under one, or under different objects, in the other)\n%s", what, diffLines(tmplAlias, got))
 		}
-		if shared := sharedPayloads(tmplIDs, payloadIDs(f)); len(shared) > 0 {
+		ids := payloadIDs(f)
+		if shared := sharedPayloads(tmplIDs, ids); len(shared) > 0 {
 			t.Errorf("%s: %d mutable payload(s) shared with the template: %s", what, len(shared), strings.Join(shared, ", "))
 		}
+		return ids
 	}
-	checkFork("fresh fork", f0)
+	f0 := fork("fork", tmpl)
+	f0IDs := checkFork("fresh fork", f0)
 	checkFork("fresh fork of a fork", fork("fork of fork", f0))
+	// Two forks of one template share nothing with each other either: a
+	// CloneNative that hands every fork the same clone would pass the
+	// template check and fail here.
+	if shared := sharedPayloads(f0IDs, checkFork("second fresh fork", fork("fork", tmpl))); len(shared) > 0 {
+		t.Errorf("two forks of one template share %d mutable payload(s): %s", len(shared), strings.Join(shared, ", "))
+	}
 
 	for i, tx := range c.Tx {
 		name := fmt.Sprintf("tx[%d]", i)
@@ -177,7 +200,7 @@ func renderResult(v *lisp.LVal) string {
 		return "error: " + normalizeFunIDs(v.String())
 	}
 	var b strings.Builder
-	w := &stateWalker{sb: &b, seen: map[*lisp.LVal]int{}}
+	w := newStateWalker(&b)
 	w.value(v)
 	return v.Type.String() + " " + b.String()
 }
@@ -214,18 +237,38 @@ func roots(env *lisp.LEnv, visit func(pkg, name string, v *lisp.LVal)) {
 	}
 }
 
-// envState renders every reachable value from every package binding, one
+// sortedBindings snapshots an environment's own bindings in key order
+// (Bindings' iteration order is unspecified).
+func sortedBindings(e *lisp.LEnv) (keys []string, vals map[string]*lisp.LVal) {
+	vals = make(map[string]*lisp.LVal, e.NumBindings())
+	for k, v := range e.Bindings() {
+		keys = append(keys, k)
+		vals[k] = v
+	}
+	sort.Strings(keys)
+	return keys, vals
+}
+
+// envState renders every value reachable from every package binding, one
 // line per binding, so two environments holding the same program state
-// render the same text.  Identity is not part of the rendering: a value
+// render the same text.  A closure renders with the environment it
+// captured — the bindings of that environment and of its parents — since
+// that is the state a fork must copy and the state a transaction can
+// mutate through the closure.  Identity is not part of the rendering
+// beyond what keeps it finite: within one binding, a header or environment
 // reached twice renders as a back-reference to its first rendering, which
-// is what keeps cyclic structures finite and what makes this an
-// alias-blind comparison (aliasSignature is the alias-aware one).
+// cuts cycles; two headers over one payload, and one header reached from
+// two bindings, render the payload in full each time.  aliasSignature is
+// the alias-aware comparison.
 func envState(env *lisp.LEnv) string {
 	var b strings.Builder
 	roots(env, func(pkg, name string, v *lisp.LVal) {
 		fmt.Fprintf(&b, "%s:%s = ", pkg, name)
-		w := &stateWalker{sb: &b, seen: map[*lisp.LVal]int{}}
-		w.value(v)
+		// One walker per root: back-references cut cycles within a
+		// binding, and a value reachable from two bindings renders in
+		// full under each, so the rendering stays blind to header
+		// identity across bindings.
+		newStateWalker(&b).value(v)
 		b.WriteByte('\n')
 	})
 	return b.String()
@@ -234,6 +277,11 @@ func envState(env *lisp.LEnv) string {
 type stateWalker struct {
 	sb   *strings.Builder
 	seen map[*lisp.LVal]int
+	envs map[*lisp.LEnv]int
+}
+
+func newStateWalker(sb *strings.Builder) *stateWalker {
+	return &stateWalker{sb: sb, seen: map[*lisp.LVal]int{}, envs: map[*lisp.LEnv]int{}}
 }
 
 func (w *stateWalker) value(v *lisp.LVal) {
@@ -269,12 +317,17 @@ func (w *stateWalker) value(v *lisp.LVal) {
 		fmt.Fprintf(w.sb, "native(%T)", v.Native)
 	case lisp.LFun:
 		w.sb.WriteString(normalizeFunIDs(v.String()))
+		w.env(funraw.Env(v))
 	default:
 		if len(v.Cells) == 0 {
 			w.sb.WriteString(normalizeFunIDs(v.String()))
 			return
 		}
-		fmt.Fprintf(w.sb, "%s[", v.Type)
+		fmt.Fprintf(w.sb, "%s", v.Type)
+		if v.Str != "" {
+			fmt.Fprintf(w.sb, "%q", v.Str)
+		}
+		w.sb.WriteString("[")
 		for i, c := range v.Cells {
 			if i > 0 {
 				w.sb.WriteString(" ")
@@ -285,18 +338,48 @@ func (w *stateWalker) value(v *lisp.LVal) {
 	}
 }
 
+// env renders a closure's captured environment chain: each environment's
+// own bindings, then its parent's, up to the root.
+func (w *stateWalker) env(e *lisp.LEnv) {
+	if e == nil {
+		return
+	}
+	if n, ok := w.envs[e]; ok {
+		fmt.Fprintf(w.sb, " env@%d", n)
+		return
+	}
+	w.envs[e] = len(w.envs)
+	keys, vals := sortedBindings(e)
+	w.sb.WriteString(" env{")
+	for i, k := range keys {
+		if i > 0 {
+			w.sb.WriteString(" ")
+		}
+		w.sb.WriteString(k)
+		w.sb.WriteString("=")
+		w.value(vals[k])
+	}
+	w.sb.WriteString("}")
+	w.env(e.Parent())
+}
+
 // aliasSignature renders the alias structure of everything reachable from
 // the package bindings: every payload that can be mutated in place — a
 // list or vector's cells, a sorted-map's storage, a bytes value's storage,
-// a native payload held by pointer — is numbered on first visit and
-// rendered as that number on every visit.  Two environments have the same
-// signature exactly when, walking them in the same order, "same object" is
-// true for the same pairs of positions.  A fork that de-aliases (issue
-// #576) or over-aliases renders differently from its template here even
-// when envState cannot tell them apart.
+// a NativeCloner payload held by pointer, the environment a closure
+// captured — is numbered on first visit and rendered as that number on
+// every visit.  Two environments have the same signature exactly when,
+// walking them in the same order, "same object" is true for the same pairs
+// of positions.  A fork that de-aliases (issue #576) or over-aliases
+// renders differently from its template here even when envState cannot
+// tell them apart.
+//
+// A payload's contents are rendered under its first visit only: the number
+// alone says "same object" on the later ones, and a shared subtree walked
+// once per path in would be exponential on a diamond-shaped graph.
 func aliasSignature(env *lisp.LEnv) string {
 	var b strings.Builder
-	w := &aliasWalker{sb: &b, ids: map[interface{}]int{}, path: map[*lisp.LVal]bool{}}
+	w := &aliasWalker{sb: &b, ids: map[interface{}]int{}, seen: map[interface{}]bool{}}
 	roots(env, func(pkg, name string, v *lisp.LVal) {
 		fmt.Fprintf(&b, "%s:%s = ", pkg, name)
 		w.value(v)
@@ -308,10 +391,10 @@ func aliasSignature(env *lisp.LEnv) string {
 type aliasWalker struct {
 	sb   *strings.Builder
 	ids  map[interface{}]int
-	path map[*lisp.LVal]bool
+	seen map[interface{}]bool
 }
 
-// id numbers a payload identity on first sight.
+// id numbers an identity on first sight.
 func (w *aliasWalker) id(key interface{}) int {
 	n, ok := w.ids[key]
 	if !ok {
@@ -326,20 +409,17 @@ func (w *aliasWalker) value(v *lisp.LVal) {
 		w.sb.WriteString("<nil>")
 		return
 	}
+	var key interface{} = v
 	if p, ok := mutablePayload(v); ok {
+		key = p
 		fmt.Fprintf(w.sb, "#%d", w.id(p))
 	} else {
 		w.sb.WriteString("_")
 	}
-	// Recurse into children.  The walk is guarded by the path, not by
-	// "seen": a payload reached twice must be rendered twice for the
-	// aliasing to show, and only a cycle needs cutting.
-	if w.path[v] {
-		w.sb.WriteString("(cycle)")
+	if w.seen[key] {
 		return
 	}
-	w.path[v] = true
-	defer delete(w.path, v)
+	w.seen[key] = true
 	switch v.Type {
 	case lisp.LSortMap:
 		md := v.Map()
@@ -355,6 +435,8 @@ func (w *aliasWalker) value(v *lisp.LVal) {
 			w.value(val)
 		}
 		w.sb.WriteString("}")
+	case lisp.LFun:
+		w.env(funraw.Env(v))
 	default:
 		if len(v.Cells) == 0 {
 			return
@@ -370,11 +452,37 @@ func (w *aliasWalker) value(v *lisp.LVal) {
 	}
 }
 
+func (w *aliasWalker) env(e *lisp.LEnv) {
+	if e == nil {
+		return
+	}
+	fmt.Fprintf(w.sb, " env#%d", w.id(e))
+	if w.seen[e] {
+		return
+	}
+	w.seen[e] = true
+	keys, vals := sortedBindings(e)
+	w.sb.WriteString("{")
+	for i, k := range keys {
+		if i > 0 {
+			w.sb.WriteString(" ")
+		}
+		w.sb.WriteString(k)
+		w.sb.WriteString("=")
+		w.value(vals[k])
+	}
+	w.sb.WriteString("}")
+	w.env(e.Parent())
+}
+
 // mutablePayload returns the identity of the storage a value can be
 // mutated through, when it has one.  Sealed values are immutable by
-// contract and may legitimately be shared, so they carry no identity; so
-// does a native payload that is not a NativeCloner, which Fork shares by
-// reference by design.
+// contract and may legitimately be shared, so they carry no identity.  So
+// does a native payload unless it is a NativeCloner held by pointer: Fork
+// shares every other native by reference by design (docs/fork.md), and
+// keys its clone memo on pointer payloads only.  Such a native renders as
+// "_" in the alias signature — its header takes part in the state
+// rendering, its contents in neither.
 func mutablePayload(v *lisp.LVal) (interface{}, bool) {
 	if v.IsSealed() {
 		return nil, false
@@ -389,24 +497,14 @@ func mutablePayload(v *lisp.LVal) (interface{}, bool) {
 			return p, true
 		}
 	case lisp.LNative:
-		// A native payload is shared between template and fork by
-		// reference unless it is a NativeCloner (docs/fork.md), so only a
-		// cloner is a per-fork payload with an identity to keep straight.
-		// A plain native still takes part in the alias signature through
-		// the header that holds it.
 		if _, ok := v.Native.(lisp.NativeCloner); !ok {
 			return nil, false
 		}
 		rv := reflect.ValueOf(v.Native)
-		switch rv.Kind() {
-		case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func, reflect.UnsafePointer:
-			if rv.IsNil() {
-				return nil, false
-			}
-			return pointerKey{rv.Type(), rv.Pointer()}, true
-		default:
-			// A cloner held by value has no identity to share.
+		if rv.Kind() != reflect.Pointer || rv.IsNil() {
+			return nil, false
 		}
+		return v.Native, true
 	default:
 		if len(v.Cells) > 0 {
 			return v, true
@@ -415,30 +513,29 @@ func mutablePayload(v *lisp.LVal) (interface{}, bool) {
 	return nil, false
 }
 
-// pointerKey identifies a native payload by its type and address, so two
-// distinct types at one address (a struct and its first field) stay
-// distinct.
-type pointerKey struct {
-	t reflect.Type
-	p uintptr
-}
-
 // payloadIDs collects every mutable payload identity reachable from the
-// package bindings, labelled by the first path it was reached on.
+// package bindings — closures' captured environments included — labelled
+// by the first path it was reached on.
 func payloadIDs(env *lisp.LEnv) map[interface{}]string {
 	out := map[interface{}]string{}
-	var walk func(v *lisp.LVal, path string, onPath map[*lisp.LVal]bool)
-	walk = func(v *lisp.LVal, path string, onPath map[*lisp.LVal]bool) {
-		if v == nil || onPath[v] {
+	seen := map[interface{}]bool{}
+	var walk func(v *lisp.LVal, path string)
+	var walkEnv func(e *lisp.LEnv, path string)
+	walk = func(v *lisp.LVal, path string) {
+		if v == nil {
 			return
 		}
+		var key interface{} = v
 		if p, ok := mutablePayload(v); ok {
-			if _, seen := out[p]; !seen {
+			key = p
+			if _, dup := out[p]; !dup {
 				out[p] = path
 			}
 		}
-		onPath[v] = true
-		defer delete(onPath, v)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
 		switch v.Type {
 		case lisp.LSortMap:
 			md := v.Map()
@@ -447,16 +544,32 @@ func payloadIDs(env *lisp.LEnv) map[interface{}]string {
 			}
 			for _, k := range md.Keys().Cells {
 				val, _ := md.Get(k)
-				walk(val, path+"/"+k.String(), onPath)
+				walk(val, path+"/"+k.String())
 			}
+		case lisp.LFun:
+			walkEnv(funraw.Env(v), path+"/env")
 		default:
 			for i, c := range v.Cells {
-				walk(c, fmt.Sprintf("%s/%d", path, i), onPath)
+				walk(c, fmt.Sprintf("%s/%d", path, i))
 			}
 		}
 	}
+	walkEnv = func(e *lisp.LEnv, path string) {
+		if e == nil || seen[e] {
+			return
+		}
+		seen[e] = true
+		if _, dup := out[e]; !dup {
+			out[e] = path
+		}
+		keys, vals := sortedBindings(e)
+		for _, k := range keys {
+			walk(vals[k], path+"/"+k)
+		}
+		walkEnv(e.Parent(), path+"/parent")
+	}
 	roots(env, func(pkg, name string, v *lisp.LVal) {
-		walk(v, pkg+":"+name, map[*lisp.LVal]bool{})
+		walk(v, pkg+":"+name)
 	})
 	return out
 }

--- a/elpstest/forkcheck_internal_test.go
+++ b/elpstest/forkcheck_internal_test.go
@@ -3,6 +3,7 @@
 package elpstest
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -38,19 +39,68 @@ func TestAliasSignatureSeesDealiasing(t *testing.T) {
 	}
 }
 
-// Nested aliasing shows too: a map reachable directly and through a list.
+// Nested aliasing shows too: a map reachable directly and through a list
+// carries the same number in both places, and so does the vector inside
+// it.
 func TestAliasSignatureSeesNestedAlias(t *testing.T) {
 	env := mustEnv(t, `(set 'a (sorted-map "k" (vector 1))) (set 'l (list a (get a "k")))`)
 	sig := aliasSignature(env)
-	// The map's storage and the vector's cells each carry one number, and
-	// each number appears twice: once under a, once under l.
+	lines := map[string]string{}
 	for _, line := range strings.Split(sig, "\n") {
-		if strings.HasPrefix(line, "user:l = ") && !strings.Contains(line, "#") {
-			t.Fatalf("list of aliases rendered without payload numbers: %s", line)
+		if name, rest, ok := strings.Cut(line, " = "); ok {
+			lines[name] = rest
 		}
 	}
-	if strings.Count(sig, "user:a = ") != 1 {
-		t.Fatalf("unexpected signature:\n%s", sig)
+	// user:a renders the map's number first and the vector's number
+	// second (the vector's own cells follow, numbered too).
+	nums := regexp.MustCompile(`#\d+`).FindAllString(lines["user:a"], -1)
+	if len(nums) < 2 {
+		t.Fatalf("user:a should carry a map number and a vector number: %q", lines["user:a"])
+	}
+	mapNum, vecNum := nums[0], nums[1]
+	// user:l is a list (its own number) holding the same map and the same
+	// vector, rendered by number only since both were rendered under a.
+	if !strings.HasSuffix(lines["user:l"], "["+mapNum+" "+vecNum+"]") {
+		t.Fatalf("user:l should hold the map and vector numbers seen under a (%s %s): %q", mapNum, vecNum, lines["user:l"])
+	}
+}
+
+// A shared subtree is rendered once: a chain of lists each holding its
+// predecessor twice is walked in linear time, not once per path in.
+func TestAliasSignatureIsLinearOnDiamonds(t *testing.T) {
+	base := mustEnv(t, `(set 'l0 (list 1))`)
+	env := mustEnv(t, `
+(set 'l0 (list 1))
+(dotimes (i 40) (set 'l0 (list l0 l0)))
+`)
+	// Forty levels add forty short lines' worth of rendering, not 2^40.
+	if grew := len(aliasSignature(env)) - len(aliasSignature(base)); grew > 40*40 {
+		t.Fatalf("diamond chain grew the signature by %d bytes; the shared subtree is being re-walked", grew)
+	}
+	if ids := payloadIDs(env); len(ids) < 40 {
+		t.Fatalf("payloadIDs found %d payloads, want at least 40", len(ids))
+	}
+}
+
+// A closure's captured environment is part of every oracle: mutating it
+// moves the state rendering, and the environment itself is a payload.
+func TestOraclesSeeClosureState(t *testing.T) {
+	env := mustEnv(t, `(let ([outer (vector 0)]) (defun bump! () (append! outer 1) ()))`)
+	before := envState(env)
+	if rc := env.LoadString("m.lisp", `(bump!)`); rc.Type == lisp.LError {
+		t.Fatal(rc)
+	}
+	if envState(env) == before {
+		t.Fatal("state rendering did not move on a write through a closure")
+	}
+	found := false
+	for _, path := range payloadIDs(env) {
+		if strings.HasPrefix(path, "user:bump!/env") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("payloadIDs did not reach the closure's captured environment")
 	}
 }
 

--- a/elpstest/forkcheck_internal_test.go
+++ b/elpstest/forkcheck_internal_test.go
@@ -1,0 +1,81 @@
+// Copyright © 2026 The ELPS authors
+
+package elpstest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// The oracles must be able to see what they exist to see.  A harness whose
+// alias check cannot tell a de-aliased environment from its template
+// would pass the very bug it was written for.
+
+func mustEnv(t *testing.T, program string) *lisp.LEnv {
+	t.Helper()
+	env, err := NewForkCheckEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc := env.LoadString("p.lisp", program); rc.Type == lisp.LError {
+		t.Fatal(rc)
+	}
+	return env
+}
+
+// Two names over one map, and two names over two equal maps, render the
+// same state and a different alias structure.
+func TestAliasSignatureSeesDealiasing(t *testing.T) {
+	aliased := mustEnv(t, `(set 'a (sorted-map "k" 1)) (set 'b (quasiquote (unquote a)))`)
+	dealiased := mustEnv(t, `(set 'a (sorted-map "k" 1)) (set 'b (sorted-map "k" 1))`)
+	if envState(aliased) != envState(dealiased) {
+		t.Fatalf("premise: the two programs must render the same state\n%s", diffLines(envState(aliased), envState(dealiased)))
+	}
+	if aliasSignature(aliased) == aliasSignature(dealiased) {
+		t.Fatalf("alias signature cannot tell two names over one map from two maps:\n%s", aliasSignature(aliased))
+	}
+}
+
+// Nested aliasing shows too: a map reachable directly and through a list.
+func TestAliasSignatureSeesNestedAlias(t *testing.T) {
+	env := mustEnv(t, `(set 'a (sorted-map "k" (vector 1))) (set 'l (list a (get a "k")))`)
+	sig := aliasSignature(env)
+	// The map's storage and the vector's cells each carry one number, and
+	// each number appears twice: once under a, once under l.
+	for _, line := range strings.Split(sig, "\n") {
+		if strings.HasPrefix(line, "user:l = ") && !strings.Contains(line, "#") {
+			t.Fatalf("list of aliases rendered without payload numbers: %s", line)
+		}
+	}
+	if strings.Count(sig, "user:a = ") != 1 {
+		t.Fatalf("unexpected signature:\n%s", sig)
+	}
+}
+
+// An environment shares every payload with itself; a cold reload of the
+// same program shares none.
+func TestSharedPayloadsSeesSharing(t *testing.T) {
+	env := mustEnv(t, `(set 'a (sorted-map "k" 1)) (set 'v (vector 1 2)) (set 'b (to-bytes "x"))`)
+	if got := sharedPayloads(payloadIDs(env), payloadIDs(env)); len(got) == 0 {
+		t.Fatal("an environment shares nothing with itself")
+	}
+	other := mustEnv(t, `(set 'a (sorted-map "k" 1)) (set 'v (vector 1 2)) (set 'b (to-bytes "x"))`)
+	if got := sharedPayloads(payloadIDs(env), payloadIDs(other)); len(got) != 0 {
+		t.Fatalf("two cold environments share payloads: %v", got)
+	}
+}
+
+// A mutation moves the state rendering, so an unchanged rendering means an
+// unchanged environment rather than a blind renderer.
+func TestEnvStateSeesMutation(t *testing.T) {
+	env := mustEnv(t, `(set 'a (sorted-map "k" 1))`)
+	before := envState(env)
+	if rc := env.LoadString("m.lisp", `(assoc! a "k" 2)`); rc.Type == lisp.LError {
+		t.Fatal(rc)
+	}
+	if envState(env) == before {
+		t.Fatal("state rendering did not move on a sorted-map write")
+	}
+}

--- a/elpstest/forkcheck_test.go
+++ b/elpstest/forkcheck_test.go
@@ -1,0 +1,145 @@
+// Copyright © 2026 The ELPS authors
+
+package elpstest_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/elpstest"
+	"github.com/luthersystems/elps/lisp"
+)
+
+// Each test here is a fork bug that shipped, written as the ForkCheck
+// that fails on the tree it shipped in and passes on the tree that fixed
+// it.  The program is the shape that reached the bug; the transactions
+// are what a caller would run on a fork and observe diverging from a
+// cold load.
+
+// Issue #576: `(quasiquote (unquote a))` yields a second header on a's
+// sorted-map.  Fork memoised copies per header, so the fork's a and b
+// were two maps, and a write through one was invisible through the other
+// — on the fork only.  Fixed in #587.
+func TestForkCheck_SortedMapAliasAcrossHeaders(t *testing.T) {
+	elpstest.RunForkCheck(t, elpstest.ForkCheck{
+		Program: `
+(set 'a (sorted-map "k" 1))
+(set 'b (quasiquote (unquote a)))
+(set 'both (list a b))
+`,
+		Tx: []string{
+			`(assoc! a "y" 7) (get b "y")`,
+			`(dissoc! b "k") (get a "k")`,
+			`(assoc! (first both) "z" 1) (list (get (second both) "z") (get a "z"))`,
+		},
+	})
+}
+
+// Issue #576, second payload kind: the same two-header shape over a bytes
+// value, which append! grows in place.  Fixed in #587.
+func TestForkCheck_BytesAliasAcrossHeaders(t *testing.T) {
+	elpstest.RunForkCheck(t, elpstest.ForkCheck{
+		Program: `
+(set 'a (to-bytes "abc"))
+(set 'b (quasiquote (unquote a)))
+`,
+		Tx: []string{
+			`(append! a 7) (length b)`,
+			`(append! b 1 2) (length a)`,
+		},
+	})
+}
+
+// countingCloner is a NativeCloner accumulator: the kind of Go payload an
+// embedder binds at load time and mutates per transaction.
+type countingCloner struct{ clones int }
+
+func (c *countingCloner) CloneNative() interface{} {
+	return &countingCloner{clones: c.clones + 1}
+}
+
+// Issue #576, third payload kind: two headers over one native payload
+// were cloned once per header, so an accumulator the template held once
+// became two independent accumulators in the fork.  Fixed in #587.  The
+// program cannot express this shape (natives are bound from Go), so
+// NewEnv binds it.
+func TestForkCheck_NativeAliasAcrossHeaders(t *testing.T) {
+	elpstest.RunForkCheck(t, elpstest.ForkCheck{
+		NewEnv: func() (*lisp.LEnv, error) {
+			env, err := elpstest.NewForkCheckEnv()
+			if err != nil {
+				return nil, err
+			}
+			a := lisp.Native(&countingCloner{})
+			b := *a // a second header over the same payload
+			env.PutGlobal(lisp.Symbol("a"), a)
+			env.PutGlobal(lisp.Symbol("b"), &b)
+			return env, nil
+		},
+		Tx: []string{`(list a b)`},
+	})
+}
+
+// Issue #579: a libschema validator minted on the template stopped being
+// a validator in a fork, because its credential was the identity of a
+// marker cell the fork had copied.  Fixed in #581.  The failing
+// validation is included so an error stays an error of the same kind.
+func TestForkCheck_SchemaValidatorCredential(t *testing.T) {
+	elpstest.RunForkCheck(t, elpstest.ForkCheck{
+		Program: `
+(s:deftype "T" s:int)
+(set 'anon (s:make-validator "Anon" s:int (s:gt 1)))
+`,
+		Tx: []string{
+			`(s:validate T 3)`,
+			`(s:validate anon 3)`,
+			`(s:validate T "nope")`,
+			`(s:deftype "U" s:string) (s:validate U "x")`,
+			`(s:validate (s:make-validator "Fresh" s:string) "x")`,
+		},
+	})
+}
+
+// Issue #381 (fixed in #581): a fork shared the template's lisp testing
+// suite, a Go accumulator held as a native global, so a test registered
+// on a fork landed in the template.  The standard library loads the
+// testing package into the template here; the suite is a native payload,
+// so the isolation half of the check sees the share and the parity half
+// sees a fork whose suite already holds another fork's tests.
+func TestForkCheck_TestingSuitePerFork(t *testing.T) {
+	elpstest.RunForkCheck(t, elpstest.ForkCheck{
+		Program: `(use-package 'testing)`,
+		Tx: []string{
+			`(test "one" (assert-equal 1 1))`,
+			`(test "two" (assert-equal 2 2))`,
+		},
+	})
+}
+
+// The shapes the existing fork tests already pin, run through the
+// harness so a regression in any of them shows up here with the same
+// diagnostics: closures over mutable state, macros, labels mutual
+// recursion, nested maps, spare-capacity vectors.
+func TestForkCheck_LoadedProgram(t *testing.T) {
+	elpstest.RunForkCheck(t, elpstest.ForkCheck{
+		Program: `
+(set 'counter-box (vector 0))
+(defun make-adder (n) (lambda (x) (+ x n)))
+(set 'add2 (make-adder 2))
+(defmacro with-logging (expr) (quasiquote (progn (unquote expr))))
+(defun handler (m) (get-default m "k" (with-logging (add2 40))))
+(labels ([even? (n) (if (= n 0) true (odd? (- n 1)))]
+         [odd? (n) (if (= n 0) false (even? (- n 1)))])
+  (set 'evens even?))
+(set 'config (sorted-map "a" 1 "b" (vector 1 2 3) "inner" (sorted-map "n" 0)))
+(set 'blob (to-bytes "mutable-bytes"))
+(set 'e (list))
+`,
+		Tx: []string{
+			`(handler (sorted-map "x" 1))`,
+			`(funcall evens 10)`,
+			`(append! counter-box 99) (assoc! config "a" 100) (assoc! (get config "inner") "n" 5) (list counter-box config)`,
+			`(set 'fv (append 'vector e 'fork)) (nth fv 0)`,
+			`(append! blob 33) (length blob)`,
+		},
+	})
+}

--- a/elpstest/forkcheck_test.go
+++ b/elpstest/forkcheck_test.go
@@ -101,16 +101,39 @@ func TestForkCheck_SchemaValidatorCredential(t *testing.T) {
 
 // Issue #381 (fixed in #581): a fork shared the template's lisp testing
 // suite, a Go accumulator held as a native global, so a test registered
-// on a fork landed in the template.  The standard library loads the
-// testing package into the template here; the suite is a native payload,
-// so the isolation half of the check sees the share and the parity half
-// sees a fork whose suite already holds another fork's tests.
+// on a fork landed in the template.  The suite is an opaque native to the
+// state and isolation oracles (rendered by type; no identity unless it
+// is a NativeCloner, which the fix made it).  Parity sees the share
+// because registering a name the template's suite already holds is an
+// error: both transactions register "one", so on a shared suite the
+// second fork to run it fails where the cold environment does not.
 func TestForkCheck_TestingSuitePerFork(t *testing.T) {
 	elpstest.RunForkCheck(t, elpstest.ForkCheck{
 		Program: `(use-package 'testing)`,
 		Tx: []string{
 			`(test "one" (assert-equal 1 1))`,
-			`(test "two" (assert-equal 2 2))`,
+			`(test "one" (assert-equal 2 2))`,
+		},
+	})
+}
+
+// Closure-captured state: the state a fork must copy and a transaction
+// mutates through the closure, invisible from the package bindings except
+// through the function.  A walker that stopped at the function header
+// would pass a fork that shared the captured environment.
+func TestForkCheck_ClosureState(t *testing.T) {
+	elpstest.RunForkCheck(t, elpstest.ForkCheck{
+		Program: `
+(let ([outer (vector 0)] [box (sorted-map "n" 0)])
+  (defun bump! () (append! outer 1) (assoc! box "n" (+ 1 (get box "n"))) ())
+  (defun peek () (list (length outer) (get box "n"))))
+(set 'shared (sorted-map "k" 1))
+(defun share-through-closure () shared)
+`,
+		Tx: []string{
+			`(bump!)`,
+			`(bump!) (bump!) (peek)`,
+			`(assoc! (share-through-closure) "k" 2) (get shared "k")`,
 		},
 	})
 }
@@ -118,7 +141,7 @@ func TestForkCheck_TestingSuitePerFork(t *testing.T) {
 // The shapes the existing fork tests already pin, run through the
 // harness so a regression in any of them shows up here with the same
 // diagnostics: closures over mutable state, macros, labels mutual
-// recursion, nested maps, spare-capacity vectors.
+// recursion, nested maps, bytes.
 func TestForkCheck_LoadedProgram(t *testing.T) {
 	elpstest.RunForkCheck(t, elpstest.ForkCheck{
 		Program: `


### PR DESCRIPTION
## Summary

- An embedder such as substrate loads a program once into a template and runs every transaction on a fork of it. Three fork bugs reached that pattern with no test that models it: #576 (two headers over one sorted-map, bytes or native payload forked to two payloads, so a write through one name was invisible through the other, on forks only), #579 (a libschema validator lost its credential across a fork) and #381 (a fork shared the template's libtesting suite). Each was caught by hand and each fix carries a test of its own shape. This adds the model itself, so the next bug of the class fails a test before it reaches an embedder.
- `elpstest.RunForkCheck` takes a program and the transactions a caller would run, and holds the template/fork model to three properties, each against a reference that never calls `Fork`, so a `Fork` bug cannot hide in the oracle:
  - **parity**: a transaction on a fork gives the same result, and leaves the same reachable state, as on a cold environment that loaded the program itself;
  - **aliasing**: "same mutable payload" holds for the same pairs of reachable positions in template and fork;
  - **isolation**: no per-fork payload is shared with the template or with another fork, the template is untouched after a fork's transaction, a later fork is pristine.
- "Reachable" includes the environment a closure captured (its bindings and its parents'), walked through `internal/funraw`, since that is the state a fork must copy and a transaction mutates through the closure. Every check also runs one hop deeper, on a fork of a fork (#579 was a one-hop-only fix once). Payload identity follows `docs/fork.md` and Fork's own memo: sorted-map storage, bytes storage, list and vector cells, captured environments and pointer `NativeCloner`s are per-fork; sealed values and plain natives are shared by design and carry no identity. `ForkOptions` lets a check exercise `ForkWithNativeReplacer` / `ForkWithContext` the way the embedder does.
- `elpstest/forkcheck_test.go` carries one `ForkCheck` per shipped bug, a closure-state shape, and the loaded-program shape the existing fork tests use. Internal tests pin that each oracle can see what it exists to see, and that the walks are linear on shared (diamond) graphs.
- Docs: a bullet under `docs/fork.md` → Verification, including what the oracles cannot see (a native's contents, package metadata beside the symbol table).

Two commits: the harness, then the adversarial-review pass (closure environments in every oracle, seen-guarded walks, pointer-only native identity, fork-vs-fork check, `ForkOptions`, doc corrections, stronger tests).

Stacked on #587 (needs its per-payload memo to pass). Test-only: no change to `lisp/`.

## Verified to fail where the bugs lived

The same three files, dropped onto the pre-fix trees:

| Tree | Result |
|---|---|
| parent of #587 (a5c3e69) | `SortedMapAliasAcrossHeaders`, `BytesAliasAcrossHeaders`, `NativeAliasAcrossHeaders` fail: "alias structure differs from the template" |
| `main` (03b789a) | those three, plus `SchemaValidatorCredential` ("tx[0] fork: result differs from the cold run") and `TestingSuitePerFork` (duplicate registration on the shared suite) |
| this branch | all green |

## Test Plan

- [x] `go build ./...`, `go test ./...`
- [x] `go test -race ./elpstest/`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `make elpsvet`
- [x] Internal anti-vacuity tests: two names over one map vs two equal maps render the same state and different alias signatures; nested aliases carry the same numbers under both bindings; a 40-deep diamond chain grows the signature linearly; an environment shares every payload with itself and none with a cold reload; a write moves the state rendering; a write through a closure moves it and the captured environment is a payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX