### PR TITLE
Key the stock sorted map on string instead of interface{}

### DIFF
--- a/lisp/maps.go
+++ b/lisp/maps.go
@@ -59,16 +59,22 @@ const (
 	symbolkey
 )
 
-type typemap map[interface{}]keytype
+// Every key a sortedmap stores is a Go string: Set keys on LVal.Str for both
+// LString and LSymbol and rejects every other type, so the Go maps are keyed
+// on string rather than interface{}.  Keying on interface{} boxed each
+// string into a heap-allocated interface value on insert (one allocation per
+// entry, on top of the map growth) and had every read wrap the key in an
+// interface before hashing; a string key hashes and compares directly.
+type typemap map[string]keytype
 
 type sortedmap struct {
-	m  map[interface{}]*LVal
+	m  map[string]*LVal
 	tm typemap
 }
 
 func newmap() sortedmap {
 	return sortedmap{
-		m:  make(map[interface{}]*LVal),
+		m:  make(map[string]*LVal),
 		tm: make(typemap),
 	}
 }
@@ -77,15 +83,15 @@ func (m sortedmap) typemap() typemap {
 	return m.tm
 }
 
-func (m sortedmap) keytype(k interface{}) keytype {
+func (m sortedmap) keytype(k string) keytype {
 	return m.typemap()[k]
 }
 
-func (m sortedmap) puttype(k interface{}, t keytype) {
+func (m sortedmap) puttype(k string, t keytype) {
 	m.typemap()[k] = t
 }
 
-func (m sortedmap) deltype(k interface{}) {
+func (m sortedmap) deltype(k string) {
 	delete(m.typemap(), k)
 }
 
@@ -97,7 +103,7 @@ func (m sortedmap) deltype(k interface{}) {
 // (TestForkSortedMapClonePrunedMapIsRightSized).
 func (m sortedmap) emptyLike() sortedmap {
 	return sortedmap{
-		m:  make(map[interface{}]*LVal, len(m.m)),
+		m:  make(map[string]*LVal, len(m.m)),
 		tm: make(typemap, len(m.tm)),
 	}
 }
@@ -170,7 +176,7 @@ type StringKeyRanger interface {
 // zero size, as newmap leaves it.
 func emptyForStringKeys(n int) sortedmap {
 	return sortedmap{
-		m:  make(map[interface{}]*LVal, n),
+		m:  make(map[string]*LVal, n),
 		tm: make(typemap),
 	}
 }
@@ -254,11 +260,7 @@ func (m sortedmap) Entries(buf []*LVal) *LVal {
 	// n LVals of dead storage for keys it never writes.
 	var keys []LVal
 	i := 0
-	for k, v := range m.m {
-		ks, ok := k.(string)
-		if !ok {
-			return Errorf("unexpected map key: %v", k)
-		}
+	for ks, v := range m.m {
 		cells := slots[2*i : 2*i+2 : 2*i+2]
 		switch m.keytype(ks) {
 		case stringkey:

--- a/lisp/sortedmap_bench_test.go
+++ b/lisp/sortedmap_bench_test.go
@@ -1,0 +1,56 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"fmt"
+	"testing"
+)
+
+// benchStringKeys returns n distinct LString keys built up front, so the
+// benchmarks below measure the map operation and not the key construction.
+func benchStringKeys(n int) []*LVal {
+	keys := make([]*LVal, n)
+	for i := range keys {
+		keys[i] = String(fmt.Sprintf("key-%04d", i))
+	}
+	return keys
+}
+
+// BenchmarkSortedMapInsert isolates the insert cost of the stock sorted
+// map: a fresh map filled with 1000 string keys through Set, the way a
+// map literal, assoc! or a JSON decode fills one.  It pins that storing a
+// string key costs the map growth and nothing else (no per-key boxing).
+func BenchmarkSortedMapInsert(b *testing.B) {
+	keys := benchStringKeys(1000)
+	val := Int(1)
+	b.ReportAllocs()
+	for b.Loop() {
+		m := newmap()
+		for _, k := range keys {
+			if lerr := m.Set(k, val); lerr.Type == LError {
+				b.Fatalf("set: %v", lerr)
+			}
+		}
+	}
+}
+
+// BenchmarkSortedMapGet isolates the lookup cost of the stock sorted map:
+// 1000 Get hits on a 1000-entry string-keyed map.
+func BenchmarkSortedMapGet(b *testing.B) {
+	keys := benchStringKeys(1000)
+	m := newmap()
+	for i, k := range keys {
+		if lerr := m.Set(k, Int(i)); lerr.Type == LError {
+			b.Fatalf("set: %v", lerr)
+		}
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		for _, k := range keys {
+			if _, ok := m.Get(k); !ok {
+				b.Fatalf("get %s: missing", k.Str)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- The stock `sortedmap` stored its entries in `map[interface{}]*LVal` and its key types in `map[interface{}]keytype`, but every key it ever stores is a Go string: `Set` writes `key.Str` for both `LString` and `LSymbol`, and `Entries` even asserted `k.(string)` and errored otherwise. Storing a string in an `interface{}`-keyed map boxes it, one heap allocation per inserted entry, and every lookup pays an interface wrap and a dynamic-type hash dispatch.
- Both maps now key on `string`. `newmap`, `emptyLike`, `emptyForStringKeys`, `keytype`/`puttype`/`deltype` and `Entries` follow. The `k.(string)` assertion in `Entries` and its "unexpected map key" error are dropped: with a string-keyed map there is no value they could fire on.
- Semantics are unchanged: same accept and reject set and identical `unhashable type` errors in `Get`/`Set`/`Del`, only symbol keys write the key-type map, a string re-set still leaves a stale symbol flag, `Entries` output and order are unchanged. Nothing outside `maps.go` needed editing: the fork clone, `copyMapData`, the `StringKeyRanger` path and `detach` already used string keys at the call site.
- Stacked on #592 (which sits on #591). **Base this PR on `claude/elps-perf-optimization-jcgfd2-json-clone`, not `main`.**

## Measurements

benchstat, three interleaved base/change rounds of `-count=2 -cpu 1` (n=6), base being #592:

| benchmark | sec/op | B/op | allocs/op |
|---|---|---|---|
| SortedMapInsert (1000 Set) | −31.5% | −12.8% | 1023 → 23 (−97.8%) |
| SortedMapGet (1000 Get) | −32.1% | 0 → 0 | 0 → 0 |
| SortedMapLiteral | −15.4% | −4.6% | 15 → 12 |
| AssocDecodedMap (1000-key document) | −40.0% | −22.5% | 1017 → 16 (−98.4%) |
| ForkDecodedMaps (20 × 200 keys) | −21.1% | −7.1% | 9006 → 5006 (−44.4%) |
| AssocLargeMap | −9.4% | unchanged | 22 → 21 |
| DissocLargeMap | −12.2% | unchanged | unchanged |
| ForkSortedMap, EnvGet, EnvFunCallPos, all `BenchmarkPackage/*` json load and dump | no significant change | unchanged | unchanged |

All starred deltas p=0.002. The lookup gain was the surprise: it is not allocation-only, string keys hash directly where the interface key paid a wrap and a dynamic dispatch on every `Get`.

The stock-map structural copies barely move in allocations because `copyInto` copied already-boxed keys by value; their time gain is the cheaper hashing. The decoded-JSON paths gain most because the `StringKeyRanger` path writes one key per entry and every write was a box.

## Test Plan

- [x] `go vet ./lisp/...`
- [x] `go test ./lisp/ ./lisp/lisplib/... ./elpstest/`
- [x] `go test -tags elpscheck ./lisp/`
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `make elpsvet`
- [x] Existing map, fork, copy and `StringKeyRanger` tests pass unchanged, including the symbol-then-string typemap probes
- [x] New benchmarks: `BenchmarkSortedMapInsert`, `BenchmarkSortedMapGet`
- [x] Adversarial review: no blockers and no should-fix items. Every write to the two maps in the repository was audited (all string-keyed, so the removed `Entries` branch was unreachable); an A/B of Go probes and ELPS programs against the parent commit was byte-identical across every key type, the stale-symbol-flag case, `Entries`, rendering, `Equal`, JSON dump and load, elpspath operations, and fork isolation; the benchmark table reproduced on a quiet machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX