### PR TITLE
Pre-size known-length results in slice, make-sequence, join and elpspath

### DIFF
--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -1944,6 +1944,60 @@ func builtinZip(env *LEnv, args *LVal) *LVal {
 	return v
 }
 
+// maxSequencePresize bounds the capacity make-sequence reserves up front,
+// on top of the runtime's own allocation limit.
+//
+// The capacity is only ever a hint: the loop appends into it and grows past
+// it exactly as it did before any of it was sized.  Past roughly a million
+// elements the growth it saves has amortised to nothing -- append doubles,
+// so a list of any size beyond this reaches its length in a handful of
+// regrows -- which is why bounding here costs nothing measurable.
+//
+// What it buys is that the number handed to make is always derived from a
+// real element count and never from MaxAlloc, which an embedder sets and
+// which has no obligation to be a number of elements that can exist.  With
+// the limit raised (WithMaxAlloc(1<<50), say) an unbounded clamp asked for a
+// capacity beyond what any slice can address, and make rejected it: a huge
+// forward range then failed as "internal-panic: makeslice: cap out of range"
+// where it used to grow until it ran out of memory.  Different behaviour,
+// and avoidable.
+const maxSequencePresize = 1 << 20
+
+// makeSequenceCap returns the capacity to reserve for the integer sequence
+// [start, stop) by step, or 0 to reserve nothing.
+//
+// Only a forward range is sized.  The length is (stop-start) rounded up to a
+// multiple of step, and that subtraction wraps NEGATIVE -- the signal an
+// overflow is skipped on -- only when stop really is the larger of the two.
+// Run backwards it wraps POSITIVE: (make-sequence 1 MinInt64) has a
+// difference of MaxInt64, so sizing without checking the direction first
+// would reserve for a sequence that has no elements at all.  Checking
+// start < stop leaves the backwards and equal-endpoint shapes at 0, and
+// makes any genuine overflow wrap negative and be skipped.
+//
+// The result is clamped to the runtime's allocation limit, because a
+// sequence longer than that fails in the loop at the same element it always
+// did, and to maxSequencePresize, because the limit is not a number of
+// elements anyone promised can be allocated.
+func makeSequenceCap(start, stop, step, limit int) int {
+	if start >= stop {
+		return 0
+	}
+	d := stop - start
+	if d <= 0 {
+		// The true difference is positive, so this is an overflow.
+		return 0
+	}
+	n := (d-1)/step + 1
+	if n > limit {
+		n = limit
+	}
+	if n > maxSequencePresize {
+		n = maxSequencePresize
+	}
+	return n
+}
+
 func builtinMakeSequence(env *LEnv, args *LVal) *LVal {
 	start, stop := args.Cells[0], args.Cells[1]
 	if !start.IsNumeric() {
@@ -1972,6 +2026,11 @@ func builtinMakeSequence(env *LEnv, args *LVal) *LVal {
 		}
 	}
 	list := QExpr(nil)
+	if start.Type == LInt && stop.Type == LInt && step.Type == LInt {
+		if n := makeSequenceCap(start.Int, stop.Int, step.Int, env.Runtime.MaxAllocBytes()); n > 0 {
+			list.Cells = make([]*LVal, 0, n)
+		}
+	}
 	for x := start; lessNumeric(x, stop); x = addNumeric(x, step) {
 		if msg := env.Runtime.CheckAlloc(len(list.Cells) + 1); msg != "" {
 			return env.Errorf("%s", msg)

--- a/lisp/builtins.go
+++ b/lisp/builtins.go
@@ -2087,7 +2087,15 @@ func builtinSlice(env *LEnv, args *LVal) *LVal {
 		case LBytes:
 			return String(string(list.Bytes()))
 		default: // LSExpr
+			// One byte per cell, so the slice is sized once.  An empty
+			// window stays nil: libjson encodes a nil []byte as JSON null
+			// and an empty non-nil one as "", a v1.13.0 compatibility
+			// contract (encodeBytes in lisp/lisplib/libjson/encode.go), so
+			// make([]byte, 0, 0) would change what the value serializes to.
 			var b []byte
+			if n := len(list.Cells); n > 0 {
+				b = make([]byte, 0, n)
+			}
 			err := appendBytes(env, list, func(x byte) {
 				b = append(b, x)
 			})
@@ -2103,7 +2111,15 @@ func builtinSlice(env *LEnv, args *LVal) *LVal {
 		case LBytes:
 			return list
 		default: // LSExpr
+			// One byte per cell, so the slice is sized once.  An empty
+			// window stays nil: libjson encodes a nil []byte as JSON null
+			// and an empty non-nil one as "", a v1.13.0 compatibility
+			// contract (encodeBytes in lisp/lisplib/libjson/encode.go), so
+			// make([]byte, 0, 0) would change what the value serializes to.
 			var b []byte
+			if n := len(list.Cells); n > 0 {
+				b = make([]byte, 0, n)
+			}
 			err := appendBytes(env, list, func(x byte) {
 				b = append(b, x)
 			})

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -753,6 +753,19 @@ func SortedMap() *LVal {
 	return SortedMapFromData(&MapData{newmap()})
 }
 
+// SortedMapSized returns an empty sorted-map whose backing is sized to
+// receive n entries, as make(map, n) sizes a Go map.  n is a capacity hint:
+// the map is empty, it grows past n as SortedMap's would, and a negative n
+// is treated as zero rather than panicking the way make(map, n) does.  Use
+// it where the entry count is known before the first Set, such as when
+// copying a map.
+func SortedMapSized(n int) *LVal {
+	if n < 0 {
+		n = 0
+	}
+	return SortedMapFromData(&MapData{newmapSized(n)})
+}
+
 // SortedMapFromData returns sorted-map with the given backing implementation.
 // Applications calling this function must make ensure the Map implementation
 // provided satisfies the semantics of Map methods.

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -755,10 +755,12 @@ func SortedMap() *LVal {
 
 // SortedMapSized returns an empty sorted-map whose backing is sized to
 // receive n entries, as make(map, n) sizes a Go map.  n is a capacity hint:
-// the map is empty, it grows past n as SortedMap's would, and a negative n
-// is treated as zero rather than panicking the way make(map, n) does.  Use
-// it where the entry count is known before the first Set, such as when
-// copying a map.
+// the map is empty and it grows past n as SortedMap's would.  A negative n
+// is clamped to zero rather than passed to make, because the language
+// requires make's size argument to be non-negative and gc's tolerance of a
+// negative map hint is not something an exported constructor should oblige
+// its callers to rely on.  Use it where the entry count is known before the
+// first Set, such as when copying a map.
 func SortedMapSized(n int) *LVal {
 	if n < 0 {
 		n = 0

--- a/lisp/lisplib/libelpspath/path.go
+++ b/lisp/lisplib/libelpspath/path.go
@@ -1390,7 +1390,7 @@ func (s *rangePath) nilMutate(in *lisp.LVal) (*lisp.LVal, error) {
 	if err != nil {
 		return nil, err
 	}
-	var newCells []*lisp.LVal
+	newCells := make([]*lisp.LVal, 0, to-from)
 	for i := from; i < to; i++ {
 		newCells = append(newCells, lisp.Nil())
 	}
@@ -1508,7 +1508,9 @@ func (s *iterPath) Get(in *lisp.LVal) (*lisp.LVal, error) {
 		return nil, err
 	}
 	collapseIter := isChainToIter(s.path)
-	var results []*lisp.LVal
+	// One result per element of the horizon; a collapsed nested iterator
+	// may add more, in which case this is a floor.
+	results := make([]*lisp.LVal, 0, len(horizon))
 	for _, item := range horizon {
 		in, err := s.path.Get(item)
 		if err != nil {

--- a/lisp/lisplib/libelpspath/path.go
+++ b/lisp/lisplib/libelpspath/path.go
@@ -181,7 +181,9 @@ func copyMapExcept(v *lisp.LVal, skip *lisp.LVal, g cycleGuard) (*lisp.LVal, err
 	if err := lisp.GoError(entries); err != nil {
 		return nil, err
 	}
-	sm := lisp.SortedMap()
+	// Sized for every entry: the copy holds all of them, or all but the
+	// one at skip.
+	sm := lisp.SortedMapSized(len(entries.Cells))
 	m := sm.Map()
 	for _, pair := range entries.Cells {
 		if skip != nil && sameMapSlot(pair.Cells[0], skip) {

--- a/lisp/lisplib/libelpspath/presize_bench_test.go
+++ b/lisp/lisplib/libelpspath/presize_bench_test.go
@@ -1,0 +1,96 @@
+// Copyright © 2026 The ELPS authors
+
+package libelpspath
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// Benchmarks for the sites that build a result of known final size one
+// entry at a time: the copy behind the non-mutating map operations, and
+// the result slices of the iterator and range paths.
+//
+//	go test -run '^$' -bench 'CopyMapWide|IterPathGet|RangePathNil' -benchmem -count=10 -cpu 1 ./lisp/lisplib/libelpspath/
+
+func benchWideMap(n int) *lisp.LVal {
+	m := lisp.SortedMap()
+	for i := range n {
+		m.MapSet(fmt.Sprintf("key%04d", i), lisp.Int(i))
+	}
+	return m
+}
+
+func benchRecords(n int) *lisp.LVal {
+	cells := make([]*lisp.LVal, n)
+	for i := range cells {
+		m := lisp.SortedMap()
+		m.MapSet("id", lisp.Int(i))
+		m.MapSet("name", lisp.String("name"))
+		cells[i] = m
+	}
+	return lisp.Vector(cells)
+}
+
+func benchIntList(n int) *lisp.LVal {
+	cells := make([]*lisp.LVal, n)
+	for i := range cells {
+		cells[i] = lisp.Int(i)
+	}
+	return lisp.QExpr(cells)
+}
+
+var presizeSizes = []int{10, 100, 1000}
+
+// BenchmarkCopyMapWide is ?set! on a flat map of n scalar entries: one
+// copyMapOffPath of the whole map per call.
+func BenchmarkCopyMapWide(b *testing.B) {
+	for _, n := range presizeSizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			env := lisp.NewEnv(nil)
+			env.Runtime.Reader = nil
+			call := lisp.QExpr([]*lisp.LVal{benchWideMap(n), lisp.String("key0000"), lisp.String("v")})
+			b.ReportAllocs()
+			for b.Loop() {
+				if v := BuiltinQuerySet(env, call); v.Type == lisp.LError {
+					b.Fatal(v)
+				}
+			}
+		})
+	}
+}
+
+func benchPath(b *testing.B, in *lisp.LVal, op func(*lisp.LVal) (*lisp.LVal, error)) {
+	b.Helper()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := op(in); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkIterPathGet covers the iterator's Get over a vector of n
+// records.
+func BenchmarkIterPathGet(b *testing.B) {
+	for _, n := range presizeSizes {
+		p := Root(Chain(Iter(Dot("id"))))
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			benchPath(b, benchRecords(n), p.Get)
+		})
+	}
+}
+
+// BenchmarkRangePathNil covers the range path's copying Nil, which
+// rebuilds the window as fresh nils.
+func BenchmarkRangePathNil(b *testing.B) {
+	for _, n := range presizeSizes {
+		p := Root(Chain(Range(0, n, false)))
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			benchPath(b, benchIntList(n), p.Nil)
+		})
+	}
+}

--- a/lisp/lisplib/libstring/join_bench_test.go
+++ b/lisp/lisplib/libstring/join_bench_test.go
@@ -1,0 +1,33 @@
+// Copyright © 2026 The ELPS authors
+
+package libstring
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// BenchmarkJoin is string:join over n short strings.
+//
+//	go test -run '^$' -bench Join -benchmem -count=10 -cpu 1 ./lisp/lisplib/libstring/
+func BenchmarkJoin(b *testing.B) {
+	for _, n := range []int{10, 100, 1000} {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			env := lisp.NewEnv(nil)
+			cells := make([]*lisp.LVal, n)
+			for i := range cells {
+				cells[i] = lisp.String(fmt.Sprintf("item%d", i))
+			}
+			args := lisp.QExpr([]*lisp.LVal{lisp.QExpr(cells), lisp.String(", ")})
+			b.ReportAllocs()
+			for b.Loop() {
+				if v := builtinJoin(env, args); v.Type == lisp.LError {
+					b.Fatal(v)
+				}
+			}
+		})
+	}
+}

--- a/lisp/lisplib/libstring/libstring.go
+++ b/lisp/lisplib/libstring/libstring.go
@@ -3,7 +3,6 @@
 package libstring
 
 import (
-	"bytes"
 	"strings"
 
 	"github.com/luthersystems/elps/lisp"
@@ -108,11 +107,22 @@ func builtinJoin(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	if sep.Type != lisp.LString {
 		return env.Errorf("second argument is not a string: %v", sep.Type)
 	}
-	var buf bytes.Buffer
-	for i, cell := range list.Cells {
+	// Type-check and measure in one pass, so the buffer is sized once.
+	// The first non-string is reported exactly where the write loop would
+	// have found it: nothing was written before it either way.
+	size := 0
+	for _, cell := range list.Cells {
 		if cell.Type != lisp.LString {
 			return env.Errorf("first argument is not a list of strings: %v", cell.Type)
 		}
+		size += len(cell.Str)
+	}
+	if len(list.Cells) > 1 {
+		size += len(sep.Str) * (len(list.Cells) - 1)
+	}
+	var buf strings.Builder
+	buf.Grow(size)
+	for i, cell := range list.Cells {
 		buf.WriteString(cell.Str)
 		if i < len(list.Cells)-1 {
 			buf.WriteString(sep.Str)

--- a/lisp/make_sequence_cap_test.go
+++ b/lisp/make_sequence_cap_test.go
@@ -1,0 +1,95 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMakeSequenceCapIsAlwaysAllocatable is the assertion that matters about
+// the pre-sized capacity: whatever make-sequence computes, make must accept
+// it.  The test hands the computed number to make itself, so it pins the
+// failure mode directly -- "makeslice: cap out of range" -- without running
+// the sequence loop, which for these inputs does not terminate in any useful
+// time and is not something a test should provoke.
+//
+// The limits below include the ones an embedder can set.  MaxAlloc is a
+// number an embedder chooses and is under no obligation to make a count of
+// elements that can exist; with it raised, a capacity clamped only to it
+// asked for more than a slice can address and make rejected it, turning a
+// huge forward range from a slow exhaustion into an immediate
+// internal-panic.
+func TestMakeSequenceCapIsAlwaysAllocatable(t *testing.T) {
+	limits := []int{1, 4096, DefaultMaxAlloc, 1 << 40, 1 << 50, math.MaxInt64}
+	starts := []int{math.MinInt64, -1 << 40, -1, 0, 1, 1 << 40, math.MaxInt64 - 1}
+	stops := []int{math.MinInt64, -1 << 40, -1, 0, 1, 1 << 40, math.MaxInt64}
+	steps := []int{1, 2, 7, 1 << 20, math.MaxInt64}
+
+	for _, limit := range limits {
+		for _, start := range starts {
+			for _, stop := range stops {
+				for _, step := range steps {
+					n := makeSequenceCap(start, stop, step, limit)
+					require.GreaterOrEqual(t, n, 0,
+						"negative capacity for (%d %d %d) limit %d", start, stop, step, limit)
+					require.LessOrEqual(t, n, maxSequencePresize,
+						"capacity above the absolute bound for (%d %d %d) limit %d", start, stop, step, limit)
+					// The assertion: make accepts it.  A capacity that
+					// makeslice rejects panics here and fails the test.
+					require.NotPanics(t, func() { _ = make([]*LVal, 0, n) },
+						"make rejected the capacity for (%d %d %d) limit %d", start, stop, step, limit)
+				}
+			}
+		}
+	}
+}
+
+// TestMakeSequenceCapValues pins what the capacity actually is, so that
+// bounding it cannot quietly turn into not sizing at all.  A sequence short
+// enough to size gets its exact length; everything that must not be sized
+// gets zero.
+func TestMakeSequenceCapValues(t *testing.T) {
+	const limit = DefaultMaxAlloc
+	tests := []struct {
+		name                    string
+		start, stop, step, want int
+	}{
+		// Ordinary forward ranges get their exact element count.
+		{"unit step", 0, 10, 1, 10},
+		{"step divides the span", 0, 10, 2, 5},
+		{"step does not divide the span", 0, 10, 3, 4},
+		{"negative start", -5, 5, 1, 10},
+		{"step past the span", 0, 10, 100, 1},
+
+		// Nothing to size.
+		{"equal endpoints", 7, 7, 1, 0},
+		{"backwards by one", 1, 0, 1, 0},
+		{"backwards to the smallest int", 1, math.MinInt64, 1, 0},
+		{"backwards from zero", 0, math.MinInt64, 3, 0},
+		{"backwards across the whole range", math.MaxInt64, math.MinInt64, 1, 0},
+
+		// Forward but longer than either bound.
+		{"clamped to the allocation limit", 0, math.MaxInt64, 1, maxSequencePresize},
+		{"clamped to the absolute bound", 0, 1 << 40, 1, maxSequencePresize},
+		{"just above the absolute bound", 0, maxSequencePresize + 1, 1, maxSequencePresize},
+		{"exactly the absolute bound", 0, maxSequencePresize, 1, maxSequencePresize},
+		{"just below the absolute bound", 0, maxSequencePresize - 1, 1, maxSequencePresize - 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, makeSequenceCap(test.start, test.stop, test.step, limit))
+		})
+	}
+}
+
+// TestMakeSequenceCapRespectsATightLimit keeps the allocation-limit clamp
+// honest: an embedder that lowers MaxAlloc gets a capacity no larger than
+// what the loop will be allowed to build.
+func TestMakeSequenceCapRespectsATightLimit(t *testing.T) {
+	assert.Equal(t, 32, makeSequenceCap(0, 1000, 1, 32))
+	assert.Equal(t, 100, makeSequenceCap(0, 100, 1, 4096))
+}

--- a/lisp/make_sequence_overflow_test.go
+++ b/lisp/make_sequence_overflow_test.go
@@ -1,0 +1,87 @@
+// Copyright © 2018 The ELPS authors
+
+package lisp_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// minInt64Literal is the smallest int64, written out because the reader
+// parses it as one literal.
+const minInt64Literal = `-9223372036854775808`
+
+// TestMakeSequenceBackwardsRangeDoesNotSize pins the direction check in
+// make-sequence's integer fast path.
+//
+// The sequence is empty whenever stop <= start, and the length the fast path
+// computes is stop-start.  That subtraction only wraps NEGATIVE -- the signal
+// the fast path relies on to bail out -- when stop is genuinely greater than
+// start.  Run backwards it wraps POSITIVE: (make-sequence 1 MinInt64) yields a
+// difference of MaxInt64, so a fast path that sizes before checking the
+// direction reserves the whole allocation limit for a sequence with no
+// elements at all.
+//
+// At the default limit that is a silent 80MB reservation for a call that
+// returns ().  Under a limit an embedder has raised it is worse: the
+// capacity is past what a slice can hold, so make panics and the call fails
+// where it used to succeed.
+func TestMakeSequenceBackwardsRangeDoesNotSize(t *testing.T) {
+	// Well past the default limit, and past what any capacity could back:
+	// the point is that a backwards range never consults the limit at all.
+	env := newLimitTestEnv(t, lisp.WithMaxAlloc(1<<50))
+
+	backwards := []string{
+		`(make-sequence 1 ` + minInt64Literal + `)`,
+		`(make-sequence 5 -9223372036854775805)`,
+		`(make-sequence 0 ` + minInt64Literal + ` 3)`,
+		// Equal endpoints: also empty, also nothing to size.
+		`(make-sequence 7 7)`,
+	}
+	for _, expr := range backwards {
+		t.Run(expr, func(t *testing.T) {
+			res := env.LoadString("test", expr)
+			require.NotEqual(t, lisp.LError, res.Type,
+				"a backwards range must return the empty sequence, not fail: %v", res)
+			assert.Equal(t, `'()`, res.String())
+		})
+	}
+}
+
+// TestMakeSequenceBackwardsRangeAllocatesNothing is the other half: the
+// default-limit call returns () on both trees, so only the memory it moves
+// distinguishes them.  Sizing from a wrapped difference reserves one pointer
+// per element of the whole allocation limit -- about 80MB -- for a result
+// with no elements.
+//
+// The bound below is three orders of magnitude under that reservation and
+// three above what the call actually costs, so it discriminates without
+// pinning an exact count.
+func TestMakeSequenceBackwardsRangeAllocatesNothing(t *testing.T) {
+	env := newLimitTestEnv(t)
+	expr := `(make-sequence 1 ` + minInt64Literal + `)`
+
+	// Warm the reader and any lazily built environment state, and confirm
+	// the shape under test before measuring it.
+	require.Equal(t, `'()`, env.LoadString("test", expr).String())
+
+	const runs = 20
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	for range runs {
+		if res := env.LoadString("test", expr); res.Type == lisp.LError {
+			t.Fatalf("unexpected error: %v", res)
+		}
+	}
+	runtime.ReadMemStats(&after)
+
+	perCall := (after.TotalAlloc - before.TotalAlloc) / runs
+	t.Logf("bytes allocated per call: %d", perCall)
+	assert.Less(t, perCall, uint64(1<<20),
+		"a backwards range must not reserve capacity for the allocation limit")
+}

--- a/lisp/maps.go
+++ b/lisp/maps.go
@@ -79,6 +79,17 @@ func newmap() sortedmap {
 	}
 }
 
+// newmapSized is newmap with the entry table sized for n keys of either
+// type.  The key-type map stays at its zero size, as newmap leaves it: Set
+// writes it only for symbol keys, which are the rare case, and a map that
+// holds none never touches it.
+func newmapSized(n int) sortedmap {
+	return sortedmap{
+		m:  make(map[string]*LVal, n),
+		tm: make(typemap),
+	}
+}
+
 func (m sortedmap) typemap() typemap {
 	return m.tm
 }
@@ -175,10 +186,7 @@ type StringKeyRanger interface {
 // keys.  Set with an LString key writes no key type, so tm stays at its
 // zero size, as newmap leaves it.
 func emptyForStringKeys(n int) sortedmap {
-	return sortedmap{
-		m:  make(map[string]*LVal, n),
-		tm: make(typemap),
-	}
+	return newmapSized(n)
 }
 
 func (m sortedmap) Len() int {

--- a/lisp/presize_bench_test.go
+++ b/lisp/presize_bench_test.go
@@ -1,0 +1,82 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+)
+
+// Benchmarks for builtins that grow a result of known final length one
+// element at a time.  Each one evaluates a single pre-parsed call against a
+// prepared environment, so the timed region is the builtin and the call
+// that reaches it; the input is built once, outside the loop.
+//
+//	go test -run '^$' -bench 'SliceTo|MakeSequenceInt' -benchmem -count=10 -cpu 1 ./lisp/
+
+func benchCall(b *testing.B, setup, call string) {
+	b.Helper()
+	p := parser.NewReader()
+	env := lisp.NewEnv(nil)
+	if err := lisp.GoError(lisp.InitializeUserEnv(env, lisp.WithReader(p), lisp.WithStderr(io.Discard))); err != nil {
+		b.Fatal(err)
+	}
+	exprs, err := p.Read("setup", strings.NewReader(setup))
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, expr := range exprs {
+		if lerr := env.Eval(expr); lerr.Type == lisp.LError {
+			b.Fatal(lerr)
+		}
+	}
+	exprs, err = p.Read("call", strings.NewReader(call))
+	if err != nil {
+		b.Fatal(err)
+	}
+	if len(exprs) != 1 {
+		b.Fatalf("call must be one expression, got %d", len(exprs))
+	}
+	expr := exprs[0]
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if lerr := env.Eval(expr); lerr.Type == lisp.LError {
+			b.Fatal(lerr)
+		}
+	}
+}
+
+var benchSizes = []int{10, 100, 1000}
+
+func BenchmarkSliceToString(b *testing.B) {
+	for _, n := range benchSizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			benchCall(b, fmt.Sprintf("(set 'l (map 'list (lambda (x) (mod x 256)) (make-sequence 0 %d)))", n),
+				fmt.Sprintf("(slice 'string l 0 %d)", n))
+		})
+	}
+}
+
+func BenchmarkSliceToBytes(b *testing.B) {
+	for _, n := range benchSizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			benchCall(b, fmt.Sprintf("(set 'l (map 'list (lambda (x) (mod x 256)) (make-sequence 0 %d)))", n),
+				fmt.Sprintf("(slice 'bytes l 0 %d)", n))
+		})
+	}
+}
+
+func BenchmarkMakeSequenceInt(b *testing.B) {
+	for _, n := range benchSizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			benchCall(b, "()", fmt.Sprintf("(make-sequence 0 %d)", n))
+		})
+	}
+}

--- a/lisp/slice_bytes_empty_test.go
+++ b/lisp/slice_bytes_empty_test.go
@@ -1,0 +1,73 @@
+// Copyright © 2018 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSliceToBytesEmptyStaysNil pins the distinction libjson's encoder draws
+// between a nil byte slice and an empty non-nil one: a nil []byte serializes
+// as JSON null and an empty non-nil one as "", a documented v1.13.0
+// compatibility contract (encodeBytes in lisp/lisplib/libjson/encode.go).
+//
+// `slice` coercing a list to bytes must therefore keep producing nil when the
+// window is empty.  Pre-sizing the destination with make([]byte, 0, n) turns
+// every empty window into a non-nil zero-length slice, which silently rewrote
+// (json:dump-string (slice 'bytes '() 0 0)) from "null" to "\"\"" -- and did
+// the same for an empty window taken out of a non-empty input, out of a
+// vector, for those values nested inside maps and lists, and for
+// json:dump-bytes.
+//
+// The environment here loads the standard library, which the TestSuite runner
+// does not, because the contract this pins lives in libjson.
+func TestSliceToBytesEmptyStaysNil(t *testing.T) {
+	tests := []struct {
+		expr string
+		want string
+	}{
+		// Every empty list-to-bytes coercion encodes as JSON null.
+		{`(json:dump-string (slice 'bytes '() 0 0))`, `"null"`},
+		{`(json:dump-string (slice 'bytes (vector) 0 0))`, `"null"`},
+		// An empty window taken out of a non-empty input: the cell count
+		// of the sliced view is what must drive the decision, not the
+		// cell count of the argument.
+		{`(json:dump-string (slice 'bytes '(1 2 3) 1 1))`, `"null"`},
+		{`(json:dump-string (slice 'bytes (vector 1 2) 2 2))`, `"null"`},
+		// Nested, where the encoder reaches the value through a container
+		// rather than at the top level.
+		{`(json:dump-string (sorted-map "b" (slice 'bytes '() 0 0)))`, `"{\"b\":null}"`},
+		{`(json:dump-string (list (slice 'bytes '(7) 0 0)))`, `"[null]"`},
+		// json:dump-bytes takes the same encoder path.
+		{`(to-string (json:dump-bytes (slice 'bytes '() 0 0)))`, `"null"`},
+
+		// Non-empty coercions are unchanged.
+		{`(json:dump-string (slice 'bytes '(104 105) 0 2))`, `"\"aGk=\""`},
+		{`(json:dump-string (slice 'string '(104 105) 0 2))`, `"\"hi\""`},
+
+		// The empty coercions themselves still behave.  The 'string arm is
+		// kept symmetric with 'bytes even though string(nil) and
+		// string([]byte{}) are both "".
+		{`(slice 'string '() 0 0)`, `""`},
+		{`(slice 'bytes '() 0 0)`, `#<bytes>`},
+		{`(length (slice 'bytes '() 0 0))`, `0`},
+		{`(to-string (slice 'bytes '() 0 0))`, `""`},
+		{`(append 'bytes (slice 'bytes '() 0 0) 1)`, `#<bytes 1>`},
+		// A bytes input with an empty window never went through the list
+		// path and was never affected; it is here so the two stay
+		// comparable.
+		{`(json:dump-string (slice 'bytes "" 0 0))`, `"\"\""`},
+	}
+	env := newLimitTestEnv(t)
+	for _, test := range tests {
+		t.Run(test.expr, func(t *testing.T) {
+			res := env.LoadString("test", test.expr)
+			require.NotEqual(t, lisp.LError, res.Type, "%v", res)
+			assert.Equal(t, test.want, res.String())
+		})
+	}
+}

--- a/lisp/sortedmap_sized_test.go
+++ b/lisp/sortedmap_sized_test.go
@@ -12,9 +12,14 @@ import (
 
 // TestSortedMapSizedIsAHintOnly pins the two properties SortedMapSized
 // promises beyond SortedMap: the size is only a hint, and no argument can
-// make it panic.  make(map, n) panics on a negative n, so an exported
-// constructor that forwards its argument would hand a caller computing a
-// size from a subtraction a panic instead of an empty map.
+// make it panic.
+//
+// The negative-n rows pin the DOCUMENTED clamp, not a panic: gc ignores a
+// negative map hint, so deleting the clamp in SortedMapSized would leave
+// this test green.  They are here because the clamp is a contract an
+// exported constructor owes a caller who computes a size from a
+// subtraction, and because the language does not oblige an implementation
+// to be as forgiving as gc is.
 func TestSortedMapSizedIsAHintOnly(t *testing.T) {
 	for _, n := range []int{-1 << 40, -1, 0, 1, 64} {
 		m := lisp.SortedMapSized(n)

--- a/lisp/sortedmap_sized_test.go
+++ b/lisp/sortedmap_sized_test.go
@@ -1,0 +1,29 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSortedMapSizedIsAHintOnly pins the two properties SortedMapSized
+// promises beyond SortedMap: the size is only a hint, and no argument can
+// make it panic.  make(map, n) panics on a negative n, so an exported
+// constructor that forwards its argument would hand a caller computing a
+// size from a subtraction a panic instead of an empty map.
+func TestSortedMapSizedIsAHintOnly(t *testing.T) {
+	for _, n := range []int{-1 << 40, -1, 0, 1, 64} {
+		m := lisp.SortedMapSized(n)
+		require.Equal(t, lisp.LSortMap, m.Type)
+		// Sized or not, the map starts empty and grows past the hint.
+		assert.Equal(t, 0, m.Len(), "hint %d", n)
+		for i := range 100 {
+			m.MapSet(string(rune('a'+i%26))+string(rune('a'+i/26)), lisp.Int(i))
+		}
+		assert.Equal(t, 100, m.Len(), "hint %d", n)
+	}
+}


### PR DESCRIPTION
## Summary

Five sites built a result whose final size was known before the first element and grew it one element at a time. Each now starts at that size. One commit per site, each kept only because it measured; the ones that did not are listed below with their numbers.

- `libelpspath` `copyMapExcept` (behind `?set`, `?nil`, `?del` on maps): the copy is built into `lisp.SortedMapSized(n)`, a new exported constructor sized like `make(map, n)`. It sizes the entry table only and leaves the key-type map at its zero size, exactly as `newmap` does, so it is correct for symbol keys as well as string keys. A negative `n` is clamped to zero rather than panicking the way `make(map, n)` does. `emptyForStringKeys` now delegates to the same internal helper.
- `slice` coercing a list window to `'string` or `'bytes`: the byte slice starts at the window's cell count, except for an empty window, which keeps its nil slice (see Review fixes).
- `make-sequence` with integer start, stop and step: `makeSequenceCap` returns the capacity for a forward range, bounded both by the runtime's allocation limit and by an absolute `maxSequencePresize`. A backwards or empty range sizes nothing at all (see Review fixes).
- `libelpspath` iterator `Get` and range-path nil rewrite: result slices start at the horizon or window length.
- `string:join`: the type-checking pass also sums the lengths, and a `strings.Builder` is grown once to the joined size.

Each kept site ships a benchmark at 10/100/1000 elements.

## Review fixes

An adversarial review found three ways the "sizing is invisible" claim did not hold. Each is fixed in the commit that introduced it, and pinned by a test.

**1. `slice` turned an empty byte result from nil into empty non-nil.** `libjson`'s `encodeBytes` emits JSON `null` for a nil `[]byte` and `""` for an empty non-nil one — a stated v1.13.0 compatibility contract. `make([]byte, 0, 0)` is not nil, so `(json:dump-string (slice 'bytes '() 0 0))` changed from `"null"` to `"\"\""`, along with an empty window taken out of a non-empty input or a vector, those values nested inside maps and lists, and `json:dump-bytes`. Both coercion arms now leave the slice nil when the window is empty; the `'string` arm is kept symmetric even though `string(nil)` and `string([]byte{})` are both `""`. Pinned by `lisp/slice_bytes_empty_test.go` (7 of its cases were red before the fix).

**2. `make-sequence` sized a backwards range off a positively-wrapped difference.** `stop - start` wraps *negative* only when `stop` really is the larger of the two. Run backwards it wraps *positive*: `(make-sequence 1 -9223372036854775808)` has a difference of `MaxInt64`, so the size was computed for an empty sequence. At the default limit that reserved about 80MB for a call returning `()`; under a raised `WithMaxAlloc`, the capacity exceeded what a slice can hold and `make` panicked, failing a call that used to succeed. The direction is now checked before the subtraction. Pinned by `lisp/make_sequence_overflow_test.go`: one test asserts `()` with no error under a raised limit, the other measures bytes allocated per call at the default limit (84,019,804 before the fix, 133,712 after — the same figure as `main`).

**3. The capacity is now bounded absolutely, not just by `MaxAlloc`.** Clamping only to the allocation limit left the same divergence on the *forward* side: `MaxAlloc` is a number the embedder picks and nothing obliges it to be a count of elements that can exist, so `(make-sequence 0 9223372036854775807)` under `WithMaxAlloc(1<<50)` asked `make` for a capacity beyond what a slice can address and failed immediately as `internal-panic: makeslice: cap out of range`, where on `main` it grows until memory runs out. Different observable behaviour, which this PR is not supposed to have. `makeSequenceCap` now also clamps to `maxSequencePresize` (1<<20 elements): the capacity is only a hint, the loop grows past it, `append` doubles, and beyond a million elements the growth being saved has amortised to nothing — so the bound keeps every measured benefit while making it impossible to hand `make` a number derived from a limit rather than from a real element count. Measured pre- and post-bound over `SliceToString`/`SliceToBytes`/`MakeSequenceInt` at 10/100/1000: allocations identical sample for sample, sec/op unchanged (geomean +0.04%, every arm p >= 0.16). Pinned by `lisp/make_sequence_cap_test.go`, which hands every computed capacity to `make` and fails if `make` rejects it — the panic is pinned directly, without running a loop that does not terminate.

Also from the review: `lisp.SortedMapSized` is exported and its argument is the kind of number a caller computes from a subtraction, so a negative `n` is clamped instead of panicking inside `make`. Pinned by `lisp/sortedmap_sized_test.go`.

The reviewer's remaining finding — a possible `CopyMapWide/10` regression — did not reproduce; see Measurements.

## Tried and dropped

Measured the same way; below the bar the user set (no negligible-effect changes).

| Site | Result | Why dropped |
|---|---|---|
| `select`/`reject` list arm | lambda predicate: time ~, allocs -0.1% to -2.5%; only the builtin-predicate/10 arm reached -8.5% | With a real predicate the calls dominate; the vector arm's presize is not worth mirroring for this |
| `AddBuiltins`/`AddSpecialOps`/`AddMacros` externals list (`slices.Grow` once per pass) | `EnvInit` time ~ (p=0.97), allocs -0.25% | Eight regrows per env init are invisible |
| iterator `Set`/`Delete`/`Nil` result slices | `IterPath/nil` time ~ (p=0.12 to 0.28), allocs -0.07% to -2.7% | The per-element copy dwarfs the slice growth |

## Semantics

Every program produces the same values, the same error text and the same evaluation order as before.

- `copyMapExcept`: only the initial table size changes; the entries list is the same one it already walked, `Set` is called with the same keys and values in the same order, and a symbol key still records its key type.
- `slice` coercion: `appendBytes` validates every cell before the first byte is written, as before, so the sized slice cannot change which error is reported or what is emitted. An empty window keeps its nil slice so that `libjson`'s nil-vs-empty distinction survives.
- `make-sequence`: the loop, its per-element `CheckAlloc` and `x.Copy()` are untouched; the capacity is only a hint, so an over-limit sequence still fails at the same element with the same message (`allocation size 10485761 exceeds maximum (10485760)`, verified against base). Only a forward integer range is sized — a backwards or equal-endpoint range takes the old path, because the difference it would size from is a wrapped value, not a length — and the capacity is bounded so that no setting of `MaxAlloc` can turn a range that used to exhaust memory into one that fails at `make`. Non-integer arguments take the old path.
- iterator `Get` and range nil: the elements are produced by the same calls in the same order; when a nested iterator collapses, the size is a floor and `append` grows past it as before.
- `string:join`: the length pass is the existing type-check loop; it stops at the first non-string with the same message, and nothing had been written before that point in either version. `strings.Builder.String()` returns the same bytes `bytes.Buffer.String()` did.
- The reviewer's differential battery (40 programs: string/symbol-keyed and nested maps, iterator and range shapes, the JSON encoding of every empty-window coercion, integer-overflow and allocation-limit shapes, and 10 error paths) is byte-identical against `main` on stdout, stderr and exit status. It was **not** identical before the review fixes; one program diverged on eight lines.

## Measurements

Re-measured on the review head against current `main` (53a24ca), not carried over from the first push. Micro benchmarks, `-count=10 -cpu 1`, arms interleaved round by round, benchstat; `~` marks p >= 0.05. `make bench-burnin` reports the machine FIT against a ±10% ceiling.

| Benchmark | sec/op | allocs/op |
|---|---|---|
| `CopyMapWide/10,100,1000` | -4.9%, -9.7%, -13.5% | -3%, -20%, -35% |
| `SliceToString/10,100,1000` | -11.6%, -16.7%, -17.3% | -22%, -33%, -50% |
| `SliceToBytes/10,100,1000` | ~ (p=0.063), -17.8%, -19.2% | -11%, -33%, -50% |
| `MakeSequenceInt/10,100,1000` | -15.6%, -13.1%, -9.5% | -12%, -3%, -0.5% (B/op -4% to -5%) |
| `IterPathGet/10,100,1000` | -18.9%, -15.4%, -9.6% | -19%, -6%, -1% |
| `RangePathNil/10,100,1000` | -42.6%, -43.1%, -37.5% | -50%, -64%, -71% |
| `Join/10,100,1000` | -41.9%, -46.7%, -50.1% | -50%, -71%, -82% |

`benchgate` over these arms: 0 significant moves in the bad direction, 0 at or above the gate.

`CopyMapWide` was measured four separate times because the review reported a `+11.9%` regression at `/10` (n=6). It did not reproduce in any of them:

| Run | /10 | /100 | /1000 |
|---|---|---|---|
| dedicated, n=10, default benchtime | -5.1% (p=0.022) | ~ (p=0.17) | -11.9% (p=0.000) |
| dedicated, n=20, fixed 3000x iterations | ~ (p=0.063) | -10.1% (p=0.000) | -14.4% (p=0.000) |
| full 7-family sweep, n=10 | ~ (p=0.44) | ~ (p=0.15) | -7.8% (p=0.015) |
| final sweep vs 53a24ca, n=10 (the table above) | -4.9% (p=0.009) | -9.7% (p=0.000) | -13.5% (p=0.000) |

No run puts `/10` on the slow side of neutral, so the sizing is left ungated: a threshold would add a branch and a magic number to defend against an effect four measurements could not find. The allocation counts are deterministic and fall at every width (-1, -7 and -16 allocations per call).

Production phylum under substrate (regression guard; 3 interleaved rounds, `-cpu 1`, burn-in FIT at ±1%) — measured on the pre-review head, and unaffected by the review fixes, which only add branches on the empty-window and backwards-range paths that this workload does not take:

| Benchmark | base | branch | verdict |
|---|---|---|---|
| preheater cold, sec/op | 100.3ms | 89.1ms | ~ (p=0.10, n=3) |
| preheater fork, sec/op | 39.1ms | 33.4ms | ~ (p=0.10, n=3) |
| preheater cold, allocs/op | 220.6k | 220.6k | unchanged |
| preheater fork, allocs/op | 30.47k | 29.49k | ~ (p=0.10, n=3) |
| unit-test suite, 29 files x 3 rounds, sec/op | 221.9ms | 221.2ms | ~ (p=0.37, n=87) |
| unit-test suite, allocs/op | 1.631M | 1.631M | unchanged |

No regression; the phylum does not lean on these sites, which is the expected shape.

## Test Plan

Re-run on the review head, rebased onto current `main` (53a24ca), unless a row says otherwise:

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (41 packages)
- [x] `go test -tags=elpscheck ./lisp/...`
- [x] `go test -race -count=1` on `lisp`, `libelpspath`, `libstring`, `libjson`
- [x] `go test -run Fuzz ./lisp/` (corpora replay)
- [x] `make elpsvet` (plain and `-tags=elpscheck`)
- [x] `make check-golangci-config`; `golangci-lint run ./...` and `--build-tags elpscheck ./lisp/...` (v2.6.2, the CI pin): 0 issues
- [x] `./elps fmt -l ./...` reports nothing; `./elps doc -m` clean
- [x] `make bench-elpscheck-smoke` (every benchmark once under elpscheck, including the new ones)
- [x] `make bench-burnin` FIT; `make bench-gate-arms` over the measured arms: 0 significant moves in the bad direction
- [x] 40-program differential battery byte-identical against `main` on stdout, stderr and exit status
- [x] every commit builds and vets on its own
- [x] substrate suites on the production phylum pass under the shared and the isolated runner — **run on the pre-review head only**, not re-run after the review fixes or the rebase

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX

---
_Generated by [Claude Code](https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX)_