### PR TITLE
Compare the best of several samples in TestBurninTakesRealTime

### DIFF
--- a/cmd/benchgate/burnin_test.go
+++ b/cmd/benchgate/burnin_test.go
@@ -339,16 +339,32 @@ func TestBurninSmoke(t *testing.T) {
 	}
 }
 
+// bestOf returns the fastest of n real samples at the given size. The minimum
+// is the quantity that tracks the fixed iteration count; any single sample also
+// carries whatever the machine did to it.
+func bestOf(n, rounds int) sample {
+	best := sample{d: time.Duration(math.MaxInt64)}
+	for range n {
+		if s := realSampler(rounds); s.d < best.d {
+			best = s
+		}
+	}
+	return best
+}
+
 // TestBurninTakesRealTime is the same claim as the 0ns check above, made
 // directly: a fixed workload four times the size must take measurably longer
 // than the small one. Ratios are not asserted (that would be a benchmark of the
-// test machine); only the ordering, which no amount of load can invert.
+// test machine); only the ordering. One sample per size is not enough for even
+// that: the whole workload is under 10ms, so a single GC pause or scheduler
+// preemption landing in the small run inverts it (#590). The best of several
+// samples is compared instead.
 func TestBurninTakesRealTime(t *testing.T) {
 	if testing.Short() {
 		t.Skip("runs the real reference workload")
 	}
-	small := realSampler(2000)
-	large := realSampler(8000)
+	small := bestOf(5, 2000)
+	large := bestOf(5, 8000)
 	if small.d <= 0 || large.d <= 0 {
 		t.Fatalf("the reference workload reported no elapsed time (%v, %v)", small.d, large.d)
 	}


### PR DESCRIPTION
## Summary

- `TestBurninTakesRealTime` timed one `realSampler(2000)` run and one `realSampler(8000)` run and asserted the 4x workload took longer. The whole workload is under 10ms, so one GC pause or scheduler preemption landing in the small run inverts the ordering (run 33817634853: 7.9ms small vs 7.4ms large).
- Take the fastest of five samples per size before comparing. The minimum tracks the fixed iteration count; a single sample also carries whatever the machine did to it.
- The comment's "no amount of load can invert" claim is corrected to say why one sample is not enough.
- The zero-elapsed and checksum assertions are unchanged. Test file only; no change to the benchgate binary.

Closes #590

## Test Plan

- [x] `go build ./...`
- [x] `go test -count=20 ./cmd/benchgate/` passes (20 consecutive runs)
- [x] `go vet ./cmd/benchgate/`
- [x] `gofmt -l ./cmd/benchgate/` reports nothing
- [x] `golangci-lint run ./cmd/benchgate/` (v2.6.2, matching CI) reports 0 issues
- [x] `make test` passes (Go suite + example programs)
- [x] `./elps fmt -l ./...` and `./elps doc -m` clean; `./elps lint ./...` reports the same 4 pre-existing `.lisp` diagnostics with and without this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX

---
_Generated by [Claude Code](https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX)_