### PR TITLE
Gate Copy's cell-view drop on the header type, and widen the drift scan to the class that let it ship

### DIFF
--- a/lisp/copy_native_lval_test.go
+++ b/lisp/copy_native_lval_test.go
@@ -1,0 +1,133 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// An LNative whose payload happens to be a *LVal is a payload like any
+// other -- lisp.NativeOf[*lisp.LVal] is a spelling the kernel blesses at
+// native.go's NativeOf (issue #546), and NativeValue[*lisp.LVal] is the
+// documented way to read it back.  It is NOT a cell view: a cell view is an
+// LSExpr whose Native names the header its Cells window (the convention on
+// cellsView), and cellsView itself gates on that header type before it
+// looks at the payload.
+//
+// Copy briefly keyed "this link is a cell view" on the payload type alone,
+// so every one of these natives came back from Copy with a nil payload.
+// These tests pin the header-type gate that detach.go's twin arm always
+// had.
+
+// TestCopyKeepsNativeLValPayload is the unit form: the payload survives a
+// Copy, and the copy still reads back through the typed accessor.
+func TestCopyKeepsNativeLValPayload(t *testing.T) {
+	payload := lisp.QExpr([]*lisp.LVal{lisp.Int(1), lisp.Int(2)})
+	v := lisp.NativeOf[*lisp.LVal](payload)
+	if v.Type != lisp.LNative {
+		t.Fatalf("NativeOf built a %v, want %v", v.Type, lisp.LNative)
+	}
+
+	cp := v.Copy()
+	if cp.Type != lisp.LNative {
+		t.Fatalf("Copy produced a %v, want %v", cp.Type, lisp.LNative)
+	}
+	if cp.Native == nil {
+		t.Fatalf("Copy dropped the native payload: %#v", cp.Native)
+	}
+	got, ok := lisp.NativeValue[*lisp.LVal](cp)
+	if !ok {
+		t.Fatalf("NativeValue[*lisp.LVal] on the copy: not ok, payload %T", cp.Native)
+	}
+	if got != payload {
+		t.Errorf("Copy replaced the payload: got %p, want %p", got, payload)
+	}
+	// Copy shares native leaves by identity (TestCopySharesFunctionAndNativeLeaves),
+	// so Int -- which the cell-view convention uses as the view's offset --
+	// must not be zeroed either.
+	if cp.Int != v.Int {
+		t.Errorf("Copy changed Int: got %d, want %d", cp.Int, v.Int)
+	}
+}
+
+// TestCopyKeepsNativeLValPayloadUnderStableSort is the reachable form, and
+// the reason this matters outside a unit test: no Go code has to call Copy
+// for the payload to vanish.  stable-sort's comparator copies both
+// elements it compares (lvalByFun.Less), so ordinary lisp sorting a list
+// of these natives hands the key function arguments whose payload is gone
+// -- surfacing to an embedder as "expected native *lisp.LVal value, got
+// native <nil>".  builtinInsertSorted copies the same way, so insert-sorted
+// is exercised alongside it.
+func TestCopyKeepsNativeLValPayloadUnderStableSort(t *testing.T) {
+	env := copyTestEnv(t)
+
+	// `boxed-rank` is the embedder-side reader: it asks for the payload
+	// through the typed accessor exactly as RequireNative documents, and
+	// reports the failure the way an embedder would see it.
+	var seen, nilPayload int
+	rank := lisp.FunInPackage(lisp.DefaultUserPackage, lisp.DefaultUserPackage+":boxed-rank", lisp.Formals("x"),
+		func(env *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+			seen++
+			box := args.Cells[0]
+			inner, lerr := lisp.RequireNative[*lisp.LVal](box)
+			if lerr != nil {
+				nilPayload++
+				return lerr
+			}
+			return inner.Cells[0]
+		})
+	if lerr := env.PutGlobal(lisp.Symbol("boxed-rank"), rank); lerr.Type == lisp.LError {
+		t.Fatalf("PutGlobal boxed-rank: %v", lerr)
+	}
+
+	box := func(n int) *lisp.LVal {
+		return lisp.NativeOf[*lisp.LVal](lisp.QExpr([]*lisp.LVal{lisp.Int(n)}))
+	}
+	env.PutGlobal(lisp.Symbol("hi"), box(2))
+	env.PutGlobal(lisp.Symbol("lo"), box(1))
+
+	sorted := env.LoadString("copy_native_lval_test.lisp",
+		`(stable-sort < (list hi lo) boxed-rank)`)
+	if sorted.Type == lisp.LError {
+		t.Fatalf("stable-sort over *LVal-payload natives failed (%d/%d arguments arrived with a nil payload): %v",
+			nilPayload, seen, sorted)
+	}
+	if nilPayload != 0 {
+		t.Errorf("stable-sort delivered %d/%d arguments with a nil payload", nilPayload, seen)
+	}
+	if got := ranks(t, sorted); got != "[1 2]" {
+		t.Errorf("stable-sort ordered the boxes %s, want [1 2]", got)
+	}
+
+	inserted := env.LoadString("copy_native_lval_test.lisp",
+		`(insert-sorted 'list (list lo) < hi boxed-rank)`)
+	if inserted.Type == lisp.LError {
+		t.Fatalf("insert-sorted over *LVal-payload natives failed (%d/%d arguments arrived with a nil payload): %v",
+			nilPayload, seen, inserted)
+	}
+	if nilPayload != 0 {
+		t.Errorf("insert-sorted delivered %d/%d arguments with a nil payload", nilPayload, seen)
+	}
+	if got := ranks(t, inserted); got != "[1 2]" {
+		t.Errorf("insert-sorted ordered the boxes %s, want [1 2]", got)
+	}
+}
+
+// ranks renders the payload rank of each box in a sequence of natives, so
+// the order assertions above read the payloads rather than the natives'
+// opaque printed form.
+func ranks(t *testing.T, seq *lisp.LVal) string {
+	t.Helper()
+	out := make([]int, len(seq.Cells))
+	for i, c := range seq.Cells {
+		inner, lerr := lisp.RequireNative[*lisp.LVal](c)
+		if lerr != nil {
+			t.Fatalf("element %d: %v", i, lerr)
+		}
+		out[i] = inner.Cells[0].Int
+	}
+	return fmt.Sprint(out)
+}

--- a/lisp/detach.go
+++ b/lisp/detach.go
@@ -219,6 +219,30 @@ func (d *detacher) detach(v *LVal) (*LVal, error) {
 			// A cell view's root (the convention on lisp.cellsView).
 			// detachCells below gives the copy storage of its own, so the
 			// link is dropped (TestCopyAndDetachDropCellViewLink).
+			//
+			// SILENTLY, and not because nobody thought about it.  Before
+			// cell views existed this whole shape -- any payload on an
+			// LSExpr -- fell to the default arm and was refused, so it is
+			// fair to ask for the refusal back for everything that is not
+			// a live view: an embedder can reach the exported Native field
+			// and set a *LVal there, and that value would now be nil'd
+			// without a word.
+			//
+			// It cannot be done, because a STALE link is the same bytes.
+			// The convention above makes staleness legitimate and
+			// expected -- "never a correctness hazard, only a lost
+			// optimisation" -- and pure lisp reaches it: (rest v) takes a
+			// view and (append! v x) past the root's exact capacity
+			// reallocates the root, after which the view's link describes
+			// memory neither header holds.  CellView, the one validated
+			// resolver, answers false for the stale link and for the
+			// embedder's scribble alike; there is no third signal to
+			// separate them.  A loud arm here would therefore refuse that
+			// ordinary program, which is worse than silently dropping a
+			// link that is already meaningless.
+			// TestDetachDropsAStaleCellViewLinkSilently is the measurement:
+			// it builds the stale shape from lisp, and reinstating the
+			// refusal fails it.
 			cp.Native = nil
 			cp.Int = 0
 		default:

--- a/lisp/detach_cellview_stale_test.go
+++ b/lisp/detach_cellview_stale_test.go
@@ -1,0 +1,67 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import "testing"
+
+// TestDetachDropsAStaleCellViewLinkSilently is the evidence for detach's
+// refusal to be LOUD about a *LVal payload on an LSExpr that is not a live
+// cell view.
+//
+// The tempting rule is "an LSExpr whose Native is a *LVal is a cell view;
+// anything else there is an embedder scribbling on a field it does not own,
+// so refuse it the way the default arm refuses every other unrecognised
+// payload".  It cannot be implemented, because a STALE link is that same
+// shape and is legitimate: the convention on cellsView says so in as many
+// words ("A stale link is therefore never a correctness hazard, only a lost
+// optimisation"), and this test reaches one from ordinary lisp -- (rest v)
+// takes a view, (append! v 5) reallocates the root past its exact capacity,
+// and the view's link now describes memory neither header holds.
+//
+// CellView, the validated resolver, answers false for BOTH -- a stale link
+// and an embedder-set payload are the same bytes -- so a loud arm would
+// reject this program.  Dropping the link silently is therefore the only
+// available behaviour, not a lapse.  Reinstating the refusal must fail
+// here.
+func TestDetachDropsAStaleCellViewLinkSilently(t *testing.T) {
+	env := newForkTestEnv(t)
+	v := setGlobal(t, env, "v", "vector", ints(30, 10, 20)...)
+	before := v.Cells[1].Cells
+	r := setGlobal(t, env, "r", "rest", Symbol("v"))
+	// (vector ...) allocates exact capacity, so this append! reallocates
+	// the root and strands r's link.
+	call(t, env, "append!", Symbol("v"), Int(5))
+	if &v.Cells[1].Cells[0] == &before[0] {
+		t.Skip("append! did not reallocate; nothing to pin")
+	}
+	if root, _ := r.cellsView(); root == nil {
+		t.Fatal("premise: r carries no link at all")
+	}
+	if _, _, ok := r.CellView(); ok {
+		t.Fatal("premise: r's link is still live, so it is not the stale shape")
+	}
+
+	for _, c := range []struct {
+		name string
+		run  func() (*LVal, error)
+	}{
+		{"Detach", func() (*LVal, error) { return Detach(r) }},
+		{"deepCopy", func() (*LVal, error) {
+			cp := call(t, env, "copy", Symbol("r"))
+			return cp, nil
+		}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			cp, err := c.run()
+			if err != nil {
+				t.Fatalf("a stale cell-view link was refused: %v", err)
+			}
+			if cp.Native != nil {
+				t.Errorf("the stale link survived: Native = %T", cp.Native)
+			}
+			if got := intsOf(t, cp); !eqInts(got, []int{10, 20}) {
+				t.Errorf("copy = %v, want [10 20]", got)
+			}
+		})
+	}
+}

--- a/lisp/fork_fundata_test.go
+++ b/lisp/fork_fundata_test.go
@@ -1,0 +1,84 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestForkRebuildsFunDataPerHeaderIndistinguishably is the measurement
+// behind the *funData row in memoExemptions.
+//
+// The forker rebuilds a *funData per HEADER (`cp.Native = &funData{...}`)
+// and memoises nothing, which is the #576 / #585 shape in outline: FunRef
+// puts two headers on ONE *funData deliberately -- that is what makes a
+// reference a reference -- and the fork gives them one each.  The row says
+// that split cannot be observed, and this is why: a funData is write-once.
+// Every one in the package is built by a composite literal and no field of
+// one is ever assigned afterwards, so the two copies are field-identical,
+// and the single field that could have differed -- env -- goes through the
+// forker's own envs memo, so both copies name the SAME copied environment.
+//
+// If a funData field ever becomes mutable, or env stops being memoised,
+// this test is what goes red and the row is what has to change.
+func TestForkRebuildsFunDataPerHeaderIndistinguishably(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		build func(t *testing.T, env *LEnv) *LVal
+	}{
+		{"lambda", func(t *testing.T, env *LEnv) *LVal {
+			t.Helper()
+			return setGlobal(t, env, "f", "lambda", QExpr([]*LVal{Symbol("x")}), Symbol("x"))
+		}},
+		{"builtin", func(t *testing.T, env *LEnv) *LVal {
+			t.Helper()
+			f := env.GetFunGlobal(Symbol("+"))
+			if f.Type != LFun {
+				t.Fatalf("(+) is not a function: %v", f)
+			}
+			if lerr := env.PutGlobal(Symbol("f"), f); lerr.Type == LError {
+				t.Fatalf("PutGlobal f: %v", lerr)
+			}
+			return f
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newForkTestEnv(t)
+			f := tc.build(t, env)
+			ref := FunRef(Symbol("g"), f)
+			if ref.Type != LFun {
+				t.Fatalf("FunRef: %v", ref)
+			}
+			if lerr := env.PutGlobal(Symbol("g"), ref); lerr.Type == LError {
+				t.Fatalf("PutGlobal g: %v", lerr)
+			}
+			if f.funData() != ref.funData() {
+				t.Fatal("premise: FunRef did not share the *funData")
+			}
+
+			_, get := forkOf(t, env)
+			ff, fg := get("f"), get("g")
+			a, b := ff.funData(), fg.funData()
+			if a == b {
+				// Not a failure -- a fork that memoised funData would be
+				// strictly better. The row only has to hold when it does not.
+				t.Skip("the fork shared the *funData; nothing to measure")
+			}
+			if a.fid != b.fid || a.pkg != b.pkg {
+				t.Errorf("the split copies differ: fid %q/%q, pkg %q/%q", a.fid, b.fid, a.pkg, b.pkg)
+			}
+			if a.env != b.env {
+				t.Errorf("the split copies name different environments (%p, %p); env is supposed to\n"+
+					"travel through the forker's envs memo, which is what makes the split unobservable",
+					a.env, b.env)
+			}
+			if reflect.ValueOf(a.builtin).Pointer() != reflect.ValueOf(b.builtin).Pointer() {
+				t.Error("the split copies hold different builtins")
+			}
+			if a.loc != nil || b.loc != nil {
+				t.Errorf("fork kept a defining location (%v, %v); it is documented to drop it", a.loc, b.loc)
+			}
+		})
+	}
+}

--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -1726,9 +1726,24 @@ func (v *LVal) Copy() *LVal {
 		cp.Native = mdata
 	default:
 		cp.Cells = v.copyCells()
-		if _, isView := v.Native.(*LVal); isView {
+		if v.IsCellView() {
 			// Fresh storage, so the struct copy's cell-view link is stale
 			// (the convention on cellsView; TestCopyAndDetachDropCellViewLink).
+			//
+			// The gate is IsCellView, not a bare `v.Native.(*LVal)`, because
+			// a *LVal payload is only a LINK when the header carrying it is
+			// an LSExpr -- which is the one thing cellsView checks before it
+			// reads the field.  On an LNative the same payload is embedder
+			// DATA, the shape lisp.NativeOf[*lisp.LVal] writes and
+			// NativeValue[*lisp.LVal] reads back (native.go, issue #546),
+			// and clearing it here destroyed it on every copy: ordinary
+			// lisp `(stable-sort < boxes key)` handed the key function
+			// arguments whose payload was gone, because lvalByFun.Less
+			// copies both elements it compares
+			// (TestCopyKeepsNativeLValPayloadUnderStableSort).  detach's
+			// twin arm has keyed on the header type all along
+			// (detach.go's `if v.Type != LSExpr`), and the *[]byte,
+			// *MapData and *CallStack arms beside it all do the same.
 			cp.Native = nil
 			cp.Int = 0
 		}

--- a/lisp/lvalcopy_drift_test.go
+++ b/lisp/lvalcopy_drift_test.go
@@ -57,6 +57,7 @@ type lvalCopySite struct {
 	Func string // enclosing function as the allowlist names it
 	Form string // "*x = *y" or "x = *y"
 	Src  string // the source line, trimmed
+	Test bool   // the site is in a _test.go file
 }
 
 func (s lvalCopySite) String() string {
@@ -95,18 +96,40 @@ func TestEveryLValStructCopyIsInAWalkerOrAllowlisted(t *testing.T) {
 		return false
 	}
 
-	allowed := map[string]LValCopyExemption{}
+	// Keyed by function AND by which list the row belongs to. A production
+	// copy can only be answered by a production row: five of the eleven
+	// rows are fixtures, so a single flat map let any `*cp = *v` added to
+	// shipping code inside a test-shaped function name find a row waiting
+	// for it.
+	type rowKey struct {
+		fn   string
+		test bool
+	}
+	allowed := map[rowKey]LValCopyExemption{}
 	for _, e := range LValCopyExemptions() {
-		allowed[e.Func] = e
+		allowed[rowKey{e.Func, e.Test}] = e
 	}
 
-	counts := map[string]int{}
+	counts := map[rowKey]int{}
 	for _, s := range sites {
 		if inWalker(s.Func) {
 			continue
 		}
-		counts[s.Func]++
-		if _, ok := allowed[s.Func]; ok {
+		key := rowKey{s.Func, s.Test}
+		counts[key]++
+		if _, ok := allowed[key]; ok {
+			continue
+		}
+		if _, wrongList := allowed[rowKey{s.Func, !s.Test}]; wrongList {
+			list, want := "lvalCopyTestExemptions", "lvalCopyExemptions"
+			if s.Test {
+				list, want = "lvalCopyExemptions", "lvalCopyTestExemptions"
+			}
+			t.Errorf("%s\n"+
+				"A row for %q exists, but in %s -- the wrong list for this site's file.\n"+
+				"The lists are matched against the site's file on purpose: a fixture row must never be\n"+
+				"able to silence a struct copy in shipping code. Move or add the row in %s.",
+				s, s.Func, list, want)
 			continue
 		}
 		t.Errorf("%s\n"+
@@ -127,7 +150,7 @@ func TestEveryLValStructCopyIsInAWalkerOrAllowlisted(t *testing.T) {
 	// Shrink-only, both directions: a row whose function no longer copies
 	// anything is dead, and a function that grew a copy needs re-review.
 	for _, e := range LValCopyExemptions() {
-		got, ok := counts[e.Func]
+		got, ok := counts[rowKey{e.Func, e.Test}]
 		if !ok {
 			t.Errorf("lvalCopyExemptions has a row for %q, which no longer contains an LVal struct copy\n"+
 				"outside a walker. Delete the row: this allowlist is shrink-only, and a row that outlives\n"+
@@ -237,6 +260,7 @@ func funcLabel(pkg *packages.Package, fd *ast.FuncDecl) string {
 
 func record(pkg *packages.Package, pos token.Pos, fn, form string, seen map[string]bool, out *[]lvalCopySite) {
 	p := pkg.Fset.Position(pos)
+	isTest := strings.HasSuffix(p.Filename, "_test.go")
 	short := p.Filename
 	if i := strings.LastIndex(short, "/"); i >= 0 {
 		short = short[i+1:]
@@ -246,7 +270,7 @@ func record(pkg *packages.Package, pos token.Pos, fn, form string, seen map[stri
 		return
 	}
 	seen[key] = true
-	*out = append(*out, lvalCopySite{Pos: key, Func: fn, Form: form, Src: srcLine(p)})
+	*out = append(*out, lvalCopySite{Pos: key, Func: fn, Form: form, Src: srcLine(p), Test: isTest})
 }
 
 // srcLine returns the trimmed source line at a position, for the report.

--- a/lisp/sharedtree_backstop_test.go
+++ b/lisp/sharedtree_backstop_test.go
@@ -1,0 +1,44 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp_test
+
+import "testing"
+
+// The backstop collapse must be narrow: it exists so that two arms stopped by
+// DIFFERENT budgets on the same runaway loop agree, and for nothing else.  A
+// collapse that reached any further would blind FuzzSharedTreeEval to the
+// divergences it exists to find, which is a worse outcome than the flake it
+// removes (crasher 423b7dd9e421bd27).
+func TestOnlyTwoBackstopsCollapse(t *testing.T) {
+	const (
+		iter     = "fuzz:1:28: s: tail-call iteration limit exceeded: 100001 (a single tail-recursive loop ran this many turns)"
+		deadline = "fuzz:1:11: context-cancelled: context cancelled: context deadline exceeded"
+		other    = "fuzz:1:11: context-cancelled: context cancelled: some other cause"
+		value    = "'(1 2 3)"
+		raised   = "fuzz:1:4: user error: rate limit exceeded"
+	)
+	for _, tt := range []struct {
+		name     string
+		a, b     string
+		collapse bool
+	}{
+		{"the two budgets, either order", iter, deadline, true},
+		{"the two budgets, reversed", deadline, iter, true},
+		{"the same budget twice", iter, iter, true},
+		// The asymmetric cases: one arm stopped by a budget and the other
+		// not.  Scheduling does not explain those, so they stay divergences.
+		{"a budget against a value", iter, value, false},
+		{"a budget against an ordinary error", deadline, other, false},
+		{"a value against a budget", value, deadline, false},
+		// A program is free to RAISE an error whose text mentions a limit.
+		// That is the program's meaning, not a backstop.
+		{"a program-raised error naming a limit", raised, iter, false},
+		{"two ordinary errors", other, value, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bothHitAResourceBackstop(tt.a, tt.b); got != tt.collapse {
+				t.Fatalf("collapse=%v, want %v\n  a: %s\n  b: %s", got, tt.collapse, tt.a, tt.b)
+			}
+		})
+	}
+}

--- a/lisp/sharedtree_fuzz_test.go
+++ b/lisp/sharedtree_fuzz_test.go
@@ -5,6 +5,7 @@ package lisp_test
 import (
 	"bytes"
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -262,7 +263,7 @@ func sharedTreeProperty(t *testing.T, src []byte) {
 			return
 		}
 		for j := range want {
-			if got[i][j] != want[j] {
+			if got[i][j] != want[j] && !bothHitAResourceBackstop(want[j], got[i][j]) {
 				t.Fatalf("evaluating a SHARED parse tree changed the program's meaning"+
 					"\n  expression %d, shared run %d"+
 					"\n  private tree: %s"+
@@ -333,4 +334,38 @@ func TestSharedTreeSeedsAgree(t *testing.T) {
 			sharedTreeProperty(t, []byte(src))
 		})
 	}
+}
+
+// bothHitAResourceBackstop reports whether two rendered results are each a
+// runaway-loop backstop tripping, and so are the same outcome reported by
+// whichever limit happened to trip first.
+//
+// A non-terminating program is stopped by one of two independent budgets: the
+// tail-call iteration counter, which is denominated in TURNS, and the context
+// deadline, which is denominated in TIME.  Which one fires is a property of
+// how fast the process was running, not of what the program means -- and the
+// shared and private arms run at different speeds, the shared arm having
+// skipped a parse.  On a loaded machine the two arms therefore disagree about
+// which limit stopped the same infinite loop, and the comparison below reads
+// that as "evaluating a SHARED parse tree changed the program's meaning".
+//
+// Measured on b076a2f, which predates this branch: `(defun s()(let()(s)))(s)(s)(s)`
+// passes 5/5 run sequentially and fails 8/8 run concurrently, on the chain head
+// itself.  CI runs eleven fuzz shards at once, which is the load that surfaced it
+// (crasher 423b7dd9e421bd27).
+//
+// Only the case where BOTH arms hit a backstop is collapsed.  One arm
+// terminating while the other is stopped by a budget remains a divergence and
+// is still reported: that asymmetry is not explained by scheduling.
+func bothHitAResourceBackstop(a, b string) bool {
+	return isResourceBackstop(a) && isResourceBackstop(b)
+}
+
+// isResourceBackstop reports whether a rendered result is one of the two
+// budgets that stop a runaway loop.  It matches those two and nothing else --
+// an ordinary error, including one raised BY the program, is not a backstop
+// and must still be compared verbatim.
+func isResourceBackstop(s string) bool {
+	return strings.Contains(s, "tail-call iteration limit exceeded") ||
+		strings.Contains(s, "context deadline exceeded")
 }

--- a/lisp/walkers.go
+++ b/lisp/walkers.go
@@ -227,6 +227,20 @@ var memoExemptions = []MemoExemption{
 			"(TestCopyAndDetachDropCellViewLink).",
 	},
 	{
+		Subject: "*funData",
+		Reason: "an LFun's function data, REBUILT per header by the fork walker (`cp.Native = &funData{...}`) " +
+			"and not memoised, so FunRef's two headers over one *funData -- the deliberate aliasing " +
+			"lvalCopyExemptions' FunRef row describes -- get one copy each in the fork. That split cannot " +
+			"be observed, because a funData is write-once: every one in this package is built by a " +
+			"composite literal and no field of one is assigned afterwards, so the copies are " +
+			"field-identical, and the only field that could have differed -- env -- travels through the " +
+			"forker's own envs memo, so both copies name the SAME copied environment. Measured by " +
+			"TestForkRebuildsFunDataPerHeaderIndistinguishably, which is what goes red if a funData " +
+			"field ever becomes mutable. NEW in the commit that widened the payload scan: this site was " +
+			"always there, expressed as a type assertion inside a `switch v.Type` arm, and the old scan " +
+			"read only `case` arms of `switch v.Native.(type)` in two named files.",
+	},
+	{
 		Subject: "lisp.sealCheckState.roots",
 		Reason: "the checked-build seal watchdog's fingerprint table (lisp/seal_check_elpscheck.go, -tags elpscheck). " +
 			"It maps a sealed root to the digest it carried at seal time; it produces no copy.",

--- a/lisp/walkers.go
+++ b/lisp/walkers.go
@@ -343,15 +343,32 @@ type LValCopyExemption struct {
 	// A function that grows one more fails until this is updated, which is
 	// the review the row exists to force.
 	Sites int
+	// Test marks a row that covers a site in a _test.go file, i.e. a
+	// FIXTURE that builds an aliased shape on purpose. Set by
+	// LValCopyExemptions from which list the row came from, and checked
+	// against the site's own file: a row from the test list can never
+	// silence a copy in production code, whatever the enclosing function
+	// happens to be called.
+	Test bool
 }
 
-// lvalCopyExemptions is SHRINK-ONLY: a row whose function no longer
-// contains a struct copy is dead and must be deleted.
+// lvalCopyExemptions is the PRODUCTION list, and it is SHRINK-ONLY: a row
+// whose function no longer contains a struct copy is dead and must be
+// deleted.
 //
 // Four of these are not hazards that happen to be safe. Quote, Splice,
 // shallowUnquote and FunRef are where the INTENTIONAL aliasing lives -- the
 // aliasing every walker in the registry above exists to PRESERVE. A walker
 // that de-aliased them would be the defect.
+//
+// FIXTURE ROWS LIVE IN lvalCopyTestExemptions, BELOW, and the split is not
+// cosmetic. Five of the eleven rows this list used to hold named test
+// functions, so "shrink-only in practice" was not true of it: nearly half
+// its rows were about code that does not ship, and a REAL `*cp = *v` added
+// to production code inside a function with a test-shaped name would have
+// found a plausible-looking row waiting for it. The drift guard now matches
+// a site against a row only when the row's list matches the site's file, so
+// a production copy can only ever be answered by a production row.
 var lvalCopyExemptions = []LValCopyExemption{
 	{
 		Func:  "Quote",
@@ -392,6 +409,14 @@ var lvalCopyExemptions = []LValCopyExemption{
 			"this registration and unreachable by anything else; the source is read-only, the subject is a " +
 			"symbol list with no payload, and both sites already carry //elps:mutates annotations saying so.",
 	},
+}
+
+// lvalCopyTestExemptions holds the rows for FIXTURES: struct copies inside
+// _test.go files that build a two-headers-over-one-payload shape on purpose,
+// so a test can assert a walker preserves or flattens it. Shrink-only on the
+// same terms as the production list, and kept apart from it so that list is
+// about shipping code only.
+var lvalCopyTestExemptions = []LValCopyExemption{
 	{
 		Func:  "TestCopyDeAliasesMapPayloadAcrossHeaders",
 		Sites: 1,
@@ -422,10 +447,19 @@ var lvalCopyExemptions = []LValCopyExemption{
 	},
 }
 
-// LValCopyExemptions returns the struct-copy allowlist, copied.
+// LValCopyExemptions returns the struct-copy allowlist -- the production
+// rows followed by the fixture rows -- copied, with each row's Test field
+// stamped from the list it came from.
 func LValCopyExemptions() []LValCopyExemption {
-	out := make([]LValCopyExemption, len(lvalCopyExemptions))
-	copy(out, lvalCopyExemptions)
+	out := make([]LValCopyExemption, 0, len(lvalCopyExemptions)+len(lvalCopyTestExemptions))
+	for _, e := range lvalCopyExemptions {
+		e.Test = false
+		out = append(out, e)
+	}
+	for _, e := range lvalCopyTestExemptions {
+		e.Test = true
+		out = append(out, e)
+	}
 	return out
 }
 

--- a/lisp/walkers_drift_test.go
+++ b/lisp/walkers_drift_test.go
@@ -35,9 +35,13 @@ import (
 //     walker nobody told it about, and cannot catch a memo DELETED from a
 //     registered one; the scan catches both, deterministically, without any
 //     test having to generate the value shape the memo protects.
-//   - The PAYLOAD SCAN half reads the two walkers' `v.Native` type switches
-//     and asserts that every payload type they copy is either a registered
-//     memo kind or an exempted one.  That is issue #585 stated exactly: a
+//   - The PAYLOAD SCAN half reads every function in this package that WRITES
+//     a header's Native field and asserts that every payload type it names —
+//     by a type switch, by a type assertion, or through a cell-view accessor —
+//     is either a registered memo kind or an exempted one.  It used to read
+//     `case` arms in a hardcoded fork.go/detach.go pair, which is why
+//     (*LVal).Copy's cell-view arm shipped unexamined; see
+//     lisp/walkers_payload_scan_test.go.  That is issue #585 stated exactly: a
 //     payload the walker rebuilds but does not memoise is a payload two
 //     headers come apart over.
 
@@ -316,6 +320,9 @@ func TestEveryCopiedPayloadTypeIsMemoisedOrExempt(t *testing.T) {
 	kindOf := map[string]PayloadKind{
 		"*[]byte":  PayloadBytes,
 		"*MapData": PayloadSortedMap,
+		// The protocol type PayloadNative names: detach and fork both route
+		// a payload implementing it through their per-payload natives memo.
+		"NativeCloner": PayloadNative,
 	}
 	exempt := map[string]bool{}
 	for _, e := range memoExemptions {
@@ -323,34 +330,37 @@ func TestEveryCopiedPayloadTypeIsMemoisedOrExempt(t *testing.T) {
 	}
 	used := map[string]bool{}
 
-	for _, file := range []string{"fork.go", "detach.go"} {
-		types, err := nativeSwitchCaseTypes(file)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(types) == 0 {
-			t.Errorf("%s: no v.Native type switch found; the scan has stopped looking", file)
+	// The scan is nativePayloadSites (lisp/walkers_payload_scan_test.go),
+	// which starts from every function that WRITES a Native field and
+	// collects the payload types it names in any form.  It replaced a
+	// hardcoded two-file list of `case` arms that could not see
+	// (*LVal).Copy's site at all -- see that file's header for the
+	// triggering example.
+	sites, _, err := nativePayloadSites()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sites) == 0 {
+		t.Fatal("the payload scan found no site in package lisp; it has stopped looking")
+	}
+	for _, s := range sites {
+		if kind, ok := kindOf[s.Typ]; ok {
+			if !memoisedByEveryRebuildingWalker(kind) {
+				t.Errorf("%s: payload type %s is rebuilt but is not memoised by every rebuilding walker",
+					s.Pos, s.Typ)
+			}
 			continue
 		}
-		for _, typ := range types {
-			if kind, ok := kindOf[typ]; ok {
-				if !memoisedByEveryRebuildingWalker(kind) {
-					t.Errorf("%s: payload type %s is rebuilt but is not memoised by every rebuilding walker",
-						file, typ)
-				}
-				continue
-			}
-			if exempt[typ] {
-				used[typ] = true
-				continue
-			}
-			t.Errorf("%s: the walker copies payload type %s, which is neither a registered memo kind\n"+
-				"nor an exempted one.  A rebuilt payload that is not memoised per payload is rebuilt\n"+
-				"once per HEADER, so two names for it come apart in the copy — issues #576 and #585.\n"+
-				"Memoise it in both rebuilding walkers, or add a row to memoExemptions in\n"+
-				"lisp/walkers.go stating why it cannot be aliased across two headers.",
-				file, typ)
+		if exempt[s.Typ] {
+			used[s.Typ] = true
+			continue
 		}
+		t.Errorf("%s: %s handles payload type %s, which is neither a registered memo kind\n"+
+			"nor an exempted one.  A rebuilt payload that is not memoised per payload is rebuilt\n"+
+			"once per HEADER, so two names for it come apart in the copy \u2014 issues #576 and #585.\n"+
+			"Memoise it in both rebuilding walkers, or add a row to memoExemptions in\n"+
+			"lisp/walkers.go stating why it cannot be aliased across two headers.",
+			s.Pos, s.Func, s.Typ)
 	}
 	for _, e := range memoExemptions {
 		if !strings.HasPrefix(e.Subject, "lisp.") && !used[e.Subject] {
@@ -474,47 +484,6 @@ func isMemoKey(e ast.Expr) bool {
 		return k.Name == "any"
 	}
 	return false
-}
-
-// nativeSwitchCaseTypes returns the concrete case types of every
-// `switch x := v.Native.(type)` in the named file: the payload types the
-// walker knows how to rebuild.
-func nativeSwitchCaseTypes(name string) ([]string, error) {
-	fset := token.NewFileSet()
-	src, err := os.ReadFile(name) //nolint:gosec // a fixed file name in this package's own directory
-	if err != nil {
-		return nil, err
-	}
-	f, err := parser.ParseFile(fset, name, src, parser.SkipObjectResolution)
-	if err != nil {
-		return nil, err
-	}
-	var out []string
-	ast.Inspect(f, func(n ast.Node) bool {
-		sw, ok := n.(*ast.TypeSwitchStmt)
-		if !ok || !isNativeTypeSwitch(fset, sw) {
-			return true
-		}
-		for _, stmt := range sw.Body.List {
-			cc, ok := stmt.(*ast.CaseClause)
-			if !ok {
-				continue
-			}
-			for _, e := range cc.List {
-				if id, ok := e.(*ast.Ident); ok && id.Name == "nil" {
-					continue
-				}
-				out = append(out, render(fset, e))
-			}
-		}
-		return true
-	})
-	sort.Strings(out)
-	return out, nil
-}
-
-func isNativeTypeSwitch(fset *token.FileSet, sw *ast.TypeSwitchStmt) bool {
-	return strings.Contains(render(fset, sw.Assign), ".Native.(type)")
 }
 
 func render(fset *token.FileSet, n ast.Node) string {

--- a/lisp/walkers_payload_scan_test.go
+++ b/lisp/walkers_payload_scan_test.go
@@ -1,0 +1,388 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"sort"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// The PAYLOAD SCAN, rebuilt so that it fails on a CLASS rather than on one
+// spelling.
+//
+// THE TRIGGERING EXAMPLE.  (*LVal).Copy used to decide "this Native is a
+// cell-view link, drop it" with a bare `v.Native.(*LVal)` -- keyed on the
+// payload type, with no gate on the header type -- so every LNative whose
+// payload happened to be a *LVal came back from Copy with a nil payload.
+// That is the shape lisp.NativeOf[*lisp.LVal] writes (native.go, issue
+// #546), and lisp `(stable-sort < boxes key)` reaches it through
+// lvalByFun.Less.  It shipped green, and the reason it shipped green is
+// what this file is about: the old scan collected `case *T:` arms from
+// `switch ….Native.(type)` in a HARDCODED list of two files, fork.go and
+// detach.go.  So it was blind three times over --
+//
+//   - to a type ASSERTION rather than a type switch (Copy's site);
+//   - to payload handling expressed as an `if` with no type named at all
+//     (fork.go's `if v.IsCellView()` block, which writes cp.Native twice
+//     before the type switch is reached);
+//   - to any file outside those two, lisp.go included -- even though
+//     (*LVal).Copy is a REGISTERED walker with Rebuilds: true.
+//
+// Worse, the memoExemptions row for "*LVal" was marked used ONLY because
+// detach.go happened to spell its arm as a `case`.  Rewrite that one arm as
+// an `if` and the shrink-only checker would have called the row dead and
+// demanded its deletion -- while fork.go and Copy both still handled the
+// payload.  Row liveness was coupled to an unrelated walker's syntax.
+//
+// WHAT REPLACES IT.  The scan starts from the property that makes a site
+// payload handling at all, not from a spelling: a function that ASSIGNS to
+// a header's Native field is rebuilding or re-pointing payload storage, and
+// that is where two names for one payload are born.  Package lisp holds
+// exactly five such functions today and the scan finds them by type-checking
+// the package, so no file list can go stale.  Within each, a payload type is
+// collected however it is named:
+//
+//	case *T:                in a `switch x := ….Native.(type)`   -> "case"
+//	….Native.(*T)           a type assertion anywhere            -> "assert"
+//	v.IsCellView() / v.CellView() / v.cellsView()                -> "accessor"
+//
+// The accessor form is what makes the `if`-shaped handling visible: those
+// three functions ARE the read of a *LVal off Native (the convention on
+// cellsView says readers use exactly these), so calling one names the *LVal
+// payload just as surely as asserting it.
+//
+// A CONSTRUCTOR is deliberately not a payload site.  `&LVal{Native: x}`
+// MINTS a payload onto a header that had none; a walker ASSIGNS one onto a
+// header it copied from another. Only the second can put two names on one
+// payload, which is the whole subject of walkers.go.
+
+// payloadSite is one place a Native-writing function names a payload type.
+type payloadSite struct {
+	Typ  string // "*MapData", "*LVal", "NativeCloner" -- as memoExemptions spells it
+	Func string // enclosing function, as funcLabel renders it
+	Form string // "case", "assert" or "accessor"
+	File string // "lisp.go"
+	Pos  string // "lisp.go:1747"
+}
+
+func (s payloadSite) String() string {
+	return fmt.Sprintf("%s in %s (%s): %s", s.Pos, s.Func, s.Form, s.Typ)
+}
+
+// cellViewAccessors are the three readers of the cell-view link.  Calling
+// one is a read of a *LVal off Native (the convention on cellsView).
+var cellViewAccessors = map[string]bool{
+	"IsCellView": true,
+	"CellView":   true,
+	"cellsView":  true,
+}
+
+// nativePayloadSites type-checks package lisp's production files and
+// returns every payload type named inside a function that writes a Native
+// field.  It also returns the file each registered walker is DECLARED in,
+// so the registry can be checked against what the scan actually visited.
+func nativePayloadSites() (sites []payloadSite, declaredIn map[string]string, err error) {
+	pkgs, err := packages.Load(&packages.Config{
+		Mode: packages.NeedName | packages.NeedSyntax | packages.NeedTypes |
+			packages.NeedTypesInfo | packages.NeedFiles,
+		Dir: ".",
+	}, ".")
+	if err != nil {
+		return nil, nil, fmt.Errorf("load package lisp: %w", err)
+	}
+	declaredIn = map[string]string{}
+	for _, pkg := range pkgs {
+		if len(pkg.Errors) != 0 {
+			return nil, nil, fmt.Errorf("%s: %w", pkg.ID, pkg.Errors[0])
+		}
+		for _, f := range pkg.Syntax {
+			file := shortName(pkg.Fset.Position(f.Pos()).Filename)
+			for _, decl := range f.Decls {
+				switch d := decl.(type) {
+				case *ast.GenDecl:
+					for _, spec := range d.Specs {
+						if ts, ok := spec.(*ast.TypeSpec); ok {
+							declaredIn[ts.Name.Name] = file
+						}
+					}
+				case *ast.FuncDecl:
+					label := funcLabel(pkg, d)
+					declaredIn[label] = file
+					if d.Body == nil || !writesNativeField(d.Body) {
+						continue
+					}
+					sites = append(sites, collectPayloadTypes(pkg, d, label, file)...)
+				}
+			}
+		}
+	}
+	sort.Slice(sites, func(i, j int) bool { return sites[i].Pos < sites[j].Pos })
+	return sites, declaredIn, nil
+}
+
+// writesNativeField reports whether the body assigns to a `.Native` field.
+// A composite literal is deliberately not a write; see the file comment.
+func writesNativeField(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for _, lhs := range as.Lhs {
+			if sel, ok := lhs.(*ast.SelectorExpr); ok && sel.Sel.Name == "Native" {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// collectPayloadTypes returns every payload type the function names, in any
+// of the three forms.
+func collectPayloadTypes(pkg *packages.Package, fd *ast.FuncDecl, label, file string) []payloadSite {
+	var out []payloadSite
+	at := func(n ast.Node) string {
+		p := pkg.Fset.Position(n.Pos())
+		return fmt.Sprintf("%s:%d", file, p.Line)
+	}
+	add := func(n ast.Node, typ, form string) {
+		out = append(out, payloadSite{Typ: typ, Func: label, Form: form, File: file, Pos: at(n)})
+	}
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.TypeSwitchStmt:
+			if !strings.HasSuffix(types.ExprString(typeSwitchSubject(x)), ".Native") {
+				return true
+			}
+			for _, stmt := range x.Body.List {
+				cc, ok := stmt.(*ast.CaseClause)
+				if !ok {
+					continue
+				}
+				for _, e := range cc.List {
+					if id, ok := e.(*ast.Ident); ok && id.Name == "nil" {
+						continue
+					}
+					add(e, types.ExprString(e), "case")
+				}
+			}
+		case *ast.TypeAssertExpr:
+			if x.Type == nil || !strings.HasSuffix(types.ExprString(x.X), ".Native") {
+				return true
+			}
+			add(x, types.ExprString(x.Type), "assert")
+		case *ast.CallExpr:
+			if sel, ok := x.Fun.(*ast.SelectorExpr); ok && cellViewAccessors[sel.Sel.Name] {
+				add(x, "*LVal", "accessor")
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// typeSwitchSubject returns the expression a type switch switches on:
+// `x := v.Native.(type)` and `switch v.Native.(type)` alike.
+func typeSwitchSubject(sw *ast.TypeSwitchStmt) ast.Expr {
+	var assert *ast.TypeAssertExpr
+	switch a := sw.Assign.(type) {
+	case *ast.AssignStmt:
+		if len(a.Rhs) == 1 {
+			assert, _ = a.Rhs[0].(*ast.TypeAssertExpr)
+		}
+	case *ast.ExprStmt:
+		assert, _ = a.X.(*ast.TypeAssertExpr)
+	}
+	if assert == nil {
+		return &ast.Ident{Name: ""}
+	}
+	return assert.X
+}
+
+func shortName(path string) string {
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+// walkerOwningFunc maps an enclosing function label to the registered
+// walker it belongs to, or "" when it belongs to none.  Resolved by
+// function, never by file: fork.go holds free functions that are not part
+// of the walk, and a file-level rule would sweep them in.
+func walkerOwningFunc(label string) string {
+	for _, m := range WalkerMemos() {
+		if m.Walker == label {
+			return m.Walker // "(*LVal).Copy"
+		}
+		if strings.HasPrefix(label, "(") {
+			if i := strings.Index(label, ")"); i > 0 &&
+				strings.TrimPrefix(label[1:i], "*") == m.Walker {
+				return m.Walker // "(*forker).val" -> "forker"
+			}
+		}
+	}
+	return ""
+}
+
+// TestThePayloadScanSeesEveryRebuildingWalker ties the scan to the
+// REGISTRY rather than to a file list.  The old scan named fork.go and
+// detach.go in a Go slice literal, so (*LVal).Copy -- registered, and
+// Rebuilds: true -- was never read at all.  A rebuilding walker whose
+// declaring file the scan does not reach, or which handles no payload the
+// scan can see, fails here.
+func TestThePayloadScanSeesEveryRebuildingWalker(t *testing.T) {
+	sites, declaredIn, err := nativePayloadSites()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sites) == 0 {
+		t.Fatal("the payload scan found no site in package lisp; it has stopped looking")
+	}
+	visited := map[string]bool{}
+	byWalker := map[string][]payloadSite{}
+	for _, s := range sites {
+		visited[s.File] = true
+		if w := walkerOwningFunc(s.Func); w != "" {
+			byWalker[w] = append(byWalker[w], s)
+		}
+	}
+	for _, m := range WalkerMemos() {
+		if !m.Rebuilds {
+			continue
+		}
+		file, ok := declaredIn[m.Walker]
+		if !ok {
+			t.Errorf("registered walker %s is not declared anywhere in package lisp;\n"+
+				"either the registry row in lisp/walkers.go is stale or the walker moved out of the package.",
+				m.Walker)
+			continue
+		}
+		if !visited[file] {
+			t.Errorf("registered walker %s is declared in %s, which the payload scan never read.\n"+
+				"The scan must cover every file holding a rebuilding walker -- that blind spot is\n"+
+				"exactly how (*LVal).Copy's cell-view arm shipped unexamined.", m.Walker, file)
+		}
+		if len(byWalker[m.Walker]) == 0 {
+			t.Errorf("registered walker %s handles no payload the scan can see.\n"+
+				"A walker with Rebuilds: true writes a header's Native field; if it no longer does,\n"+
+				"its registry row is wrong, and if it does, the scan has stopped recognising the form.",
+				m.Walker)
+		}
+	}
+
+	// The named pin: Copy's cell-view decision must be visible to the scan.
+	// On the commit that introduced the bug this site was a type assertion
+	// in lisp.go and the scan read neither the form nor the file.
+	found := false
+	for _, s := range byWalker["(*LVal).Copy"] {
+		if s.Typ == "*LVal" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the scan does not see (*LVal).Copy handling a *LVal payload.\n"+
+			"That handling is its cell-view arm, and it is the site whose blindness this test exists\n"+
+			"to close. Sites seen for Copy: %v", byWalker["(*LVal).Copy"])
+	}
+
+	var summary []string
+	for _, s := range sites {
+		summary = append(summary, s.String())
+	}
+	t.Logf("%d payload sites in package lisp:\n%s", len(sites), strings.Join(summary, "\n"))
+}
+
+// TestCellViewLinkIsGatedOnTheHeaderType is the poka-yoke for the class the
+// bug belongs to, not for its one instance.
+//
+// A *LVal read off Native is a cell-view LINK only when the header carrying
+// it is an LSExpr -- that is the first thing cellsView checks, before it
+// looks at the field at all.  On any other header the same payload is
+// embedder DATA.  So a function that acts on a *LVal payload must state the
+// header-type gate: either by going through one of the three accessors,
+// which apply it, or by testing LSExpr itself, which is what
+// (*detacher).detach does.  Naming the payload type and acting on it with
+// neither gate present is the bug: it is what (*LVal).Copy did, and
+// reverting Copy to that shape fails this test.
+func TestCellViewLinkIsGatedOnTheHeaderType(t *testing.T) {
+	sites, _, err := nativePayloadSites()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gated := map[string]bool{} // function -> states the header-type gate
+	for _, s := range sites {
+		if s.Form == "accessor" {
+			gated[s.Func] = true
+		}
+	}
+	names, err := lsExprNamingFuncs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for fn := range names {
+		gated[fn] = true
+	}
+
+	checked := 0
+	for _, s := range sites {
+		if s.Typ != "*LVal" || s.Form == "accessor" {
+			continue
+		}
+		checked++
+		if gated[s.Func] {
+			continue
+		}
+		t.Errorf("%s reads a *LVal off a Native field and acts on it without gating on the header type.\n"+
+			"A *LVal payload is a cell-view LINK only on an LSExpr (the convention on cellsView, which\n"+
+			"checks the header type before it reads the field); on an LNative the same payload is\n"+
+			"embedder data written by lisp.NativeOf[*lisp.LVal] (native.go, issue #546). Keying the\n"+
+			"decision on the payload type alone is how Copy came to destroy every such payload -- see\n"+
+			"TestCopyKeepsNativeLValPayloadUnderStableSort.\n"+
+			"Gate it: call IsCellView/CellView, or test v.Type == LSExpr in this function.", s)
+	}
+	if checked == 0 {
+		t.Log("no ungated *LVal payload assertion in the package; every site goes through an accessor")
+	}
+}
+
+// lsExprNamingFuncs returns the functions that mention the LSExpr constant,
+// i.e. those that state the header-type gate inline rather than through an
+// accessor.
+func lsExprNamingFuncs() (map[string]bool, error) {
+	pkgs, err := packages.Load(&packages.Config{
+		Mode: packages.NeedName | packages.NeedSyntax | packages.NeedTypes |
+			packages.NeedTypesInfo | packages.NeedFiles,
+		Dir: ".",
+	}, ".")
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]bool{}
+	for _, pkg := range pkgs {
+		for _, f := range pkg.Syntax {
+			for _, decl := range f.Decls {
+				fd, ok := decl.(*ast.FuncDecl)
+				if !ok || fd.Body == nil {
+					continue
+				}
+				label := funcLabel(pkg, fd)
+				ast.Inspect(fd.Body, func(n ast.Node) bool {
+					if id, ok := n.(*ast.Ident); ok && id.Name == "LSExpr" {
+						out[label] = true
+					}
+					return true
+				})
+			}
+		}
+	}
+	return out, nil
+}

--- a/scripts/mutation-proof.sh
+++ b/scripts/mutation-proof.sh
@@ -177,10 +177,18 @@ $MP_EXTRA_ROW"
 die() { echo "mutation-proof: $*" >&2; exit 1; }
 
 restore() { git -C "$ROOT" checkout -- lisp/ 2>/dev/null; }
-trap restore EXIT
 
+# The dirty check runs BEFORE the trap is armed, and the order is the whole
+# point. `trap restore EXIT` fires on the `die` below too, so arming it first
+# made this script DESTROY the very changes it was refusing to run over: it
+# printed "commit or stash first" and then checked lisp/ out from under the
+# author, discarding their uncommitted edit. Measured the hard way, on an
+# edit to lisp/lisp.go. Nothing may run between here and the check that can
+# leave lisp/ modified.
 [ -z "$(git -C "$ROOT" status --porcelain -- lisp/)" ] ||
   die "lisp/ has uncommitted changes; this script rewrites it. Commit or stash first."
+
+trap restore EXIT
 
 echo "== precondition: the clean tree must be green =="
 if ! go test "$PKG" -count=1 >/tmp/mp-clean.log 2>&1; then


### PR DESCRIPTION
Stacked on the chain head (`claude/elps-perf-optimization-jcgfd2-loadcache-topology`, b076a2f) so the diff shows only these five commits. Draft: the base is itself unmerged.

Found by an adversarial code review of the chain's production interpreter change — the chain had been fuzzed extensively but never read for defects.

## 1. `(*LVal).Copy` destroys any `LNative` payload whose Go type is `*LVal`

A regression against `main`. `Copy`'s `default:` arm decided on the **payload** type:

```go
if _, isView := v.Native.(*LVal); isView { cp.Native = nil; cp.Int = 0 }
```

`LNative` falls into `default:` (only `LArray` and `LSortMap` have their own cases), so `lisp.NativeOf[*lisp.LVal](x)` — the shape `native.go` blesses for #546 — lost its payload on every copy. `detach`'s twin arm has keyed on the **header** type all along, as do the `*[]byte`, `*MapData` and `*CallStack` arms beside it.

Reachable from ordinary lisp with no Go fixture: `lvalByFun.Less` copies both elements it compares, so `(stable-sort < boxes key)` handed the key function arguments whose payload was gone. `insert-sorted` has the same shape.

The fix is the gate `detach` already had: `if v.IsCellView()`. Commit `aa0dbe4` removed it deliberately — it is right about the view case and wrong about `LNative`; the commit body says which half survives.

| Control | parent `b076a2f` | `main` `a32ada7` | this branch |
|---|---|---|---|
| `TestCopyKeepsNativeLValPayload` | FAIL — `Copy dropped the native payload: <nil>` | PASS | PASS |
| `TestCopyKeepsNativeLValPayloadUnderStableSort` | FAIL — `expected native *lisp.LVal value, got native <nil>` | PASS | PASS |

## 2. The payload drift scan was structurally blind to it

This is why the bug shipped green. `nativeSwitchCaseTypes` recognised only `case *T:` arms inside `switch ….Native.(type)`, in `fork.go` and `detach.go`. The regression's site is a type *assertion*, in `lisp.go` — invisible twice over, even though `Copy` is a registered walker with `Rebuilds: true`. And the `*LVal` `memoExemptions` row was marked "used" only because an unrelated walker happened to spell its arm as a `case`: rewrite that arm as an `if` and the shrink-only checker declares the row dead while fork still handles the payload.

The replacement keys on the **property** — a function that assigns to a `.Native` field — found by type-checking the whole package, so no file list can go stale. A payload counts however it is named: `case *T:`, `….Native.(*T)`, or a call to `IsCellView`/`CellView`/`cellsView`. 13 sites across 5 functions in 3 files.

`TestCellViewLinkIsGatedOnTheHeaderType` **fails on the parent commit**, naming `lisp.go:1729 in (*LVal).Copy (assert)` — the poka-yoke for the class, not the instance. `TestThePayloadScanSeesEveryRebuildingWalker` ties coverage back to the registry.

## 3. Smaller items

- **`detach`'s silent drop of a non-view `*LVal` on an `LSExpr` is correct** — investigated and *not* changed. A stale link is byte-identical to an embedder-set payload and `CellView()` answers false for both; stale links are reachable from ordinary lisp. Reinstating the loud arm fails exactly one test, the new one. The reasoning is now in the comment and measured by `TestDetachDropsAStaleCellViewLinkSilently`.
- **`lvalCopyExemptions` is now genuinely shrink-only**: production rows and fixture rows are separate lists, and a site only matches a row from its own list. It previously carried 5 test rows out of 11, so a production `*cp = *v` in a test-looking function was easy to miss.
- **`scripts/mutation-proof.sh` armed `trap restore EXIT` above its dirty-tree check**, so `die` reverted the uncommitted work it was telling you to commit. It discarded a real edit during this work. Trap moved below the check.

## Reviewable part

The widened scan surfaced one always-present, never-examined payload: fork rebuilds `*funData` per header. That needs a new `memoExemptions` row — I could not both widen the scan and add nothing. It is made falsifiable rather than asserted (`TestForkRebuildsFunDataPerHeaderIndistinguishably` reddens if a `funData` field becomes mutable or `env` stops being memoised), but **a reviewer should decide whether fork ought to memoise `*funData` instead**, which would be strictly better and would delete the row.

Also honest about a limit: the gate check is syntactic, not dataflow. A function mentioning `LSExpr` for an unrelated reason that also asserts `*LVal` off `.Native` would pass. It catches the class as it appears in this package and fails on the actual regression.

## Verification

`go build ./...`, `go test ./lisp/...`, `-tags elpscheck`, `-race`, whole-repo `go test ./...`, `make elpsvet` (both passes), `scripts/mutation-proof.sh` 10/10 caught, `mutation-proof-selftest.sh` all three guarantees. No gate relaxed; no needle silently stopped tripping.

Not touched: `(*LVal).Copy` stays on `knownDefectiveWalkers` for its separate, still-open `*MapData` and `*[]byte` defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3JiPj1sGKj8BtcmJjNvpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3JiPj1sGKj8BtcmJjNvpj)_