### PR TITLE
Copy decoded JSON maps structurally in Fork, assoc and dissoc

### DIFF
--- a/lisp/fork.go
+++ b/lisp/fork.go
@@ -627,6 +627,24 @@ func (f *forker) mapData(md *MapData) *MapData {
 		sm.copyInto(nm, f.val)
 		return cp
 	}
+	if r, ok := md.mapBacking.(StringKeyRanger); ok {
+		// A string-keyed embedder map (libjson.SortedMap) becomes the same
+		// stock sorted map the entries path below builds for it -- Set with
+		// an LString key stores the value under the string and writes no
+		// key type -- without the sorted pair list in between.  The memo is
+		// published before the values are walked, as above (issue #576).
+		nm := emptyForStringKeys(md.Len())
+		cp := NewMapData(nm)
+		f.maps[md] = cp
+		if err := r.RangeStringKeys(func(k string, v *LVal) {
+			nm.m[k] = f.val(v)
+		}); err != nil {
+			// The entries path panics on an enumeration failure too: loud
+			// beats a silently partial fork.
+			panic(fmt.Sprintf("fork: sorted-map entries cannot be enumerated: %v", err))
+		}
+		return cp
+	}
 	entries := sortedMapEntries(md)
 	if entries.Type == LError {
 		// Unreachable for the stock sorted map (its entry enumeration

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -1668,6 +1668,17 @@ func (v *LVal) copyMapData() (*MapData, error) {
 	if sm, ok := m0.mapBacking.(sortedmap); ok {
 		return &MapData{sm.clone(nil)}, nil
 	}
+	if r, ok := m0.mapBacking.(StringKeyRanger); ok {
+		// Same stock map the entries path builds for a string-keyed
+		// embedder map, without boxing the entries first.
+		nm := emptyForStringKeys(m0.Len())
+		if err := r.RangeStringKeys(func(k string, v *LVal) {
+			nm.m[k] = v
+		}); err != nil {
+			return nil, fmt.Errorf("failed to copy map: %w", err)
+		}
+		return &MapData{nm}, nil
+	}
 	m := &MapData{newmap()}
 	for _, pair := range sortedMapEntries(m0).Cells {
 		lerr := m.Set(pair.Cells[0], pair.Cells[1])

--- a/lisp/lisplib/libjson/clone_test.go
+++ b/lisp/lisplib/libjson/clone_test.go
@@ -1,0 +1,223 @@
+// Copyright © 2026 The ELPS authors
+
+package libjson_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/lisp/lisplib/libjson"
+	"github.com/luthersystems/elps/parser"
+)
+
+// decodedMapEnv returns an environment with libjson loaded and the global m
+// bound to a decoded JSON object of n string keys.  One value is an array,
+// so a copy that must duplicate mutable values has something to duplicate.
+func decodedMapEnv(t testing.TB, n int) (*lisp.LEnv, *lisp.LVal) {
+	t.Helper()
+	env := lisp.NewEnv(nil)
+	env.Runtime.Reader = parser.NewReader()
+	if rc := lisp.InitializeUserEnv(env); rc.Type == lisp.LError {
+		t.Fatalf("InitializeUserEnv: %v", rc)
+	}
+	if rc := libjson.LoadPackage(env); rc.Type == lisp.LError {
+		t.Fatalf("LoadPackage: %v", rc)
+	}
+	if rc := env.InPackage(lisp.String(lisp.DefaultUserPackage)); rc.Type == lisp.LError {
+		t.Fatalf("InPackage: %v", rc)
+	}
+	var sb strings.Builder
+	sb.WriteString(`(set 'm (json:load-string "{`)
+	for i := range n {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		if i == 1 {
+			fmt.Fprintf(&sb, `\"k%04d\": [1, 2]`, i)
+		} else {
+			fmt.Fprintf(&sb, `\"k%04d\": %d`, i, i)
+		}
+	}
+	sb.WriteString(`}"))`)
+	m := env.LoadString("decoded_map_test.lisp", sb.String())
+	if m.Type != lisp.LSortMap {
+		t.Fatalf("json:load-string returned %v, want a sorted map", m)
+	}
+	// The decoded map's backing is not reachable from outside package lisp;
+	// its contract is: it rejects any key that is not a string.  That is
+	// what tells a decoded map apart from the stock map its copies become.
+	if lerr := m.Map().Set(lisp.Symbol("probe"), lisp.Int(0)); lerr.Type != lisp.LError {
+		t.Fatalf("decoded map accepted a symbol key; json:load-string no longer returns libjson.SortedMap")
+	}
+	return env, m
+}
+
+// keysAndValues returns the map's keys in sorted order with the value bound
+// to each, through the Map interface only.
+func keysAndValues(t testing.TB, m *lisp.LVal) ([]string, []*lisp.LVal) {
+	t.Helper()
+	keys := m.Map().Keys()
+	if keys.Type == lisp.LError {
+		t.Fatalf("keys: %v", keys)
+	}
+	ks := make([]string, 0, len(keys.Cells))
+	vs := make([]*lisp.LVal, 0, len(keys.Cells))
+	for _, k := range keys.Cells {
+		if k.Type != lisp.LString {
+			t.Fatalf("key %v has type %v, want string", k, k.Type)
+		}
+		v, ok := m.Map().Get(k)
+		if !ok {
+			t.Fatalf("key %v enumerated but not found", k)
+		}
+		ks = append(ks, k.Str)
+		vs = append(vs, v)
+	}
+	return ks, vs
+}
+
+// TestForkOfDecodedMapMatchesEntriesPath pins that Fork turns a decoded
+// JSON map into what the entries path always produced for it -- a stock
+// sorted map with the same string keys, mutable values copied, storage
+// private to the fork -- now built through libjson.SortedMap's
+// RangeStringKeys instead of a sorted pair list.
+func TestForkOfDecodedMapMatchesEntriesPath(t *testing.T) {
+	env, m := decodedMapEnv(t, 5)
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	fm := fork.Runtime.Package.Get(lisp.Symbol("m"))
+	if fm.Type != lisp.LSortMap {
+		t.Fatalf("forked m: want sorted map, got %v", fm)
+	}
+	if fm.Native == m.Native {
+		t.Fatalf("forked map shares MapData with the template")
+	}
+	// The fork's copy is the stock map, as before: unlike the decoded
+	// original (see decodedMapEnv) it accepts a symbol key.
+	if lerr := fm.Map().Set(lisp.Symbol("sym"), lisp.Int(0)); lerr.Type == lisp.LError {
+		t.Errorf("forked copy rejected a symbol key: it is not the stock sorted map the entries path produced: %v", lerr)
+	}
+	if lerr := fm.Map().Del(lisp.Symbol("sym")); lerr.Type == lisp.LError {
+		t.Fatalf("del: %v", lerr)
+	}
+
+	ok, ov := keysAndValues(t, m)
+	nk, nv := keysAndValues(t, fm)
+	if len(ok) != len(nk) {
+		t.Fatalf("fork has %d keys, template %d", len(nk), len(ok))
+	}
+	for i := range ok {
+		if ok[i] != nk[i] {
+			t.Errorf("key %d: template %q, fork %q", i, ok[i], nk[i])
+		}
+		if eq := ov[i].Equal(nv[i]); eq.Type != lisp.LSymbol || eq.Str != lisp.TrueSymbol {
+			t.Errorf("value %q differs: template %v, fork %v", ok[i], ov[i], nv[i])
+		}
+		if ov[i].Type == lisp.LArray && ov[i] == nv[i] {
+			t.Errorf("mutable array value %q is shared between template and fork", ok[i])
+		}
+	}
+
+	// Independence in both directions.
+	if lerr := fm.Map().Set(lisp.String("fork-only"), lisp.Int(1)); lerr.Type == lisp.LError {
+		t.Fatalf("fork set: %v", lerr)
+	}
+	if _, found := m.Map().Get(lisp.String("fork-only")); found {
+		t.Errorf("a key set in the fork appeared in the template")
+	}
+	if lerr := m.Map().Set(lisp.String("template-only"), lisp.Int(1)); lerr.Type == lisp.LError {
+		t.Fatalf("template set: %v", lerr)
+	}
+	if _, found := fm.Map().Get(lisp.String("template-only")); found {
+		t.Errorf("a key set in the template appeared in the fork")
+	}
+}
+
+// TestAssocOnDecodedMapMatchesEntriesPath pins the non-mutating assoc and
+// dissoc on a decoded map: the result is a stock sorted map with the same
+// keys, the same value POINTERS (these copy structure, not values), the
+// requested change, and no effect on the original.
+func TestAssocOnDecodedMapMatchesEntriesPath(t *testing.T) {
+	env, m := decodedMapEnv(t, 5)
+	ok, ov := keysAndValues(t, m)
+
+	got := env.LoadString("assoc_test.lisp", `(assoc m "new" 42)`)
+	if got.Type != lisp.LSortMap {
+		t.Fatalf("assoc returned %v", got)
+	}
+	if got.Native == m.Native {
+		t.Fatalf("assoc returned the original map")
+	}
+	if _, found := m.Map().Get(lisp.String("new")); found {
+		t.Errorf("assoc mutated the original")
+	}
+	nk, nv := keysAndValues(t, got)
+	if len(nk) != len(ok)+1 {
+		t.Fatalf("assoc result has %d keys, want %d", len(nk), len(ok)+1)
+	}
+	for i := range ok {
+		if nk[i] != ok[i] {
+			t.Errorf("key %d: original %q, copy %q", i, ok[i], nk[i])
+		}
+		if nv[i] != ov[i] {
+			t.Errorf("value %q: copy holds %p, want the original's %p (values are shared)", ok[i], nv[i], ov[i])
+		}
+	}
+	if v, _ := got.Map().Get(lisp.String("new")); v.Type != lisp.LInt || v.Int != 42 {
+		t.Errorf("new key: got %v", v)
+	}
+	// As before, the copy is the stock map and accepts a symbol key even
+	// though the decoded original does not.
+	if lerr := got.Map().Set(lisp.Symbol("sym"), lisp.Int(0)); lerr.Type == lisp.LError {
+		t.Errorf("assoc result rejected a symbol key: it is not the stock sorted map the entries path produced: %v", lerr)
+	}
+
+	got = env.LoadString("dissoc_test.lisp", `(dissoc m "k0002")`)
+	if got.Type != lisp.LSortMap {
+		t.Fatalf("dissoc returned %v", got)
+	}
+	if _, found := got.Map().Get(lisp.String("k0002")); found {
+		t.Errorf("dissoc result still holds the key")
+	}
+	if _, found := m.Map().Get(lisp.String("k0002")); !found {
+		t.Errorf("dissoc mutated the original")
+	}
+	if got.Map().Len() != len(ok)-1 {
+		t.Errorf("dissoc result has %d keys, want %d", got.Map().Len(), len(ok)-1)
+	}
+}
+
+// BenchmarkForkDecodedMaps measures Fork on a template whose mutable state
+// is 20 decoded JSON documents of 200 keys, the shape of a phylum that
+// loads configuration or fixtures with json:load at load time.
+func BenchmarkForkDecodedMaps(b *testing.B) {
+	env, _ := decodedMapEnv(b, 200)
+	for i := range 19 {
+		if v := env.LoadString("bench.lisp", fmt.Sprintf(`(set 'm%d (json:load-string (json:dump-string m)))`, i)); v.Type == lisp.LError {
+			b.Fatalf("copy: %v", v)
+		}
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := env.Fork(); err != nil {
+			b.Fatalf("fork: %v", err)
+		}
+	}
+}
+
+// BenchmarkAssocDecodedMap measures the non-mutating assoc on a decoded
+// 1000-key document: the request-handling shape of parse, then add a field.
+func BenchmarkAssocDecodedMap(b *testing.B) {
+	env, _ := decodedMapEnv(b, 1000)
+	expr := lisp.SExpr([]*lisp.LVal{lisp.Symbol("assoc"), lisp.Symbol("m"), lisp.String("new-key"), lisp.Int(1)})
+	b.ReportAllocs()
+	for b.Loop() {
+		if v := env.Eval(expr); v.Type == lisp.LError {
+			b.Fatalf("assoc: %v", v)
+		}
+	}
+}

--- a/lisp/lisplib/libjson/sortedmap.go
+++ b/lisp/lisplib/libjson/sortedmap.go
@@ -11,6 +11,21 @@ import (
 type SortedMap map[string]interface{}
 
 var _ lisp.Map = SortedMap(nil)
+var _ lisp.StringKeyRanger = SortedMap(nil)
+
+// RangeStringKeys implements lisp.StringKeyRanger: fn sees each key as the
+// string Entries emits for it and each value exactly as Entries emits it
+// (an error value for a non-LVal, as mapLVal does there).  Enumerating a Go
+// map cannot fail, so it always returns nil.  Fork and the copy behind
+// assoc, dissoc and lisp.LVal.Copy use it to build the stock sorted-map
+// copy of a decoded document without first materialising every entry as a
+// pair list.
+func (m SortedMap) RangeStringKeys(fn func(key string, val *lisp.LVal)) error {
+	for k, x := range m {
+		fn(k, mapLVal(x))
+	}
+	return nil
+}
 
 func (m SortedMap) Len() int {
 	return len(m)

--- a/lisp/maps.go
+++ b/lisp/maps.go
@@ -142,6 +142,39 @@ func (m sortedmap) clone(val func(*LVal) *LVal) sortedmap {
 	return cp
 }
 
+// StringKeyRanger is an optional interface a Map implementation can
+// provide when its Entries emits every key as an unquoted LString, never a
+// symbol.  RangeStringKeys calls fn exactly once per entry, in unspecified
+// order, with the key string Entries would emit and the value exactly as
+// Entries would emit it, and must not mutate the map while doing so.  It
+// returns nil, or the failure Entries would have reported; every caller
+// discards a partial walk on error.  Len is used only as a size hint.
+//
+// A map whose Entries can emit a symbol key must not implement this: the
+// callers store every key as a string, which is what Set does with an
+// LString key, so a symbol flag the entries path would have recorded
+// through Set(LSymbol) would be lost.
+//
+// Fork and the copy behind assoc, dissoc and LVal.Copy use it to build the
+// stock sorted-map copy of such a map without first boxing every entry
+// into a pair list: the copy is the same stock map the Entries path
+// produces for it, so nothing observable changes -- only the sort, the
+// pair cells and the incremental growth go.  libjson.SortedMap, what
+// json:load returns, implements it.
+type StringKeyRanger interface {
+	RangeStringKeys(fn func(key string, val *LVal)) error
+}
+
+// emptyForStringKeys returns an empty stock sortedmap sized for n string
+// keys.  Set with an LString key writes no key type, so tm stays at its
+// zero size, as newmap leaves it.
+func emptyForStringKeys(n int) sortedmap {
+	return sortedmap{
+		m:  make(map[interface{}]*LVal, n),
+		tm: make(typemap),
+	}
+}
+
 func (m sortedmap) Len() int {
 	return len(m.m)
 }

--- a/lisp/stringkey_ranger_test.go
+++ b/lisp/stringkey_ranger_test.go
@@ -1,0 +1,155 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// rangerMap is a Map that implements StringKeyRanger and whose Entries
+// panics: it proves that Fork and copyMapData take the ranger path, which
+// the libjson-level tests cannot (they pass on the entries path too).
+type rangerMap struct {
+	m   map[string]*LVal
+	err error
+}
+
+func (r *rangerMap) Len() int { return len(r.m) }
+func (r *rangerMap) Get(k *LVal) (*LVal, bool) {
+	v, ok := r.m[k.Str]
+	if !ok {
+		return Nil(), false
+	}
+	return v, true
+}
+func (r *rangerMap) Set(k, v *LVal) *LVal { r.m[k.Str] = v; return Nil() }
+func (r *rangerMap) Del(k *LVal) *LVal    { delete(r.m, k.Str); return Nil() }
+func (r *rangerMap) Keys() *LVal          { return sortedMapEntries(r) }
+func (r *rangerMap) Entries([]*LVal) *LVal {
+	panic("rangerMap.Entries: the entries path was taken for a StringKeyRanger")
+}
+func (r *rangerMap) RangeStringKeys(fn func(string, *LVal)) error {
+	if r.err != nil {
+		return r.err
+	}
+	for k, v := range r.m {
+		fn(k, v)
+	}
+	return nil
+}
+
+// TestForkTakesStringKeyRangerPath pins the fork's ranger path: the copy is
+// the stock map with an empty key-type map and the same keys; the values
+// went through the fork walk (a mutable value is copied, a value that
+// reaches back to the map closes on the clone, a second binding maps to
+// the same clone); and the template is untouched.
+func TestForkTakesStringKeyRangerPath(t *testing.T) {
+	env := newForkTestEnv(t)
+	arr := Array(nil, []*LVal{Int(1), Int(2)})
+	r := &rangerMap{m: map[string]*LVal{"n": Int(7), "arr": arr}}
+	m := SortedMapFromData(NewMapData(r))
+	r.m["self"] = Array(nil, []*LVal{m})
+	env.PutGlobal(Symbol("doc"), m)
+	env.PutGlobal(Symbol("doc-alias"), m)
+
+	fork, err := env.Fork()
+	if err != nil {
+		t.Fatalf("fork: %v", err)
+	}
+	fm := fork.Runtime.Package.Get(Symbol("doc"))
+	if fm.Type != LSortMap || fm.Native == m.Native {
+		t.Fatalf("forked doc: %v (native %p, template %p)", fm, fm.Native, m.Native)
+	}
+	sm, ok := fm.Map().mapBacking.(sortedmap)
+	if !ok {
+		t.Fatalf("fork copy is backed by %T, want the stock sortedmap", fm.Map().mapBacking)
+	}
+	if len(sm.tm) != 0 {
+		t.Errorf("fork copy has key types %v, want none for string keys", sm.tm)
+	}
+	if fork.Runtime.Package.Get(Symbol("doc-alias")).Native != fm.Native {
+		t.Errorf("aliased binding was not remapped to the same clone")
+	}
+	if got := fm.Map().Len(); got != 3 {
+		t.Fatalf("fork copy has %d entries, want 3", got)
+	}
+	if v, _ := fm.Map().Get(String("n")); v.Type != LInt || v.Int != 7 {
+		t.Errorf("n: got %v", v)
+	}
+	fv, _ := fm.Map().Get(String("arr"))
+	if fv == arr {
+		t.Errorf("mutable array value is shared with the template")
+	}
+	if eq := fv.Equal(arr); eq.Type != LSymbol || eq.Str != TrueSymbol {
+		t.Errorf("array value differs: %v vs %v", fv, arr)
+	}
+	self, _ := fm.Map().Get(String("self"))
+	if got := self.Cells[1].Cells[0].Native; got != fm.Native { // Cells[1] holds an array's elements
+		t.Errorf("self-reference points at %p, want the clone %p", got, fm.Native)
+	}
+	if lerr := fm.Map().Set(String("fork-only"), Int(1)); lerr.Type == LError {
+		t.Fatalf("fork set: %v", lerr)
+	}
+	if _, found := r.m["fork-only"]; found {
+		t.Errorf("a key set in the fork appeared in the template")
+	}
+}
+
+// TestCopyMapDataTakesStringKeyRangerPath pins copyMapData's ranger path:
+// a stock map with an empty key-type map, the same keys, and the value
+// pointers SHARED.
+func TestCopyMapDataTakesStringKeyRangerPath(t *testing.T) {
+	v1, v2 := Int(1), Array(nil, []*LVal{Int(2)})
+	src := SortedMapFromData(NewMapData(&rangerMap{m: map[string]*LVal{"x": v1, "y": v2}}))
+	md, err := src.copyMapData()
+	if err != nil {
+		t.Fatalf("copyMapData: %v", err)
+	}
+	sm, ok := md.mapBacking.(sortedmap)
+	if !ok {
+		t.Fatalf("copy is backed by %T, want the stock sortedmap", md.mapBacking)
+	}
+	if len(sm.tm) != 0 {
+		t.Errorf("copy has key types %v, want none", sm.tm)
+	}
+	if md.Len() != 2 {
+		t.Fatalf("copy has %d entries, want 2", md.Len())
+	}
+	if got, _ := md.Get(String("x")); got != v1 {
+		t.Errorf("x: copy holds %p, want the source's %p", got, v1)
+	}
+	if got, _ := md.Get(String("y")); got != v2 {
+		t.Errorf("y: copy holds %p, want the source's %p", got, v2)
+	}
+}
+
+// TestStringKeyRangerFailureIsNotSilent pins the error channel: a ranger
+// that fails must not yield a partial copy.  copyMapData returns the error
+// the entries path would have wrapped; Fork refuses the way it does when
+// entries cannot be enumerated.
+func TestStringKeyRangerFailureIsNotSilent(t *testing.T) {
+	r := &rangerMap{m: map[string]*LVal{"x": Int(1)}, err: errors.New("enumeration failed")}
+	src := SortedMapFromData(NewMapData(r))
+	if md, err := src.copyMapData(); err == nil || !strings.Contains(err.Error(), "enumeration failed") {
+		t.Errorf("copyMapData: got (%v, %v), want the ranger's error", md, err)
+	}
+
+	env := newForkTestEnv(t)
+	env.PutGlobal(Symbol("doc"), src)
+	refused := false
+	func() {
+		defer func() {
+			if recover() != nil {
+				refused = true
+			}
+		}()
+		if _, err := env.Fork(); err != nil {
+			refused = true
+		}
+	}()
+	if !refused {
+		t.Errorf("Fork silently succeeded on a map whose enumeration fails")
+	}
+}


### PR DESCRIPTION
## Summary

- `json:load` returns a map backed by `libjson.SortedMap`, a Go `map[string]interface{}` that rejects any key that is not a string. Fork and `LVal.copyMapData` (behind the non-mutating `assoc` and `dissoc`) only knew how to copy the stock `sortedmap` structurally, so every decoded document still went through the generic path: `Entries` sorts the keys and boxes each entry as a two-cell pair list, then `Set` re-inserts them one by one into a stock map that grows step by step. For a phylum that is every request body: parse, then `assoc` a field.
- Adds `lisp.StringKeyRanger`, an optional interface a `Map` implementation can provide when its `Entries` emits every key as an unquoted `LString`. `RangeStringKeys` hands each entry to a callback with the key as the string `Entries` would emit and the value exactly as `Entries` would emit it, in unspecified order, and returns nil or the failure `Entries` would have reported. A map whose enumeration can fail therefore still fails loudly (`copyMapData` returns the error, Fork panics as it does when entries cannot be enumerated) instead of yielding a partial copy.
- Fork and `copyMapData` use it to build the same stock map the entries path produced: a `sortedmap` sized to `Len()` whose entries are stored under the key string with no key type, which is what `Set` does with an `LString` key. The result is indistinguishable from before. In particular the copy is still the stock map and still accepts a symbol key even though the decoded original does not; the tests pin that.
- The fork registers its copy in the memo before the values are walked, as its other paths do (#576).
- `libjson.SortedMap` implements the interface in one loop. Its type and key contract are unchanged.
- Stacked on #591 (the `sortedmap` clone helpers). **Base this PR on `claude/elps-perf-optimization-jcgfd2-map-clone`, not `main`.**

The allocation that remains is one per entry: the stock map keys on `interface{}`, so storing a string key boxes it. That is the same cost `Set` paid before and is a candidate for a separate change to the key type.

## Measurements

benchstat, three interleaved base/change rounds of `-count=2 -cpu 1` (n=6), base being #591:

| benchmark | metric | base | change | delta |
|---|---|---|---|---|
| AssocDecodedMap (1000-key document) | sec/op | 624.7µ | 132.1µ | −78.9% (p=0.002) |
| AssocDecodedMap | B/op | 368.3Ki | 69.6Ki | −81.1% |
| AssocDecodedMap | allocs/op | 2038 | 1017 | −50.1% |
| ForkDecodedMaps (20 documents × 200 keys) | sec/op | 5.200m | 1.649m | −68.3% (p=0.002) |
| ForkDecodedMaps | B/op | 2.70Mi | 0.86Mi | −68.2% |
| ForkDecodedMaps | allocs/op | 17.3k | 9.0k | −48.0% |

## Test Plan

- [x] `go test ./lisp/ ./lisp/lisplib/... ./elpstest/`
- [x] `go test -tags elpscheck ./lisp/ ./lisp/lisplib/libjson/`
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `./elps fmt -l ./...` lists nothing; `./elps doc -m` clean
- [x] `make elpsvet` (plain and elpscheck)
- [x] `lisp/stringkey_ranger_test.go`: a `Map` whose `Entries` panics proves the ranger path is taken by both Fork and `copyMapData`; pins the stock backing with an empty key-type map, mutable values copied by the fork, a value that reaches back to the map closing on the clone, a second binding mapping to the same clone, shared value pointers in the copy, and that a failing ranger is not silent
- [x] `TestForkOfDecodedMapMatchesEntriesPath` pins at the language level: the fork's copy is the stock map (accepts a symbol key while the decoded original rejects one), same keys, mutable values copied, storage private in both directions
- [x] `TestAssocOnDecodedMapMatchesEntriesPath` pins: `assoc` and `dissoc` results are stock maps with the same keys, the same value pointers, the requested change, and no effect on the original
- [x] New benchmarks: `BenchmarkForkDecodedMaps`, `BenchmarkAssocDecodedMap`
- [x] Adversarial review: no blockers; its three should-fix items (fallible enumeration, sharper contract doc, fast-path-taken tests) are in this head

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX