### PR TITLE
Audit every native payload type with an elpsvet analyzer

### DIFF
--- a/.github/workflows/elps.yml
+++ b/.github/workflows/elps.yml
@@ -111,10 +111,11 @@ jobs:
         run: make test-elpscheck
 
       # The seal contract's static half.  golangci-lint above checks Go style;
-      # this checks the three rules that exist because a raw Go write can
+      # this checks the four rules that exist because a raw Go write can
       # launder around the seal bit -- package-level LVal tables, writes to
-      # LVal fields on values the function did not construct, and escaping
-      # uncopied *token.Location pointers.  ~3s.
+      # LVal fields on values the function did not construct, escaping
+      # uncopied *token.Location pointers, and native payloads minted
+      # without a fork-safety classification.  ~3s.
       #
       # Runs TWO passes.  The second is the whole reason this is a make target
       # rather than one line here: elpsvet accepts -tags and silently ignores

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,62 @@ Functions return `*LVal`. Errors are LVal values with type `LError`. Check with 
 - **`analysis/`** — Semantic analysis: scope building, symbol resolution, reference counting. `prescan()` uses a two-phase approach (definitions first, exports second) so `(export 'name)` before `(defun name ...)` works correctly.
 - **`lint/`** — Static analysis modeled after `go vet`. Each check is an `Analyzer` with a `Run func(pass *Pass) error`. Uses `Walk()`/`WalkSExprs()` for AST traversal, plus custom walkers for context-sensitive checks.
 - **`diagnostic/`** — Rust-style annotated source snippets for error and lint output. Zero dependencies on `lisp/`.
-- **`cmd/elpsvet/`** — Go static analyzers over elps's *own* Go source, enforcing invariants the compiler cannot: the freshness rule (writes rooted at `lisp.LVal` storage) and the slice-alias tracking that catches writes laundered through a local alias first (issues #369, #371).
+- **`cmd/elpsvet/`** — Go static analyzers over elps's *own* Go source, enforcing invariants the compiler cannot: the freshness rule (writes rooted at `lisp.LVal` storage), the slice-alias tracking that catches writes laundered through a local alias first (issues #369, #371), and the native-payload audit (see "Go static analysis over elps's own sources" below).
+
+## Go static analysis over elps's own sources
+
+`cmd/elpsvet` is a `golang.org/x/tools/go/analysis` harness over elps's own
+Go code: focused analyzers, an audited `//elpsvet:allow` suppression carrying
+a justification, and testdata-driven `analysistest` fixtures under
+`cmd/elpsvet/testdata/src`. CI runs it as `make elpsvet`, which is two passes
+of `go run ./cmd/elpsvet -test=false ./...` (the second under
+`GOFLAGS=-tags=elpscheck`, because elpsvet silently ignores `-tags`; see the
+Makefile comment). The package list is `./...`, so there is no hand-scoped
+list to drift away from where the code lives and no scope-drift check to
+maintain.
+
+Its fourth rule, `elpsnativepayload` (`cmd/elpsvet/nativepayload.go`), closes
+a class of bug the fork/isolation tests cannot see from the outside: `Fork`
+shares `lisp.LVal.Native` **by reference**, so a mutable native payload that
+reaches a template is state shared by every fork in the process, and the
+isolation oracle in `elpstest` only recognises a payload as stateful when its
+type declares `lisp.NativeCloner`. The rule is ported from the substrate
+repository's nativepayload analyzer and adapted to the module that defines
+the constructors.
+
+A native construction is any of these SPELLINGS, and the list is the first
+thing to check when the gate looks suspiciously quiet: `lisp.Native(x)`, the
+typed `lisp.NativeOf[T](x)` (inferred or explicitly instantiated — the latter
+wraps the callee in an `*ast.IndexExpr`, which `calleeFunc` unwraps), a
+`lisp.Value(x)` the compiler can see falling through to Native (a defined
+type over `[]byte` DOES fall through; the type switch matches the unnamed
+type only), a `lisp.LVal{Native: x}` literal, and a write to a `.Native`
+field. `NativeOf` needs its own arm even though it is *implemented* as a call
+to `Native`: a generic instantiation resolves to the generic `*types.Func`,
+whose name is never `Native`.
+
+A construction is reported unless the payload's static type has a basic
+underlying type (a value of which is immutable inside an interface —
+`unsafe.Pointer` excluded), declares `lisp.NativeCloner` (the kernel's clone
+protocol, checked structurally as an interface assertion would), is on the
+audited allowlist in `cmd/elpsvet/nativepayload.go` — the kernel's own
+representation slots (`*funData`, `*[]byte`, `*MapData`, `*CallStack`, each
+with an explicit fork/detach arm), `*regexp.Regexp`, `time.Time`, `error`,
+libschema's `*validatorTag`, libjson's `*ownMessage`, each row carrying its
+reason — or a `//elpsvet:allow <justification>` comment covers the line (or
+the enclosing function's doc). **A bare `//elpsvet:allow` with no
+justification does not suppress.** An interface-typed payload (or a type
+parameter) is REPORTED, not skipped: this module is where `interface{}`
+enters the system, so the constructors themselves (`Native`, `NativeOf`,
+`Value`'s fallthrough), the fork and detach walkers' policy application, the
+error-condition data arm and libgolang's reflected field projection each
+carry an allow naming the contract. A NEW payload type fails until a human
+classifies it; that is the point, not an oversight.
+
+`cmd/elpsvet/nativepayload_test.go` pins the allowlist's shape: every row in
+`allowedPayloadTypes` must appear in the test's audited inventory with a
+justification long enough to read, so adding a row is a two-file change a
+reviewer sees.
 
 ## Development Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,8 +127,8 @@ Functions return `*LVal`. Errors are LVal values with type `LError`. Check with 
 ## Go static analysis over elps's own sources
 
 `cmd/elpsvet` is a `golang.org/x/tools/go/analysis` harness over elps's own
-Go code: focused analyzers, an audited `//elpsvet:allow` suppression carrying
-a justification, and testdata-driven `analysistest` fixtures under
+Go code: focused analyzers, audited suppression markers, and testdata-driven
+`analysistest` fixtures under
 `cmd/elpsvet/testdata/src`. CI runs it as `make elpsvet`, which is two passes
 of `go run ./cmd/elpsvet -test=false ./...` (the second under
 `GOFLAGS=-tags=elpscheck`, because elpsvet silently ignores `-tags`; see the
@@ -151,10 +151,19 @@ typed `lisp.NativeOf[T](x)` (inferred or explicitly instantiated — the latter
 wraps the callee in an `*ast.IndexExpr`, which `calleeFunc` unwraps), a
 `lisp.Value(x)` the compiler can see falling through to Native (a defined
 type over `[]byte` DOES fall through; the type switch matches the unnamed
-type only), a `lisp.LVal{Native: x}` literal, and a write to a `.Native`
-field. `NativeOf` needs its own arm even though it is *implemented* as a call
-to `Native`: a generic instantiation resolves to the generic `*types.Func`,
-whose name is never `Native`.
+type only), a keyed literal setting the `lisp.LVal.Native` field, and a write
+to that field. The field is matched by its **object**, not by the receiver's
+spelled type, so `lisp.ErrorVal{Native: x}` (`type ErrorVal LVal` shares the
+struct), `(*lisp.ErrorVal)(v).Native = x`, and a promoted `w.Native` through
+an embedding struct are all seen. Taking the field's address (`&v.Native`)
+is reported unconditionally — whatever is later stored through the pointer
+has no type at that site. `NativeOf` needs its own arm even though it is
+*implemented* as a call to `Native`: a generic instantiation resolves to the
+generic `*types.Func`, whose name is never `Native`. Invisible, and
+documented in the analyzer's header: an indirect call through a function
+value, a multi-value assignment (`v.Native, ok = g()`), a positional
+`LVal{...}` literal (only spellable inside package lisp), and anything done
+through `reflect`.
 
 A construction is reported unless the payload's static type has a basic
 underlying type (a value of which is immutable inside an interface —
@@ -164,9 +173,17 @@ audited allowlist in `cmd/elpsvet/nativepayload.go` — the kernel's own
 representation slots (`*funData`, `*[]byte`, `*MapData`, `*CallStack`, each
 with an explicit fork/detach arm), `*regexp.Regexp`, `time.Time`, `error`,
 libschema's `*validatorTag`, libjson's `*ownMessage`, each row carrying its
-reason — or a `//elpsvet:allow <justification>` comment covers the line (or
-the enclosing function's doc). **A bare `//elpsvet:allow` with no
-justification does not suppress.** An interface-typed payload (or a type
+reason — or a `//elpsvet:allow-native <justification>` comment covers the
+site: trailing on the reported line, standalone on the line above, or for a
+multi-line literal on either the opening line or the `Native:` line; or the
+enclosing function's doc carries one. **The justification must be at least
+three words; a bare or shorter marker does not suppress.** One justification
+covers every construction on its line. The marker is this rule's own:
+`elpsownership`'s `//elpsvet:allow` is a bare prefix match that enforces no
+justification, so sharing it would let one sentence about sealed formals
+silence both rules — and the ownership matcher stops at the marker's word
+boundary so `allow-native` does not satisfy it either. An interface-typed
+payload (or a type
 parameter) is REPORTED, not skipped: this module is where `interface{}`
 enters the system, so the constructors themselves (`Native`, `NativeOf`,
 `Value`'s fallthrough), the fork and detach walkers' policy application, the

--- a/Makefile
+++ b/Makefile
@@ -168,10 +168,13 @@ static-checks: check-golangci-version check-golangci-config
 	golangci-lint run --build-tags elpscheck ./lisp/...
 
 # elpsvet: the seal contract's static half.  golangci-lint checks Go style;
-# this checks the three rules that exist because a Go write can launder around
+# this checks the four rules that exist because a Go write can launder around
 # the seal bit (see cmd/elpsvet/main.go): no package-level var keeps an *LVal
 # reachable by every Runtime, no function writes an LVal field on a value it
-# did not construct, and no runtime-owned *token.Location escapes uncopied.
+# did not construct, no runtime-owned *token.Location escapes uncopied, and
+# no native payload type is minted without being classified as fork-safe
+# (cmd/elpsvet/nativepayload.go).  The package list is ./..., so there is no
+# hand-scoped list for native construction sites to drift out of.
 #
 # TWO PASSES, and the second one is not optional.  elpsvet ACCEPTS -tags and
 # SILENTLY IGNORES IT: x/tools registers that flag as a deliberate no-op

--- a/cmd/elpsvet/freshness.go
+++ b/cmd/elpsvet/freshness.go
@@ -145,11 +145,21 @@ func hasMutates(cg *ast.CommentGroup) bool {
 // violation, which is the opposite of an audited annotation: the flag
 // vanishes and nothing in the source says it was ever considered.
 func markerLines(fset *token.FileSet, file *ast.File, marker string) map[int]bool {
+	return markerLinesMatching(fset, file, func(text string) bool {
+		return commentHasMarker(text, marker)
+	})
+}
+
+// markerLinesMatching is markerLines with the marker test abstracted, so a
+// rule that holds its marker to a stricter standard (the native-payload
+// rule's //elpsvet:allow must carry a justification) shares the placement
+// convention rather than re-deriving it.
+func markerLinesMatching(fset *token.FileSet, file *ast.File, match func(text string) bool) map[int]bool {
 	code := codeLines(fset, file)
 	lines := make(map[int]bool)
 	for _, cg := range file.Comments {
 		for _, c := range cg.List {
-			if !commentHasMarker(c.Text, marker) {
+			if !match(c.Text) {
 				continue
 			}
 			line := fset.Position(c.Pos()).Line

--- a/cmd/elpsvet/main.go
+++ b/cmd/elpsvet/main.go
@@ -1,11 +1,12 @@
 // Copyright © 2026 The ELPS authors
 
-// Command elpsvet is a go/analysis prototype with three rules: no
+// Command elpsvet is a go/analysis prototype with four rules: no
 // package-level variable may keep a *lisp.LVal reachable (elpsownership,
 // below), no function may write a lisp.LVal field on a value it did not
-// construct (elpsfreshness, freshness.go), and no function may store a
+// construct (elpsfreshness, freshness.go), no function may store a
 // runtime-owned *token.Location uncopied into a field of an escaping value
-// (elpsescape, escape.go).
+// (elpsescape, escape.go), and no native payload type may be minted without
+// being classified as fork-safe (elpsnativepayload, nativepayload.go).
 //
 // A package-level var whose type transitively contains *lisp.LVal is the
 // producer pattern behind issue #363 — `var builtins = []*libutil.Builtin{...}`
@@ -59,7 +60,7 @@ var analyzer = &analysis.Analyzer{
 	Run:  run,
 }
 
-func main() { multichecker.Main(analyzer, freshnessAnalyzer, escapeAnalyzer) }
+func main() { multichecker.Main(analyzer, freshnessAnalyzer, escapeAnalyzer, nativePayloadAnalyzer) }
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {

--- a/cmd/elpsvet/main.go
+++ b/cmd/elpsvet/main.go
@@ -100,12 +100,20 @@ func run(pass *analysis.Pass) (interface{}, error) {
 }
 
 // allowed reports whether a comment group carries an //elpsvet:allow marker.
+//
+// A bare marker suppresses: this rule asks for a justification by convention
+// and does not enforce one.  The match stops at the marker's word boundary
+// so that the native-payload rule's own //elpsvet:allow-native (which does
+// enforce a justification, nativepayload.go) is not mistaken for it -- a
+// shared marker would let one sentence written for either rule silence
+// both.
 func allowed(cg *ast.CommentGroup) bool {
 	if cg == nil {
 		return false
 	}
 	for _, c := range cg.List {
-		if strings.HasPrefix(strings.TrimPrefix(c.Text, "//"), "elpsvet:allow") {
+		rest, ok := strings.CutPrefix(strings.TrimPrefix(c.Text, "//"), "elpsvet:allow")
+		if ok && (rest == "" || rest[0] == ' ' || rest[0] == '\t') {
 			return true
 		}
 	}

--- a/cmd/elpsvet/nativepayload.go
+++ b/cmd/elpsvet/nativepayload.go
@@ -1,0 +1,482 @@
+// Copyright © 2026 The ELPS authors
+
+// The elpsnativepayload analyzer is the fourth elpsvet rule: nothing
+// plausibly MUTABLE may become a native payload unless a human has written
+// down why sharing it is safe.
+//
+// # The invariant
+//
+// Fork copies the LVal spine and SHARES LVal.Native by reference (lisp/fork.go).
+// A template is forked once per request, so a mutable native that reaches a
+// template is state shared by every fork in the process.  The fork/isolation
+// oracle in elpstest can only recognise a payload as stateful when its type
+// declares lisp.NativeCloner; a mutable payload type that does not declare it
+// is a leak channel no isolation test can see from the outside.  This rule
+// is the static half of that audit, ported from the substrate repository's
+// nativepayload analyzer and adapted to the module that DEFINES the
+// constructors.
+//
+// # The rule
+//
+// A native construction -- `lisp.Native(x)`, the typed `lisp.NativeOf[T](x)`
+// (inferred or explicitly instantiated), a `lisp.Value(x)` the compiler can
+// see falling through to Native, a `lisp.LVal{Native: x}` literal, or a
+// write to a `.Native` field -- is REPORTED unless one of:
+//
+//  1. the payload's static type has a BASIC underlying type (string, int,
+//     bool, a float, a defined type over one of those, ...).  A non-pointer
+//     value of basic underlying type inside an interface is immutable by
+//     construction: it is not addressable, so every type assertion yields a
+//     copy and no fork can reach the shared value.  A soundness decision,
+//     not an allowlist one.  unsafe.Pointer is excluded -- a pointer wearing
+//     a basic type's clothes;
+//
+//  2. the payload's type declares lisp.NativeCloner, i.e. its method set
+//     carries `CloneNative() interface{}`.  That is the kernel's clone
+//     protocol: Fork, detach and the lisp copy builtin all duplicate such a
+//     payload instead of sharing it, and it is the same test the isolation
+//     oracle applies, so the static rule and the dynamic one agree;
+//
+//  3. the payload's type is on allowedPayloadTypes below -- the AUDITED
+//     inventory, each row carrying the reason a human checked;
+//
+//  4. an audited `//elpsvet:allow <justification>` comment covers the line
+//     (trailing, or standalone on the line above), or the enclosing
+//     function's doc comment carries one.  A bare marker with no
+//     justification does NOT suppress: an allow that says nothing is a
+//     classification nobody made.
+//
+// # Interface-typed payloads
+//
+// A payload whose static type is an interface (or a type parameter) has no
+// type to classify: whatever it is at runtime was decided elsewhere.  Unlike
+// the substrate port, this rule REPORTS those by default rather than hiding
+// them behind a flag, because this module is where `interface{}` enters the
+// system -- Native, NativeOf and Value are defined here, the fork and detach
+// walkers apply the policy here, and the error-condition constructors accept
+// arbitrary data here.  Each of those sites is a contract, and the contract
+// has to be written down at the site as an `//elpsvet:allow`, never silently
+// passed through as "unknowable".
+//
+// # Why it is deliberately dumb
+//
+// "Is this payload mutable" is undecidable, so the rule does not guess.  A
+// composite type -- pointer, slice, map, chan, func, struct, array -- is
+// reported whether or not it happens to be used immutably, and a NEW payload
+// type FAILS until somebody classifies it.  That fail-closed property is the
+// whole point: the check is a forcing function for the audit, not a
+// mutability oracle.  time.Time is a struct holding a *Location and
+// *regexp.Regexp is a pointer; no structural rule can call them safe, only
+// the audit can, and the audit is what allowedPayloadTypes records.
+//
+// # What it does not see
+//
+// The payload type must be visible AT THE CONSTRUCTION SITE.  An indirect
+// call (`f := lisp.Native; f(x)`) is not a call the callee resolver can see;
+// a multi-value assignment (`v.Native, ok = g()`) has no expression type for
+// its right-hand side and is skipped.  A payload constructed in ANOTHER
+// module is that module's to audit -- substrate runs the same rule over its
+// own tree for exactly that reason.
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	// nativeAllowMarker is the audited suppression: the ownership rule's
+	// marker, held to a stricter standard here (see justifiedAllow).
+	nativeAllowMarker = "elpsvet:allow"
+
+	// nativeClonerMethod is the one method of lisp.NativeCloner.
+	nativeClonerMethod = "CloneNative"
+)
+
+var nativePayloadAnalyzer = &analysis.Analyzer{
+	Name: "elpsnativepayload",
+	Doc: "flag lisp.LVal native payloads whose type is not provably safe to SHARE across forks" +
+		" (Fork shares LVal.Native by reference) unless the type declares lisp.NativeCloner," +
+		" is on the audited allowlist, or //elpsvet:allow <justification> covers the site",
+	Run: runNativePayload,
+}
+
+// allowedPayloadTypes is the AUDITED inventory of native payload types that
+// are safe to share by reference across every fork of a template, keyed by
+// the type as types.TypeString spells it with full import paths (so a
+// pointer type is keyed with its `*`), with WHY as the value.  The reasons
+// print nowhere; they are here so the next author adding a row can see what
+// a real justification looks like, and so a reviewer can check the claim.
+//
+// Adding a row is a claim that a human checked the value cannot be MUTATED
+// through the payload a fork shares -- either because the type has no
+// mutating API, because every operation on it allocates, or because the
+// kernel's own walkers copy it on every path.  It is not a claim that the
+// value is small, or that the current callers behave.
+//
+// This map may only SHRINK.
+var allowedPayloadTypes = map[string]string{
+	// Kernel-owned representation slots.  LVal.Native doubles as the backing
+	// store for several non-LNative types, and the fork and detach walkers
+	// carry an explicit arm for each, so none of them travels by reference.
+
+	"*github.com/luthersystems/elps/lisp.funData": "the LFun payload. The fork walker's LFun arm " +
+		"(fork.go) re-mints the funData per fork with the captured env remapped into the fork, so " +
+		"a fork never shares the template's; detach refuses LFun values rather than copy them. A " +
+		"builtin's Go function pointer travels by reference, which is code, not state",
+
+	"*[]byte": "LBytes backing storage. The *[]byte arms in the fork walker (fork.go) and the " +
+		"detach walker (detach.go) each allocate a fresh slice and copy the bytes, so no fork can " +
+		"reach the template's buffer",
+
+	"*github.com/luthersystems/elps/lisp.MapData": "LSortMap backing storage. The fork walker's " +
+		"mapData arm, detachMapData and copyMapData each rebuild the map structure, so a fork's " +
+		"assoc!/dissoc! cannot reach the template's maps",
+
+	"*github.com/luthersystems/elps/lisp.CallStack": "an LError's recorded stack. It is minted by " +
+		"CallStack.Copy at the capture point and is a snapshot from then on -- the stack the " +
+		"evaluator pushes and pops is Runtime.Stack, never the copy -- and the *CallStack arms of " +
+		"both walkers deep-copy it through detachCallStack, frames, locations and GoStack bytes " +
+		"included",
+
+	// Standard-library payloads.
+
+	"*regexp.Regexp": "immutable after Compile by documented contract ('A Regexp is safe for " +
+		"concurrent use by multiple goroutines'). The one mutating method, Longest, is documented " +
+		"as such and nothing in libregexp calls it; every other method allocates its result",
+
+	"time.Time": "value type with no mutating API: every method returns a new Time, the only " +
+		"pointer-receiver methods (UnmarshalJSON/UnmarshalBinary/GobDecode) assign through a copy " +
+		"taken by type assertion, and the *Location it holds is either a process-wide immutable " +
+		"singleton or a Location loaded once and never written",
+
+	"error": "read-only by contract. The kernel stores an error only as an LError's data cell " +
+		"(ErrorCondition, LEnv.ErrorCondition) and thereafter only reads it -- Error() for the " +
+		"message, GoError to hand it back -- and nothing in the tree asserts it to a concrete type " +
+		"and writes through it. The row is a contract, not a proof: an embedder's error value can " +
+		"point at anything, and what the kernel promises is never to mutate it, which is all " +
+		"sharing needs",
+
+	"*github.com/luthersystems/elps/lisp/lisplib/libschema.validatorTag": "a pointer to a " +
+		"zero-size struct, shared process-wide on purpose: the validator credential is the payload's " +
+		"TYPE (isValidator asserts *validatorTag), it has no field to read or write through, and the " +
+		"type is unexported with no constructor, so nothing outside the package can mint one",
+
+	"*github.com/luthersystems/elps/lisp/lisplib/libjson.ownMessage": "immutable after " +
+		"construction: an unexported type with unexported fields, minted on one line " +
+		"(DumpMessageBuiltin) from bytes the serializer just wrote, and every method and reader " +
+		"(MarshalJSON, jsonMessage) only reads msg and loadable -- nothing assigns to either " +
+		"afterwards, and no other package can name the type to try",
+}
+
+func runNativePayload(pass *analysis.Pass) (interface{}, error) {
+	for _, file := range pass.Files {
+		allow := markerLinesMatching(pass.Fset, file, justifiedAllow)
+		for _, decl := range file.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				if d.Body == nil || hasJustifiedAllow(d.Doc) {
+					continue
+				}
+				checkNativeConstructions(pass, d.Body, allow)
+			case *ast.GenDecl:
+				// Package-level var/const initializers, including function
+				// literals inside them.  A native built at package scope is
+				// shared by every Runtime in the process before Fork is even
+				// involved -- the ownership rule's territory, reached from
+				// the payload side.
+				checkNativeConstructions(pass, d, allow)
+			}
+		}
+	}
+	return nil, nil
+}
+
+// checkNativeConstructions reports every native construction under n.
+func checkNativeConstructions(pass *analysis.Pass, n ast.Node, allow map[int]bool) {
+	ast.Inspect(n, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.CallExpr:
+			checkNativeCall(pass, x, allow)
+		case *ast.CompositeLit:
+			checkNativeLiteral(pass, x, allow)
+		case *ast.AssignStmt:
+			checkNativeAssign(pass, x, allow)
+		}
+		return true
+	})
+}
+
+// checkNativeCall handles lisp.Native(x), the typed lisp.NativeOf[T](x), and
+// the lisp.Value(x) calls the compiler can see falling through to Native.
+func checkNativeCall(pass *analysis.Pass, call *ast.CallExpr, allow map[int]bool) {
+	if len(call.Args) != 1 {
+		return
+	}
+	fn := calleeFunc(pass, call)
+	if fn == nil || fn.Pkg() == nil || fn.Pkg().Path() != lispPkgPath {
+		return
+	}
+	arg := call.Args[0]
+	switch fn.Name() {
+	case "Native":
+	case "NativeOf":
+		// Implemented as a call to Native, so it constructs exactly the
+		// same value.  A generic instantiation still resolves to the
+		// generic *types.Func, whose name is NativeOf and never Native, so
+		// it needs its own arm -- without one the typed constructor is a
+		// spelling the rule cannot see, and a rule that cannot see a
+		// spelling fails open.
+	case "Value":
+		if directlyRepresentable(pass.TypesInfo.TypeOf(arg)) {
+			// Value's type switch handles it without a Native.
+			return
+		}
+	default:
+		return
+	}
+	reportNativePayload(pass, call.Pos(), pass.TypesInfo.TypeOf(arg), "lisp."+fn.Name(), allow)
+}
+
+// checkNativeLiteral handles `lisp.LVal{Native: x}` -- the constructor
+// bypass the kernel itself uses for every non-LNative payload slot.
+func checkNativeLiteral(pass *analysis.Pass, lit *ast.CompositeLit, allow map[int]bool) {
+	if !isLValType(pass.TypesInfo.TypeOf(lit)) {
+		return
+	}
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != "Native" {
+			continue
+		}
+		reportNativePayload(pass, kv.Value.Pos(), pass.TypesInfo.TypeOf(kv.Value), "lisp.LVal literal", allow)
+	}
+}
+
+// checkNativeAssign handles `v.Native = x` on an existing LVal -- the other
+// bypass, and the one that can put a payload into a value the assigning
+// function does not own.
+func checkNativeAssign(pass *analysis.Pass, stmt *ast.AssignStmt, allow map[int]bool) {
+	if len(stmt.Lhs) != len(stmt.Rhs) {
+		// Multi-value RHS: the payload type is a tuple element, not an
+		// expression type.  Documented blind spot (file comment).
+		return
+	}
+	for i, lhs := range stmt.Lhs {
+		sel, ok := lhs.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Native" {
+			continue
+		}
+		if !isLValType(pass.TypesInfo.TypeOf(sel.X)) {
+			continue
+		}
+		reportNativePayload(pass, stmt.Pos(), pass.TypesInfo.TypeOf(stmt.Rhs[i]), "LVal.Native assignment", allow)
+	}
+}
+
+func reportNativePayload(pass *analysis.Pass, pos token.Pos, payload types.Type, what string, allow map[int]bool) {
+	if allow[pass.Fset.Position(pos).Line] {
+		return
+	}
+	switch classifyPayload(payload) {
+	case payloadSafe:
+		return
+	case payloadDynamic:
+		pass.Reportf(pos,
+			"%s payload type %s is not statically known (an interface or type parameter), so whether it is"+
+				" safe to share across forks cannot be checked here; construct the native from a concrete"+
+				" type, or annotate //%s with a justification naming the contract the payload is held to",
+			what, payloadTypeString(payload), nativeAllowMarker)
+	case payloadReport:
+		pass.Reportf(pos,
+			"%s payload type %s is not a known-safe value type: Fork shares LVal.Native BY REFERENCE, so a"+
+				" payload that reaches a template is shared by every fork in the process; implement"+
+				" lisp.NativeCloner on the type, add it to allowedPayloadTypes in cmd/elpsvet/nativepayload.go"+
+				" with a justification, or annotate //%s with one",
+			what, payloadTypeString(payload), nativeAllowMarker)
+	}
+}
+
+type payloadVerdict int
+
+const (
+	// payloadSafe: sharing this payload across forks cannot be observed.
+	payloadSafe payloadVerdict = iota
+	// payloadReport: plausibly mutable, or simply unclassified.
+	payloadReport
+	// payloadDynamic: interface-typed or a type parameter, so there is no
+	// static payload type to classify.
+	payloadDynamic
+)
+
+// classifyPayload decides a payload type's verdict.  The ORDER matters: the
+// allowlist and the NativeCloner check are consulted on the type itself
+// before the underlying type is looked at, since every audited row
+// (time.Time, *regexp.Regexp, the kernel's pointer slots) has a composite
+// underlying type that would otherwise be reported.
+func classifyPayload(t types.Type) payloadVerdict {
+	if t == nil {
+		return payloadDynamic
+	}
+	t = types.Unalias(t)
+	if _, ok := t.(*types.TypeParam); ok {
+		return payloadDynamic
+	}
+	if _, ok := allowedPayloadTypes[types.TypeString(t, nil)]; ok {
+		return payloadSafe
+	}
+	if declaresNativeCloner(t) {
+		return payloadSafe
+	}
+	switch u := t.Underlying().(type) {
+	case *types.Basic:
+		if u.Kind() == types.UnsafePointer {
+			return payloadReport
+		}
+		return payloadSafe
+	case *types.Interface:
+		return payloadDynamic
+	}
+	return payloadReport
+}
+
+// declaresNativeCloner reports whether t's method set carries
+// `CloneNative() interface{}` -- structurally, which is what a Go interface
+// assertion checks too.  It is t's OWN method set that matters: a value of a
+// type whose CloneNative has a pointer receiver does not satisfy
+// lisp.NativeCloner at runtime, so Native(v) of such a value is reported
+// while Native(&v) is not.
+func declaresNativeCloner(t types.Type) bool {
+	sel := types.NewMethodSet(t).Lookup(nil, nativeClonerMethod)
+	if sel == nil {
+		return false
+	}
+	sig, ok := sel.Type().(*types.Signature)
+	if !ok || sig.Params().Len() != 0 || sig.Results().Len() != 1 {
+		return false
+	}
+	iface, ok := types.Unalias(sig.Results().At(0).Type()).Underlying().(*types.Interface)
+	return ok && iface.Empty()
+}
+
+// payloadTypeString renders a payload type for a diagnostic without the
+// full import path, which keeps the messages readable.
+func payloadTypeString(t types.Type) string {
+	if t == nil {
+		return "unknown"
+	}
+	return types.TypeString(t, func(p *types.Package) string { return p.Name() })
+}
+
+// directlyRepresentable reports whether lisp.Value's type switch converts t
+// without falling through to Native.  Mirrors the switch in lisp/lisp.go:
+// bool, string, []byte, int, float64, []*LVal.  Identity is the right
+// comparison -- a Go type switch matches `case []byte` only for the unnamed
+// type, so `type Blob []byte` DOES become a native.
+func directlyRepresentable(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	switch u := types.Unalias(t).(type) {
+	case *types.Basic:
+		switch u.Kind() {
+		case types.Bool, types.String, types.Int, types.Float64,
+			types.UntypedBool, types.UntypedString, types.UntypedInt, types.UntypedFloat:
+			return true
+		default:
+			return false
+		}
+	case *types.Slice:
+		if b, ok := types.Unalias(u.Elem()).(*types.Basic); ok && b.Kind() == types.Uint8 {
+			return true // []byte
+		}
+		ptr, ok := types.Unalias(u.Elem()).(*types.Pointer)
+		return ok && isLValType(ptr.Elem()) // []*lisp.LVal
+	}
+	return false
+}
+
+// isLValType reports whether t is lisp.LVal or *lisp.LVal.
+func isLValType(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	t = types.Unalias(t)
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = types.Unalias(ptr.Elem())
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Name() == "LVal" && obj.Pkg() != nil && obj.Pkg().Path() == lispPkgPath
+}
+
+// calleeFunc resolves a call's callee to its *types.Func, so package aliases
+// and dot imports resolve like the compiler resolves them rather than by
+// matching the source text "lisp.Native".  An EXPLICITLY instantiated
+// generic -- lisp.NativeOf[*Handle](h) -- wraps the callee in an index
+// expression (IndexExpr for one type argument, IndexListExpr for several),
+// which is unwrapped first; missing that would leave a spelling the rule
+// cannot see.
+func calleeFunc(pass *analysis.Pass, call *ast.CallExpr) *types.Func {
+	fun := ast.Unparen(call.Fun)
+	switch idx := fun.(type) {
+	case *ast.IndexExpr:
+		fun = ast.Unparen(idx.X)
+	case *ast.IndexListExpr:
+		fun = ast.Unparen(idx.X)
+	}
+	var id *ast.Ident
+	switch fun := fun.(type) {
+	case *ast.Ident:
+		id = fun
+	case *ast.SelectorExpr:
+		id = fun.Sel
+	default:
+		return nil
+	}
+	fn, _ := pass.TypesInfo.Uses[id].(*types.Func)
+	return fn
+}
+
+// justifiedAllow reports whether a comment's text is an //elpsvet:allow
+// marker THAT CARRIES A JUSTIFICATION: the marker followed by whitespace and
+// at least one non-blank character.  A bare marker is not an audit and does
+// not suppress.  The rule cannot check that the words are true, only that
+// somebody wrote them down where the next reader will see them.
+func justifiedAllow(text string) bool {
+	text = strings.TrimPrefix(text, "//")
+	text = strings.TrimPrefix(text, "/*")
+	text = strings.TrimSuffix(text, "*/")
+	text = strings.TrimSpace(text)
+	rest, ok := strings.CutPrefix(text, nativeAllowMarker)
+	if !ok || rest == "" {
+		return false
+	}
+	if rest[0] != ' ' && rest[0] != '\t' {
+		return false // a different marker sharing the prefix
+	}
+	return strings.TrimSpace(rest) != ""
+}
+
+func hasJustifiedAllow(cg *ast.CommentGroup) bool {
+	if cg == nil {
+		return false
+	}
+	for _, c := range cg.List {
+		if justifiedAllow(c.Text) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/elpsvet/nativepayload.go
+++ b/cmd/elpsvet/nativepayload.go
@@ -20,8 +20,12 @@
 //
 // A native construction -- `lisp.Native(x)`, the typed `lisp.NativeOf[T](x)`
 // (inferred or explicitly instantiated), a `lisp.Value(x)` the compiler can
-// see falling through to Native, a `lisp.LVal{Native: x}` literal, or a
-// write to a `.Native` field -- is REPORTED unless one of:
+// see falling through to Native, a keyed literal setting the lisp.LVal.Native
+// FIELD (`lisp.LVal{Native: x}`, or `lisp.ErrorVal{Native: x}` -- ErrorVal is
+// `type ErrorVal LVal`, the same struct and the same field object), or a
+// write to that field however it is reached (`v.Native`, `e.Native` on an
+// ErrorVal, `(*lisp.ErrorVal)(v).Native`, a promoted `w.Native` through an
+// embedding struct) -- is REPORTED unless one of:
 //
 //  1. the payload's static type has a BASIC underlying type (string, int,
 //     bool, a float, a defined type over one of those, ...).  A non-pointer
@@ -40,11 +44,29 @@
 //  3. the payload's type is on allowedPayloadTypes below -- the AUDITED
 //     inventory, each row carrying the reason a human checked;
 //
-//  4. an audited `//elpsvet:allow <justification>` comment covers the line
-//     (trailing, or standalone on the line above), or the enclosing
-//     function's doc comment carries one.  A bare marker with no
-//     justification does NOT suppress: an allow that says nothing is a
-//     classification nobody made.
+//  4. an audited `//elpsvet:allow-native <justification>` comment covers the
+//     site: trailing on the reported line, standalone on the line above it,
+//     or -- for a multi-line literal -- on either the opening line or the
+//     `Native:` line; or the enclosing function's doc comment carries one.
+//     The justification must be at least three words.  A bare or one-word
+//     marker does NOT suppress: an allow that says nothing is a
+//     classification nobody made.  One justification covers every
+//     construction on its line, which is deliberate -- the line is the unit
+//     an author annotates and a reader audits.
+//
+// Taking the field's ADDRESS (`&v.Native`) is reported unconditionally: what
+// is later stored through the pointer has no type at this site, so the only
+// honest verdict is that the rule cannot see it.
+//
+// # The marker is this rule's own
+//
+// elpsownership's `//elpsvet:allow` is a bare prefix match with no
+// justification enforced.  Had this rule shared it, one sentence written for
+// the ownership rule ("guarded singleton", "sealed formals") on a
+// package-level native would have silenced both rules with a reason that
+// addresses neither.  `//elpsvet:allow-native` is therefore separate, and
+// the ownership rule's matcher stops at the marker's word boundary so the
+// native marker does not satisfy it either (main.go, allowed).
 //
 // # Interface-typed payloads
 //
@@ -55,8 +77,8 @@
 // system -- Native, NativeOf and Value are defined here, the fork and detach
 // walkers apply the policy here, and the error-condition constructors accept
 // arbitrary data here.  Each of those sites is a contract, and the contract
-// has to be written down at the site as an `//elpsvet:allow`, never silently
-// passed through as "unknowable".
+// has to be written down at the site as an `//elpsvet:allow-native`, never
+// silently passed through as "unknowable".
 //
 // # Why it is deliberately dumb
 //
@@ -71,12 +93,20 @@
 //
 // # What it does not see
 //
-// The payload type must be visible AT THE CONSTRUCTION SITE.  An indirect
-// call (`f := lisp.Native; f(x)`) is not a call the callee resolver can see;
-// a multi-value assignment (`v.Native, ok = g()`) has no expression type for
-// its right-hand side and is skipped.  A payload constructed in ANOTHER
-// module is that module's to audit -- substrate runs the same rule over its
-// own tree for exactly that reason.
+// The payload type must be visible AT THE CONSTRUCTION SITE, and the site
+// must be one of the spellings above.  Invisible:
+//
+//   - an indirect call (`f := lisp.Native; f(x)`): the callee resolver sees
+//     objects, not function values;
+//   - a multi-value assignment (`v.Native, ok = g()`): the right-hand side
+//     is a tuple, with no expression type per element;
+//   - a positional (unkeyed) `LVal{...}` literal: only possible inside
+//     package lisp, where the struct's unexported fields are nameable, and
+//     not written anywhere;
+//   - anything done through reflect (`reflect.ValueOf(v).Elem().FieldByName
+//     ("Native").Set(...)`): a runtime property, not a source one;
+//   - a payload constructed in ANOTHER module: that module's to audit --
+//     substrate runs the same rule over its own tree for exactly that reason.
 package main
 
 import (
@@ -89,19 +119,31 @@ import (
 )
 
 const (
-	// nativeAllowMarker is the audited suppression: the ownership rule's
-	// marker, held to a stricter standard here (see justifiedAllow).
-	nativeAllowMarker = "elpsvet:allow"
+	// nativeAllowMarker is this rule's audited suppression.  It is NOT the
+	// ownership rule's //elpsvet:allow (see the file comment) and is held to
+	// a stricter standard: see justifiedNativeAllow.
+	nativeAllowMarker = "elpsvet:allow-native"
+
+	// nativeAllowMinWords is the least a justification may be.  Three words
+	// is not an audit standard; it is the line below which a marker is
+	// punctuation ("//elpsvet:allow-native .") rather than a sentence.
+	nativeAllowMinWords = 3
 
 	// nativeClonerMethod is the one method of lisp.NativeCloner.
 	nativeClonerMethod = "CloneNative"
+
+	// nativeFieldName is the lisp.LVal field this rule tracks.  The field
+	// OBJECT is what is matched (isNativeField), never the receiver's
+	// spelled type, so ErrorVal, conversions and embedding all resolve to
+	// the same field.
+	nativeFieldName = "Native"
 )
 
 var nativePayloadAnalyzer = &analysis.Analyzer{
 	Name: "elpsnativepayload",
 	Doc: "flag lisp.LVal native payloads whose type is not provably safe to SHARE across forks" +
 		" (Fork shares LVal.Native by reference) unless the type declares lisp.NativeCloner," +
-		" is on the audited allowlist, or //elpsvet:allow <justification> covers the site",
+		" is on the audited allowlist, or //elpsvet:allow-native <justification> covers the site",
 	Run: runNativePayload,
 }
 
@@ -122,12 +164,16 @@ var nativePayloadAnalyzer = &analysis.Analyzer{
 var allowedPayloadTypes = map[string]string{
 	// Kernel-owned representation slots.  LVal.Native doubles as the backing
 	// store for several non-LNative types, and the fork and detach walkers
-	// carry an explicit arm for each, so none of them travels by reference.
+	// carry an explicit arm for each, so none of them travels by reference
+	// into a fork.
 
-	"*github.com/luthersystems/elps/lisp.funData": "the LFun payload. The fork walker's LFun arm " +
-		"(fork.go) re-mints the funData per fork with the captured env remapped into the fork, so " +
-		"a fork never shares the template's; detach refuses LFun values rather than copy them. A " +
-		"builtin's Go function pointer travels by reference, which is code, not state",
+	"*github.com/luthersystems/elps/lisp.funData": "the LFun payload. Fork re-mints it per fork " +
+		"with the captured env remapped into the fork (fork.go's LFun arm), so a fork never shares " +
+		"the template's. The detach walker either refuses an LFun (Detach, shareOpaque false) or " +
+		"shares the LFun VALUE whole (the lisp copy builtin runs the same walker with shareOpaque " +
+		"true, detach.go's LFun arm) -- a copy stays inside one runtime, where sharing a closure is " +
+		"the existing semantics, not a fork leak. A builtin's Go function pointer travels by " +
+		"reference, which is code, not state",
 
 	"*[]byte": "LBytes backing storage. The *[]byte arms in the fork walker (fork.go) and the " +
 		"detach walker (detach.go) each allocate a fresh slice and copy the bytes, so no fork can " +
@@ -170,16 +216,19 @@ var allowedPayloadTypes = map[string]string{
 		"construction: an unexported type with unexported fields, minted on one line " +
 		"(DumpMessageBuiltin) from bytes the serializer just wrote, and every method and reader " +
 		"(MarshalJSON, jsonMessage) only reads msg and loadable -- nothing assigns to either " +
-		"afterwards, and no other package can name the type to try",
+		"afterwards, and no other package can name the type to try. One aliasing to know about: " +
+		"MessageBytesBuiltin hands msg to lisp.Bytes([]byte(msg)), a conversion rather than a copy, " +
+		"so that LBytes shares the message's backing array WITHIN one runtime -- fine for this row, " +
+		"because a fork copies bytes (the *[]byte arm above) and so never shares it across runtimes",
 }
 
 func runNativePayload(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
-		allow := markerLinesMatching(pass.Fset, file, justifiedAllow)
+		allow := markerLinesMatching(pass.Fset, file, justifiedNativeAllow)
 		for _, decl := range file.Decls {
 			switch d := decl.(type) {
 			case *ast.FuncDecl:
-				if d.Body == nil || hasJustifiedAllow(d.Doc) {
+				if d.Body == nil || hasJustifiedNativeAllow(d.Doc) {
 					continue
 				}
 				checkNativeConstructions(pass, d.Body, allow)
@@ -206,6 +255,8 @@ func checkNativeConstructions(pass *analysis.Pass, n ast.Node, allow map[int]boo
 			checkNativeLiteral(pass, x, allow)
 		case *ast.AssignStmt:
 			checkNativeAssign(pass, x, allow)
+		case *ast.UnaryExpr:
+			checkNativeAddress(pass, x, allow)
 		}
 		return true
 	})
@@ -242,28 +293,33 @@ func checkNativeCall(pass *analysis.Pass, call *ast.CallExpr, allow map[int]bool
 	reportNativePayload(pass, call.Pos(), pass.TypesInfo.TypeOf(arg), "lisp."+fn.Name(), allow)
 }
 
-// checkNativeLiteral handles `lisp.LVal{Native: x}` -- the constructor
-// bypass the kernel itself uses for every non-LNative payload slot.
+// checkNativeLiteral handles a keyed literal setting the lisp.LVal.Native
+// field -- `lisp.LVal{Native: x}`, and equally `lisp.ErrorVal{Native: x}`,
+// since ErrorVal is a defined type over LVal and its keys resolve to the
+// same field objects.  The literal's TYPE is not consulted; the key's
+// object is.
+//
+// The report sits on the literal's opening line, where a call would be
+// reported, so a trailing marker on `&lisp.LVal{` covers a payload two
+// lines down; a marker on the `Native:` line itself is honoured as well.
 func checkNativeLiteral(pass *analysis.Pass, lit *ast.CompositeLit, allow map[int]bool) {
-	if !isLValType(pass.TypesInfo.TypeOf(lit)) {
-		return
-	}
 	for _, elt := range lit.Elts {
 		kv, ok := elt.(*ast.KeyValueExpr)
 		if !ok {
 			continue
 		}
 		key, ok := kv.Key.(*ast.Ident)
-		if !ok || key.Name != "Native" {
+		if !ok || !isNativeField(pass.TypesInfo.Uses[key]) {
 			continue
 		}
-		reportNativePayload(pass, kv.Value.Pos(), pass.TypesInfo.TypeOf(kv.Value), "lisp.LVal literal", allow)
+		reportNativePayload(pass, lit.Pos(), pass.TypesInfo.TypeOf(kv.Value), "LVal.Native literal", allow,
+			kv.Key.Pos(), kv.Value.Pos())
 	}
 }
 
-// checkNativeAssign handles `v.Native = x` on an existing LVal -- the other
-// bypass, and the one that can put a payload into a value the assigning
-// function does not own.
+// checkNativeAssign handles a write to the lisp.LVal.Native field on an
+// existing value -- the bypass that can put a payload into a value the
+// assigning function does not own -- however the field is reached.
 func checkNativeAssign(pass *analysis.Pass, stmt *ast.AssignStmt, allow map[int]bool) {
 	if len(stmt.Lhs) != len(stmt.Rhs) {
 		// Multi-value RHS: the payload type is a tuple element, not an
@@ -271,20 +327,45 @@ func checkNativeAssign(pass *analysis.Pass, stmt *ast.AssignStmt, allow map[int]
 		return
 	}
 	for i, lhs := range stmt.Lhs {
-		sel, ok := lhs.(*ast.SelectorExpr)
-		if !ok || sel.Sel.Name != "Native" {
-			continue
-		}
-		if !isLValType(pass.TypesInfo.TypeOf(sel.X)) {
+		sel, ok := ast.Unparen(lhs).(*ast.SelectorExpr)
+		if !ok || !selectsNativeField(pass, sel) {
 			continue
 		}
 		reportNativePayload(pass, stmt.Pos(), pass.TypesInfo.TypeOf(stmt.Rhs[i]), "LVal.Native assignment", allow)
 	}
 }
 
-func reportNativePayload(pass *analysis.Pass, pos token.Pos, payload types.Type, what string, allow map[int]bool) {
+// checkNativeAddress handles `&v.Native`: a pointer through which any
+// payload can later be stored, with no type at this site to classify.
+func checkNativeAddress(pass *analysis.Pass, expr *ast.UnaryExpr, allow map[int]bool) {
+	if expr.Op != token.AND {
+		return
+	}
+	sel, ok := ast.Unparen(expr.X).(*ast.SelectorExpr)
+	if !ok || !selectsNativeField(pass, sel) {
+		return
+	}
+	if allow[pass.Fset.Position(expr.Pos()).Line] {
+		return
+	}
+	pass.Reportf(expr.Pos(),
+		"address of LVal.Native taken: whatever is later stored through the pointer is a native payload"+
+			" this rule cannot see the type of; store through the field directly so the payload is"+
+			" checked at the store, or annotate //%s with a justification",
+		nativeAllowMarker)
+}
+
+// reportNativePayload classifies payload and reports at pos unless a
+// justified marker covers pos's line or any of the also lines (a literal's
+// key and value positions).
+func reportNativePayload(pass *analysis.Pass, pos token.Pos, payload types.Type, what string, allow map[int]bool, also ...token.Pos) {
 	if allow[pass.Fset.Position(pos).Line] {
 		return
+	}
+	for _, p := range also {
+		if allow[pass.Fset.Position(p).Line] {
+			return
+		}
 	}
 	switch classifyPayload(payload) {
 	case payloadSafe:
@@ -404,7 +485,9 @@ func directlyRepresentable(t types.Type) bool {
 	return false
 }
 
-// isLValType reports whether t is lisp.LVal or *lisp.LVal.
+// isLValType reports whether t is lisp.LVal or *lisp.LVal.  Used only to
+// recognise Value's `[]*LVal` arm; field access is matched on the field
+// object (isNativeField), never on the receiver's spelled type.
 func isLValType(t types.Type) bool {
 	if t == nil {
 		return false
@@ -419,6 +502,24 @@ func isLValType(t types.Type) bool {
 	}
 	obj := named.Obj()
 	return obj != nil && obj.Name() == "LVal" && obj.Pkg() != nil && obj.Pkg().Path() == lispPkgPath
+}
+
+// isNativeField reports whether obj is the lisp.LVal.Native field object --
+// the one field of that name declared in package lisp (lisp/lisp.go).  A
+// defined type over LVal (ErrorVal) shares the struct and therefore the
+// object; a promoted selection through an embedding struct resolves to it;
+// a struct in another package that happens to have a field called Native
+// does not.
+func isNativeField(obj types.Object) bool {
+	v, ok := obj.(*types.Var)
+	return ok && v.IsField() && v.Name() == nativeFieldName && v.Pkg() != nil && v.Pkg().Path() == lispPkgPath
+}
+
+// selectsNativeField reports whether sel is a field selection of
+// lisp.LVal.Native, by whatever receiver expression and embedding path.
+func selectsNativeField(pass *analysis.Pass, sel *ast.SelectorExpr) bool {
+	s, ok := pass.TypesInfo.Selections[sel]
+	return ok && s.Kind() == types.FieldVal && isNativeField(s.Obj())
 }
 
 // calleeFunc resolves a call's callee to its *types.Func, so package aliases
@@ -449,12 +550,12 @@ func calleeFunc(pass *analysis.Pass, call *ast.CallExpr) *types.Func {
 	return fn
 }
 
-// justifiedAllow reports whether a comment's text is an //elpsvet:allow
-// marker THAT CARRIES A JUSTIFICATION: the marker followed by whitespace and
-// at least one non-blank character.  A bare marker is not an audit and does
-// not suppress.  The rule cannot check that the words are true, only that
-// somebody wrote them down where the next reader will see them.
-func justifiedAllow(text string) bool {
+// justifiedNativeAllow reports whether a comment's text is an
+// //elpsvet:allow-native marker THAT CARRIES A JUSTIFICATION: the marker,
+// whitespace, and at least nativeAllowMinWords words.  The rule cannot check
+// that the words are true, only that somebody wrote a sentence down where
+// the next reader will see it.
+func justifiedNativeAllow(text string) bool {
 	text = strings.TrimPrefix(text, "//")
 	text = strings.TrimPrefix(text, "/*")
 	text = strings.TrimSuffix(text, "*/")
@@ -466,15 +567,15 @@ func justifiedAllow(text string) bool {
 	if rest[0] != ' ' && rest[0] != '\t' {
 		return false // a different marker sharing the prefix
 	}
-	return strings.TrimSpace(rest) != ""
+	return len(strings.Fields(rest)) >= nativeAllowMinWords
 }
 
-func hasJustifiedAllow(cg *ast.CommentGroup) bool {
+func hasJustifiedNativeAllow(cg *ast.CommentGroup) bool {
 	if cg == nil {
 		return false
 	}
 	for _, c := range cg.List {
-		if justifiedAllow(c.Text) {
+		if justifiedNativeAllow(c.Text) {
 			return true
 		}
 	}

--- a/cmd/elpsvet/nativepayload_test.go
+++ b/cmd/elpsvet/nativepayload_test.go
@@ -1,0 +1,104 @@
+// Copyright © 2026 The ELPS authors
+
+package main
+
+import (
+	"go/types"
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+// TestNativePayloadAnalyzer runs the rule over testdata/src/nativepayload,
+// which carries every construction spelling (Native, NativeOf inferred and
+// explicitly instantiated, an aliased import, a parenthesised callee, the
+// Value fallthrough, the LVal literal, the field write), the basic tier,
+// the NativeCloner rule on both receiver kinds, the audited allowlist keyed
+// on exact type, the interface-typed report, and the allow marker in every
+// placement -- with and without a justification.
+//
+// analysistest checks absence as strictly as presence: a construction with
+// no `// want` comment asserts NO diagnostic there, so the exemptions are
+// pinned by this run as firmly as the reports.
+func TestNativePayloadAnalyzer(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), nativePayloadAnalyzer, "nativepayload")
+}
+
+// TestAllowedPayloadTypesJustified guards the allowlist's shape: every row
+// must carry a justification a reviewer can read, and every row's key must
+// be spelled the way classifyPayload will look it up.  The rule cannot check
+// that the words are TRUE -- that is what review is for -- but an empty or
+// thin row is a classification nobody made, which is the thing the rule
+// exists to prevent.
+func TestAllowedPayloadTypesJustified(t *testing.T) {
+	// The audited inventory.  A row added without a justification, or a key
+	// that drifts from the type it names, fails here; a row deleted fails
+	// here too, so that shrinking the map is a deliberate act.
+	want := []string{
+		"*github.com/luthersystems/elps/lisp.funData",
+		"*[]byte",
+		"*github.com/luthersystems/elps/lisp.MapData",
+		"*github.com/luthersystems/elps/lisp.CallStack",
+		"*regexp.Regexp",
+		"time.Time",
+		"error",
+		"*github.com/luthersystems/elps/lisp/lisplib/libschema.validatorTag",
+		"*github.com/luthersystems/elps/lisp/lisplib/libjson.ownMessage",
+	}
+	for _, key := range want {
+		why, ok := allowedPayloadTypes[key]
+		if !ok {
+			t.Errorf("allowedPayloadTypes lost the audited row for %s;"+
+				" this map may only shrink deliberately, and shrinking it means the type"+
+				" is no longer used as a native payload", key)
+			continue
+		}
+		if len(why) < 60 {
+			t.Errorf("allowedPayloadTypes[%s] justification is too thin to audit: %q", key, why)
+		}
+	}
+	if len(allowedPayloadTypes) != len(want) {
+		t.Errorf("allowedPayloadTypes has %d rows, the audited inventory lists %d;"+
+			" add the new row to this test with its justification reviewed",
+			len(allowedPayloadTypes), len(want))
+	}
+	for key, why := range allowedPayloadTypes {
+		if why == "" {
+			t.Errorf("allowedPayloadTypes[%s] has no justification", key)
+		}
+	}
+}
+
+// TestClassifyPayloadUniverseError pins that the `error` row is reachable:
+// the universe type has no package, and types.TypeString spells it bare,
+// which is how the row is keyed.
+func TestClassifyPayloadUniverseError(t *testing.T) {
+	if got := classifyPayload(types.Universe.Lookup("error").Type()); got != payloadSafe {
+		t.Errorf("classifyPayload(error) = %v, want payloadSafe via the allowlist row", got)
+	}
+	if got := classifyPayload(types.Universe.Lookup("any").Type()); got != payloadDynamic {
+		t.Errorf("classifyPayload(any) = %v, want payloadDynamic", got)
+	}
+}
+
+// TestJustifiedAllow pins the justification requirement on the marker text
+// itself, independent of placement.
+func TestJustifiedAllow(t *testing.T) {
+	cases := map[string]bool{
+		"//elpsvet:allow the handle is immutable":   true,
+		"// elpsvet:allow\tthe handle is immutable": true,
+		"/*elpsvet:allow the handle is immutable*/": true,
+		"//elpsvet:allow":                           false,
+		"//elpsvet:allow   ":                        false,
+		"/*elpsvet:allow*/":                         false,
+		"//elpsvet:allowed by nobody":               false,
+		"//elpsvet:allow-ish":                       false,
+		"//elps:mutates a different marker":         false,
+		"// plain comment":                          false,
+	}
+	for text, want := range cases {
+		if got := justifiedAllow(text); got != want {
+			t.Errorf("justifiedAllow(%q) = %v, want %v", text, got, want)
+		}
+	}
+}

--- a/cmd/elpsvet/nativepayload_test.go
+++ b/cmd/elpsvet/nativepayload_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"go/ast"
 	"go/types"
 	"testing"
 
@@ -12,14 +13,16 @@ import (
 // TestNativePayloadAnalyzer runs the rule over testdata/src/nativepayload,
 // which carries every construction spelling (Native, NativeOf inferred and
 // explicitly instantiated, an aliased import, a parenthesised callee, the
-// Value fallthrough, the LVal literal, the field write), the basic tier,
+// Value fallthrough, the field literal, the field write), the basic tier,
 // the NativeCloner rule on both receiver kinds, the audited allowlist keyed
 // on exact type, the interface-typed report, and the allow marker in every
-// placement -- with and without a justification.
+// placement -- with and without a justification.  review.go adds the field
+// reached through lisp.ErrorVal, a conversion, and embedding; the field's
+// address; and multi-line literals with the marker on each candidate line.
 //
 // analysistest checks absence as strictly as presence: a construction with
-// no `// want` comment asserts NO diagnostic there, so the exemptions are
-// pinned by this run as firmly as the reports.
+// no want-expectation comment asserts NO diagnostic there, so the exemptions
+// are pinned by this run as firmly as the reports.
 func TestNativePayloadAnalyzer(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), nativePayloadAnalyzer, "nativepayload")
 }
@@ -81,24 +84,51 @@ func TestClassifyPayloadUniverseError(t *testing.T) {
 	}
 }
 
-// TestJustifiedAllow pins the justification requirement on the marker text
-// itself, independent of placement.
-func TestJustifiedAllow(t *testing.T) {
+// TestJustifiedNativeAllow pins the justification requirement on the marker
+// text itself, independent of placement: the rule's own marker, at least
+// three words after it, and nothing that merely shares the prefix.
+func TestJustifiedNativeAllow(t *testing.T) {
 	cases := map[string]bool{
-		"//elpsvet:allow the handle is immutable":   true,
-		"// elpsvet:allow\tthe handle is immutable": true,
-		"/*elpsvet:allow the handle is immutable*/": true,
-		"//elpsvet:allow":                           false,
-		"//elpsvet:allow   ":                        false,
-		"/*elpsvet:allow*/":                         false,
-		"//elpsvet:allowed by nobody":               false,
-		"//elpsvet:allow-ish":                       false,
-		"//elps:mutates a different marker":         false,
-		"// plain comment":                          false,
+		"//elpsvet:allow-native the handle is immutable":   true,
+		"// elpsvet:allow-native\tthe handle is immutable": true,
+		"/*elpsvet:allow-native the handle is immutable*/": true,
+		"//elpsvet:allow-native one two three":             true,
+		"//elpsvet:allow-native":                           false,
+		"//elpsvet:allow-native   ":                        false,
+		"/*elpsvet:allow-native*/":                         false,
+		"//elpsvet:allow-native .":                         false,
+		"//elpsvet:allow-native one two":                   false,
+		"//elpsvet:allow-natives by nobody at all":         false,
+		"//elpsvet:allow-native-ish reason given here":     false,
+		"//elpsvet:allow the ownership rule's own marker":  false,
+		"//elps:mutates a different marker entirely":       false,
+		"// plain comment with several words":              false,
 	}
 	for text, want := range cases {
-		if got := justifiedAllow(text); got != want {
-			t.Errorf("justifiedAllow(%q) = %v, want %v", text, got, want)
+		if got := justifiedNativeAllow(text); got != want {
+			t.Errorf("justifiedNativeAllow(%q) = %v, want %v", text, got, want)
+		}
+	}
+}
+
+// TestOwnershipAllowStopsAtWordBoundary pins the other half of the marker
+// separation: the ownership rule's bare //elpsvet:allow still suppresses,
+// with or without a justification (that rule enforces none), but the native
+// rule's //elpsvet:allow-native does not satisfy it -- otherwise one native
+// justification on a package-level var would silence both rules.
+func TestOwnershipAllowStopsAtWordBoundary(t *testing.T) {
+	cases := map[string]bool{
+		"//elpsvet:allow":                             true,
+		"//elpsvet:allow guarded singleton":           true,
+		"//elpsvet:allow\tsealed formals":             true,
+		"//elpsvet:allow-native a native reason":      false,
+		"//elpsvet:allowed by nobody":                 false,
+		"// a plain comment mentioning elpsvet:allow": false,
+	}
+	for text, want := range cases {
+		cg := &ast.CommentGroup{List: []*ast.Comment{{Text: text}}}
+		if got := allowed(cg); got != want {
+			t.Errorf("allowed(%q) = %v, want %v", text, got, want)
 		}
 	}
 }

--- a/cmd/elpsvet/testdata/src/github.com/luthersystems/elps/lisp/lisp.go
+++ b/cmd/elpsvet/testdata/src/github.com/luthersystems/elps/lisp/lisp.go
@@ -139,6 +139,40 @@ func Bytes(b []byte) *LVal   { return &LVal{Native: &b} }
 
 func Native(v interface{}) *LVal { return &LVal{Native: v} }
 
+// NativeOf mirrors the real typed constructor: implemented as a call to
+// Native, so the elpsnativepayload fixtures can pin that the rule sees the
+// generic spelling (inferred and explicitly instantiated) as a construction.
+func NativeOf[T any](x T) *LVal { return Native(x) }
+
+// Value mirrors the real conversion's fallthrough shape: the directly
+// representable types are handled without a Native, everything else becomes
+// one.
+func Value(v interface{}) *LVal {
+	switch v := v.(type) {
+	case bool:
+		return Bool(v)
+	case string:
+		return String(v)
+	case []byte:
+		return Bytes(v)
+	case int:
+		return Int(v)
+	case float64:
+		return Float(v)
+	case []*LVal:
+		return QExpr(v)
+	default:
+		return Native(v)
+	}
+}
+
+// NativeCloner mirrors the real clone protocol.  The elpsnativepayload rule
+// checks for the method structurally, as an interface assertion would; the
+// interface is here so a fixture can say what it is satisfying.
+type NativeCloner interface {
+	CloneNative() interface{}
+}
+
 func SExpr(cells []*LVal) *LVal { return &LVal{Cells: cells} }
 func QExpr(cells []*LVal) *LVal { return &LVal{Cells: cells, Quoted: true} }
 

--- a/cmd/elpsvet/testdata/src/nativepayload/nativepayload.go
+++ b/cmd/elpsvet/testdata/src/nativepayload/nativepayload.go
@@ -93,11 +93,11 @@ func valueDirect(s string, b []byte, i int, f float64, ok bool, cells []*lisp.LV
 }
 
 func literalPointer(h *handle) *lisp.LVal {
-	return &lisp.LVal{Type: lisp.LError, Native: h} // want `lisp\.LVal literal payload type \*nativepayload\.handle is not a known-safe value type`
+	return &lisp.LVal{Type: lisp.LError, Native: h} // want `LVal\.Native literal payload type \*nativepayload\.handle is not a known-safe value type`
 }
 
 func literalValue(h *handle) lisp.LVal {
-	return lisp.LVal{Native: h} // want `lisp\.LVal literal payload type \*nativepayload\.handle is not a known-safe value type`
+	return lisp.LVal{Native: h} // want `LVal\.Native literal payload type \*nativepayload\.handle is not a known-safe value type`
 }
 
 func literalOtherFields(cells []*lisp.LVal) *lisp.LVal {
@@ -214,57 +214,71 @@ func dynamicFieldWrite(v *lisp.LVal, payload interface{}) {
 }
 
 func dynamicAllowed(v interface{}) *lisp.LVal {
-	return lisp.Native(v) //elpsvet:allow fixture: a pass-through constructor whose callers are checked at their own sites
+	return lisp.Native(v) //elpsvet:allow-native fixture: a pass-through constructor whose callers are checked at their own sites
 }
 
 // --- the allow marker --------------------------------------------------------
 
 func allowTrailing(h *handle) *lisp.LVal {
-	return lisp.Native(h) //elpsvet:allow fixture: the handle is immutable after construction
+	return lisp.Native(h) //elpsvet:allow-native fixture: the handle is immutable after construction
 }
 
 func allowStandalone(h *handle) *lisp.LVal {
-	//elpsvet:allow fixture: the handle is immutable after construction
+	//elpsvet:allow-native fixture: the handle is immutable after construction
 	return lisp.Native(h)
 }
 
 func allowStandaloneReachesOneLine(h *handle) {
-	//elpsvet:allow fixture: covers only the statement below
+	//elpsvet:allow-native fixture: covers only the statement below
 	_ = lisp.Native(h)
 	_ = lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
 }
 
 func allowTrailingReachesItsLineOnly(h *handle) {
-	_ = lisp.Native(h) //elpsvet:allow fixture: covers this line
+	_ = lisp.Native(h) //elpsvet:allow-native fixture: covers this line
 	_ = lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
 }
 
 func allowEmptyStandalone(h *handle) *lisp.LVal {
-	//elpsvet:allow
+	//elpsvet:allow-native
 	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
 }
 
 func allowEmptyWithTrailingSpace(h *handle) *lisp.LVal {
-	//elpsvet:allow
+	//elpsvet:allow-native
 	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
 }
 
+func allowTooShort(h *handle) *lisp.LVal {
+	//elpsvet:allow-native two words
+	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func allowOwnershipMarkerIsNotThisRules(h *handle) *lisp.LVal {
+	//elpsvet:allow the ownership rule's marker, however justified, is a different rule's
+	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func allowOneLineCoversEveryConstructionOnIt(h *handle) {
+	_, _ = lisp.Native(h), lisp.NativeOf(h) //elpsvet:allow-native fixture: one justification covers the whole line
+}
+
 func allowMarkerPrefixOnly(h *handle) *lisp.LVal {
-	//elpsvet:allowed by nobody -- a different marker sharing the prefix
+	//elpsvet:allow-natives by nobody -- a different marker sharing the prefix
 	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
 }
 
 // allowDoc has its whole body exempted by a justified marker in its doc
 // comment.
 //
-//elpsvet:allow fixture: every native this function mints is a fresh, unshared handle
+//elpsvet:allow-native fixture: every native this function mints is a fresh, unshared handle
 func allowDoc(h *handle) *lisp.LVal {
 	return lisp.Native(h)
 }
 
 // allowDocEmpty carries a bare marker in its doc, which is not an audit.
 //
-//elpsvet:allow
+//elpsvet:allow-native
 func allowDocEmpty(h *handle) *lisp.LVal {
 	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
 }
@@ -273,7 +287,7 @@ func allowDocEmpty(h *handle) *lisp.LVal {
 
 var marker = lisp.Native(&handle{}) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
 
-var markerAllowed = lisp.Native(&handle{}) //elpsvet:allow fixture: identity-only credential, never written
+var markerAllowed = lisp.Native(&handle{}) //elpsvet:allow-native fixture: identity-only credential, never written
 
 var makeNative = func(h *handle) *lisp.LVal {
 	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`

--- a/cmd/elpsvet/testdata/src/nativepayload/nativepayload.go
+++ b/cmd/elpsvet/testdata/src/nativepayload/nativepayload.go
@@ -1,0 +1,284 @@
+// Package nativepayload exercises the elpsnativepayload analyzer: every
+// construction spelling, the basic-type tier, the NativeCloner rule, the
+// audited allowlist, the interface-typed report, and the allow marker with
+// and without a justification.
+//
+// analysistest checks absence as strictly as presence: a construction with
+// no want-expectation comment asserts NO diagnostic there.
+package nativepayload
+
+import (
+	"regexp"
+	"time"
+	"unsafe"
+
+	"github.com/luthersystems/elps/lisp"
+	l "github.com/luthersystems/elps/lisp"
+)
+
+// handle is the plausibly-mutable payload every reported shape uses.
+type handle struct{ n int }
+
+// counter has a basic underlying type, so a value of it is immutable inside
+// an interface.
+type counter int
+
+// blob is a defined type over []byte: lisp.Value's `case []byte` does not
+// match it, so it falls through to Native.
+type blob []byte
+
+// suite declares lisp.NativeCloner on its POINTER receiver.
+type suite struct{ tests []string }
+
+func (s *suite) CloneNative() interface{} { return &suite{tests: append([]string(nil), s.tests...)} }
+
+var _ lisp.NativeCloner = (*suite)(nil)
+
+// valueCloner declares it on the VALUE receiver, so both a value and a
+// pointer satisfy the protocol.
+type valueCloner struct{ n int }
+
+func (valueCloner) CloneNative() interface{} { return valueCloner{} }
+
+// wrongCloner has a method of the right name and the wrong shape; a
+// type assertion to lisp.NativeCloner would fail, and so must the rule.
+type wrongCloner struct{ n int }
+
+func (*wrongCloner) CloneNative(deep bool) interface{} { return nil }
+
+// notAnLVal has a field named Native that is nothing of the kind.
+type notAnLVal struct{ Native *handle }
+
+// --- the spellings ---------------------------------------------------------
+
+func native(h *handle) *lisp.LVal {
+	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func nativeOfInferred(h *handle) *lisp.LVal {
+	return lisp.NativeOf(h) // want `lisp\.NativeOf payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func nativeOfExplicit(h *handle) *lisp.LVal {
+	return lisp.NativeOf[*handle](h) // want `lisp\.NativeOf payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func nativeAliasedImport(h *handle) *lisp.LVal {
+	return l.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func nativeParenthesised(h *handle) *lisp.LVal {
+	return (lisp.Native)(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func valueFallthrough(h *handle) *lisp.LVal {
+	return lisp.Value(h) // want `lisp\.Value payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func valueNamedBytes(b blob) *lisp.LVal {
+	return lisp.Value(b) // want `lisp\.Value payload type nativepayload\.blob is not a known-safe value type`
+}
+
+// valueDirect covers every arm of lisp.Value's type switch: none of these
+// falls through to Native, so none is a construction.
+func valueDirect(s string, b []byte, i int, f float64, ok bool, cells []*lisp.LVal) {
+	_ = lisp.Value(s)
+	_ = lisp.Value(b)
+	_ = lisp.Value(i)
+	_ = lisp.Value(f)
+	_ = lisp.Value(ok)
+	_ = lisp.Value(cells)
+	_ = lisp.Value("literal")
+	_ = lisp.Value(42)
+}
+
+func literalPointer(h *handle) *lisp.LVal {
+	return &lisp.LVal{Type: lisp.LError, Native: h} // want `lisp\.LVal literal payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func literalValue(h *handle) lisp.LVal {
+	return lisp.LVal{Native: h} // want `lisp\.LVal literal payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func literalOtherFields(cells []*lisp.LVal) *lisp.LVal {
+	return &lisp.LVal{Cells: cells, Str: "no payload"}
+}
+
+func fieldWrite(v *lisp.LVal, h *handle) {
+	v.Native = h // want `LVal\.Native assignment payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func fieldWriteThroughValue(v lisp.LVal, h *handle) lisp.LVal {
+	v.Native = h // want `LVal\.Native assignment payload type \*nativepayload\.handle is not a known-safe value type`
+	return v
+}
+
+func fieldWriteNotAnLVal(o *notAnLVal, h *handle) {
+	o.Native = h
+}
+
+// --- the basic tier --------------------------------------------------------
+
+func basics(s string, i int, f float64, ok bool, c counter, r rune) {
+	_ = lisp.Native(s)
+	_ = lisp.Native(i)
+	_ = lisp.Native(f)
+	_ = lisp.Native(ok)
+	_ = lisp.Native(c)
+	_ = lisp.Native(r)
+	_ = lisp.Native(nil)
+	_ = lisp.NativeOf(c)
+	_ = lisp.NativeOf[counter](c)
+	_ = &lisp.LVal{Native: c}
+}
+
+func unsafePointer(p unsafe.Pointer) *lisp.LVal {
+	return lisp.Native(p) // want `lisp\.Native payload type unsafe\.Pointer is not a known-safe value type`
+}
+
+func composites(m map[string]int, sl []int, ch chan int, fn func(), arr [2]int, st struct{ n int }) {
+	_ = lisp.Native(m)   // want `lisp\.Native payload type map\[string\]int is not a known-safe value type`
+	_ = lisp.Native(sl)  // want `lisp\.Native payload type \[\]int is not a known-safe value type`
+	_ = lisp.Native(ch)  // want `lisp\.Native payload type chan int is not a known-safe value type`
+	_ = lisp.Native(fn)  // want `lisp\.Native payload type func\(\) is not a known-safe value type`
+	_ = lisp.Native(arr) // want `lisp\.Native payload type \[2\]int is not a known-safe value type`
+	_ = lisp.Native(st)  // want `lisp\.Native payload type struct\{n int\} is not a known-safe value type`
+}
+
+// --- the NativeCloner rule -------------------------------------------------
+
+func cloner(s *suite) {
+	_ = lisp.Native(s)
+	_ = lisp.NativeOf[*suite](s)
+	_ = &lisp.LVal{Native: s}
+}
+
+func clonerValueOfPointerReceiver(s suite) *lisp.LVal {
+	// A suite VALUE does not satisfy lisp.NativeCloner (the method has a
+	// pointer receiver), so an assertion on the payload would fail at fork
+	// time; the rule must not accept it either.
+	return lisp.Native(s) // want `lisp\.Native payload type nativepayload\.suite is not a known-safe value type`
+}
+
+func clonerValueReceiver(v valueCloner) {
+	_ = lisp.Native(v)
+	_ = lisp.Native(&v)
+}
+
+func clonerWrongShape(w *wrongCloner) *lisp.LVal {
+	return lisp.Native(w) // want `lisp\.Native payload type \*nativepayload\.wrongCloner is not a known-safe value type`
+}
+
+// --- the audited allowlist ---------------------------------------------------
+
+func allowlisted(re *regexp.Regexp, t time.Time, d time.Duration, err error, s *lisp.CallStack) {
+	_ = lisp.Native(re)
+	_ = lisp.Native(t)
+	_ = lisp.Native(d) // a defined type over int64: the basic tier, not a row
+	_ = lisp.Native(err)
+	_ = lisp.Native(s)
+	_ = &lisp.LVal{Native: s}
+	_ = lisp.Value(re)
+}
+
+func allowlistedByValueNotPointer(re regexp.Regexp, t *time.Time) {
+	// The rows are keyed on the exact type, pointer-ness included.
+	_ = lisp.Native(re) // want `lisp\.Native payload type regexp\.Regexp is not a known-safe value type`
+	_ = lisp.Native(t)  // want `lisp\.Native payload type \*time\.Time is not a known-safe value type`
+}
+
+// --- interface-typed payloads ----------------------------------------------
+
+func dynamicEmptyInterface(v interface{}) *lisp.LVal {
+	return lisp.Native(v) // want `lisp\.Native payload type interface\{\} is not statically known`
+}
+
+func dynamicAny(v any) *lisp.LVal {
+	return lisp.Native(v) // want `lisp\.Native payload type any is not statically known`
+}
+
+func dynamicValue(v interface{}) *lisp.LVal {
+	return lisp.Value(v) // want `lisp\.Value payload type interface\{\} is not statically known`
+}
+
+func dynamicMethodSet(v interface{ Close() error }) *lisp.LVal {
+	return lisp.Native(v) // want `lisp\.Native payload type interface\{Close\(\) error\} is not statically known`
+}
+
+func dynamicTypeParam[T any](x T) *lisp.LVal {
+	return lisp.Native(x) // want `lisp\.Native payload type T is not statically known`
+}
+
+func dynamicFieldWrite(v *lisp.LVal, payload interface{}) {
+	v.Native = payload // want `LVal\.Native assignment payload type interface\{\} is not statically known`
+}
+
+func dynamicAllowed(v interface{}) *lisp.LVal {
+	return lisp.Native(v) //elpsvet:allow fixture: a pass-through constructor whose callers are checked at their own sites
+}
+
+// --- the allow marker --------------------------------------------------------
+
+func allowTrailing(h *handle) *lisp.LVal {
+	return lisp.Native(h) //elpsvet:allow fixture: the handle is immutable after construction
+}
+
+func allowStandalone(h *handle) *lisp.LVal {
+	//elpsvet:allow fixture: the handle is immutable after construction
+	return lisp.Native(h)
+}
+
+func allowStandaloneReachesOneLine(h *handle) {
+	//elpsvet:allow fixture: covers only the statement below
+	_ = lisp.Native(h)
+	_ = lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func allowTrailingReachesItsLineOnly(h *handle) {
+	_ = lisp.Native(h) //elpsvet:allow fixture: covers this line
+	_ = lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func allowEmptyStandalone(h *handle) *lisp.LVal {
+	//elpsvet:allow
+	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func allowEmptyWithTrailingSpace(h *handle) *lisp.LVal {
+	//elpsvet:allow
+	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func allowMarkerPrefixOnly(h *handle) *lisp.LVal {
+	//elpsvet:allowed by nobody -- a different marker sharing the prefix
+	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+// allowDoc has its whole body exempted by a justified marker in its doc
+// comment.
+//
+//elpsvet:allow fixture: every native this function mints is a fresh, unshared handle
+func allowDoc(h *handle) *lisp.LVal {
+	return lisp.Native(h)
+}
+
+// allowDocEmpty carries a bare marker in its doc, which is not an audit.
+//
+//elpsvet:allow
+func allowDocEmpty(h *handle) *lisp.LVal {
+	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+// --- package scope -----------------------------------------------------------
+
+var marker = lisp.Native(&handle{}) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+
+var markerAllowed = lisp.Native(&handle{}) //elpsvet:allow fixture: identity-only credential, never written
+
+var makeNative = func(h *handle) *lisp.LVal {
+	return lisp.Native(h) // want `lisp\.Native payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+var _ = marker
+var _ = markerAllowed
+var _ = makeNative

--- a/cmd/elpsvet/testdata/src/nativepayload/review.go
+++ b/cmd/elpsvet/testdata/src/nativepayload/review.go
@@ -1,0 +1,112 @@
+// The review-round cases: writes reaching the lisp.LVal.Native FIELD through
+// a type that is not spelled LVal (lisp.ErrorVal is `type ErrorVal LVal`, so
+// it shares the struct and the field object), through a promoted field of an
+// embedding struct, through the field's address, and a multi-line literal
+// whose payload sits on a later line than the opening brace.
+package nativepayload
+
+import "github.com/luthersystems/elps/lisp"
+
+// wrapped embeds an LVal by value; wrappedPtr by pointer.  Either way
+// `w.Native` selects the lisp.LVal.Native field.
+type wrapped struct{ lisp.LVal }
+
+type wrappedPtr struct{ *lisp.LVal }
+
+// --- lisp.ErrorVal: a defined type over LVal, same struct, same field -------
+
+func errorValLiteral(h *handle) *lisp.ErrorVal {
+	return &lisp.ErrorVal{Native: h} // want `LVal\.Native literal payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func errorValAssign(e *lisp.ErrorVal, h *handle) {
+	e.Native = h // want `LVal\.Native assignment payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func errorValConversionAssign(v *lisp.LVal, h *handle) {
+	// Writes into a real *LVal through a conversion.
+	(*lisp.ErrorVal)(v).Native = h // want `LVal\.Native assignment payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+// --- promoted field through embedding --------------------------------------
+
+func promotedWrite(w *wrapped, h *handle) {
+	w.Native = h // want `LVal\.Native assignment payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func promotedPointerWrite(w *wrappedPtr, h *handle) {
+	w.Native = h // want `LVal\.Native assignment payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+func explicitEmbeddedWrite(w *wrapped, h *handle) {
+	w.LVal.Native = h // want `LVal\.Native assignment payload type \*nativepayload\.handle is not a known-safe value type`
+}
+
+// --- the field's address ------------------------------------------------------
+
+func addressOfNative(v *lisp.LVal, h *handle) {
+	p := &v.Native // want `address of LVal\.Native taken`
+	*p = h
+}
+
+func addressOfNativeErrorVal(e *lisp.ErrorVal) *interface{} {
+	return &e.Native // want `address of LVal\.Native taken`
+}
+
+func addressOfNativePromoted(w *wrapped) *interface{} {
+	return &w.Native // want `address of LVal\.Native taken`
+}
+
+func addressOfNativeParenthesised(v *lisp.LVal) *interface{} {
+	return &(v.Native) // want `address of LVal\.Native taken`
+}
+
+func addressOfNativeAllowed(v *lisp.LVal) *interface{} {
+	return &v.Native //elpsvet:allow-native fixture: the pointer is consumed by a reader that never stores through it
+}
+
+func addressOfOtherField(v *lisp.LVal) *string {
+	return &v.Str
+}
+
+func addressOfNotAnLVal(o *notAnLVal) **handle {
+	return &o.Native
+}
+
+// --- multi-line literals ------------------------------------------------------
+
+func multiLineLiteral(h *handle) *lisp.LVal {
+	return &lisp.LVal{ // want `LVal\.Native literal payload type \*nativepayload\.handle is not a known-safe value type`
+		Type:   lisp.LError,
+		Native: h,
+	}
+}
+
+func multiLineLiteralAllowOpening(h *handle) *lisp.LVal {
+	return &lisp.LVal{ //elpsvet:allow-native fixture: a marker on the opening line covers the payload below
+		Type:   lisp.LError,
+		Native: h,
+	}
+}
+
+func multiLineLiteralAllowField(h *handle) *lisp.LVal {
+	return &lisp.LVal{
+		Type:   lisp.LError,
+		Native: h, //elpsvet:allow-native fixture: a marker on the field line covers it as well
+	}
+}
+
+func multiLineLiteralAllowAbove(h *handle) *lisp.LVal {
+	//elpsvet:allow-native fixture: standalone above the opening line
+	return &lisp.LVal{
+		Type:   lisp.LError,
+		Native: h,
+	}
+}
+
+func multiLineLiteralAllowOnOtherField(h *handle) *lisp.LVal {
+	return &lisp.LVal{ // want `LVal\.Native literal payload type \*nativepayload\.handle is not a known-safe value type`
+		Type:   lisp.LError, //elpsvet:allow-native fixture: this line is neither the opening nor the payload line
+		Native: h,
+	}
+}

--- a/docs/fork.md
+++ b/docs/fork.md
@@ -211,6 +211,17 @@ A shared stateful native is the one way to leak state between template and
 forks that no isolation test in this repository can see from the outside —
 audit your template's native census when adopting Fork.
 
+Inside this repository that census is mechanical: the `elpsnativepayload`
+rule in `cmd/elpsvet` (run by `make elpsvet` in CI) reports every native
+construction — `lisp.Native`, `lisp.NativeOf`, a `lisp.Value` falling through
+to a native, an `LVal{Native: x}` literal, a `.Native` write — whose payload
+type is not of basic underlying type, does not declare `NativeCloner`, is not
+on the audited allowlist in `cmd/elpsvet/nativepayload.go`, and is not
+covered by a justified `//elpsvet:allow`. It audits elps's own sources only;
+an embedder's payloads are the embedder's census to take (substrate runs the
+same rule over its tree). See CLAUDE.md, "Go static analysis over elps's own
+sources".
+
 A payload type can also *declare* which runtime it belongs to, by
 implementing `RuntimeBound` (`BoundRuntime() *lisp.Runtime`, returning nil
 while unbound). Declaring costs a production build nothing — nothing there

--- a/docs/fork.md
+++ b/docs/fork.md
@@ -214,10 +214,13 @@ audit your template's native census when adopting Fork.
 Inside this repository that census is mechanical: the `elpsnativepayload`
 rule in `cmd/elpsvet` (run by `make elpsvet` in CI) reports every native
 construction — `lisp.Native`, `lisp.NativeOf`, a `lisp.Value` falling through
-to a native, an `LVal{Native: x}` literal, a `.Native` write — whose payload
-type is not of basic underlying type, does not declare `NativeCloner`, is not
-on the audited allowlist in `cmd/elpsvet/nativepayload.go`, and is not
-covered by a justified `//elpsvet:allow`. It audits elps's own sources only;
+to a native, a keyed literal or a write setting the `LVal.Native` field by
+any path (`ErrorVal`, a conversion, a promoted field), the field's address —
+whose payload type is not of basic underlying type, does not declare
+`NativeCloner`, is not on the audited allowlist in
+`cmd/elpsvet/nativepayload.go`, and is not covered by a
+`//elpsvet:allow-native` carrying a justification of at least three words.
+It audits elps's own sources only;
 an embedder's payloads are the embedder's census to take (substrate runs the
 same rule over its tree). See CLAUDE.md, "Go static analysis over elps's own
 sources".

--- a/docs/sealed-ast.md
+++ b/docs/sealed-ast.md
@@ -577,7 +577,10 @@ Four `go/analysis` rules, run as `go run ./cmd/elpsvet -test=false ./...`:
 
 - **elpsownership** (`main.go`): no package-level var may keep a
   `*lisp.LVal` reachable — the process-wide-shared-table producer pattern
-  behind #363. Suppression: `//elpsvet:allow` with a justification.
+  behind #363. Suppression: `//elpsvet:allow`. What is enforced: the bare
+  marker suppresses — a justification is asked for by convention and is
+  not checked (`allowed()` is a prefix match stopping at the marker's word
+  boundary, so `//elpsvet:allow-native` does not satisfy it).
 - **elpsfreshness** (`freshness.go` + `alias.go`): no function may write a
   `lisp.LVal` field on a value it did not construct (#333/#334's pattern),
   including writes laundered through local slice aliases of LVal backing —
@@ -615,13 +618,17 @@ Four `go/analysis` rules, run as `go run ./cmd/elpsvet -test=false ./...`:
   by reference, and the isolation oracle only recognises a payload as
   stateful when its type declares `NativeCloner`, so a mutable payload type
   without one is a leak the dynamic checks cannot see. Every construction
-  spelling (`Native`, `NativeOf`, `Value`'s fallthrough, an `LVal{Native:}`
-  literal, a `.Native` write) is reported unless the payload has a basic
-  underlying type, declares `NativeCloner`, is on the audited allowlist, or
-  a justified `//elpsvet:allow` covers it; interface-typed payloads are
-  reported too, so the constructors themselves carry the contract. Ported
-  from the substrate repository's nativepayload analyzer. Suppression:
-  `//elpsvet:allow` with a justification — a bare marker does not suppress.
+  spelling (`Native`, `NativeOf`, `Value`'s fallthrough, a keyed literal or
+  a write setting the `LVal.Native` field — matched by field object, so
+  `ErrorVal`, conversions and promoted fields count — and the field's
+  address) is reported unless the payload has a basic underlying type,
+  declares `NativeCloner`, is on the audited allowlist, or a justified
+  `//elpsvet:allow-native` covers it; interface-typed payloads are reported
+  too, so the constructors themselves carry the contract. Ported from the
+  substrate repository's nativepayload analyzer. Suppression:
+  `//elpsvet:allow-native` with a justification of at least three words —
+  what is enforced: a bare or shorter marker does not suppress, and one
+  justification covers every construction on its line.
 
 *Blind spots (documented in the analyzers' own headers):* intraprocedural
 within a function body — the escape rule's location-freshness fact is the

--- a/docs/sealed-ast.md
+++ b/docs/sealed-ast.md
@@ -573,7 +573,7 @@ tool and silently missed by another.
 
 ### 3.1 elpsvet (static; `cmd/elpsvet`)
 
-Three `go/analysis` rules, run as `go run ./cmd/elpsvet -test=false ./...`:
+Four `go/analysis` rules, run as `go run ./cmd/elpsvet -test=false ./...`:
 
 - **elpsownership** (`main.go`): no package-level var may keep a
   `*lisp.LVal` reachable — the process-wide-shared-table producer pattern
@@ -610,6 +610,18 @@ Three `go/analysis` rules, run as `go run ./cmd/elpsvet -test=false ./...`:
   keeps the conservative treatment, so the fact can only ever retire a
   proven false positive. Suppression: `//elps:aliases` with a
   justification.
+- **elpsnativepayload** (`nativepayload.go`): no native payload type may be
+  minted without being classified as fork-safe. `Fork` shares `LVal.Native`
+  by reference, and the isolation oracle only recognises a payload as
+  stateful when its type declares `NativeCloner`, so a mutable payload type
+  without one is a leak the dynamic checks cannot see. Every construction
+  spelling (`Native`, `NativeOf`, `Value`'s fallthrough, an `LVal{Native:}`
+  literal, a `.Native` write) is reported unless the payload has a basic
+  underlying type, declares `NativeCloner`, is on the audited allowlist, or
+  a justified `//elpsvet:allow` covers it; interface-typed payloads are
+  reported too, so the constructors themselves carry the contract. Ported
+  from the substrate repository's nativepayload analyzer. Suppression:
+  `//elpsvet:allow` with a justification — a bare marker does not suppress.
 
 *Blind spots (documented in the analyzers' own headers):* intraprocedural
 within a function body — the escape rule's location-freshness fact is the

--- a/internal/fuzzval/fuzzval.go
+++ b/internal/fuzzval/fuzzval.go
@@ -590,6 +590,9 @@ var fuzzPatterns = []string{
 // seed corpus and the switch cannot drift apart silently.
 const nativeNumKinds = 10
 
+// native builds one of the nativeNumKinds payload shapes described above.
+//
+//elpsvet:allow fuzz corpus generator, not a payload contract: every native here is minted fresh per iteration to exercise the builtins' type switches, and the deliberately mutable shapes (a map, a byte slice, a json.RawMessage) are the point -- a builtin writing through one is caught by the harness rather than hidden; nothing here reaches a production template
 func (g *Gen) native() *lisp.LVal {
 	switch g.Intn(nativeNumKinds) {
 	case 0:

--- a/internal/fuzzval/fuzzval.go
+++ b/internal/fuzzval/fuzzval.go
@@ -592,7 +592,7 @@ const nativeNumKinds = 10
 
 // native builds one of the nativeNumKinds payload shapes described above.
 //
-//elpsvet:allow fuzz corpus generator, not a payload contract: every native here is minted fresh per iteration to exercise the builtins' type switches, and the deliberately mutable shapes (a map, a byte slice, a json.RawMessage) are the point -- a builtin writing through one is caught by the harness rather than hidden; nothing here reaches a production template
+//elpsvet:allow-native fuzz corpus generator, not a payload contract: every native here is minted fresh per iteration to exercise the builtins' type switches, and the deliberately mutable shapes (a map, a byte slice, a json.RawMessage) are the point -- a builtin writing through one is caught by the harness rather than hidden; nothing here reaches a production template
 func (g *Gen) native() *lisp.LVal {
 	switch g.Intn(nativeNumKinds) {
 	case 0:

--- a/lisp/detach.go
+++ b/lisp/detach.go
@@ -187,7 +187,7 @@ func (d *detacher) detach(v *LVal) (*LVal, error) {
 	// the *MapData behind LSortMap, the *CallStack behind LError — whose
 	// guards key off the elps type carrying them.
 	if cloner != nil {
-		cp.Native = d.cloneNative(v.Native, cloner) //elpsvet:allow a NativeCloner clone -- the protocol this rule accepts at construction sites -- stored by the walker that invoked it
+		cp.Native = d.cloneNative(v.Native, cloner) //elpsvet:allow-native a NativeCloner clone -- the protocol this rule accepts at construction sites -- stored by the walker that invoked it
 	} else {
 		switch native := v.Native.(type) {
 		case nil:

--- a/lisp/detach.go
+++ b/lisp/detach.go
@@ -187,7 +187,7 @@ func (d *detacher) detach(v *LVal) (*LVal, error) {
 	// the *MapData behind LSortMap, the *CallStack behind LError — whose
 	// guards key off the elps type carrying them.
 	if cloner != nil {
-		cp.Native = d.cloneNative(v.Native, cloner)
+		cp.Native = d.cloneNative(v.Native, cloner) //elpsvet:allow a NativeCloner clone -- the protocol this rule accepts at construction sites -- stored by the walker that invoked it
 	} else {
 		switch native := v.Native.(type) {
 		case nil:

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -856,7 +856,7 @@ func (env *LEnv) builtin(f LBuiltinDef) *LVal {
 func (env *LEnv) Terminal(expr *LVal) *LVal {
 	return &LVal{
 		Type:   LMarkTerminal,
-		Native: env,
+		Native: env, //elpsvet:allow evaluator-internal trampoline marker: an LMarkTerminal is consumed by the eval loop that produced it and never bound into a scope, so it cannot reach a template, and detach refuses it
 		Cells:  []*LVal{expr},
 	}
 }
@@ -1127,7 +1127,7 @@ func (env *LEnv) ErrorCondition(condition string, v ...interface{}) *LVal {
 		case string:
 			cells = append(cells, String(v))
 		default:
-			cells = append(cells, Native(v))
+			cells = append(cells, Native(v)) //elpsvet:allow error-data cell holding a caller's arbitrary condition argument: read-only by the same contract as the `error` allowlist row (the kernel only formats condition data), and the value stays the caller's to keep fork-safe
 		}
 	}
 	lerr := &LVal{

--- a/lisp/env.go
+++ b/lisp/env.go
@@ -856,7 +856,7 @@ func (env *LEnv) builtin(f LBuiltinDef) *LVal {
 func (env *LEnv) Terminal(expr *LVal) *LVal {
 	return &LVal{
 		Type:   LMarkTerminal,
-		Native: env, //elpsvet:allow evaluator-internal trampoline marker: an LMarkTerminal is consumed by the eval loop that produced it and never bound into a scope, so it cannot reach a template, and detach refuses it
+		Native: env, //elpsvet:allow-native evaluator-internal trampoline marker: an LMarkTerminal is consumed by the eval loop that produced it and never bound into a scope, so it cannot reach a template, and detach refuses it
 		Cells:  []*LVal{expr},
 	}
 }
@@ -1127,7 +1127,7 @@ func (env *LEnv) ErrorCondition(condition string, v ...interface{}) *LVal {
 		case string:
 			cells = append(cells, String(v))
 		default:
-			cells = append(cells, Native(v)) //elpsvet:allow error-data cell holding a caller's arbitrary condition argument: read-only by the same contract as the `error` allowlist row (the kernel only formats condition data), and the value stays the caller's to keep fork-safe
+			cells = append(cells, Native(v)) //elpsvet:allow-native error-data cell holding a caller's arbitrary condition argument: read-only by the same contract as the `error` allowlist row (the kernel only formats condition data), and the value stays the caller's to keep fork-safe
 		}
 	}
 	lerr := &LVal{

--- a/lisp/fork.go
+++ b/lisp/fork.go
@@ -489,7 +489,7 @@ func (f *forker) val(v *LVal) *LVal {
 			}
 		}
 	case LNative:
-		cp.Native = f.native(v.Native)
+		cp.Native = f.native(v.Native) //elpsvet:allow the fork walker applying the native policy (replacer, then NativeCloner, then share by reference) to a payload minted, and checked, at its own construction site
 	default:
 		switch native := v.Native.(type) {
 		case nil:
@@ -507,7 +507,7 @@ func (f *forker) val(v *LVal) *LVal {
 			// A payload the kernel has no copy strategy for, riding on a
 			// non-LNative type.  Apply the native policy: the embedder put
 			// it there, the embedder's protocol decides.
-			cp.Native = f.native(v.Native)
+			cp.Native = f.native(v.Native) //elpsvet:allow the fork walker applying the native policy to a payload minted, and checked, at its own construction site
 		}
 	}
 	if len(v.Cells) > 0 {

--- a/lisp/fork.go
+++ b/lisp/fork.go
@@ -489,7 +489,7 @@ func (f *forker) val(v *LVal) *LVal {
 			}
 		}
 	case LNative:
-		cp.Native = f.native(v.Native) //elpsvet:allow the fork walker applying the native policy (replacer, then NativeCloner, then share by reference) to a payload minted, and checked, at its own construction site
+		cp.Native = f.native(v.Native) //elpsvet:allow-native the fork walker applying the native policy (replacer, then NativeCloner, then share by reference) to a payload minted, and checked, at its own construction site
 	default:
 		switch native := v.Native.(type) {
 		case nil:
@@ -507,7 +507,7 @@ func (f *forker) val(v *LVal) *LVal {
 			// A payload the kernel has no copy strategy for, riding on a
 			// non-LNative type.  Apply the native policy: the embedder put
 			// it there, the embedder's protocol decides.
-			cp.Native = f.native(v.Native) //elpsvet:allow the fork walker applying the native policy to a payload minted, and checked, at its own construction site
+			cp.Native = f.native(v.Native) //elpsvet:allow-native the fork walker applying the native policy to a payload minted, and checked, at its own construction site
 		}
 	}
 	if len(v.Cells) > 0 {

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -530,7 +530,7 @@ func Value(v interface{}) *LVal {
 	case []*LVal:
 		return QExpr(v)
 	default:
-		return Native(v)
+		return Native(v) //elpsvet:allow Value's fallthrough: the payload type is the caller's, and every Value call is checked at its own call site
 	}
 }
 
@@ -627,7 +627,7 @@ func Nil() *LVal {
 func Native(v interface{}) *LVal {
 	return &LVal{
 		Type:   LNative,
-		Native: v,
+		Native: v, //elpsvet:allow the constructor itself: the payload type is the caller's, and every Native call is checked at its own call site
 	}
 }
 

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -530,7 +530,7 @@ func Value(v interface{}) *LVal {
 	case []*LVal:
 		return QExpr(v)
 	default:
-		return Native(v) //elpsvet:allow Value's fallthrough: the payload type is the caller's, and every Value call is checked at its own call site
+		return Native(v) //elpsvet:allow-native Value's fallthrough: the payload type is the caller's, and every Value call is checked at its own call site
 	}
 }
 
@@ -627,7 +627,7 @@ func Nil() *LVal {
 func Native(v interface{}) *LVal {
 	return &LVal{
 		Type:   LNative,
-		Native: v, //elpsvet:allow the constructor itself: the payload type is the caller's, and every Native call is checked at its own call site
+		Native: v, //elpsvet:allow-native the constructor itself: the payload type is the caller's, and every Native call is checked at its own call site
 	}
 }
 

--- a/lisp/lisplib/libgolang/libgolang.go
+++ b/lisp/lisplib/libgolang/libgolang.go
@@ -183,7 +183,7 @@ func BuiltinStructField(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	if !x.CanInterface() {
 		return env.Errorf("cannot return struct field: %v", field.Str)
 	}
-	return lisp.Native(x.Interface())
+	return lisp.Native(x.Interface()) //elpsvet:allow a reflected projection of an existing native payload (s.Native): a field value aliases at most the storage its parent payload already shares, so the sharing decision was made where that payload was constructed and this site opens no new channel
 }
 
 func nameIsExported(name string) bool {

--- a/lisp/lisplib/libgolang/libgolang.go
+++ b/lisp/lisplib/libgolang/libgolang.go
@@ -183,7 +183,7 @@ func BuiltinStructField(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
 	if !x.CanInterface() {
 		return env.Errorf("cannot return struct field: %v", field.Str)
 	}
-	return lisp.Native(x.Interface()) //elpsvet:allow a reflected projection of an existing native payload (s.Native): a field value aliases at most the storage its parent payload already shares, so the sharing decision was made where that payload was constructed and this site opens no new channel
+	return lisp.Native(x.Interface()) //elpsvet:allow-native a reflected projection of an existing native payload (s.Native): a field value aliases at most the storage its parent payload already shares, so the sharing decision was made where that payload was constructed and this site opens no new channel
 }
 
 func nameIsExported(name string) bool {

--- a/lisp/native.go
+++ b/lisp/native.go
@@ -142,5 +142,5 @@ func RequireNative[T any](v *LVal) (T, *LVal) {
 // implement NativeCloner; NativeOf stores the value as-is and takes no
 // position on that.
 func NativeOf[T any](x T) *LVal {
-	return Native(x)
+	return Native(x) //elpsvet:allow the typed constructor: T is the caller's, and every NativeOf call is checked at its own call site
 }

--- a/lisp/native.go
+++ b/lisp/native.go
@@ -142,5 +142,5 @@ func RequireNative[T any](v *LVal) (T, *LVal) {
 // implement NativeCloner; NativeOf stores the value as-is and takes no
 // position on that.
 func NativeOf[T any](x T) *LVal {
-	return Native(x) //elpsvet:allow the typed constructor: T is the caller's, and every NativeOf call is checked at its own call site
+	return Native(x) //elpsvet:allow-native the typed constructor: T is the caller's, and every NativeOf call is checked at its own call site
 }


### PR DESCRIPTION
## The class of bug

`Fork` copies the LVal spine and shares `LVal.Native` **by reference**. A template is forked once per request, so a mutable native payload that reaches a template is state shared by every fork in the process. The fork/isolation oracle in `elpstest` can only recognise a payload as stateful when its Go type declares `lisp.NativeCloner`; a mutable payload type that does not declare it is a leak channel no isolation test can see from the outside. The failure is a wrong answer with no error, only under forking.

This PR adds `elpsnativepayload`, the fourth `cmd/elpsvet` rule, ported from the substrate repository's nativepayload analyzer and adapted to the module that defines the constructors. It runs in CI through the existing `make elpsvet` target (both passes; the package list is `./...`, so there is no hand-scoped list to drift and no scope-drift grep to maintain).

## The rules

Every construction spelling is checked: `lisp.Native(x)`, `lisp.NativeOf[T](x)` (inferred or explicitly instantiated — the callee is unwrapped from the `*ast.IndexExpr`), a `lisp.Value(x)` the compiler can see falling through to Native (a defined type over `[]byte` does fall through), a keyed literal setting the `lisp.LVal.Native` field, a write to that field by any path (matched on the field object: `ErrorVal`, conversions, promoted fields), and taking the field's address.

A construction is reported unless one of:

1. the payload's static type has a **basic underlying type** (`unsafe.Pointer` excluded) — a soundness decision, not an allowlist one;
2. the type **declares `lisp.NativeCloner`** (checked structurally on the type's own method set, as an interface assertion would — a value of a pointer-receiver cloner is still reported);
3. the type is on the **audited allowlist** in `cmd/elpsvet/nativepayload.go`, each row keyed on the exact type (pointer-ness included) with its reason;
4. a **`//elpsvet:allow-native <justification>`** (at least three words) covers the site: trailing, standalone on the line above, or for a multi-line literal on the opening or the `Native:` line; or the enclosing function's doc. A bare or shorter marker does not suppress; one justification covers every construction on its line.

Unlike the substrate port, an **interface-typed payload (or type parameter) is reported**, not hidden behind a flag: this module is where `interface{}` enters the system, so the sites that pass it through carry an allow naming their contract rather than being silently unknowable.

## Classification of the real sites

| Site | Payload type | Verdict | Reason |
|---|---|---|---|
| `lisp/env.go`, `lisp/lisp.go`, `lisp/fork.go` (LFun) | `*funData` | allowlist | fork re-mints it per fork with the env remapped; detach refuses (Detach) or shares the LFun value whole (`copy`, same walker with `shareOpaque`) — inside one runtime, not a fork leak |
| `lisp.Bytes`, fork/detach `*[]byte` arms | `*[]byte` | allowlist | both walkers allocate a fresh slice and copy |
| `SortedMapFromData`, `copy`, fork/detach map arms | `*MapData` | allowlist | `f.mapData` / `detachMapData` / `copyMapData` rebuild the structure |
| `ErrorCondition[f]`, `SetCallStack`, fork/detach stack arms | `*CallStack` | allowlist | a `Stack.Copy()` snapshot at capture, never pushed again; both walkers deep-copy via `detachCallStack` |
| `lisp/env.go` `ErrorCondition` (`case error`), `lisp.ErrorCondition` | `error` | allowlist | read-only by contract: the kernel only formats it / hands it back; the row is a contract, not a proof |
| `libregexp` | `*regexp.Regexp` | allowlist | documented concurrency-safe after Compile; `Longest` (the one mutator) is never called |
| `libtime.Time` | `time.Time` | allowlist | value type, no mutating API |
| `libtime.Duration` | `time.Duration` | basic tier | defined type over `int64`, no row needed |
| `libschema.validatorMarkerCell` | `*validatorTag` | allowlist | pointer to a zero-size struct; the credential is the type, nothing to write through |
| `libjson.DumpMessageBuiltin` | `*ownMessage` | allowlist | `msg`/`loadable` are written on the one mint line and only ever read afterwards; `MessageBytesBuiltin` converts (not copies) `msg` into an LBytes, so the two alias within one runtime — forks copy bytes, so the fork claim holds |
| `libtesting` suite global | `*TestSuite` | NativeCloner | declares `CloneNative` on `main` (libtesting.go:113) |
| `lisp.Native` / `lisp.NativeOf` / `lisp.Value` fallthrough | `interface{}` / `T` | allow | the constructors themselves; every caller is checked at its own site |
| `fork.go` LNative + default arms, `detach.go` clone store | `interface{}` | allow | the walkers applying the policy (replacer → NativeCloner → share) to a payload already checked where it was minted |
| `env.go` `ErrorCondition` default arm | `interface{}` | allow | error-data cell, same read-only contract as the `error` row; the value stays the caller's |
| `env.Terminal` | `*LEnv` | allow | `LMarkTerminal` trampoline marker consumed by the eval loop that produced it, never bound; detach refuses it |
| `libgolang` struct-field accessor | `interface{}` (reflected) | allow | projection of an existing native payload; aliases at most what its parent already shares |
| `internal/fuzzval.native` | assorted | allow (func doc) | fuzz corpus generator, minted fresh per iteration; the mutable shapes are the point |

Nothing genuinely mutable and unprotected was found on `main`. The one thing worth flagging: an earlier checkout (28747b4, before `TestSuite.CloneNative` landed) would have been reported at the libtesting site — which is exactly the gap this rule exists to make visible.

## How a new payload type fails

`lisp.Native(&myHandle{})` anywhere in the module fails `make elpsvet` with a message naming the type and the three ways out (implement `NativeCloner`, add an allowlist row with a reason, or annotate with a justified allow). Adding an allowlist row also requires adding it to the audited inventory in `nativepayload_test.go`, so the reason is reviewed.

## Test plan

- `cmd/elpsvet/nativepayload_test.go` + `testdata/src/nativepayload`: every spelling, the basic tier, both `NativeCloner` receiver kinds (and a wrong-shaped `CloneNative`), allowlist keyed on exact type, interface-typed reports, and the allow marker in every placement with and without a justification.
- `go run ./cmd/elpsvet -test=false ./...` is clean on this branch; CI runs it via `make elpsvet`.

## Review round 1 (fixed in `fb65f1b` analyzer, `3afb543` docs)

| # | Finding | Fix |
|---|---|---|
| 1 | `isLValType` keyed on the receiver being named `LVal`, so writes through `lisp.ErrorVal` (`type ErrorVal LVal`) — `&lisp.ErrorVal{Native: h}`, `e.Native = h`, `(*lisp.ErrorVal)(v).Native = h` — were invisible | Match the **field object**: `TypesInfo.Selections[sel].Obj()` for writes, `TypesInfo.Uses[key]` for literal keys, accepted when it is the field named `Native` declared in package lisp (`isNativeField`). Fixture: `review.go` `errorValLiteral`, `errorValAssign`, `errorValConversionAssign` |
| 2 | Promoted-field write through embedding (`w.Native = h`) invisible | Closed by 1 (Selections resolves the promoted path to the same object). Fixture: `promotedWrite`, `promotedPointerWrite`, `explicitEmbeddedWrite` |
| 3 | Shared `//elpsvet:allow` marker: `elpsownership` accepts a bare marker, so one unrelated sentence on a package-level native silenced both rules | Own marker `//elpsvet:allow-native`; every annotation, doc and fixture updated. `elpsownership`'s `allowed()` now stops at the marker's word boundary so `allow-native` does not satisfy it either (`TestOwnershipAllowStopsAtWordBoundary`). `docs/sealed-ast.md` now states what each rule actually enforces: ownership — bare marker suppresses, justification is convention; native — three-word justification enforced, one per line covers the line |
| 4 | `p := &v.Native; *p = h` unreported and undocumented | Any `&<LVal>.Native` (UnaryExpr `&` over the Native field selector, parenthesised or promoted) is reported unconditionally — there is no payload type at that site. Multi-value assign stays a documented blind spot; reflection and positional literals added to the "what it does not see" list. Fixture: `addressOfNative*` (4 reported, 1 allowed, 2 negative) |
| 5 | Literal reported at `kv.Value.Pos()`, so a marker on the `&lisp.LVal{` line did not cover a `Native:` two lines down | Report at `lit.Pos()`; a marker on the opening line, the `Native:` line (key or value), or standalone above the opening line all suppress; a marker on some other field's line does not. Fixture: `multiLineLiteral*` (5 cases) |
| 6 | A one-character justification (`//elpsvet:allow .`) suppressed | Justification must be **at least three words** (`nativeAllowMinWords`), documented in the analyzer header, CLAUDE.md and sealed-ast.md; `TestJustifiedNativeAllow` pins `.`, one and two words as non-suppressing, three as suppressing. One justification covering every construction on its line is stated as deliberate |
| 7 | `*funData` row said detach "refuses LFun"; `copy` runs the same walker with `shareOpaque` and shares the value whole | Row reworded: fork re-mints (fork.go LFun arm); detach refuses (Detach) or shares the LFun value whole (copy) — inside one runtime, not a fork leak |
| 8 | `.github/workflows/elps.yml` comment said "three rules" | Now four, with the fourth named |
| 9 | (note) `MessageBytesBuiltin` converts `m.msg` rather than copying | Recorded in the `*ownMessage` row's reason so the next reader does not re-derive it |

**Evidence for 1/2/4/5:** the new `review.go` fixture was run against the unchanged `b38ea1f` analyzer before the fix. Result: `no diagnostic was reported` at review.go:19, 23, 28 (ErrorVal literal/assign/conversion), 34, 38 (promoted writes), 48, 53, 57, 61 (address-of), and 79, 108 (multi-line literal wanted on the opening line), plus `unexpected diagnostic` at :81, :88, :95, :103, :110 (the old analyzer reporting the multi-line literals on the `Native:` line — including the ones whose marker sits on the opening line). On `fb65f1b` the whole package test passes.

Local verification on `3afb543`: `gofmt -l` on touched files, `go build ./...`, `go vet ./cmd/elpsvet/...`, `go test -run . ./cmd/elpsvet`, `golangci-lint run ./cmd/elpsvet/...` (0 issues), one `go run ./cmd/elpsvet -test=false ./...` (exit 0, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RgUjSmaNsv8hyZdDwqGNX