### PR TITLE
Render LQSymbol as a quoted symbol instead of %#v of the LVal

### DIFF
--- a/internal/fuzzval/fuzzval.go
+++ b/internal/fuzzval/fuzzval.go
@@ -245,11 +245,14 @@ func (g *Gen) value(depth int) *lisp.LVal {
 // Locations come from a fixed process-wide pool rather than being allocated
 // per node, for two reasons.
 //
-//   - Reproducibility.  LVal.String() renders an LQSymbol with %#v, which
-//     prints the Source POINTER.  A freshly allocated Location per node would
-//     therefore make the rendering of a generated value depend on the
-//     allocator, and TestGeneratorIsDeterministic -- the property every saved
-//     crasher rests on -- would fail.
+//   - Reproducibility.  LVal.String() used to render an LQSymbol with %#v,
+//     which prints the Source POINTER, so a freshly allocated Location per
+//     node made the rendering of a generated value depend on the allocator and
+//     TestGeneratorIsDeterministic -- the property every saved crasher rests
+//     on -- failed.  Issue #606 gave LQSymbol a rendering arm and took the
+//     %#v out of the fallback, and lisp.TestStringNoAddressForEveryLType now
+//     holds every LType to that, so no rendering prints an address today.  The
+//     pool is kept for the reason below, which is the durable one.
 //   - Fidelity.  LVal.Source documents itself as shared: "the reference may be
 //     shared by multiple LVals".  A pool models that, and it is the sharing
 //     that gives an in-place edit of a Location its real blast radius.

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -1839,6 +1839,23 @@ func (v *LVal) str(onTheRecord bool, g cycleGuard) string {
 			quote = QUOTE
 		}
 		return quote + v.Str
+	case LQSymbol:
+		// A qsymbol carries a level of quoting in its type rather than in
+		// v.quoted, so it always renders with at least one quote -- the
+		// text a quoted symbol renders, and the text the debugger's
+		// inspector has always shown for one.  A further level (v.quoted,
+		// which Quote sets, or an enclosing LQuote, which passes
+		// onTheRecord) adds a second quote exactly as it does for LSymbol.
+		//
+		// Without this arm the value fell through to strNested's default,
+		// which printed %#v of the LVal and so leaked the address of
+		// v.source into the rendering: the same value rendered
+		// differently in two processes, and a copy rendered differently
+		// from its source in one.  See issue #606.
+		if v.quoted {
+			quote = QUOTE
+		}
+		return quote + QUOTE + v.Str
 	case LNative:
 		return fmt.Sprintf("#<native value: %T>", v.Native)
 	default:
@@ -1919,7 +1936,15 @@ func (v *LVal) strNested(onTheRecord bool, g cycleGuard) string {
 	case LMarkMacExpand:
 		return quote + fmt.Sprintf("#<macro-expansion %s)>", v.Cells[0].str(false, g))
 	default:
-		return quote + fmt.Sprintf("#<%s %#v>", v.Type, v)
+		// Nothing reaches this arm today: every LType is rendered either
+		// here or by str above, and TestStringNoAddressForEveryLType
+		// fails if a newly added type stops being covered.  It renders
+		// the type name ALONE -- never %#v of the LVal, which printed
+		// the LVal's pointer fields and made the rendering depend on the
+		// allocator (issue #606).  ELPS output has to be byte-identical
+		// across processes; a fallback that can embed a heap address is
+		// not an acceptable one, however unreachable it looks.
+		return quote + fmt.Sprintf("#<%s>", v.Type)
 	}
 }
 

--- a/lisp/string_address_test.go
+++ b/lisp/string_address_test.go
@@ -1,0 +1,131 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// lvalSamples holds one representative value per LType.  It is keyed by LType
+// rather than written as a slice so that the coverage assertion below can name
+// the type that is missing.
+//
+// LTypeMax is deliberately absent: it is a bound, not a type.
+var lvalSamples = map[lisp.LType]func() *lisp.LVal{
+	lisp.LInvalid: func() *lisp.LVal { return &lisp.LVal{} },
+	lisp.LInt:     func() *lisp.LVal { return lisp.Int(42) },
+	lisp.LFloat:   func() *lisp.LVal { return lisp.Float(1.5) },
+	lisp.LError:   func() *lisp.LVal { return lisp.Errorf("boom %d", 1) },
+	lisp.LSymbol:  func() *lisp.LVal { return lisp.Symbol("foo") },
+	lisp.LQSymbol: func() *lisp.LVal { return lisp.QSymbol("pkg:sym") },
+	lisp.LSExpr:   func() *lisp.LVal { return lisp.SExpr([]*lisp.LVal{lisp.Int(1), lisp.Symbol("a")}) },
+	lisp.LFun: func() *lisp.LVal {
+		return lisp.Fun("f", lisp.Formals("x"), func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+			return lisp.Nil()
+		})
+	},
+	lisp.LQuote:   func() *lisp.LVal { return lisp.Quote(lisp.Quote(lisp.Symbol("foo"))) },
+	lisp.LString:  func() *lisp.LVal { return lisp.String("hello") },
+	lisp.LBytes:   func() *lisp.LVal { return lisp.Bytes([]byte{0x01, 0x02}) },
+	lisp.LSortMap: func() *lisp.LVal { return lisp.SortedMap() },
+	lisp.LArray:   func() *lisp.LVal { return lisp.Array(nil, []*lisp.LVal{lisp.Int(1), lisp.Int(2)}) },
+	// A POINTER payload: %T renders the type, %v would render the address.
+	lisp.LNative: func() *lisp.LVal { return lisp.Native(&struct{ N int }{7}) },
+	lisp.LTaggedVal: func() *lisp.LVal {
+		return &lisp.LVal{Type: lisp.LTaggedVal, Str: "my-type", Cells: []*lisp.LVal{lisp.Int(1)}}
+	},
+	lisp.LMarkTerminal: func() *lisp.LVal {
+		return &lisp.LVal{Type: lisp.LMarkTerminal, Cells: []*lisp.LVal{lisp.Int(1)}}
+	},
+	lisp.LMarkTailRec: func() *lisp.LVal {
+		return &lisp.LVal{Type: lisp.LMarkTailRec, Cells: []*lisp.LVal{lisp.Int(2), lisp.Symbol("f"), lisp.SExpr(nil)}}
+	},
+	lisp.LMarkMacExpand: func() *lisp.LVal {
+		return &lisp.LVal{Type: lisp.LMarkMacExpand, Cells: []*lisp.LVal{lisp.Symbol("f")}}
+	},
+}
+
+// TestStringNoAddressForEveryLType is the invariant behind issue #606: no
+// LVal renders a heap address, for any LType.
+//
+// ELPS runs on a ledger where every peer must produce byte-identical output,
+// so a rendering that embeds a pointer is nondeterministic across peers BY
+// CONSTRUCTION -- the same value renders differently in two processes, and a
+// copy renders differently from its source in one.  That is what an LQSymbol
+// did: it had no arm in str/strNested and fell through to a default that
+// printed %#v of the LVal, which prints LVal.source, a *token.Location.
+//
+// The loop walks every LType from the source (LType(0) up to the LTypeMax
+// bound) rather than a hand-written list, so a newly added type fails here
+// until somebody gives it a sample AND a rendering arm; it cannot fall into a
+// default arm unnoticed.  A LOCATED value is used for the same reason: an
+// unlocated one has a nil source, which prints no address even when the
+// rendering is wrong.
+func TestStringNoAddressForEveryLType(t *testing.T) {
+	for typ := lisp.LType(0); typ < lisp.LTypeMax; typ++ {
+		mk, ok := lvalSamples[typ]
+		if !ok {
+			t.Errorf("LType %d (%s) has no sample in lvalSamples: a new LType needs a sample here and a rendering arm in LVal.str or LVal.strNested", typ, typ)
+			continue
+		}
+		v := mk()
+		if v.Type != typ {
+			t.Errorf("lvalSamples[%s] built a %s", typ, v.Type)
+			continue
+		}
+		unlocated := v.String()
+		v.SetSource(&token.Location{File: "test.lisp", Line: 3, Col: 7, Pos: 11})
+		located := v.String()
+		if strings.Contains(located, "0x") {
+			t.Errorf("%s renders a heap address: %s", typ, located)
+		}
+		// An error renders its location deliberately, as file:line:col --
+		// text, not an address -- so only it is exempt from this half.
+		if typ != lisp.LError && located != unlocated {
+			t.Errorf("%s renders differently once located:\n  unlocated: %s\n  located:   %s", typ, unlocated, located)
+		}
+		// A copy holds a different *token.Location, so a rendering that
+		// leaked the pointer would differ here even within one process.
+		if cp := v.Copy().String(); cp != located {
+			t.Errorf("%s renders differently after Copy:\n  original: %s\n  copy:     %s", typ, located, cp)
+		}
+	}
+	for typ := range lvalSamples {
+		if typ >= lisp.LTypeMax {
+			t.Errorf("lvalSamples holds LType %d, which is not a valid type", typ)
+		}
+	}
+}
+
+// TestQSymbolString pins the rendering an LQSymbol got in issue #606: the
+// quoted symbol name, the same text a quoted LSymbol renders, and the same
+// text the debugger's inspector has always shown for one.
+func TestQSymbolString(t *testing.T) {
+	loc := &token.Location{File: "test.lisp", Line: 1, Col: 1}
+	qsym := func() *lisp.LVal {
+		v := lisp.QSymbol("pkg:sym")
+		v.SetSource(loc)
+		return v
+	}
+	tests := []struct {
+		name string
+		val  *lisp.LVal
+		want string
+	}{
+		{"bare", qsym(), "'pkg:sym"},
+		{"in list", lisp.SExpr([]*lisp.LVal{lisp.Symbol("f"), qsym()}), "(f 'pkg:sym)"},
+		{"quoted list", lisp.QExpr([]*lisp.LVal{qsym()}), "'('pkg:sym)"},
+		{"double quoted", lisp.Quote(qsym()), "''pkg:sym"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.val.String(); got != test.want {
+				t.Errorf("String() = %s, want %s", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`strNested` had no `case LQSymbol`, so a quoted-symbol value fell through to the default arm, `quote + fmt.Sprintf("#<%s %#v>", v.Type, v)`. `%#v` of an `*LVal` prints its pointer fields, so a LOCATED LQSymbol rendered the address of its `*token.Location`.

Closes #606

## Reproduction

```go
v := lisp.QSymbol("pkg:sym")
fmt.Printf("unlocated: %s\n", v.String())
v.SetSource(&token.Location{File: "test.lisp", Line: 3, Col: 7})
fmt.Printf("located:   %s\n", v.String())
fmt.Printf("copy:      %s\n", v.Copy().String())
```

Exact output on `origin/main` (a32ada7):

```
unlocated: #<qsymbol &lisp.LVal{Native:interface {}(nil), source:(*token.Location)(nil), meta:(*fmtmeta.Meta)(nil), macroExpansion:(*lisp.macroExpansionInfo)(nil), Str:"pkg:sym", Cells:[]*lisp.LVal(nil), Type:0x5, Int:0, Float:0, FunType:0x0, quoted:false, spliced:false, sealed:false}>
located:   #<qsymbol &lisp.LVal{Native:interface {}(nil), source:(*token.Location)(0xc000137810), meta:(*fmtmeta.Meta)(nil), macroExpansion:(*lisp.macroExpansionInfo)(nil), Str:"pkg:sym", Cells:[]*lisp.LVal(nil), Type:0x5, Int:0, Float:0, FunType:0x0, quoted:false, spliced:false, sealed:false}>
copy:      #<qsymbol &lisp.LVal{Native:interface {}(nil), source:(*token.Location)(0xc000137860), meta:(*fmtmeta.Meta)(nil), macroExpansion:(*lisp.macroExpansionInfo)(nil), Str:"pkg:sym", Cells:[]*lisp.LVal(nil), Type:0x5, Int:0, Float:0, FunType:0x0, quoted:false, spliced:false, sealed:false}>
```

`0xc000137810` vs `0xc000137860`: the same value renders two different strings in one process, and a different string again in the next process. ELPS runs phylum code on a ledger where every peer must produce byte-identical output, so a rendering that embeds a heap address is nondeterministic across peers by construction.

## Is it reachable from lisp?

**Latent for elps alone; live for any embedding whose Go code returns a qsymbol.** Evidence, both directions:

**Ordinary lisp code cannot build one.** `lisp.QSymbol` (lisp.go:609) is the only place in the module that sets `Type: LQSymbol`, and it has no non-test callers — `grep` finds only `internal/fuzzval` and `lisp/x/debugger/inspector_test.go`. Every other `LQSymbol` mention in the tree is a defensive type-switch arm. Confirmed empirically: parsing and evaluating the quoting forms produces `LSymbol` with the `quoted` flag, never `LQSymbol`.

```
'foo                             => type=symbol   str='foo  qsymbol=false
''foo                            => type=quote    str=''foo  qsymbol=false
'''foo                           => type=quote    str='''foo  qsymbol=false
(quote foo)                      => type=symbol   str='foo  qsymbol=false
(quote (quote foo))              => type=list     str='(quote foo)  qsymbol=false
'lisp:car                        => type=symbol   str='lisp:car  qsymbol=false
(type 'foo)                      => type=symbol   str='symbol  qsymbol=false
(car '(a b))                     => type=symbol   str=a  qsymbol=false
(to-string 'foo)                 => type=string   str="foo"  qsymbol=false
(format-string "{}" 'foo)        => type=string   str="'foo"  qsymbol=false
(quasiquote (unquote 'foo))      => type=quote    str=''foo  qsymbol=false
```

(`qsymbol=` is a walk of the whole result value for an `LQSymbol` node, not just the root.)

**But an embedder's builtin can, and then it is lisp-visible.** With a builtin `make-qsym` returning `lisp.QSymbol("pkg:sym")` with a location, on `origin/main`:

```
(to-string (make-qsym))            => t.lisp:1:1: lisp:to-string: cannot convert type to string: qsymbol
(format-string "{}" (make-qsym))   => "#<qsymbol &lisp.LVal{... source:(*token.Location)(0xc000188500), ...}>"
(debug-print (make-qsym))          => prints #<qsymbol &lisp.LVal{... source:(*token.Location)(0xc0001887d0), ...}>
```

`to-string` refuses the type, but `format-string` puts the heap address into a lisp string **value**, and `debug-print` puts it on stdout. Also reachable through any error message that renders the value. So: not reachable from lisp alone, reachable from lisp the moment a Go builtin hands one back — which is the shape substrate phyla run in.

## Option chosen: (a), a real rendering arm

Not (b), removing `LQSymbol`. `LQSymbol` is an exported constant in an ordered `iota` block and `lisp.QSymbol` is exported API, so removing it renumbers every `LType` above it and breaks compilation of every embedder that names either. Inside this repo alone the name appears in `seal.go`, `detach.go`, `embed.go`, `loader.go`, `env.go`, `package.go`, `libjson`, `libschema`, `minifier`, `lsp/semantic_tokens.go`, `lisp/x/profiler` and the debugger's inspector; `env.Get`/`Put` and the package registry deliberately accept `LQSymbol` keys, so removal is a behaviour change for embedders too. That is a breaking cross-repo API change, not a small behaviour-preserving migration, so the TODO on `lisp.go:46` stays for a release that can carry it.

Two details of the arm:

- It goes in `str`, not `strNested`. A qsymbol renders from its own `Str` field and reaches nothing, so it does not belong on the cycle guard's path — that is exactly the split the `default:` comment in `str` asks a new type to decide.
- It renders the quoted symbol name, the text a quoted `LSymbol` renders and the text `lisp/x/debugger/inspector.go` has always shown for one. A second quote is emitted when `v.quoted` is set (which `Quote` does, since `QSymbol` does not set the flag) or when an enclosing `LQuote` passes `onTheRecord`, so quote levels count exactly as they do for a symbol: `'pkg:sym`, `''pkg:sym`, `'''pkg:sym`.

The `default:` arm keeps its place but loses the `%#v`: an unhandled type now renders `#<typename>` alone. That closes the class rather than the instance, and it also fixes `LInvalid`, which was the other type with no arm and leaked an address the same way. Nothing in the tree asserted on the old `%#v` text.

## The all-types invariant

`TestStringNoAddressForEveryLType` (`lisp/string_address_test.go`) walks `LType(0)` up to the `LTypeMax` bound — enumerated from the source, not hand-listed — and for each type takes a sample from a `map[LType]func() *LVal`, locates it, and asserts its rendering:

- contains no `0x`,
- is unchanged by locating the value (`LError` exempt: it renders `file:line:col` deliberately, which is text, not an address),
- is unchanged by `Copy` (a copy holds a different `*token.Location`, so a leaked pointer differs even within one process).

A missing sample is a test failure naming the type, so a newly added `LType` cannot silently stop being covered — it fails until it has both a sample here and a rendering arm. `LNative`'s sample carries a **pointer** payload so that a `%v` regression would be caught. `TestQSymbolString` pins the four quote-level renderings.

## Test plan

`TestStringNoAddressForEveryLType` / `TestQSymbolString` on `origin/main` (fix reverted, test kept):

```
--- FAIL: TestStringNoAddressForEveryLType (0.00s)
    string_address_test.go:82: INVALID renders a heap address: #<INVALID &lisp.LVal{... source:(*token.Location)(0xc000015a40) ...}>
    string_address_test.go:87: INVALID renders differently once located: ...
    string_address_test.go:92: INVALID renders differently after Copy: ... 0xc000015a40 vs 0xc000015a90
    string_address_test.go:82: qsymbol renders a heap address: #<qsymbol &lisp.LVal{... source:(*token.Location)(0xc000015e50) ...}>
    string_address_test.go:87: qsymbol renders differently once located: ...
    string_address_test.go:92: qsymbol renders differently after Copy: ... 0xc000015e50 vs 0xc000015ea0
--- FAIL: TestQSymbolString (0.00s)
    --- FAIL: TestQSymbolString/bare        String() = #<qsymbol &lisp.LVal{...}>, want 'pkg:sym
    --- FAIL: TestQSymbolString/in_list     String() = (f #<qsymbol &lisp.LVal{...}>), want (f 'pkg:sym)
    --- FAIL: TestQSymbolString/quoted_list String() = '(#<qsymbol &lisp.LVal{...}>), want '('pkg:sym)
    --- FAIL: TestQSymbolString/double_quoted String() = #<qsymbol &lisp.LVal{...}>, want ''pkg:sym
FAIL
```

After the fix:

```
=== RUN   TestStringNoAddressForEveryLType
--- PASS: TestStringNoAddressForEveryLType (0.00s)
=== RUN   TestQSymbolString
    --- PASS: TestQSymbolString/bare (0.00s)
    --- PASS: TestQSymbolString/in_list (0.00s)
    --- PASS: TestQSymbolString/quoted_list (0.00s)
    --- PASS: TestQSymbolString/double_quoted (0.00s)
--- PASS: TestQSymbolString (0.00s)
PASS
```

And the reproduction above, after the fix:

```
unlocated: 'pkg:sym
located:   'pkg:sym
copy:      'pkg:sym
```

Gates run locally (slow box, so scoped rather than the whole suite):

| Gate | Result |
|---|---|
| `go build ./...` | pass |
| `go vet ./lisp/` | pass |
| `gofmt -l` on touched files | clean (the five files `gofmt -l ./lisp` reports are untouched and already listed on `main`) |
| `golangci-lint run ./lisp/...` | `0 issues.` |
| `make elpsvet` (both passes) | pass |
| `go test ./lisp -run 'TestString\|TestFormat\|TestSymbol\|TestQuote\|TestRender\|TestLVal' -count=1` | ok |
| same, `-tags elpscheck` | ok |
| `go test ./elpstest -count=1` | ok — fingerprinting encodes renderings, so this is the one that would catch a knock-on |
| `go test ./lisp/... -count=1` | all ok (31.6s for `lisp`) |
| `go test ./internal/fuzzval/... ./lisp/x/debugger/... -count=1` | ok |

## Note for #604

`internal/fuzzval`'s pooled-`Location` comment justified the pool partly by this rendering ("`LVal.String()` renders an `LQSymbol` with `%#v`, which prints the Source POINTER"). That rationale is now stale, so the comment is updated to record that #606 closed it and that the pool stands on the fidelity argument alone. The pool itself is unchanged.

`FuzzCyclicValueWalks` in PR #604 blanks `0x[0-9a-f]+` before comparing renderings, for the four inputs (`8c00000000000000`, `8c01020304050607`, `0bfffefdfcfbfaf9`, `0cfffefdfcfbfaf9`) that failed on the rendering alone. **That workaround can be removed once both this and #604 land** — no rendering prints an address any more, and `TestStringNoAddressForEveryLType` is the standing guard for that. Deliberately not touched here, since #604 is a separate open branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3JiPj1sGKj8BtcmJjNvpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3JiPj1sGKj8BtcmJjNvpj)_