### PR TITLE
Clone sorted maps structurally in assoc and dissoc too

### DIFF
--- a/lisp/copy_sortedmap_test.go
+++ b/lisp/copy_sortedmap_test.go
@@ -1,0 +1,249 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+// TestCopyMapDataStructuralClone pins LVal.copyMapData -- what assoc, dissoc
+// and LVal.Copy build on every call -- against the contract of the
+// enumerate-and-reinsert path it replaced for the stock sorted map: the same
+// entries in the same order with the same key types, the value pointers
+// SHARED (it copies the map's structure, not its values), and no storage
+// shared with the source in either direction, the key-type map included.
+func TestCopyMapDataStructuralClone(t *testing.T) {
+	m := SortedMap()
+	inner := Array(nil, []*LVal{Int(1), Int(2)})
+	for _, kv := range []struct {
+		k, v *LVal
+	}{
+		{String("b-string"), inner},
+		{Symbol("a-symbol"), String("sym-val")},
+		{String("c-string"), Int(3)},
+	} {
+		if lerr := m.Map().Set(kv.k, kv.v); lerr.Type == LError {
+			t.Fatalf("map set: %v", lerr)
+		}
+	}
+
+	md, err := m.copyMapData()
+	if err != nil {
+		t.Fatalf("copyMapData: %v", err)
+	}
+	if md == m.Map() {
+		t.Fatalf("copy returned the source MapData")
+	}
+	if _, ok := md.mapBacking.(sortedmap); !ok {
+		t.Fatalf("copy of the stock map is backed by %T, want sortedmap", md.mapBacking)
+	}
+	cp := SortedMapFromData(md)
+
+	// Same entries, same order, same key types, same value pointers.
+	oe, ne := sortedMapEntries(m.Map()), sortedMapEntries(cp.Map())
+	if len(oe.Cells) != len(ne.Cells) {
+		t.Fatalf("entry count differs: source %d, copy %d", len(oe.Cells), len(ne.Cells))
+	}
+	for i := range oe.Cells {
+		ok, nk := oe.Cells[i].Cells[0], ne.Cells[i].Cells[0]
+		if ok.Type != nk.Type || ok.Str != nk.Str {
+			t.Errorf("entry %d key: source %v (%v), copy %v (%v)", i, ok, ok.Type, nk, nk.Type)
+		}
+		if oe.Cells[i].Cells[1] != ne.Cells[i].Cells[1] {
+			t.Errorf("entry %d value: copy holds %p, want the source's %p (values are shared, not copied)", i, ne.Cells[i].Cells[1], oe.Cells[i].Cells[1])
+		}
+	}
+
+	// Independence in both directions.
+	if lerr := cp.Map().Set(String("copy-only"), Int(1)); lerr.Type == LError {
+		t.Fatalf("copy map set: %v", lerr)
+	}
+	if _, found := m.Map().Get(String("copy-only")); found {
+		t.Errorf("a key set in the copy appeared in the source")
+	}
+	if lerr := m.Map().Set(String("source-only"), Int(1)); lerr.Type == LError {
+		t.Fatalf("source map set: %v", lerr)
+	}
+	if _, found := cp.Map().Get(String("source-only")); found {
+		t.Errorf("a key set in the source appeared in the copy")
+	}
+	if lerr := cp.Map().Del(String("c-string")); lerr.Type == LError {
+		t.Fatalf("copy map del: %v", lerr)
+	}
+	if _, found := m.Map().Get(String("c-string")); !found {
+		t.Errorf("a key deleted from the copy disappeared from the source")
+	}
+
+	// The key-type map is independent too (see TestForkSortedMapClone for
+	// why this probe is the one that sees a shared typemap).
+	if lerr := cp.Map().Set(Symbol("k"), Int(1)); lerr.Type == LError {
+		t.Fatalf("copy map set: %v", lerr)
+	}
+	if lerr := m.Map().Set(String("k"), Int(2)); lerr.Type == LError {
+		t.Fatalf("source map set: %v", lerr)
+	}
+	for _, p := range sortedMapEntries(m.Map()).Cells {
+		if p.Cells[0].Str == "k" && p.Cells[0].Type != LString {
+			t.Errorf("source key %q enumerates as %v, want string: copy and source share a typemap", p.Cells[0].Str, p.Cells[0].Type)
+		}
+	}
+}
+
+// TestCopyMapDataIsRightSized is the copyMapData twin of
+// TestForkSortedMapClonePrunedMapIsRightSized: assoc on a map filled to 100k
+// entries and pruned to 3 must not pay for the abandoned table.
+func TestCopyMapDataIsRightSized(t *testing.T) {
+	m := SortedMap()
+	const highWater = 100_000
+	for i := range highWater {
+		if lerr := m.Map().Set(String(strconv.Itoa(i)), Int(i)); lerr.Type == LError {
+			t.Fatalf("map set: %v", lerr)
+		}
+	}
+	for i := 3; i < highWater; i++ {
+		m.Map().Del(String(strconv.Itoa(i)))
+	}
+	res := testing.Benchmark(func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := m.copyMapData(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	const limit = 64 << 10
+	if got := res.AllocedBytesPerOp(); got > limit {
+		t.Errorf("copy of a pruned 3-entry map allocates %d B/op, want at most %d: the copy kept the source's %d-entry table", got, limit, highWater)
+	}
+}
+
+// TestCopyMapDataIsStructural is the assertion the contract tests above
+// cannot make: they pass on the entries path too.  The entries path costs
+// one pair list, its cells and a key per entry plus the sort, so a copy of a
+// 1000-entry map made about 1030 allocations; the structural clone makes
+// under ten.  A regression back to per-entry boxing fails this.
+func TestCopyMapDataIsStructural(t *testing.T) {
+	m := SortedMap()
+	for i := range 1000 {
+		if lerr := m.Map().Set(String(fmt.Sprintf("key-%04d", i)), Int(i)); lerr.Type == LError {
+			t.Fatalf("map set: %v", lerr)
+		}
+	}
+	res := testing.Benchmark(func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := m.copyMapData(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	const limit = 16
+	if got := res.AllocsPerOp(); got > limit {
+		t.Errorf("copy of a 1000-entry map makes %d allocations, want at most %d: the copy is boxing entries again", got, limit)
+	}
+}
+
+// entriesOnlyMap is an embedder-style Map that offers nothing but the Map
+// interface, so copyMapData has to take the entries path for it.
+type entriesOnlyMap struct{ m map[string]*LVal }
+
+func (e *entriesOnlyMap) Len() int { return len(e.m) }
+func (e *entriesOnlyMap) Get(k *LVal) (*LVal, bool) {
+	v, ok := e.m[k.Str]
+	if !ok {
+		return Nil(), false
+	}
+	return v, true
+}
+func (e *entriesOnlyMap) Set(k, v *LVal) *LVal { e.m[k.Str] = v; return Nil() }
+func (e *entriesOnlyMap) Del(k *LVal) *LVal    { delete(e.m, k.Str); return Nil() }
+func (e *entriesOnlyMap) Keys() *LVal          { return sortedMapEntries(e) }
+func (e *entriesOnlyMap) Entries(buf []*LVal) *LVal {
+	i := 0
+	for k, v := range e.m {
+		buf[i] = QExpr([]*LVal{String(k), v})
+		i++
+	}
+	return Int(i)
+}
+
+// TestCopyMapDataEmbedderMapKeepsEntriesPath pins that a map with a custom
+// backing is still copied through its entries into a stock sorted map, as
+// before, with the same entries and shared values.
+func TestCopyMapDataEmbedderMapKeepsEntriesPath(t *testing.T) {
+	v1, v2 := Int(1), Array(nil, []*LVal{Int(2)})
+	src := SortedMapFromData(NewMapData(&entriesOnlyMap{m: map[string]*LVal{"x": v1, "y": v2}}))
+	md, err := src.copyMapData()
+	if err != nil {
+		t.Fatalf("copyMapData: %v", err)
+	}
+	if _, ok := md.mapBacking.(sortedmap); !ok {
+		t.Fatalf("copy is backed by %T, want the stock sortedmap", md.mapBacking)
+	}
+	if md.Len() != 2 {
+		t.Fatalf("copy has %d entries, want 2", md.Len())
+	}
+	if got, _ := md.Get(String("x")); got != v1 {
+		t.Errorf("x: copy holds %p, want the source's %p", got, v1)
+	}
+	if got, _ := md.Get(String("y")); got != v2 {
+		t.Errorf("y: copy holds %p, want the source's %p", got, v2)
+	}
+}
+
+// largeStringKeyedMap binds m to a 1000-entry string-keyed sorted map.
+func largeStringKeyedMap(b *testing.B, env *LEnv) {
+	b.Helper()
+	m := SortedMap()
+	for i := range 1000 {
+		if lerr := m.Map().Set(String(fmt.Sprintf("key-%04d", i)), Int(i)); lerr.Type == LError {
+			b.Fatalf("map set: %v", lerr)
+		}
+	}
+	env.PutGlobal(Symbol("m"), m)
+}
+
+// BenchmarkAssocLargeMap measures the non-mutating assoc on a 1000-entry
+// map: its cost is the map copy, which is what copyMapData's structural
+// clone pins.
+func BenchmarkAssocLargeMap(b *testing.B) {
+	env := newForkTestEnv(b)
+	largeStringKeyedMap(b, env)
+	b.ReportAllocs()
+	for b.Loop() {
+		v := env.Eval(SExpr([]*LVal{Symbol("assoc"), Symbol("m"), String("new-key"), Int(1)}))
+		if v.Type == LError {
+			b.Fatalf("assoc: %v", v)
+		}
+	}
+}
+
+// BenchmarkDissocLargeMap is the dissoc twin of BenchmarkAssocLargeMap.
+func BenchmarkDissocLargeMap(b *testing.B) {
+	env := newForkTestEnv(b)
+	largeStringKeyedMap(b, env)
+	b.ReportAllocs()
+	for b.Loop() {
+		v := env.Eval(SExpr([]*LVal{Symbol("dissoc"), Symbol("m"), String("key-0500")}))
+		if v.Type == LError {
+			b.Fatalf("dissoc: %v", v)
+		}
+	}
+}
+
+// BenchmarkSortedMapLiteral measures building a small string-keyed map,
+// the shape of most map literals in a phylum; it pins the construction
+// cost of the stock map (in particular that a string-keyed map allocates no
+// key-type map).
+func BenchmarkSortedMapLiteral(b *testing.B) {
+	env := newForkTestEnv(b)
+	expr := SExpr([]*LVal{Symbol("sorted-map"), String("a"), Int(1), String("b"), Int(2), String("c"), Int(3)})
+	b.ReportAllocs()
+	for b.Loop() {
+		if v := env.Eval(expr); v.Type == LError {
+			b.Fatalf("sorted-map: %v", v)
+		}
+	}
+}

--- a/lisp/fork.go
+++ b/lisp/fork.go
@@ -607,48 +607,24 @@ func (f *forker) mapData(md *MapData) *MapData {
 		return cp
 	}
 	if sm, ok := md.mapBacking.(sortedmap); ok {
-		// The stock sorted map is a Go map plus a key-type map, so it can be
-		// cloned structurally: copy both maps and remap the values through
-		// the fork walk.  This is what Set would store for every entry, so
-		// the contents, key types, aliasing and cycles come out identical to
-		// the enumerate-and-reinsert path below, without the sorted entry
-		// list, the per-entry pair cells, or the incremental map growth.
-		//
-		// make(..., len(sm.m)) right-sizes the clone on purpose.  Go maps
-		// never shrink after deletes and maps.Clone copies the table at its
-		// high-water mark, so a load-time map filled to 100k entries and
-		// pruned to 3 would cost every fork 3.7MB instead of 0.2MB (pinned
-		// by TestForkSortedMapClonePrunedMapIsRightSized); the per-entry
-		// copy costs nothing measurable over maps.Clone.
-		//
-		// The key-type map is copied verbatim rather than rebuilt from the
-		// entries (as detach's mapData still does).  An entry in tm with no
-		// partner in m cannot exist today (Set and Del keep the two in
-		// step), so nothing is laundered here, and a future desync shows
-		// up in the fork instead of being hidden by the rebuild.
+		// The stock sorted map is a Go map plus a key-type map, so it is
+		// cloned structurally (sortedmap.copyInto) with the values remapped
+		// through the fork walk; the contents, key types, aliasing and
+		// cycles come out identical to the enumerate-and-reinsert path
+		// below.  Embedder map implementations keep the generic path: their
+		// entry enumeration is the only contract they offer.
 		//
 		// Measured on a 72k-line production phylum whose template holds
 		// large load-time sorted maps (rating tables, templates): this one
 		// branch removed 28% of the bytes and 15% of the allocations of
 		// every fork, and 15% of the wall time of building a retained pool
-		// of forked VMs.  Embedder map implementations keep the generic
-		// path: their entry enumeration is the only contract they offer.
-		nm := sortedmap{
-			m:  make(map[interface{}]*LVal, len(sm.m)),
-			tm: make(typemap, len(sm.tm)),
-		}
+		// of forked VMs.
+		nm := sm.emptyLike()
 		// Memo before descending, as the generic path does (issue #576):
-		// an entry may reach back to md.  The Go maps inside nm are
-		// references, so filling them after the memo stores the *MapData
-		// is visible through it.
+		// an entry may reach back to md.
 		cp := NewMapData(nm)
 		f.maps[md] = cp
-		for k, v := range sm.m {
-			nm.m[k] = f.val(v)
-		}
-		for k, t := range sm.tm {
-			nm.tm[k] = t
-		}
+		sm.copyInto(nm, f.val)
 		return cp
 	}
 	entries := sortedMapEntries(md)

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -1654,10 +1654,19 @@ func (v *LVal) Copy() *LVal {
 	return cp
 }
 
+// copyMapData returns a fresh *MapData holding v's entries with the value
+// pointers shared: the map structure is private to the copy, the values are
+// not.  This is what assoc and dissoc build on every call, so the stock
+// sorted map is cloned structurally (sortedmap.clone) rather than by
+// enumerating its entries in sorted order and re-inserting them; an
+// embedder map implementation keeps the entries path.
 func (v *LVal) copyMapData() (*MapData, error) {
 	m0 := v.Map()
 	if m0 == nil {
 		return nil, nil
+	}
+	if sm, ok := m0.mapBacking.(sortedmap); ok {
+		return &MapData{sm.clone(nil)}, nil
 	}
 	m := &MapData{newmap()}
 	for _, pair := range sortedMapEntries(m0).Cells {

--- a/lisp/maps.go
+++ b/lisp/maps.go
@@ -89,6 +89,59 @@ func (m sortedmap) deltype(k interface{}) {
 	delete(m.typemap(), k)
 }
 
+// emptyLike returns an empty sortedmap sized to receive a copy of m: both
+// Go maps are made with m's CURRENT lengths.  Sizing to the current length
+// rather than cloning the table matters: Go maps never shrink after
+// deletes, so a map filled to 100k entries and pruned to 3 would otherwise
+// cost every copy the high-water-mark table
+// (TestForkSortedMapClonePrunedMapIsRightSized).
+func (m sortedmap) emptyLike() sortedmap {
+	return sortedmap{
+		m:  make(map[interface{}]*LVal, len(m.m)),
+		tm: make(typemap, len(m.tm)),
+	}
+}
+
+// copyInto copies m's entries and its key-type map into cp, an emptyLike
+// of m, passing each value through val (nil shares the value pointer).  The
+// entries are what Set stores -- the value under its key string -- and the
+// key-type map is copied verbatim, which is what Entries reads when it
+// decides whether a key comes back as a string or a symbol (including a
+// stale symbol flag on a key later re-set as a string: Set does not clear
+// it, and neither path invents or drops one).  The result is therefore
+// indistinguishable from enumerating the entries in sorted order and
+// re-inserting them, minus the sort, the per-entry pair cells and the
+// incremental map growth.
+//
+// It is split from emptyLike so a caller that memoises copies by identity
+// (the fork walker, issue #576) can publish cp before the values are
+// walked: an entry may reach back to the map being copied, and the Go maps
+// inside cp are references, so entries written here are visible through a
+// *MapData built around cp earlier.  val runs in Go map order, which is
+// unspecified; a caller that must see entries in a fixed order (detach,
+// which reports the first failing key) stays on the Entries path.
+func (m sortedmap) copyInto(cp sortedmap, val func(*LVal) *LVal) {
+	if val == nil {
+		for k, v := range m.m {
+			cp.m[k] = v
+		}
+	} else {
+		for k, v := range m.m {
+			cp.m[k] = val(v)
+		}
+	}
+	for k, t := range m.tm {
+		cp.tm[k] = t
+	}
+}
+
+// clone is emptyLike followed by copyInto.
+func (m sortedmap) clone(val func(*LVal) *LVal) sortedmap {
+	cp := m.emptyLike()
+	m.copyInto(cp, val)
+	return cp
+}
+
 func (m sortedmap) Len() int {
 	return len(m.m)
 }
@@ -182,10 +235,10 @@ func (m sortedmap) Entries(buf []*LVal) *LVal {
 			keys[i] = LVal{Type: LString, Str: ks}
 			cells[0] = &keys[i]
 		default:
-			// A symbol key is quoted, and Quote wraps rather than
-			// flagging, so this arm needs a second LVal that the string
-			// arm does not.  Symbol keys are the rare case, so they keep
-			// the straightforward construction.
+			// A symbol key is quoted, and Quote copies a not-yet-quoted
+			// value to flag it, so this arm allocates a second LVal that
+			// the string arm does not.  Symbol keys are the rare case, so
+			// they keep the straightforward construction.
 			cells[0] = Quote(Symbol(ks))
 		}
 		cells[1] = v


### PR DESCRIPTION
## Summary

- `LVal.copyMapData` is what the non-mutating `assoc` and `dissoc` build on every call (and what `LVal.Copy` uses for a sorted map). It still rebuilt the stock map by enumerating the entries in sorted order and calling `Set` once per pair: a sort, one pair list per entry, and a Go map grown step by step, on every call.
- #572 gave the fork a structural clone. This PR moves that clone into `sortedmap` itself as three unexported helpers and uses it from both places:
  - `emptyLike` returns an empty map sized to the current entry count (the right-sizing argument from #572 applies here too: Go maps never shrink, so the copy must not inherit a pruned table's high-water mark).
  - `copyInto` fills it with the entries and the key-type map, passing each value through an optional func. The entries are what `Set` stores and the key-type map is what `Entries` reads, so the result is indistinguishable from the entries path, including a stale symbol flag on a key later re-set as a string (neither path invents or drops one).
  - `clone` is the two in sequence.
- The split exists for the fork, which must register the copy in its memo before the values are walked (#576): `emptyLike`, memoise, then `copyInto` with the fork walker. `copyMapData` calls `clone` with a nil func, which shares the value pointers as the entries path did.
- Embedder map implementations keep the entries path in both callers. `detach` stays on it as well: it reports the first failing key, and the sorted entries path gives that a deterministic order.
- Semantics are unchanged. No language-visible surface.

Follow-up in the same series: #592 gives decoded JSON maps (`libjson.SortedMap`, a different backing type) the same structural path in fork and `assoc`.

## Measurements

benchstat, three interleaved base/change rounds of `-count=2 -cpu 1` (n=6), 1000-entry string-keyed map:

| benchmark | metric | base | change | delta |
|---|---|---|---|---|
| AssocLargeMap | sec/op | 622.6µ | 89.5µ | −85.6% (p=0.002) |
| AssocLargeMap | B/op | 371.5Ki | 54.5Ki | −85.3% |
| AssocLargeMap | allocs/op | 1045 | 22 | −97.9% |
| DissocLargeMap | sec/op | 619.7µ | 90.2µ | −85.4% (p=0.002) |
| DissocLargeMap | allocs/op | 1043 | 20 | −98.1% |
| ForkSortedMap | all | unchanged | unchanged | control: the fork already took this path |
| SortedMapLiteral | B/op, allocs | unchanged | unchanged | construction is untouched |

## Test Plan

- [x] `go test ./lisp/ ./lisp/lisplib/... ./elpstest/`
- [x] `go test -tags elpscheck ./lisp/`
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `./elps fmt -l ./...` lists nothing; `./elps doc -m` clean
- [x] `make elpsvet` (plain and elpscheck)
- [x] `TestCopyMapDataStructuralClone` pins the copy against the entries-path contract: same entries in the same order with the same key types, value pointers shared, no storage shared in either direction including the key-type map (symbol-then-string probe)
- [x] `TestCopyMapDataIsStructural` is the discriminating test: a copy of a 1000-entry map must make at most 16 allocations (the entries path made about 1030); it fails on the previous code
- [x] `TestCopyMapDataIsRightSized` pins the pruned-map sizing for the copy
- [x] `TestCopyMapDataEmbedderMapKeepsEntriesPath` pins that a custom Map backing is still copied through its entries into a stock map
- [x] New benchmarks: `BenchmarkAssocLargeMap`, `BenchmarkDissocLargeMap`, `BenchmarkSortedMapLiteral`
- [x] Adversarial review: no blockers. An A/B of 17 programs and a Go-level probe (symbol/string typemap edge, self-reference, empty and nil maps, error paths) against the previous head produced identical output. Its nits (a discriminating allocation test, two comment corrections) are in this head

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX