### PR TITLE
Digest sealed nodes by content in the fuzz env-state oracle (#613)

### DIFF
--- a/lisp/loadcache_reader_fuzz_test.go
+++ b/lisp/loadcache_reader_fuzz_test.go
@@ -57,6 +57,23 @@ import (
 // Also asserted, in every mode: termination under the scheduled-time
 // watchdog, and no recovered Go panic (lisp.IsInternalPanic) — both from the
 // shared budgeted harness.
+//
+// "Indistinguishable" means BY WHAT A PROGRAM CAN OBSERVE: every load's
+// value, and every binding's content, sealed-ness, mutable-storage aliasing
+// and sealed-node PROVENANCE (the frozen parse location every error and
+// stack note through that node prints -- see envStateFingerprintProv, which
+// this target uses and its siblings do not).  It does not mean the same
+// storage: a cache hit serves the
+// sealed nodes the miss served (that is the contract, pinned by
+// TestLoadCacheServesTheSameNodes), so a file loaded twice through the cache
+// rebinds its literals to nodes an earlier load already captured, where two
+// fresh parses give two equal nodes.  The environment digest used to record
+// that identity and reported the contract as a divergence (issue #613, seed
+// bfe6dc31a652ced0: A binds a literal, B captures it, A is loaded again);
+// valueFingerprint now digests sealed nodes by content alone (memoised by
+// pointer, so a sealed DAG or cycle stays cheap), and
+// TestLoadCacheRebindAcrossLoadsMatchesFreshParse pins the shape
+// deterministically in every mode.
 
 // loadCacheHostileReader wraps the real parser and then does one plausible,
 // contract-legal thing to what it returns.
@@ -361,7 +378,29 @@ func runHostilePair(t *testing.T, mode uint8, a, b []byte, cache *fuzzLoadCache)
 		if !ok {
 			return programRun{}, false
 		}
-		fp := valueFingerprint([]*lisp.LVal{result})
+		// PROVENANCE variant, scoped to this function.  A cached load must
+		// serve the parse of the file that was ASKED FOR, and a sealed
+		// node's frozen source location is the lisp-observable witness of
+		// which file that was: it is printed by every error and stack note
+		// raised through the node.  A content-only digest cannot see a cache
+		// that serves one file's parse for another's -- mutate loadCacheKey
+		// to drop name and loc, load two byte-identical files, and the
+		// second file's errors name the first file's path while the
+		// content-only digest reports nothing.
+		//
+		// The per-load RESULT is where that shows up, not the env state: for
+		// two byte-identical files the A,B,A sequence rebinds the same
+		// symbols from the same content, so the final environment converges
+		// whichever parse was served.  Load B's own value does not.
+		// (TestLoadCacheRebindAcrossLoadsMatchesFreshParse's identical-bytes
+		// case is the deterministic form; under that mutation it fails on
+		// `eval 2` in every transparent mode.)
+		//
+		// Scoped because FuzzSharedProgramMultiEnv deliberately evaluates one
+		// parse under several stream names; see valueFingerprintProv
+		// (valuefp_test.go) for the three tests a global provenance rule
+		// turns red.
+		fp := valueFingerprintProv([]*lisp.LVal{result})
 		if isAdmissionRefusal(result) {
 			// Tagged rather than merely digested so hostileRefusalOnly can
 			// tell "the cache refused this load" from "the cache answered
@@ -371,7 +410,10 @@ func runHostilePair(t *testing.T, mode uint8, a, b []byte, cache *fuzzLoadCache)
 		}
 		run.results = append(run.results, fp)
 	}
-	run.state = envStateFingerprint(env)
+	// Provenance here too, for the same reason as the per-load digests above
+	// -- a binding that survives to the end of the sequence must hold the
+	// parse of the file it came from.
+	run.state = envStateFingerprintProv(env)
 	return run, true
 }
 

--- a/lisp/loadcache_rebind_test.go
+++ b/lisp/loadcache_rebind_test.go
@@ -1,0 +1,337 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #613: a literal bound by one load, captured by a second, and rebound
+// by a third load of the first file.
+//
+// Under a LoadCache the third load serves the SAME sealed nodes the first
+// did (the alias contract, TestLoadCacheServesTheSameNodes), so `lit` and
+// `A`'s element end up one node; two fresh parses give two equal nodes.
+// Nothing a program can do tells the two apart -- a sealed node cannot be
+// written through and `equal?` is structural -- so the differential oracle
+// must not tell them apart either.  It used to: valueFingerprint recorded
+// aliasing for every node, sealed or not, and FuzzLoadCacheHostileReader
+// reported seed bfe6dc31a652ced0 as a cache divergence in which `lit`
+// digested as a back-reference to A's element under the cache and as a full
+// walk without one.  (The per-binding digest streams were diffed and that was
+// the differing line; "the only differing BYTE" overstated it, since the
+// digest is a hash and the claim was never pinned at byte level.)
+//
+// The seed's own shape is kept verbatim as the first case, zero-width
+// `slice 'list` and all, even though the minimal shape below shows the slice
+// is incidental (the fuzzer's minimiser stopped at a parse boundary, not at
+// the mechanism).
+
+const (
+	loadCacheRebindSeedA = "(set'lit'(0))(and'1(slice'list lit 0 0))"
+	loadCacheRebindSeedB = "(set'A(list lit))"
+	loadCacheRebindMinA  = "(set 'lit '(0))"
+	loadCacheRebindMinB  = "(set 'A (list lit))"
+)
+
+// TestLoadCacheRebindAcrossLoadsMatchesFreshParse is the deterministic form
+// of the crasher, in every transparent Reader mode: A, B, A through a cache
+// must fingerprint identically to A, B, A without one.
+func TestLoadCacheRebindAcrossLoadsMatchesFreshParse(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, a, b string }{
+		{"seed", loadCacheRebindSeedA, loadCacheRebindSeedB},
+		{"minimal", loadCacheRebindMinA, loadCacheRebindMinB},
+		// Two DIFFERENT streams with IDENTICAL bytes.  Nothing about #613
+		// needs it; it is here because runHostilePair digests sealed
+		// PROVENANCE and this is the shape that exercises it.  Drop name and
+		// loc from loadCacheKey and the second stream is served the first's
+		// parse, so every error it raises names the first stream's file --
+		// with this case that mutation fails on `eval 2` in all seven
+		// transparent modes, and without it nothing in this test notices
+		// (the A,B,A sequence rebinds the same symbols from the same bytes,
+		// so the final environment converges either way).
+		{"identical-bytes", loadCacheRebindMinA, loadCacheRebindMinA},
+	} {
+		for _, mode := range transparentReaderModes {
+			t.Run(fmt.Sprintf("%s/mode=%d", tc.name, mode), func(t *testing.T) {
+				t.Parallel()
+				baseline, ok := runHostilePair(t, mode, []byte(tc.a), []byte(tc.b), nil)
+				require.True(t, ok)
+				cached, ok := runHostilePair(t, mode, []byte(tc.a), []byte(tc.b), newFuzzLoadCache())
+				require.True(t, ok)
+				assert.Truef(t, cached.equal(baseline),
+					"A,B,A through a cache diverged from A,B,A without one\n--- baseline ---\n%s\n--- cached ---\n%s",
+					baseline, cached)
+			})
+		}
+	}
+}
+
+// TestValueFingerprintSealedIdentityIsNotState pins the oracle rule directly,
+// without a cache in the picture: one sealed node reached from two bindings
+// digests the same as two equal sealed nodes, and one MUTABLE node reached
+// from two bindings does not.  The second half is the positive control -- it
+// is what stops the fix from blinding the digest to a real cross-binding
+// leak of writable storage, which is the class envStateFingerprint exists
+// to catch.
+func TestValueFingerprintSealedIdentityIsNotState(t *testing.T) {
+	t.Parallel()
+	env, _, rc := newFuzzEnv()
+	require.Nil(t, rc)
+	env.Runtime.Reader = parser.NewReader()
+
+	// Two parses of the same literal: two sealed, equal, distinct nodes --
+	// exactly what two uncached loads of `(set 'lit '(0))` bind.
+	one := env.LoadString("one", "'(0)")
+	two := env.LoadString("two", "'(0)")
+	require.NotEqual(t, lisp.LError, one.Type, one)
+	require.True(t, one.IsSealed(), "a quoted literal evaluates to the sealed parse node")
+	require.True(t, two.IsSealed())
+	require.NotSame(t, one, two, "two parses must mint two nodes for this test to mean anything")
+	require.Equal(t, one.String(), two.String())
+
+	// The #613 shape: A = (list lit) captured the first node; lit is either
+	// the same node (cached rebinding) or the second (fresh parse).
+	shared := []*lisp.LVal{lisp.SExpr([]*lisp.LVal{one}), one}
+	fresh := []*lisp.LVal{lisp.SExpr([]*lisp.LVal{one}), two}
+	assert.Equal(t, valueFingerprint(fresh), valueFingerprint(shared),
+		"sealed-node identity is not lisp-observable and must not be state")
+
+	// Positive control: the same shape over MUTABLE storage stays distinct.
+	// A write through one alias is visible through the other, so these are
+	// different environments.
+	v1 := lisp.Vector([]*lisp.LVal{lisp.Int(0)})
+	v2 := lisp.Vector([]*lisp.LVal{lisp.Int(0)})
+	require.False(t, v1.IsSealed())
+	sharedMut := []*lisp.LVal{lisp.SExpr([]*lisp.LVal{v1}), v1}
+	freshMut := []*lisp.LVal{lisp.SExpr([]*lisp.LVal{v1}), v2}
+	assert.NotEqual(t, valueFingerprint(freshMut), valueFingerprint(sharedMut),
+		"aliasing of mutable storage must still be recorded")
+
+	// Termination no longer rests on the visited set for sealed nodes, so
+	// both a mutable cycle (back-reference) and a sealed one (the memo, the
+	// depth cap and the node budget) must still return, and deterministically.
+	cyc := lisp.SExpr([]*lisp.LVal{lisp.Int(1)})
+	cyc.Cells[0] = cyc
+	cycFirst := valueFingerprint([]*lisp.LVal{cyc})
+	cycAgain := valueFingerprint([]*lisp.LVal{cyc})
+	assert.Equal(t, cycFirst, cycAgain, "a mutable cycle must digest deterministically")
+	sealedCyc := lisp.SExpr([]*lisp.LVal{lisp.Int(1)})
+	sealedCyc.Cells[0] = sealedCyc
+	sealedCyc.SealAST()
+	require.True(t, sealedCyc.IsSealed())
+	sealedFirst, sealedNodes := valueFingerprintNodes([]*lisp.LVal{sealedCyc})
+	sealedAgain := valueFingerprint([]*lisp.LVal{sealedCyc})
+	assert.Equal(t, sealedFirst, sealedAgain, "a sealed cycle must digest deterministically")
+	assert.NotEqual(t, cycFirst, sealedFirst, "sealed-ness itself stays part of the digest")
+
+	// A single-cell self-cycle is the CHEAP shape: one child per level, so
+	// the depth cap alone stops it after ~512 nodes whether or not anything
+	// is memoised.  It therefore proves nothing about the exponential case,
+	// which is why the two below are here.
+	assert.Lessf(t, sealedNodes, valueFPMaxNodes,
+		"a one-cell sealed self-cycle must not exhaust the node budget (visited %d)", sealedNodes)
+
+	// A BRANCHING sealed cycle: two cells, both the node itself.  With
+	// content-only digesting and no memo this unfolds as 2^depth and spends
+	// the entire 65536-node budget (measured: 31.4ms).  The memo makes the
+	// second cell a lookup, so it costs the depth cap once (0.70ms).
+	branch := lisp.SExpr([]*lisp.LVal{lisp.Int(1), lisp.Int(2)})
+	branch.Cells[0] = branch
+	branch.Cells[1] = branch
+	branch.SealAST()
+	require.True(t, branch.IsSealed())
+	start := time.Now()
+	branchFP, branchNodes := valueFingerprintNodes([]*lisp.LVal{branch})
+	branchElapsed := time.Since(start)
+	branchAgain, branchNodesAgain := valueFingerprintNodes([]*lisp.LVal{branch})
+	assert.Equal(t, branchFP, branchAgain, "a branching sealed cycle must digest deterministically")
+	assert.Equal(t, branchNodes, branchNodesAgain, "and must cost the same both times")
+	// 4*valueFPMaxDepth is slack over the ~1 node per level the memo leaves
+	// while still being two orders of magnitude under the budget the
+	// unmemoised walk consumed in full.
+	assert.Lessf(t, branchNodes, 4*valueFPMaxDepth,
+		"a branching sealed cycle must not unfold (visited %d nodes in %v)", branchNodes, branchElapsed)
+
+	// A sealed DAG whose UNFOLDED size is 2^25.  This is the shape the memo
+	// exists for: every node is reached twice, so content-only digesting
+	// without a memo is exponential (measured: 25.9ms without the memo, 79us
+	// with it, against 13us for the aliasing walk over the same graph
+	// unsealed).
+	dag := lisp.Int(0)
+	for range 25 {
+		dag = lisp.SExpr([]*lisp.LVal{dag, dag})
+	}
+	dag.SealAST()
+	require.True(t, dag.IsSealed())
+	start = time.Now()
+	dagFP, dagNodes := valueFingerprintNodes([]*lisp.LVal{dag})
+	dagElapsed := time.Since(start)
+	assert.Lessf(t, dagNodes, 4*26,
+		"a 26-node sealed DAG must be walked once per node, not unfolded (visited %d nodes in %v)",
+		dagNodes, dagElapsed)
+
+	// And the consequence that made the unmemoised version a CORRECTNESS
+	// problem rather than only a slow one: the node budget is shared across
+	// every value in one digest (envStateFingerprint hands valueFingerprint
+	// every binding at once), so a value that spends it all leaves every
+	// later value digesting as "trunc" -- blinding the oracle to real
+	// differences behind the hog.
+	hog := []*lisp.LVal{branch, lisp.Vector([]*lisp.LVal{lisp.Int(1)})}
+	notHog := []*lisp.LVal{branch, lisp.Vector([]*lisp.LVal{lisp.Int(2)})}
+	assert.NotEqual(t, valueFingerprint(hog), valueFingerprint(notHog),
+		"a budget hog must not blind the digest to the values walked after it")
+	assert.NotEmpty(t, dagFP)
+}
+
+// TestEnvStateFingerprintRecordsMutableAliasing is the positive control at
+// the level the fuzz targets actually assert on.  Every other control in this
+// file calls valueFingerprint directly; this one goes through
+// envStateFingerprint, so a change that blinded the ENV digest -- a shared
+// budget spent before the interesting binding, a walk that stopped at package
+// boundaries -- would be caught here and not there.
+//
+// Two bindings holding ONE mutable vector is a different environment from two
+// bindings holding two equal vectors: a write through either name is visible
+// through the other in the first and not in the second.
+func TestEnvStateFingerprintRecordsMutableAliasing(t *testing.T) {
+	t.Parallel()
+	fp := func(src string) string {
+		env, _, rc := newFuzzEnv()
+		require.Nil(t, rc)
+		env.Runtime.Reader = parser.NewReader()
+		res := env.LoadString("alias", src)
+		require.NotEqual(t, lisp.LError, res.Type, res)
+		return envStateFingerprint(env)
+	}
+	aliased := fp(`(set 'x (vector 1 2))(set 'y x)`)
+	distinct := fp(`(set 'x (vector 1 2))(set 'y (vector 1 2))`)
+	assert.Equal(t, aliased, fp(`(set 'x (vector 1 2))(set 'y x)`),
+		"the env digest must be deterministic before it can be discriminating")
+	assert.NotEqual(t, aliased, distinct,
+		"two bindings sharing one mutable vector is not the same environment as two equal vectors")
+}
+
+// TestLoadCacheSharedLiteralIsNotLispObservable is the lisp-level probe
+// behind the classification: after A, B, A the shared sealed node can be
+// compared, viewed, and attacked with every guarded mutator, and every
+// outcome is the same with and without the cache.  In particular every
+// write attempt through `lit` is refused, so no write can reach `A` (or
+// the cache entry) through it -- the channel that would have made the
+// sharing observable does not exist.
+//
+// This is a PREMISE test, not a regression test.  It passes on origin/main
+// too, and it is meant to: it establishes the fact the #613 fix RESTS on
+// (the sharing is unobservable) rather than exercising the fix.  Its value is
+// that it FALSIFIES cheaply -- if a future carve-out ever let a write reach
+// sealed backing, this goes red and the fix's justification goes with it,
+// which is why the two derived-value writes below are here.  A probe that
+// only ever reads cannot do that job.
+func TestLoadCacheSharedLiteralIsNotLispObservable(t *testing.T) {
+	t.Parallel()
+	// Element order is pinned by the names below; keep the two in step.
+	const probe = `(list
+		(equal? A (list lit))
+		(equal? (car A) lit)
+		(handler-bind ((modify-literal-error (lambda (c &rest args) 'refused))) (slice 'vector lit 0 1))
+		(handler-bind ((modify-literal-error (lambda (c &rest args) 'refused))) (append 'vector lit 1))
+		(handler-bind ((modify-literal-error (lambda (c &rest args) 'refused))) (stable-sort < lit))
+		(slice 'list lit 0 0)
+		(slice 'vector lit 0 0)
+		(copy lit)
+		(handler-bind ((modify-literal-error (lambda (c &rest args) 'refused))) (append! (slice 'vector lit 0 0) 99))
+		(handler-bind ((modify-literal-error (lambda (c &rest args) 'refused))) (append! (slice 'vector (copy lit) 0 1) 99))
+		A
+		lit)`
+	// probeNames labels the probe's elements so a failure names the form that
+	// diverged instead of an index, and so the refusal assertions below do
+	// not depend on how the whole list renders (the old assertion matched the
+	// literal substring "'refused 'refused 'refused", which any change to
+	// spacing or to a neighbouring element would have broken silently).
+	probeNames := []string{
+		"(equal? A (list lit))",
+		"(equal? (car A) lit)",
+		"(slice 'vector lit 0 1)",
+		"(append 'vector lit 1)",
+		"(stable-sort < lit)",
+		"(slice 'list lit 0 0)",
+		"(slice 'vector lit 0 0)",
+		"(copy lit)",
+		"(append! (slice 'vector lit 0 0) 99)",
+		"(append! (slice 'vector (copy lit) 0 1) 99)",
+		"A",
+		"lit",
+	}
+	run := func(cache *fuzzLoadCache) []string {
+		env, _, rc := newFuzzEnv()
+		require.Nil(t, rc)
+		env.Runtime.Reader = parser.NewReader()
+		if cache != nil {
+			env.Runtime.LoadCache = cache
+		}
+		for _, step := range []struct{ name, src string }{
+			{loadCacheHostileFileA, loadCacheRebindMinA},
+			{loadCacheHostileFileB, loadCacheRebindMinB},
+			{loadCacheHostileFileA, loadCacheRebindMinA},
+		} {
+			res := env.LoadLocation(step.name, step.name, strings.NewReader(step.src))
+			require.NotEqual(t, lisp.LError, res.Type, res)
+		}
+		out := env.LoadString("probe", probe)
+		require.NotEqual(t, lisp.LError, out.Type, out)
+		require.Len(t, out.Cells, len(probeNames))
+		got := make([]string, len(out.Cells))
+		for i, c := range out.Cells {
+			got[i] = c.String()
+		}
+		return got
+	}
+	uncached := run(nil)
+	cached := run(newFuzzLoadCache())
+	for i, name := range probeNames {
+		assert.Equalf(t, uncached[i], cached[i],
+			"%s must be indistinguishable with and without the cache", name)
+		t.Logf("%-46s => %s", name, cached[i])
+	}
+
+	// Every guarded write through the shared literal is refused, named one by
+	// one.  These three are the reason the sharing is unobservable: with no
+	// write channel into the sealed node, `A` and the cache entry cannot be
+	// reached through `lit`.
+	for _, i := range []int{2, 3, 4} {
+		assert.Equalf(t, "'refused", cached[i], "%s must be refused", probeNames[i])
+		assert.Equalf(t, "'refused", uncached[i], "%s must be refused without the cache too", probeNames[i])
+	}
+
+	// The two writes through a DERIVED value.  Neither is refused -- both are
+	// legal today -- and that is the point: they are the two shapes that would
+	// FALSIFY the classification if the derivation ever leaked sealed backing.
+	//
+	//   - `(slice 'vector lit 0 0)` is the zero-width seal carve-out
+	//     (builtins.go, CondModifyLiteral): a zero-width window over sealed
+	//     backing is handed out as a vector with FRESH empty backing rather
+	//     than refused, so `append!` into it must not be able to reach lit's
+	//     cell 0 through retained capacity.
+	//   - `(copy lit)` clears the seal, so the slice of the copy is genuinely
+	//     mutable; `append!` into it must write the copy and not the original.
+	//
+	// lit and A are re-read AFTER both writes (the last two probe elements),
+	// so a leak shows up as a changed literal rather than as a changed
+	// intermediate nobody looks at again.
+	for _, i := range []int{8, 9} {
+		assert.NotEqualf(t, "'refused", cached[i],
+			"%s is expected to be legal today; if it is now refused this test's premise changed",
+			probeNames[i])
+	}
+	assert.Equal(t, "'(0)", cached[len(cached)-1], "lit must still be the literal it was parsed as")
+	assert.Equal(t, "'('(0))", cached[len(cached)-2], "A must still hold the literal it captured")
+}

--- a/lisp/shared_program_fuzz_test.go
+++ b/lisp/shared_program_fuzz_test.go
@@ -425,7 +425,34 @@ func confirmSharedDivergence(t *testing.T, src []byte, shared lisp.Program, seal
 // type and formals: the stdlib's ~250 function bindings are identical in
 // every environment and contribute a constant prefix, while a `defun` the
 // program performed shows up as a new symbol name.
+//
+// The digest is by CONTENT for sealed nodes and by content-plus-aliasing for
+// unsealed ones (see valuefp_test.go).  That split is what makes this a
+// statement about what a program can observe rather than about storage: a
+// cached load serves the same sealed nodes a fresh parse would mint anew,
+// so two bindings that hold one sealed node under a cache and two equal
+// nodes without it are the same environment (issue #613), while two
+// bindings sharing one mutable vector are not.
+//
+// That content-only rule is blind to sealed PROVENANCE, which is observable
+// (a sealed node's frozen location is printed by every error raised through
+// it).  envStateFingerprintProv is the variant that sees it; it is scoped to
+// the one caller whose property is provenance, because THIS target reparses
+// one source under several stream names on purpose and a global provenance
+// rule would make it report its own premise as a divergence.  See
+// valueFingerprintProv in valuefp_test.go.
 func envStateFingerprint(env *lisp.LEnv) string {
+	return envStateFingerprintWith(env, valueFingerprint)
+}
+
+// envStateFingerprintProv is envStateFingerprint with sealed-node provenance
+// mixed in.  Used only by runHostilePair (loadcache_reader_fuzz_test.go);
+// see valueFingerprintProv for why it must not become the default.
+func envStateFingerprintProv(env *lisp.LEnv) string {
+	return envStateFingerprintWith(env, valueFingerprintProv)
+}
+
+func envStateFingerprintWith(env *lisp.LEnv, fp func([]*lisp.LVal) string) string {
 	names := fnv.New64a()
 	var vals []*lisp.LVal
 	for _, pkgName := range env.Runtime.Registry.PackageNames() {
@@ -443,7 +470,7 @@ func envStateFingerprint(env *lisp.LEnv) string {
 	// The current package is state too: `in-package` is one of the few ways
 	// a program changes an environment without binding anything.
 	_, _ = fmt.Fprintf(names, "cur:%s;", env.Runtime.Package.Name)
-	return fmt.Sprintf("%016x/%s", names.Sum64(), valueFingerprint(vals))
+	return fmt.Sprintf("%016x/%s", names.Sum64(), fp(vals))
 }
 
 // TestSharedProgramSeedsAreDeterministic is the harness's own gate.

--- a/lisp/testdata/fuzz/FuzzLoadCacheHostileReader/bfe6dc31a652ced0
+++ b/lisp/testdata/fuzz/FuzzLoadCacheHostileReader/bfe6dc31a652ced0
@@ -1,0 +1,4 @@
+go test fuzz v1
+byte('5')
+[]byte("(set'lit'(0))(and'1(slice'list lit 0 0))")
+[]byte("(set'A(list lit))")

--- a/lisp/valuefp_test.go
+++ b/lisp/valuefp_test.go
@@ -4,6 +4,7 @@ package lisp_test
 
 import (
 	"fmt"
+	"hash"
 	"hash/fnv"
 	"io"
 	"math"
@@ -58,10 +59,48 @@ import (
 //
 // # What it deliberately does NOT cover
 //
-//   - Pointer identity and sharing topology.  Two structurally equal values
-//     digest equally.  Detecting that a builtin swapped one child for a
-//     different-but-equal child is the -race seal watchdog's job, not a
+//   - Pointer identity of SEALED nodes.  Two structurally equal sealed
+//     values digest equally whether they are one node or two.  A sealed
+//     node is frozen storage (lisp/seal.go): no lisp-reachable write can go
+//     through it, and the language has no identity primitive (`equal?` is
+//     structural), so no program can ask WHICH of two equal sealed nodes it
+//     holds -- and which one it holds is a thing the load cache changes BY
+//     CONTRACT.  A cache hit serves the same sealed nodes the miss served
+//     (TestLoadCacheServesTheSameNodes is the alias proof), so a file loaded
+//     twice through a cache rebinds its literals to the nodes an earlier
+//     load already captured, where two fresh parses yield two equal nodes.
+//     Digesting that identity turned the cache's contract into a divergence:
+//     issue #613, found by FuzzLoadCacheHostileReader with `(set 'lit '(0))`
+//     loaded, `(set 'A (list lit))` loaded, and the first loaded again --
+//     every evaluation result equal, and the environment digest differing in
+//     `lit` being a back-reference to A's element under the cache and a full
+//     walk without it.  Detecting that a builtin swapped one sealed child
+//     for a different-but-equal one is the -race seal watchdog's job, not a
 //     content digest's.
+//
+//     That rule is narrower than "sealed identity is unobservable", which is
+//     what this comment used to claim and is FALSE in general.  A sealed node
+//     carries its parse-time source location and carries it forever --
+//     SetSource is a no-op once sealed (lisp/lisp.go) -- and that location is
+//     printed by every stack note and error the node raises, so two equal
+//     sealed nodes minted from two different files ARE distinguishable from
+//     lisp.  That is precisely why the load cache keys on the stream's name
+//     and location and not on its bytes alone; the "# Keying" paragraph in
+//     lisp/loadcache.go spells out the misattribution a content-only key
+//     produces (the second file's errors naming the first file's lines).
+//     Content-only digesting is therefore right for the IDENTITY question and
+//     blind to the PROVENANCE one.  valueFingerprintProv below restores
+//     provenance for the callers whose property is provenance -- today just
+//     the load-cache hostile-reader pair -- and is deliberately not the
+//     default: FuzzSharedProgramMultiEnv reparses one source under different
+//     stream names on purpose, so a global provenance rule would make that
+//     target report its own premise as a divergence.
+//   - Pointer identity of UNSEALED nodes IS recorded, through the
+//     back-reference marker below.  Mutable storage is where identity is
+//     observable -- a write through one alias is visible through the other
+//     -- so two bindings sharing one vector and two bindings holding two
+//     equal vectors are different environments, and a cache (or a builtin)
+//     that turned one into the other would be a real semantic change.
 //   - Native payloads other than LBytes.  An arbitrary Go value has no
 //     order-stable rendering (`%v` of a map is randomised), so it
 //     contributes its dynamic TYPE only.  Nothing in the container families
@@ -78,6 +117,21 @@ import (
 // depth cap and a node budget.  Traversal order is fixed, so a truncated
 // digest is still deterministic: an equal-before/equal-after comparison
 // stays meaningful and corruption past the horizon is simply out of scope.
+//
+// Back-references are for UNSEALED nodes only (above), which on its own
+// makes a sealed DAG exponential and a sealed cycle a budget hog -- and the
+// budget is shared across every value in one envStateFingerprint, so a hog
+// blinds the digest to every value walked after it.  Measured, before the
+// memo below and after it: a 26-node sealed DAG (2^25 unfolded) 25.9ms ->
+// 79us (13us is what the aliasing walk costs on the same graph unsealed), a
+// two-cell branching sealed cycle 31.4ms -> 0.70ms, and -- the part that is
+// a correctness bug and not a slow test -- `[hog, Vector(1)]` digested EQUAL
+// to `[hog, Vector(2)]` before and distinct after.  The fix is memoisation,
+// not bookkeeping: a sealed
+// subtree's CONTENT hash is cached by pointer, so the second reach costs a
+// map lookup and the digest is still the content digest.  That is a
+// different claim from a back-reference -- "the same content again", not
+// "the node you saw at position N" -- so it does not reintroduce identity.
 
 const (
 	// valueFPMaxNodes bounds the nodes one digest visits.  Far above
@@ -92,9 +146,23 @@ const (
 
 // valueFP is the running digest state plus the walk's termination budget.
 type valueFP struct {
-	h      io.Writer
-	seen   map[*lisp.LVal]int
+	// h is the accumulator the walk currently writes to: root, or the
+	// private accumulator of a sealed subtree being memoised.
+	h io.Writer
+	// root is the digest the whole walk sums to.
+	root hash.Hash64
+	seen map[*lisp.LVal]int
+	// memo caches a SEALED node's content hash by pointer, so a sealed DAG
+	// or cycle is walked once rather than unfolded.  See walk.
+	memo   map[*lisp.LVal]uint64
 	budget int
+	// prov mixes a sealed node's frozen source location into its digest.
+	// Off by default; see valueFingerprintProv.
+	prov bool
+	// touchedUnsealed records whether the walk currently in progress reached
+	// an unsealed node, which is what makes its digest unmemoisable.  See
+	// walk.
+	touchedUnsealed bool
 }
 
 // valueFingerprint returns a content digest of the runtime values reachable
@@ -103,12 +171,60 @@ type valueFP struct {
 // The digest is a string rather than a uint64 so a failure message can print
 // it next to a sealed fingerprint without the two being confusable.
 func valueFingerprint(vs []*lisp.LVal) string {
-	h := fnv.New64a()
-	s := &valueFP{h: h, seen: make(map[*lisp.LVal]int), budget: valueFPMaxNodes}
+	return newValueFP(false).run(vs)
+}
+
+// valueFingerprintProv is valueFingerprint plus sealed-node PROVENANCE: a
+// sealed node additionally mixes the source location it froze at.
+//
+// It exists because the content-only rule is blind to a real, observable
+// difference.  A sealed node's location is frozen (SetSource is a no-op once
+// sealed) and is printed by every stack note and error raised through it, so
+// serving one file's nodes for another file's load is a lisp-observable
+// misattribution -- which is exactly the failure a content-only cache key
+// produces, described in loadcache.go's "# Keying" paragraph.  Mutating
+// loadCacheKey to drop name and loc and then loading two byte-identical files
+// makes the second file's errors name the first file's path; plain
+// valueFingerprint cannot see that, and this variant can.
+//
+// It is NOT the default, and must not become it.  FuzzSharedProgramMultiEnv
+// deliberately evaluates ONE parse under several stream names, and
+// TestSharedProgramSeedsAgreeWithSharedParse and
+// TestValueFingerprintSealedIdentityIsNotState compare nodes minted by
+// different loads on purpose; a global provenance rule turns all three red on
+// their own premise.  The one caller today is runHostilePair
+// (loadcache_reader_fuzz_test.go), where "the cache served the right file's
+// parse" is the property under test.
+func valueFingerprintProv(vs []*lisp.LVal) string {
+	return newValueFP(true).run(vs)
+}
+
+func newValueFP(prov bool) *valueFP {
+	root := fnv.New64a()
+	return &valueFP{
+		h:      root,
+		root:   root,
+		seen:   make(map[*lisp.LVal]int),
+		memo:   make(map[*lisp.LVal]uint64),
+		budget: valueFPMaxNodes,
+		prov:   prov,
+	}
+}
+
+// valueFingerprintNodes is valueFingerprint plus the number of nodes the
+// walk actually charged against its budget.  The count is what the sealed
+// memo exists to bound, and it is exactly deterministic, so a test can pin
+// "this sealed graph does not unfold" without pinning a wall-clock time.
+func valueFingerprintNodes(vs []*lisp.LVal) (string, int) {
+	s := newValueFP(false)
+	return s.run(vs), valueFPMaxNodes - s.budget
+}
+
+func (s *valueFP) run(vs []*lisp.LVal) string {
 	for _, v := range vs {
 		s.walk(v, 0)
 	}
-	return fmt.Sprintf("%016x", h.Sum64())
+	return fmt.Sprintf("%016x", s.root.Sum64())
 }
 
 func (s *valueFP) mix(format string, args ...interface{}) {
@@ -120,20 +236,96 @@ func (s *valueFP) walk(v *lisp.LVal, depth int) {
 		s.mix("<nil>;")
 		return
 	}
-	if id, ok := s.seen[v]; ok {
-		// A back-reference, not a re-walk: this is what makes a cyclic or
-		// heavily-aliased value terminate, and it also records the SHAPE of
-		// the aliasing, so collapsing two aliases into one copy changes the
-		// digest.
-		s.mix("back:%d;", id)
-		return
+	// Only UNSEALED nodes take part in the back-reference bookkeeping.  A
+	// sealed node is digested by content every time it is reached: its
+	// identity is not lisp-observable and the load cache legitimately
+	// shares one sealed node between loads that a fresh parse would give two
+	// equal nodes (issue #613; see the file comment).
+	sealed := v.IsSealed()
+	if !sealed {
+		// Recorded BEFORE the back-reference return, because emitting
+		// `back:N` is itself the visit-order-dependent thing that makes an
+		// enclosing sealed digest unmemoisable.
+		s.touchedUnsealed = true
+		if id, ok := s.seen[v]; ok {
+			// A back-reference, not a re-walk: this is what makes a cyclic
+			// or heavily-aliased mutable value terminate, and it also records
+			// the SHAPE of the aliasing, so collapsing two aliases of mutable
+			// storage into one copy changes the digest.
+			s.mix("back:%d;", id)
+			return
+		}
 	}
 	if s.budget <= 0 || depth > valueFPMaxDepth {
 		s.mix("trunc;")
 		return
 	}
+	if !sealed {
+		s.walkContent(v, depth)
+		return
+	}
+
+	// A sealed node is memoised by pointer.  Without this, "digest sealed
+	// nodes by content every time" is exponential on a sealed DAG and burns
+	// the whole node budget on a sealed cycle -- and because the budget is
+	// shared across every value in one envStateFingerprint, a single hog
+	// blinds the digest to every value after it.  A memo hit emits the same
+	// bytes a full walk would have emitted, so nothing about the digest's
+	// MEANING changes: it still says "this content", never "the node you saw
+	// at position N".  Termination for sealed subgraphs rests on this memo
+	// plus the depth cap and the node budget.
+	if sum, ok := s.memo[v]; ok {
+		s.mix("sealed:%016x;", sum)
+		return
+	}
+	// The subtree is hashed into its own accumulator so its content hash can
+	// be cached, but it SHARES seen, budget and memo with the parent: the
+	// budget must still bound the whole walk, and an unsealed node reached
+	// from here must take part in the parent's aliasing bookkeeping.
+	sub := fnv.New64a()
+	outerH, outerTouched := s.h, s.touchedUnsealed
+	s.h, s.touchedUnsealed = sub, false
+	s.walkContent(v, depth)
+	sum, touched := sub.Sum64(), s.touchedUnsealed
+	s.h, s.touchedUnsealed = outerH, outerTouched || touched
+	if !touched {
+		// Cached only when the subtree stayed inside sealed storage.  A
+		// sealed subtree that REACHES an unsealed node must not be memoised:
+		// its digest embeds `back:N` markers and `seen` ids that are valid
+		// only at the visit where they were minted, so replaying them at a
+		// later reach would assert an aliasing shape that was never
+		// observed.  The parser cannot produce that shape -- sealAST stops
+		// at the first non-sealable type, so nothing below a sealed node is
+		// unsealed -- but an embedder that calls SealAST on a hand-built
+		// tree can, and the memo must be correct for the tree it is handed
+		// rather than for the tree the parser happens to build.
+		//
+		// A sum that embeds a `trunc` (the walk hit the depth cap or ran the
+		// budget out inside the subtree) IS still cached, deliberately.  It
+		// makes the digest of a truncated subtree depend on where it was
+		// first reached rather than on where it is reused, which costs a
+		// little fidelity past the horizon that is already out of scope --
+		// and it is what keeps a branching sealed cycle linear: refusing to
+		// cache truncated sums turns that shape back into O(depth^2), which
+		// for valueFPMaxDepth=512 is over the node budget again.
+		s.memo[v] = sum
+	}
+	s.mix("sealed:%016x;", sum)
+}
+
+// walkContent digests v itself and its children.  The caller has already
+// settled the back-reference, budget, depth and memo questions.
+func (s *valueFP) walkContent(v *lisp.LVal, depth int) {
 	s.budget--
-	s.seen[v] = len(s.seen)
+	if !v.IsSealed() {
+		s.seen[v] = len(s.seen)
+	} else if s.prov {
+		// Provenance, for the callers that asked for it: a sealed node's
+		// location is frozen and lisp-observable through errors and stack
+		// notes.  See valueFingerprintProv.
+		loc, ok := v.Source()
+		s.mix("src:%s:%d:%d/%v;", loc.File, loc.Line, loc.Col, ok)
+	}
 
 	// The float mixes its BIT PATTERN rather than its value, so NaN payloads
 	// and the two zeros digest distinctly and deterministically — `==` on


### PR DESCRIPTION
## What

`FuzzLoadCacheHostileReader` reported seed `bfe6dc31a652ced0` (reader mode 4) as a cache divergence. Loading A=`(set'lit'(0))(and'1(slice'list lit 0 0))`, B=`(set'A(list lit))`, A again through one env with a shared `LoadCache` gave the same three evaluation results as the same sequence with no cache, but a different `envStateFingerprint`.

**Classification: (iii) a harness/fingerprint artefact.** `valueFingerprint` (test-only oracle) keyed its back-reference bookkeeping on every node, sealed or not, so it encoded storage identity that a sealed cache entry legitimately shares. A cache hit serves the SAME sealed nodes the miss served (`TestLoadCacheServesTheSameNodes`), so the third load of A rebinds `lit` to the node B captured from the first load, where two fresh parses mint two equal nodes. No lisp program can observe WHICH of two equal sealed nodes it holds: a sealed node cannot be written through and `equal?` is structural.

Fix: the oracle digests SEALED nodes by content and keeps aliasing bookkeeping for UNSEALED nodes, where identity is observable. Nothing in `lisp/` (non-test) changed.

Closes #613

## Adversarial-review follow-ups

A QA review confirmed the classification (154 probes found no lisp-observable difference) but found the weakening broader than the artefact required. Three things landed on top of the original fix.

### 1. Sealed content hashes are memoised by pointer

Digesting sealed nodes by content on every reach is exponential on a sealed DAG and a budget hog on a sealed cycle — and the node budget is shared across every value in one `envStateFingerprint`, so a hog blinds the digest to every value walked *after* it. That is a correctness bug, not a slow test. Reachable from three lines of lisp.

`valueFP` gains `memo map[*lisp.LVal]uint64` and `touchedUnsealed bool`. A sealed node under budget returns its memoised sum if present; otherwise it is walked into a private `fnv.New64a()` that SHARES `seen`/`budget`/`memo` with the parent, and the sum is cached only when `!touchedUnsealed`. A sealed subtree that reaches an unsealed node is not memoised — its digest embeds `back:N` markers and `seen` ids valid only at the visit that minted them. The parser cannot build that shape (`sealAST` stops at the first non-sealable type) but an embedder calling `SealAST` on a hand-built tree can.

A memo hit emits the bytes a full walk would have emitted, so the digest still says "this content", never "the node you saw at position N".

### 2. Sealed provenance, SCOPED

A sealed node's `source` is frozen (`SetSource` is a no-op once sealed) and IS lisp-observable — every error and stack note raised through the node prints it. That is why the cache keys on the stream's name and location, not its bytes alone (`loadcache.go` "# Keying"), and the content-only rule is blind to it.

`valueFingerprintProv` / `envStateFingerprintProv` additionally mix `src:<file>:<line>:<col>` for sealed nodes, and are used **only** from `runHostilePair` — on the per-load results as well as the env state. (For byte-identical files the A,B,A sequence rebinds the same symbols from the same bytes, so the final environment converges either way; load B's own *value* does not, which is where the mutation shows.)

Deliberately **not** global: `FuzzSharedProgramMultiEnv` evaluates one parse under several stream names on purpose, and a global rule turns that target, `TestSharedProgramSeedsAgreeWithSharedParse` and `TestValueFingerprintSealedIdentityIsNotState` red on their own premise.

### 3. Test and comment fixes

- The file comment's claim that "whether two bindings hold one sealed node or two equal ones is not a fact any program can observe" was false in general. It now names the source-location exception and points at `loadcache.go`'s keying paragraph.
- `TestLoadCacheSharedLiteralIsNotLispObservable` now writes through a DERIVED value: `(append! (slice 'vector lit 0 0) 99)` (the zero-width seal carve-out) and `(append! (slice 'vector (copy lit) 0 1) 99)` (`copy` clears the seal), then re-reads `lit` and `A`. Both are safe today; these are the two shapes that would falsify the classification. The test's comment now states it is a PREMISE test (it passes on `origin/main` too), not a regression test.
- The whitespace-sensitive `assert.Contains(t, cached, "'refused 'refused 'refused")` is replaced by per-element assertions over named probe elements.
- Subtest naming uses `fmt.Sprintf("%s/mode=%d", tc.name, mode)` instead of `string(rune('0'+mode))`, which breaks past mode 9.
- `TestEnvStateFingerprintRecordsMutableAliasing`: an env-level positive control through `envStateFingerprint` itself — the function the fuzz targets call — asserting `(set 'x (vector 1 2))(set 'y x)` fingerprints differently from `(set 'x (vector 1 2))(set 'y (vector 1 2))`.
- `TestValueFingerprintSealedIdentityIsNotState`'s termination arm gains the 2-cell branching sealed cycle and the 26-node sealed DAG, asserted with deterministic NODE-COUNT bounds (`valueFingerprintNodes`) rather than only determinism, plus the hog-blindness case.
- `TestLoadCacheRebindAcrossLoadsMatchesFreshParse` gains an `identical-bytes` case (two different streams, identical content) — the shape that exercises provenance.
- The "differing ONLY in `lit`" claim is softened: the digest is a hash and that was never pinned at byte level.

## Measurements (reproduced on this box, before → after)

| Measurement | Before (PR head `06e990b`) | After (`f466bb1`) |
|---|---|---|
| 26-node sealed DAG (2^25 unfolded) | 25.9 ms | 79 µs |
| Same graph UNSEALED (aliasing-walk reference) | — | 13 µs |
| 2-cell branching sealed self-cycle | 31.4 ms (whole 65536-node budget) | 0.70 ms |
| Hog blindness: `fp([hog, Vector(1)]) == fp([hog, Vector(2)])` | `true` (blind) | `false` (discriminates) |
| `loadCacheKey` mutation (drop `name`+`loc`) caught? | not caught by the fingerprint | caught — `identical-bytes` fails on `eval 2` in all 7 transparent modes |

The `loadCacheKey` mutation was applied and reverted locally to confirm both directions: mutated → `TestLoadCacheRebindAcrossLoadsMatchesFreshParse/identical-bytes` fails in every transparent mode; unmutated → green, and the #613 seed stays green.

## Gates

- `go build ./...` — OK
- `go vet ./lisp/` — OK
- `gofmt -l` on the four touched files — clean
- `golangci-lint run ./lisp/...` (v2.6.2) — 0 issues
- `make elpsvet` (both passes, plain and `-tags=elpscheck`) — OK
- `go test ./lisp -run 'TestLoadCache|TestSealed|TestSlice|TestValueFingerprint|TestEnvStateFingerprint|FuzzLoadCache|FuzzSharedProgram|FuzzSequenceOps' -count=1` — ok 5.7 s
- same with `-tags elpscheck` — ok 17.6 s
- same with `-race` — ok 44.0 s
- `go test ./lisp -count=1` (whole package) — ok 33.2 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3JiPj1sGKj8BtcmJjNvpj