### PR TITLE
Close the demonstrated blind spots in the isolation/parity oracle

### DIFF
--- a/elpstest/aliasguard.go
+++ b/elpstest/aliasguard.go
@@ -265,6 +265,49 @@ const (
 	// one would report a documented behaviour as a leak -- and would be a
 	// write into storage the guard does not own, which is the very defect
 	// class checkStamp exists for.
+	//
+	// ARRAY HEADERS ARE SKIPPED TOO, for a different reason: an LArray's
+	// own Cells is not the storage a vector is mutated through.  It is a
+	// fixed two-slot structural record -- [0] the dims list, [1] the data
+	// holder (lisp/lisp.go's LArray doc) -- and every writer of a
+	// vector's ELEMENTS goes through seqCells/seqHolder, which for an
+	// LArray hand back Cells[1].Cells, the HOLDER's array.  Nothing in this
+	// repository assigns an array header's own slot: cmd/elpsvet's alias
+	// rule forbids `v.Cells[i] = x` on a header the function did not
+	// construct, and the only such assignment reachable from a vector
+	// operation is the probe write below.  So a site here measures an alias
+	// no writer can exploit -- and it COSTS a false positive.
+	//
+	// lisp.Quote's struct copy gives `(quasiquote (unquote vec))` a second
+	// LArray header over the SAME two-slot array (lisp/walkers.go's
+	// lvalCopyExemptions: the intentional aliasing).  Fork memoises per
+	// *LVal and per registered payload kind, and a Cells backing array is
+	// neither, so the fork lands three private two-slot arrays whose SLOTS
+	// hold the same dims header and the same holder header.  Measured on
+	//
+	//	(set 'v1 (vector 3 1 2))
+	//	(set 'v2 (quasiquote (unquote v1)))
+	//	(set 'v3 (quasiquote (unquote v1)))
+	//	(set 'probe (list v1 v2 v3))
+	//
+	// which FuzzAliasGuard found (crasher cbfd49dfda179e65): the sweep
+	// called Fork's rebuild a leak, and EVERY mutation the language can
+	// perform through any of the three names -- stable-sort, append!,
+	// append! past capacity -- agrees between a cold load and a fork.
+	// TestAnArrayHeaderIsNotAProbeSite and
+	// TestAQuasiquotedVectorForksLikeAColdLoad pin the two halves.
+	//
+	// Fork's ONE cells-sharing contract is the cell VIEW, and a view is an
+	// LSExpr: lisp.cellsView returns nothing for any other type, so no view
+	// is lost here.  It is asserted by cellViewWitnesses
+	// (aliasguard_cellview.go) as well as by the sweep.
+	//
+	// NOTHING IS LOST BY SKIPPING IT.  Both slots are walked as ordinary
+	// cells, so the dims list and the data holder each contribute their own
+	// cell-slot site over storage that IS written, and *LVal-level sharing
+	// of either is already in the fingerprint.  The vector rows of
+	// TestGuardDetectsACopierThatReturnsItsInput still fail on a copier
+	// that returns its input, through the holder's site.
 	ProbeCellSlot ProbeKind = "cell-slot"
 )
 
@@ -379,7 +422,9 @@ func indentLines(s string) string {
 // site per payload: a sorted-map entry is 1, a captured binding is 1, a
 // BYTES buffer is 2 (its first byte and its last, or 1 when it holds a
 // single byte), and a cells-carrying header is 1 (slot 0), sealed headers
-// excepted.  The last two kinds are newer than the figures below, so a
+// and ARRAY headers excepted (ProbeCellSlot states why for each; a vector
+// costs 2 -- its dims list and its data holder -- not 3).  The last two
+// kinds are newer than the figures below, so a
 // graph an embedder measured against this cap before them counts higher
 // now -- a list of n multi-byte buffers went from n sites to 2n+1.  The
 // cap is a site count, not a payload count, and the truncation witness
@@ -1085,9 +1130,9 @@ func (p *siteWalker) value(v *lisp.LVal) {
 
 // cellSlot records slot 0 of a header's backing array as a probe site.  See
 // ProbeCellSlot for why it is one site rather than one per slot, and why a
-// sealed header contributes none.
+// sealed header and an ARRAY header each contribute none.
 func (p *siteWalker) cellSlot(v *lisp.LVal) {
-	if len(v.Cells) == 0 || v.IsSealed() {
+	if len(v.Cells) == 0 || v.IsSealed() || v.Type == lisp.LArray {
 		return
 	}
 	hdr := v

--- a/elpstest/aliasguard.go
+++ b/elpstest/aliasguard.go
@@ -235,6 +235,37 @@ const (
 	// ProbeCapturedBinding rebinds one symbol in an environment a closure
 	// captured.  Only walkers whose Closures is ClosuresInScope have these.
 	ProbeCapturedBinding ProbeKind = "captured-binding"
+	// ProbeCellSlot writes a sentinel over slot 0 of a header's Cells --
+	// the backing array a list, a vector, a quote or any other
+	// cells-carrying header is mutated through.
+	//
+	// IT WAS MISSING, and its absence made the whole mutation-probe layer
+	// VACUOUS for a graph whose only mutable storage is cells.  Measured:
+	// `(vector 1 2 3)` and `(list 1 2 3)` yielded ZERO probe sites, so
+	// comparePair returned early on len(sSites)==0 and the only surviving
+	// channel was fingerprint equality -- whose ordinals are per-walk, so
+	// it cannot tell a copier that RETURNS ITS OWN INPUT from a real copy.
+	// CheckWalker is the only oracle `copy` and Detach ever run under (no
+	// transaction runs "on" their output, so CheckTransactions does not
+	// cover them), which made it their blind spot rather than a gap
+	// somebody else's channel covered.
+	//
+	// SLOT 0 ONLY, not every slot: one site per header keeps the O(n²)
+	// sweep affordable on ordinary graphs, and slot 0 is enough to answer
+	// the question the sweep asks -- "is this header's backing array the
+	// same array as that one's".  Two headers over one array (a cdr view,
+	// or a copier that shared the slice) both see the write; two headers
+	// over two arrays do not.  A copier that shared only the TAIL of a
+	// cells slice would be missed, which is the same bounded claim
+	// ProbeBytesElement makes and the reason that one now probes its last
+	// byte as well as its first.
+	//
+	// SEALED HEADERS ARE SKIPPED.  A sealed value is immutable by contract
+	// and Fork shares it outright (docs/sealed-ast.md), so writing through
+	// one would report a documented behaviour as a leak -- and would be a
+	// write into storage the guard does not own, which is the very defect
+	// class checkStamp exists for.
+	ProbeCellSlot ProbeKind = "cell-slot"
 )
 
 // ProbeSite is one place the oracle can write a sentinel and undo it.
@@ -343,6 +374,16 @@ func indentLines(s string) string {
 // sorted map of 96 int entries is 96 probe sites (pinned by
 // TestASortedMapEntryIsAProbeSite, in both directions), so 96 was inside
 // ordinary range.
+//
+// WHAT A GRAPH COSTS IN SITES, since two of the four kinds are not one
+// site per payload: a sorted-map entry is 1, a captured binding is 1, a
+// BYTES buffer is 2 (its first byte and its last, or 1 when it holds a
+// single byte), and a cells-carrying header is 1 (slot 0), sealed headers
+// excepted.  The last two kinds are newer than the figures below, so a
+// graph an embedder measured against this cap before them counts higher
+// now -- a list of n multi-byte buffers went from n sites to 2n+1.  The
+// cap is a site count, not a payload count, and the truncation witness
+// reports the measured number to raise it to.
 //
 // Cost, measured on a 4-core box over a list of n buffers, best of three.
 // The sweep is quadratic in the site count, and the figures are PER
@@ -650,17 +691,59 @@ func comparePair(w Walker, c AliasCheck, what string, src, cp *lisp.LVal, scope 
 		out = append(out, wit...)
 		gotAff, wit := affectedSet(w, c, opts, cSites, cBase, i, fpSrc, src, "the source")
 		out = append(out, wit...)
-		if !sameIndexSet(wantAff, gotAff) {
+		wantCmp := aliasClass(w, sSites, wantAff)
+		gotCmp := aliasClass(w, cSites, gotAff)
+		if !sameIndexSet(wantCmp, gotCmp) {
 			out = append(out, Witness{
 				Walker:       w.Name,
 				Property:     "a write through the copy is seen exactly where it is seen through the source",
 				Site:         sSites[i],
-				WantAffected: paths(sSites, wantAff),
-				GotAffected:  paths(cSites, gotAff),
-				Leak:         leakPath(sSites, cSites, wantAff, gotAff),
+				WantAffected: paths(sSites, wantCmp),
+				GotAffected:  paths(cSites, gotCmp),
+				Leak:         leakPath(sSites, cSites, wantCmp, gotCmp),
 				Repro:        c.Repro,
 			})
 		}
+	}
+	return out
+}
+
+// cellSlotAliasingIsContractual reports whether a walker promises that two
+// headers sharing ONE cells backing array in its input still share one in
+// its output.
+//
+// It is a contract for FORK -- a view records its root where it is made (PR
+// #602) and cellViewWitnesses asserts the fork's view windows the fork's own
+// root -- and for the macro stamp, which shares an unchanged node outright.
+// It is DELIBERATELY NOT PRESERVED by `copy` and detach: two headers that
+// shared one array land in the copy with separate arrays, stated in
+// lisp/copy.go's doc comment and in docs/func.md and pinned by
+// TestCopyDoesNotPreserveBackingArraySharing.  BackingRebuilt's doc has
+// always said the mutation probe does not test it for them; ProbeCellSlot
+// is the first site kind that COULD, so this is where that sentence stops
+// being a description of an absence and becomes a rule with a name.
+//
+// It bounds the ALIAS-CLASS comparison only.  The leak check in
+// affectedSet -- "a write on one side is invisible on the other" -- is
+// untouched and applies to every site of every walker, because a copy
+// holding the SOURCE's array is a leak under every contract here.  That is
+// also the property that catches a `copy` which simply returns its input
+// (TestGuardDetectsACopierThatReturnsItsInput), so the exemption costs that
+// control nothing.
+func cellSlotAliasingIsContractual(w Walker) bool { return w.Kind != WalkerCopy }
+
+// aliasClass drops from an alias equivalence class the sites whose sharing
+// the walker's contract does not cover.  See cellSlotAliasingIsContractual.
+func aliasClass(w Walker, sites []ProbeSite, idx []int) []int {
+	if cellSlotAliasingIsContractual(w) {
+		return idx
+	}
+	out := make([]int, 0, len(idx))
+	for _, i := range idx {
+		if sites[i].Kind == ProbeCellSlot {
+			continue
+		}
+		out = append(out, i)
 	}
 	return out
 }
@@ -991,12 +1074,52 @@ func (p *siteWalker) value(v *lisp.LVal) {
 			p.pop()
 		}
 	default:
+		p.cellSlot(v)
 		for i, c := range v.Cells {
 			p.push("cell " + strconv.Itoa(i))
 			p.value(c)
 			p.pop()
 		}
 	}
+}
+
+// cellSlot records slot 0 of a header's backing array as a probe site.  See
+// ProbeCellSlot for why it is one site rather than one per slot, and why a
+// sealed header contributes none.
+func (p *siteWalker) cellSlot(v *lisp.LVal) {
+	if len(v.Cells) == 0 || v.IsSealed() {
+		return
+	}
+	hdr := v
+	orig := hdr.Cells[0]
+	p.push("cell[0]")
+	p.sites = append(p.sites, ProbeSite{
+		Kind: ProbeCellSlot,
+		Path: p.here(),
+		// The length guards are for a graph a TRANSACTION shortened
+		// between enumeration and the write.  Nothing in the sweep itself
+		// resizes a Cells slice; a probe that found its slot gone reports
+		// so rather than panicking inside the oracle.
+		write: func(s int) {
+			if len(hdr.Cells) > 0 {
+				//elps:mutates writing a value the guard does not own IS the probe -- the whole sweep exists to write a sentinel into reachable storage and observe where it appears -- and reset below undoes it exactly, which affectedSet re-measures on every write
+				hdr.Cells[0] = lisp.Int(s)
+			}
+		},
+		read: func() string {
+			if len(hdr.Cells) == 0 {
+				return "<no cells>"
+			}
+			return renderProbeValue(hdr.Cells[0])
+		},
+		reset: func() {
+			if len(hdr.Cells) > 0 {
+				//elps:mutates the undo half of the write above; restoring the original *LVal is what keeps the sweep non-destructive
+				hdr.Cells[0] = orig
+			}
+		},
+	})
+	p.pop()
 }
 
 func (p *siteWalker) sortedMap(v *lisp.LVal) {
@@ -1035,17 +1158,39 @@ func (p *siteWalker) bytes(v *lisp.LVal) {
 		return
 	}
 	p.seen[buf] = true
-	p.push("bytes[0]")
-	orig := (*buf)[0]
 	b := buf
-	p.sites = append(p.sites, ProbeSite{
-		Kind:  ProbeBytesElement,
-		Path:  p.here(),
-		write: func(s int) { (*b)[0] = byte(s) },
-		read:  func() string { return strconv.Itoa(int((*b)[0])) },
-		reset: func() { (*b)[0] = orig },
-	})
-	p.pop()
+	// The FIRST and the LAST byte.  One site was not enough: a six-byte
+	// buffer yielded exactly one site, bytes[0] (measured), so a copier
+	// that privately copied a buffer's head while sharing its tail wrote
+	// through storage no probe ever read.  Two sites bound the array at
+	// both ends for one extra write per buffer; a copier that shared only
+	// the MIDDLE is still outside the claim, which is why the claim is
+	// stated here rather than left as "bytes are covered".
+	for _, i := range bytesProbeIndices(len(*b)) {
+		idx := i
+		orig := (*b)[idx]
+		p.push("bytes[" + strconv.Itoa(idx) + "]")
+		p.sites = append(p.sites, ProbeSite{
+			Kind:  ProbeBytesElement,
+			Path:  p.here(),
+			write: func(s int) { (*b)[idx] = byte(s) },
+			read:  func() string { return strconv.Itoa(int((*b)[idx])) },
+			reset: func() { (*b)[idx] = orig },
+		})
+		p.pop()
+	}
+}
+
+// bytesProbeIndices is the set of byte offsets the sweep writes: the first
+// and, when the buffer has more than one byte, the last.  A one-byte buffer
+// must yield ONE site, not two identical ones -- a duplicate site would
+// make the two probes read each other's write and every affected-set
+// comparison meaningless.
+func bytesProbeIndices(n int) []int {
+	if n <= 1 {
+		return []int{0}
+	}
+	return []int{0, n - 1}
 }
 
 func (p *siteWalker) env(e *lisp.LEnv) {

--- a/elpstest/aliasguard_broken_test.go
+++ b/elpstest/aliasguard_broken_test.go
@@ -24,6 +24,7 @@ package elpstest_test
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -2090,5 +2091,261 @@ func TestTheConcurrentArmStillRunsForASubstitutedWalker(t *testing.T) {
 			"old axis: substitution is not a declaration that the walker shares, and an embedder\n"+
 			"wrapping Fork for instrumentation must not silently lose the -race gate. Key the skip\n"+
 			"on SkipConcurrentArm.", builds, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Control 16: an ARRAY header is not a probe site, and why that is not a
+// weakening.
+//
+// FuzzAliasGuard found crasher cbfd49dfda179e65 the day ProbeCellSlot
+// landed:
+//
+//	(set 'v0 7)
+//	(set 'v1 (vector v0 v0))
+//	(set 'v2 (quasiquote (unquote v1)))
+//	(set 'v3 (quasiquote (unquote v1)))
+//	(set 'probe (list v0 v1 v2 v3))
+//
+// The sweep reported a Fork leak: a slot-0 write through v1 was seen at v2
+// and v3 in the template and nowhere but v1 in the fork.  Both halves are
+// TRUE of the memory — lisp.Quote's `*cp = *v` gives v2 and v3 a second and
+// a third LArray header over v1's two-slot Cells array, and Fork, which
+// memoises per *LVal and per registered payload kind, gives each of the
+// three its own — and the conclusion drawn from them was false.  An
+// LArray's own Cells is [dims, holder]; nothing writes those slots, so no
+// program can tell the two shapes apart.  ProbeCellSlot now skips an array
+// header for that reason and these three tests are the reason, stated as
+// measurements: one for the site count, one for the behaviour, and one for
+// the premise that makes the skip sound.
+// ---------------------------------------------------------------------------
+
+// quasiquotedVectorProgram is the crasher's template, reduced to the part
+// that matters and given distinguishable elements so an in-place sort is
+// visible.
+const quasiquotedVectorProgram = `
+(set 'v1 (vector 3 1 2))
+(set 'v2 (quasiquote (unquote v1)))
+(set 'v3 (quasiquote (unquote v1)))
+(set 'probe (list v1 v2 v3))
+`
+
+// TestAnArrayHeaderIsNotAProbeSite pins the site count in BOTH directions,
+// the way TestASortedMapEntryIsAProbeSite does, because one direction is
+// not enough.  `(vector 1 2 3)` is two probe sites — its dims list and its
+// data holder — and not three: the array header itself contributes none.
+//
+// Upward: a cap of 2 must sweep COMPLETELY, so the array header costs
+// nothing.  Downward: a cap of 1 must TRUNCATE, so the vector's own storage
+// still costs two sites and the skip did not swallow the holder along with
+// the header.  Without the second, deleting the cell-slot site for every
+// sequence would leave this green.
+func TestAnArrayHeaderIsNotAProbeSite(t *testing.T) {
+	t.Parallel()
+	const prog = `(set 'probe (vector 1 2 3))`
+	at := func(capSites int) []elpstest.Witness {
+		t.Helper()
+		got, err := elpstest.CheckWalker(bytesSharingWalker(),
+			elpstest.AliasCheck{Program: prog, MaxProbeSites: capSites})
+		if err != nil {
+			t.Fatalf("MaxProbeSites=%d: harness error: %v", capSites, err)
+		}
+		return probeTruncationWitnesses(got)
+	}
+	if tw := at(2); len(tw) != 0 {
+		t.Errorf("a one-dimensional 3-element vector at MaxProbeSites=2 reported partial\n"+
+			"coverage:\n%s\nIt costs more than two probe sites, which means the ARRAY HEADER is\n"+
+			"being probed again. Its Cells is [dims, holder] and nothing writes those slots, so a\n"+
+			"site there measures an alias no writer can exploit -- and reintroduces the\n"+
+			"cbfd49dfda179e65 false positive on `(quasiquote (unquote vec))`. See ProbeCellSlot.",
+			tw[0])
+	}
+	if tw := at(1); len(tw) == 0 {
+		t.Errorf("a one-dimensional 3-element vector at MaxProbeSites=1 did NOT report partial\n" +
+			"coverage. It now costs at most one probe site, so the array-header skip has grown\n" +
+			"into 'a vector is barely probed': its dims list and its data holder must each be a\n" +
+			"site, and the holder's is what catches a copier that returns its own input over a\n" +
+			"graph of vectors (TestGuardDetectsACopierThatReturnsItsInput).")
+	}
+}
+
+// TestAQuasiquotedVectorForksLikeAColdLoad is the behavioural half: the
+// justification for skipping the array header is that NO PROGRAM can tell
+// the template's shape from the fork's, so that is what is measured rather
+// than argued.
+//
+// The premise is asserted first.  If lisp.Quote stops handing a second
+// header the same array — or if Fork starts preserving it — the shape this
+// control is named for is gone, and the right response is to re-read
+// ProbeCellSlot's array paragraph, not to edit the assertion that noticed.
+func TestAQuasiquotedVectorForksLikeAColdLoad(t *testing.T) {
+	t.Parallel()
+	build := func() *lisp.LEnv {
+		t.Helper()
+		env, err := elpstest.NewForkCheckEnv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rc := env.LoadString("p.lisp", quasiquotedVectorProgram); rc.Type == lisp.LError {
+			t.Fatal(rc)
+		}
+		return env
+	}
+	// cellsArray is the address of a header's backing array, which is what
+	// two headers do or do not have in common.  reflect, not unsafe:
+	// Pointer on a slice Value is its data pointer.
+	cellsArray := func(v *lisp.LVal) uintptr { return reflect.ValueOf(v.Cells).Pointer() }
+	names := []string{"v1", "v2", "v3"}
+	get := func(env *lisp.LEnv) []*lisp.LVal {
+		t.Helper()
+		out := make([]*lisp.LVal, len(names))
+		for i, n := range names {
+			out[i] = env.Get(lisp.Symbol(n))
+			if out[i] == nil || out[i].Type != lisp.LArray {
+				t.Fatalf("premise: %s is not an array (%v)", n, out[i])
+			}
+		}
+		return out
+	}
+
+	// Premise 1: the template really is three headers over ONE array.
+	tmpl := build()
+	tv := get(tmpl)
+	if tv[0] == tv[1] || tv[0] == tv[2] || tv[1] == tv[2] {
+		t.Fatalf("premise: quasiquote returned the same header, not a second one; this control is "+
+			"not exercising the shape it describes (%p %p %p)", tv[0], tv[1], tv[2])
+	}
+	if cellsArray(tv[0]) != cellsArray(tv[1]) || cellsArray(tv[0]) != cellsArray(tv[2]) {
+		t.Fatalf("premise: the three headers no longer share one Cells backing array (%#x %#x %#x). "+
+			"lisp.Quote has stopped struct-copying, so the false positive ProbeCellSlot's array "+
+			"paragraph describes can no longer arise -- re-read it before trusting the skip.",
+			cellsArray(tv[0]), cellsArray(tv[1]), cellsArray(tv[2]))
+	}
+	// Premise 2: and the fork really does give each of them its own.  This
+	// is the structural difference the sweep used to report; it is skipped
+	// because it is unobservable, not because it stopped happening.
+	forked, err := tmpl.Fork()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fv := get(forked)
+	if cellsArray(fv[0]) == cellsArray(fv[1]) || cellsArray(fv[0]) == cellsArray(fv[2]) {
+		t.Logf("Fork now preserves the array-header sharing; the skip in ProbeCellSlot has become " +
+			"a no-op rather than a correction. Nothing is wrong, but the paragraph explaining it " +
+			"is stale.")
+	}
+
+	// The measurement: every mutation the language can perform through any
+	// of the three names reads back the same in a fork as in a cold load,
+	// through all three names.
+	const readback = `(list v1 v2 v3 (nth probe 0) (nth probe 1) (nth probe 2))`
+	for _, mut := range []string{
+		`(stable-sort < v1)`,
+		`(stable-sort < v2)`,
+		`(append! v1 99)`,
+		`(append! v2 99)`,
+		// Past capacity, so the holder's Cells slice is REALLOCATED and
+		// the dims cardinality rewritten: the two writes an array header's
+		// own slots would have to carry if they carried any.
+		`(append! v1 4 5 6 7 8 9 10 11 12)`,
+		`(stable-sort < (append 'vector v1))`,
+	} {
+		cold := build()
+		coldRes := cold.LoadString("m.lisp", mut)
+		if coldRes.Type == lisp.LError {
+			t.Fatalf("%s: cold load raised: %v", mut, coldRes)
+		}
+		coldAfter := cold.LoadString("r.lisp", readback).String()
+
+		tmpl := build()
+		fork, err := tmpl.Fork()
+		if err != nil {
+			t.Fatal(err)
+		}
+		forkRes := fork.LoadString("m.lisp", mut)
+		if forkRes.Type == lisp.LError {
+			t.Fatalf("%s: fork raised: %v", mut, forkRes)
+		}
+		forkAfter := fork.LoadString("r.lisp", readback).String()
+
+		if coldRes.String() != forkRes.String() || coldAfter != forkAfter {
+			t.Errorf("%s diverges between a cold load and a fork:\n  cold: %s -> %s\n  fork: %s -> %s\n"+
+				"The array-header sharing IS observable after all, so ProbeCellSlot must probe an\n"+
+				"array header again and the finding it reported on cbfd49dfda179e65 is a real bug\n"+
+				"in Fork. Do not weaken anything here: fix the walker.",
+				mut, coldRes, coldAfter, forkRes, forkAfter)
+		}
+		// And the fork's mutation must not have reached the template.
+		got := tmpl.LoadString("r.lisp", readback).String()
+		want := build().LoadString("r.lisp", readback).String()
+		if got != want {
+			t.Errorf("%s: the fork's mutation reached the template:\n  got:  %s\n  want: %s", mut, got, want)
+		}
+	}
+
+	// And with all of that true, no live walker may report anything.
+	for _, w := range elpstest.Walkers() {
+		got, err := elpstest.CheckWalker(w, elpstest.AliasCheck{Program: quasiquotedVectorProgram})
+		if err != nil {
+			t.Fatalf("%s: harness error: %v", w.Name, err)
+		}
+		if len(got) != 0 {
+			t.Errorf("%s reports %d witness(es) on `(quasiquote (unquote vector))`:\n%s\n"+
+				"Every mutation above agrees between a cold load and a fork, so this is the\n"+
+				"cbfd49dfda179e65 false positive again: a guard red on behaviour no program can\n"+
+				"distinguish is a guard that gets switched off.", w.Name, len(got), got[0])
+		}
+	}
+}
+
+// TestAnArrayHeadersOwnSlotsAreNeverReassigned is the premise the skip
+// rests on, as a drift guard rather than as prose.
+//
+// ProbeCellSlot skips an array header because [dims, holder] is a
+// structural record no writer assigns into: every writer of a vector's
+// ELEMENTS goes through seqCells/seqHolder onto the HOLDER's array, and
+// cmd/elpsvet's alias rule forbids `v.Cells[i] = x` on a header a function
+// did not construct.  The day a vector operation replaces its own dims or
+// holder header in place, that stops being true, the array header becomes
+// storage a program can write, and the skip has to go.  This fails on that
+// day.
+func TestAnArrayHeadersOwnSlotsAreNeverReassigned(t *testing.T) {
+	t.Parallel()
+	for _, mut := range []string{
+		`(stable-sort < v)`,
+		`(append! v 99)`,
+		`(append! v 4 5 6 7 8 9 10 11 12 13 14 15 16)`,
+		`(append 'vector v 7)`,
+		`(slice 'vector v 1 3)`,
+		`(nth v 0)`,
+	} {
+		env, err := elpstest.NewForkCheckEnv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rc := env.LoadString("p.lisp", `(set 'v (vector 3 1 2))`); rc.Type == lisp.LError {
+			t.Fatal(rc)
+		}
+		v := env.Get(lisp.Symbol("v"))
+		if v.Type != lisp.LArray || len(v.Cells) != 2 {
+			t.Fatalf("premise: a vector is no longer a two-slot array header (%v, %d cells).\n"+
+				"ProbeCellSlot's array paragraph describes [dims, holder]; re-read it.",
+				v.Type, len(v.Cells))
+		}
+		dims, holder := v.Cells[0], v.Cells[1]
+		if rc := env.LoadString("m.lisp", mut); rc.Type == lisp.LError {
+			t.Fatalf("%s: %v", mut, rc)
+		}
+		if v.Cells[0] != dims {
+			t.Errorf("%s replaced the array header's dims SLOT (%p -> %p).\n"+
+				"An array header's own Cells is now storage a program writes, so it must be a probe\n"+
+				"site again: drop the `v.Type == lisp.LArray` skip in siteWalker.cellSlot and\n"+
+				"re-examine the Fork finding in ProbeCellSlot's array paragraph.", mut, dims, v.Cells[0])
+		}
+		if v.Cells[1] != holder {
+			t.Errorf("%s replaced the array header's data-holder SLOT (%p -> %p).\n"+
+				"Same conclusion as for the dims slot above: the skip in siteWalker.cellSlot is no\n"+
+				"longer sound.", mut, holder, v.Cells[1])
+		}
 	}
 }

--- a/elpstest/aliasguard_broken_test.go
+++ b/elpstest/aliasguard_broken_test.go
@@ -1371,6 +1371,201 @@ func TestAPointerToABasicTypeIsNotStateless(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Control 13: a "copier" that returns its own input.
+//
+// A rebuild that rebuilds nothing, and the mutation-probe layer is the only
+// channel that can see it.  The fingerprint cannot: its identity ordinals
+// are PER WALK, so a value and itself produce byte-identical streams.  Only
+// writing through one side and reading the other tells them apart.
+//
+// It went undetected on a graph whose only mutable storage is CELLS.
+// Measured before ProbeCellSlot existed: `(vector 1 2 3)` and
+// `(list 1 2 3)` yielded ZERO probe sites, so comparePair returned early on
+// len(sSites)==0 and the identity-blind fingerprint was all that was left.
+// That is `copy` and Detach's blind spot in particular -- no transaction
+// runs "on" their output, so CheckTransactions never covers them and
+// CheckWalker is the only oracle they have.
+//
+// The sorted-map row is the control on the control: the SAME walker is
+// caught there, which pins the miss on the missing probe kind rather than
+// on the walker being benign.
+// ---------------------------------------------------------------------------
+
+// identityWalker returns its argument unchanged, so every payload of the
+// "copy" is the source's payload.
+func identityWalker() elpstest.Walker {
+	return elpstest.Walker{
+		Name:     "broken-copier/returns-its-input",
+		Kind:     elpstest.WalkerCopy,
+		Copy:     func(_ *lisp.LEnv, v *lisp.LVal) (*lisp.LVal, error) { return v, nil },
+		Closures: elpstest.ClosuresInScope,
+		Backing:  elpstest.BackingRebuilt,
+	}
+}
+
+func TestGuardDetectsACopierThatReturnsItsInput(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, program string }{
+		{"a vector", `(set 'probe (vector 1 2 3))`},
+		{"a list", `(set 'probe (list 1 2 3))`},
+		{"a list of vectors", `(set 'probe (list (vector 1 2) (vector 1 2)))`},
+		// The control on the control: a payload kind the sweep already
+		// covered before ProbeCellSlot existed.
+		{"a sorted map", `(set 'probe (sorted-map "k" 1))`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := elpstest.CheckWalker(identityWalker(), elpstest.AliasCheck{
+				Program: tc.program,
+				Repro:   "a copier that returns its own input, over " + tc.name,
+			})
+			if err != nil {
+				t.Fatalf("harness error: %v", err)
+			}
+			if len(got) == 0 {
+				t.Fatalf("the oracle reported NOTHING for a copier that returns its own input, on\n"+
+					"%s.\nThe fingerprint cannot see this -- its ordinals are per walk, so a value and\n"+
+					"itself fingerprint identically -- so the mutation sweep is the only channel there\n"+
+					"is, and a graph with no probe site in it is a graph the oracle does not check at\n"+
+					"all.", tc.program)
+			}
+			assertWitnessMentions(t, "identity-copier/"+tc.name, got,
+				"a write on one side is invisible on the other")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Control 14: the cells-aliasing exemption `copy` and detach declare.
+//
+// ProbeCellSlot is the first site kind that can observe WHICH HEADERS SHARE
+// ONE CELLS BACKING ARRAY, and two of the four walkers deliberately do not
+// preserve that: `copy` and detach give two headers over one array separate
+// arrays (lisp/copy.go, docs/func.md, TestCopyDoesNotPreserveBackingArraySharing),
+// which BackingRebuilt's doc has always covered with "the mutation probe
+// does not test it for them".
+//
+// Measured while writing that probe: without the exemption, `copy` and
+// Detach both produced two alias-class witnesses on the graph below -- a
+// guard red on documented, intended behaviour, which is the failure mode
+// DefaultMaxProbeSites's own doc calls "a failure that is not a bug, and
+// that trains an embedder to raise the cap reflexively".
+//
+// The exemption is bounded to the alias-class comparison.  The leak check
+// -- "a write on one side is invisible on the other" -- still covers every
+// cell-slot site of every walker, which is why control 13's identity copier
+// is caught anyway; the last row here pins that, so the exemption cannot
+// quietly grow into "cell slots are not probed for copiers".
+// ---------------------------------------------------------------------------
+
+// offsetZeroViewProgram binds a view whose slot 0 IS its root's slot 0, the
+// one shape in which de-aliasing a cells backing array is observable from a
+// slot-0 probe.
+const offsetZeroViewProgram = `
+(set 'l (list 1 2 3))
+(set 'w (slice 'list l 0 3))
+(set 'probe (list l w))
+`
+
+func TestTheCellsAliasingExemptionHoldsForEveryLiveWalker(t *testing.T) {
+	t.Parallel()
+	for _, w := range elpstest.Walkers() {
+		got, err := elpstest.CheckWalker(w, elpstest.AliasCheck{Program: offsetZeroViewProgram})
+		if err != nil {
+			t.Fatalf("%s: harness error: %v", w.Name, err)
+		}
+		if len(got) != 0 {
+			t.Errorf("%s reports %d witness(es) on a graph holding a view over its root's own\n"+
+				"slot 0:\n%s\n`copy` and detach do not preserve cells backing-array sharing BY\n"+
+				"CONTRACT, and Fork preserves it (PR #602), so no live walker may be red here. A\n"+
+				"guard that reddens on documented behaviour is a guard that gets switched off.",
+				w.Name, len(got), got[0])
+		}
+	}
+	// And the exemption has not swallowed the leak check: the identity
+	// copier, whose cells ARE the source's, is still caught on the same
+	// graph.
+	got, err := elpstest.CheckWalker(identityWalker(), elpstest.AliasCheck{Program: offsetZeroViewProgram})
+	if err != nil {
+		t.Fatalf("harness error: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("the identity copier went undetected on the exemption's own graph. The exemption " +
+			"has grown from 'the alias class of cell slots is not compared for a copier' into 'cell " +
+			"slots are not probed for a copier', which is the whole channel.")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Control 15: a bytes buffer is bounded at BOTH ends.
+//
+// ProbeBytesElement wrote byte 0 and nothing else, so a six-byte buffer
+// yielded exactly ONE site (measured) and the sweep bounded a buffer at one
+// end only.  Two headers whose arrays OVERLAP -- `(slice 'bytes b 3 6)` is
+// a view, not a copy -- share b's last byte with the view's last byte, and
+// nothing but a last-byte probe can see that they do.
+//
+// PINNED GAP, and the reason this test asserts a witness from the LIVE
+// walkers rather than from a broken reference one: all three copiers
+// rebuild each *[]byte independently, so an overlapping bytes view comes
+// out of Fork, `copy` and detach de-aliased.  For cells that is a contract
+// for Fork (PR #602) and a documented exemption for the other two; for
+// BYTES nothing states either, and a cold load DOES share the overlap --
+// so a fork diverges from a cold load on `(set 'tail (slice 'bytes b 3 6))`
+// followed by a write through b.  That is the bytes analogue of issue #600
+// gap 3, it is out of scope here, and this test is what stops it going
+// quiet again: it will fail the day somebody fixes it, and the fix is to
+// replace it with the contract, not to delete it.
+// ---------------------------------------------------------------------------
+
+const overlappingBytesProgram = `
+(set 'b (to-bytes "abcdef"))
+(set 'tail (slice 'bytes b 3 6))
+(set 'probe (list b tail))
+`
+
+func TestTheBytesProbeSeesAnOverlappingView(t *testing.T) {
+	t.Parallel()
+	// Ground truth: the two headers really do share storage on a cold
+	// load, so the witnesses below are about a rebuild losing it.
+	env, err := elpstest.NewForkCheckEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc := env.LoadString("p.lisp", overlappingBytesProgram); rc.Type == lisp.LError {
+		t.Fatal(rc)
+	}
+	b := env.Get(lisp.Symbol("b"))
+	tail := env.Get(lisp.Symbol("tail"))
+	bp, ok1 := b.Native.(*[]byte)
+	tp, ok2 := tail.Native.(*[]byte)
+	if !ok1 || !ok2 {
+		t.Fatalf("the fixture is not two bytes headers: %v %v", b, tail)
+	}
+	(*bp)[5] = 'Z'
+	if got := (*tp)[2]; got != 'Z' {
+		t.Fatalf("premise: `slice` did not return a view sharing b's array (read %q); this control "+
+			"is not exercising the shape it describes", got)
+	}
+
+	for _, w := range elpstest.Walkers() {
+		if w.Kind == elpstest.WalkerStamp {
+			continue // not a copier; it shares its input by contract
+		}
+		got, err := elpstest.CheckWalker(w, elpstest.AliasCheck{Program: overlappingBytesProgram})
+		if err != nil {
+			t.Fatalf("%s: harness error: %v", w.Name, err)
+		}
+		if len(got) == 0 {
+			t.Errorf("%s: the sweep reports nothing for a rebuild that de-aliases an overlapping\n"+
+				"bytes view. Either the last-byte probe has gone (the overlap is at b's LAST byte,\n"+
+				"which byte 0 cannot reach) or the walker now preserves the overlap -- in which case\n"+
+				"delete this pinned gap and state the contract, do not weaken the probe.", w.Name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Claims-under-test.
 //
 // Three rounds of review each found a FALSE SENTENCE in newly-added prose,
@@ -1565,25 +1760,35 @@ func TestAProbeCountEqualToTheCapIsNotReportedAsPartial(t *testing.T) {
 		b.WriteString("))")
 		return b.String()
 	}
+	// THE SITE COUNT OF EACH SHAPE, stated rather than left implicit, so a
+	// change in what counts as a probe site fails this control loudly
+	// instead of quietly sliding the boundary it pins.  A buffer of more
+	// than one byte is TWO sites -- its first byte and its last
+	// (ProbeBytesElement) -- and the list holding them is ONE, slot 0 of
+	// its Cells (ProbeCellSlot).  A sorted map of int entries is one site
+	// per entry and nothing else: LSortMap carries no Cells.
+	const listSites = 2*capSites + 1
+	const mapSites = capSites
 	cases := []struct {
 		name      string
 		program   string
+		cap       int
 		truncated bool
 	}{
-		{"exactly at the cap, nothing after", buffers(capSites) + "))", false},
-		{"at the cap plus a trailing int", buffers(capSites) + " 7))", false},
-		{"at the cap plus a repeated buffer", buffers(capSites) + " u0))", false},
-		{"at the cap plus an empty list", buffers(capSites) + " (list)))", false},
-		{"at the cap plus an empty bytes", buffers(capSites) + " (to-bytes \"\")))", false},
-		{"a bare sorted map at the cap", sortedMap(capSites), false},
-		{"one site over the cap", buffers(capSites+1) + "))", true},
-		{"well over the cap", buffers(capSites+20) + "))", true},
+		{"exactly at the cap, nothing after", buffers(capSites) + "))", listSites, false},
+		{"at the cap plus a trailing int", buffers(capSites) + " 7))", listSites, false},
+		{"at the cap plus a repeated buffer", buffers(capSites) + " u0))", listSites, false},
+		{"at the cap plus an empty list", buffers(capSites) + " (list)))", listSites, false},
+		{"at the cap plus an empty bytes", buffers(capSites) + " (to-bytes \"\")))", listSites, false},
+		{"a bare sorted map at the cap", sortedMap(capSites), mapSites, false},
+		{"one site over the cap", buffers(capSites) + "))", listSites - 1, true},
+		{"well over the cap", buffers(capSites+20) + "))", listSites, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := elpstest.CheckWalker(bytesSharingWalker(),
-				elpstest.AliasCheck{Program: tc.program, MaxProbeSites: capSites})
+				elpstest.AliasCheck{Program: tc.program, MaxProbeSites: tc.cap})
 			if err != nil {
 				t.Fatalf("harness error: %v", err)
 			}

--- a/elpstest/aliasguard_broken_test.go
+++ b/elpstest/aliasguard_broken_test.go
@@ -1104,6 +1104,186 @@ func TestReachableEnvironmentsNClampsANonPositiveLimit(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Control 11: a stateful native payload whose Go kind is NOT a pointer.
+//
+// Control 5 above covers the pointer case.  Fork's default policy shares an
+// undeclared payload with every fork BY REFERENCE (docs/fork.md), and Go
+// has six kinds for which that means both forks write through to one
+// object: pointer, map, slice, chan, func and unsafe pointer.  Every
+// surface that asks "is this payload shared" keyed on reflect.Pointer, so
+// the other five were invisible: reachableNatives never collected one (so
+// property 4 could not fire), NativeDeclarations never listed its type (so
+// an embedder running the exported pre-ship census got a clean bill of
+// health for a payload every transaction shares), and the fingerprint
+// emitted `native(T,by-value)` -- no identity, no contents.
+//
+// Measured before the widening, on the map-kind row below: fork 0 wrote 41
+// through the payload, fork 1 read 41 back, and SharedNativePayloads
+// returned an empty slice.
+//
+// The FUNC row is the one substrate cares about -- a closure over mutable
+// Go state, which is how an embedder hands lisp a handle to something it
+// keeps -- and it is also the row whose identity is subtlest, so it gets a
+// ground-truth write of its own below.
+//
+// The negative half is a payload held BY VALUE.  Without it this control
+// would pass on a census that reported everything, and "held by reference"
+// would have stopped meaning anything.
+// ---------------------------------------------------------------------------
+
+// refKindPayloads are the payload shapes the census must see, one per Go
+// kind that Fork shares by reference.  A chan is included because it is a
+// reference kind Fork shares like the others, not because a program can do
+// much with one.
+func refKindPayloads() map[string]any {
+	counter := new(int)
+	return map[string]any{
+		"map":   map[string]int{"n": 0},
+		"slice": []int{0, 0},
+		"chan":  make(chan int, 1),
+		// A closure over mutable Go state: the substrate-relevant shape.
+		"func": func() int { *counter++; return *counter },
+	}
+}
+
+// refKindEnv binds one payload per reference kind, plus a struct held BY
+// VALUE, which must NOT be censused.
+func refKindEnv() (*lisp.LEnv, error) {
+	env, err := elpstest.NewForkCheckEnv()
+	if err != nil {
+		return nil, err
+	}
+	for name, payload := range refKindPayloads() {
+		if rc := env.PutGlobal(lisp.Symbol("p-"+name), lisp.Native(payload)); rc.Type == lisp.LError {
+			return nil, lisp.GoError(rc)
+		}
+	}
+	if rc := env.PutGlobal(lisp.Symbol("p-byvalue"), lisp.Native(sharedCloner{n: 1})); rc.Type == lisp.LError {
+		return nil, lisp.GoError(rc)
+	}
+	return env, nil
+}
+
+func TestGuardDetectsForkSharingANonPointerNative(t *testing.T) {
+	t.Parallel()
+	tmpl, err := refKindEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f0, err := tmpl.Fork()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f1, err := tmpl.Fork()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// GROUND TRUTH, so this control cannot pass on a census that reports
+	// sharing that is not there: one Go map and one Go closure, each
+	// written through fork 0 and read back through fork 1.
+	payloadOf := func(env *lisp.LEnv, name string) any {
+		t.Helper()
+		v := env.GetGlobal(lisp.Symbol("p-" + name))
+		if v == nil || v.Type != lisp.LNative {
+			t.Fatalf("p-%s is %v, not a native", name, v)
+		}
+		return v.Native
+	}
+	payloadOf(f0, "map").(map[string]int)["n"] = 41
+	if got := payloadOf(f1, "map").(map[string]int)["n"]; got != 41 {
+		t.Fatalf("premise: the two forks do not share the map payload (read %d, want 41); "+
+			"this control is not exercising the shape it describes", got)
+	}
+	payloadOf(f0, "func").(func() int)()
+	if got := payloadOf(f1, "func").(func() int)(); got != 2 {
+		t.Fatalf("premise: the two forks do not share the closure's captured counter "+
+			"(read %d, want 2)", got)
+	}
+
+	// The cross-fork census must name every reference kind.
+	shared := map[string]bool{}
+	for _, sh := range elpstest.SharedNativePayloads(f0, f1) {
+		shared[sh.PathB] = true
+	}
+	for name := range refKindPayloads() {
+		if !shared["user:p-"+name] {
+			t.Errorf("SharedNativePayloads did not report the %s-kind payload both forks write "+
+				"through.\nFork shares an undeclared payload of EVERY reference kind, not just a "+
+				"pointer, so a census keyed on reflect.Pointer reports a clean result for a payload "+
+				"that is one transaction's state and another's.\nreported: %v", name, shared)
+		}
+	}
+	if shared["user:p-byvalue"] {
+		t.Error("SharedNativePayloads reported a payload held BY VALUE. Two copies of such a payload " +
+			"are the same payload in every sense the language can observe, so the census has become " +
+			"`everything reachable` and every witness it produces from now on is noise.")
+	}
+
+	// And the exported pre-ship census must list the types, or an embedder
+	// running it over its loaded environment is told they are not there.
+	declared := map[string]bool{}
+	for _, d := range elpstest.NativeDeclarations(tmpl) {
+		declared[d.Type] = true
+	}
+	for _, typ := range []string{"map[string]int", "[]int", "chan int", "func() int"} {
+		if !declared[typ] {
+			t.Errorf("NativeDeclarations does not list %s, so the pre-ship census an embedder is "+
+				"told to run reports a clean bill of health for it.\ndeclared: %v", typ, declared)
+		}
+	}
+}
+
+// The same shape through the whole transaction-isolation oracle, which is
+// where an embedder meets it: property 4 with ExpectNoSharedNatives set.
+// Measured at ZERO witnesses before the widening.
+func TestTransactionIsolationSeesANonPointerNative(t *testing.T) {
+	t.Parallel()
+	got, err := elpstest.CheckTransactions(elpstest.TransactionCheck{
+		NewEnv:  refKindEnv,
+		Program: `(set 'm (sorted-map "n" 0))`,
+		Tx: []string{
+			`(assoc! m "n" 1)`,
+			`(assoc! m "n" 2)`,
+		},
+		ExpectNoSharedNatives: true,
+	})
+	if err != nil {
+		t.Fatalf("harness error: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("the oracle reported nothing for a template whose every fork shares a map-kind, " +
+			"slice-kind, chan-kind and func-kind native payload; the census has narrowed back to " +
+			"pointers and property 4 cannot fire for the other five reference kinds")
+	}
+	assertWitnessMentions(t, "non-pointer-native", got, "no stateful native payload is reachable from two transactions at once")
+	assertWitnessMentions(t, "non-pointer-native", got, "func() int")
+}
+
+// The fingerprint half: a payload held by reference gets an identity
+// ordinal, so two headers over ONE payload are distinguishable from two
+// headers over two equal ones.  Without it a walker that de-aliased a
+// map-kind payload -- or interned two into one -- fingerprints identically
+// either way, since `native(T,by-value)` carries neither identity nor
+// contents.
+func TestFingerprintEncodesANonPointerNativeIdentity(t *testing.T) {
+	t.Parallel()
+	one := func(a, b any) string {
+		return elpstest.FingerprintValue(lisp.QExpr([]*lisp.LVal{
+			lisp.Native(a), lisp.Native(b),
+		}), elpstest.FingerprintOptions{}).String()
+	}
+	shared := map[string]int{"n": 1}
+	aliased := one(shared, shared)
+	distinct := one(map[string]int{"n": 1}, map[string]int{"n": 1})
+	if aliased == distinct {
+		t.Errorf("two headers over ONE map-kind payload fingerprint the same as two headers over "+
+			"two equal ones:\n  %s\nThe fingerprint cannot see sharing for any reference kind but "+
+			"a pointer, so every fingerprint-expressed property is blind to it.", aliased)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Claims-under-test.
 //
 // Three rounds of review each found a FALSE SENTENCE in newly-added prose,

--- a/elpstest/aliasguard_broken_test.go
+++ b/elpstest/aliasguard_broken_test.go
@@ -1284,6 +1284,93 @@ func TestFingerprintEncodesANonPointerNativeIdentity(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Control 12: a *int is not stateless.
+//
+// NativeDeclaration.Declared() is what an embedder's pre-ship census reads:
+// a type that declares neither NativeCloner nor RuntimeBound is reported as
+// clean only if it is "provably stateless".  isStatelessPayload unwrapped
+// ONE pointer before asking whether the type was basic, so a *int -- which
+// is nothing but a shared mutable cell -- came back stateless=true and
+// Declared()=true, with the doc comment asserting in so many words that
+// "such a payload holds no reference to anything else".
+//
+// Ground truth first, then the classification: fork 0 writes 41 through the
+// cell and fork 1 reads it back, so the census is being asked about a
+// payload that demonstrably carries one transaction's state into another.
+//
+// The negative half cannot live here, because a payload held BY VALUE is
+// not censused at all -- it has no identity to share -- so no bare int ever
+// reaches NativeDeclarations.  It lives beside the function instead:
+// TestIsStatelessPayloadClassifiesByTheOwnType, which pins that a bool, an
+// int and a string are still stateless.
+// ---------------------------------------------------------------------------
+
+func pointerCellEnv() (*lisp.LEnv, error) {
+	env, err := elpstest.NewForkCheckEnv()
+	if err != nil {
+		return nil, err
+	}
+	n := 0
+	if rc := env.PutGlobal(lisp.Symbol("cell"), lisp.Native(&n)); rc.Type == lisp.LError {
+		return nil, lisp.GoError(rc)
+	}
+	return env, nil
+}
+
+func TestAPointerToABasicTypeIsNotStateless(t *testing.T) {
+	t.Parallel()
+	tmpl, err := pointerCellEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f0, err := tmpl.Fork()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f1, err := tmpl.Fork()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cellOf := func(env *lisp.LEnv) *int {
+		t.Helper()
+		p, ok := env.GetGlobal(lisp.Symbol("cell")).Native.(*int)
+		if !ok {
+			t.Fatal("the fork does not hold a *int under `cell`")
+		}
+		return p
+	}
+	*cellOf(f0) = 41
+	if got := *cellOf(f1); got != 41 {
+		t.Fatalf("premise: the two forks do not share the cell (read %d, want 41); this control "+
+			"is not exercising the shape it describes", got)
+	}
+
+	byType := map[string]elpstest.NativeDeclaration{}
+	for _, d := range elpstest.NativeDeclarations(tmpl) {
+		byType[d.Type] = d
+	}
+	cell, ok := byType["*int"]
+	if !ok {
+		t.Fatalf("the census does not reach the *int at all, so this control checks nothing: %v", byType)
+	}
+	if cell.Declared() {
+		t.Errorf("the census reports %s as having declared its sharing semantics.\n"+
+			"It has not: it is neither a NativeCloner nor a RuntimeBound, and a POINTER to a basic\n"+
+			"type is a shared mutable cell, not a value with no state to share -- fork 0 wrote 41\n"+
+			"through this one and fork 1 read it back. An embedder running the exported pre-ship\n"+
+			"census gets a clean bill of health for a payload every transaction shares.", cell)
+	}
+	// The census must not have gone permissive the other way either: the
+	// standard library's own payload declares NativeCloner and is still
+	// reported as having declared.
+	if suite, ok := byType["*libtesting.TestSuite"]; ok && !suite.Declared() {
+		t.Errorf("a NativeCloner payload is no longer reported as declared: %s\n"+
+			"Declared() has become `nothing is ever declared`, which reddens the census for every "+
+			"payload that did the right thing.", suite)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Claims-under-test.
 //
 // Three rounds of review each found a FALSE SENTENCE in newly-added prose,

--- a/elpstest/aliasguard_concurrent_test.go
+++ b/elpstest/aliasguard_concurrent_test.go
@@ -1,0 +1,155 @@
+// Copyright © 2026 The ELPS authors
+
+// Controls for the CONCURRENT ARM of the transaction-isolation oracle.
+//
+// The arm used to re-check property 1 and nothing else -- the template's
+// fingerprint -- so a defect confined to the concurrent forks was
+// unobserved by every channel.  The sequential sweep never sees those
+// forks; the cell-view channel, the native census and parity all run on
+// the SEQUENTIAL forks.  -race catches the shape only when two goroutines
+// actually write in one window, and a fork that merely INHERITS another's
+// state races with nothing.
+
+package elpstest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+)
+
+// concurrentSharingProgram holds two independent maps, one per
+// transaction, so a fork can be handed another fork's map without the two
+// transactions ever touching one payload at the same time.
+const concurrentSharingProgram = `
+(set 'm (sorted-map "n" 0))
+(set 'k (sorted-map "n" 0))
+(set 'probe (list m k))
+`
+
+// concurrentSharingTx: transaction 0 writes m, transaction 1 writes k.
+// Nothing writes what another transaction reads, so the walker below is a
+// LEAK WITHOUT A DATA RACE -- which is the whole point.  A control that
+// raced would be caught by -race and would prove nothing about the oracle,
+// and it would take every other parallel test down with it (see
+// SkipConcurrentArm's doc).
+var concurrentSharingTx = []string{
+	`(assoc! m "n" 1)`,
+	`(assoc! k "n" 2)`,
+}
+
+// forkSharingBetweenConcurrentForks is faithful for every role except
+// forkRoleConcurrent, where it hands every fork after the first that
+// FIRST fork's `m`.  Nothing is shared with any template, so the
+// sequential sweep, the census, the cell-view channel and parity all see a
+// correct walker.
+func forkSharingBetweenConcurrentForks() (func(*lisp.LEnv) (*lisp.LEnv, error), func(forkRole)) {
+	var role forkRole
+	var first *lisp.LVal
+	fork := func(env *lisp.LEnv) (*lisp.LEnv, error) {
+		f, err := env.Fork()
+		if err != nil {
+			return nil, err
+		}
+		if role != forkRoleConcurrent {
+			return f, nil
+		}
+		if first == nil {
+			first = f.GetGlobal(lisp.Symbol("m"))
+			return f, nil
+		}
+		if rc := f.PutGlobal(lisp.Symbol("m"), first); rc.Type == lisp.LError {
+			return nil, lisp.GoError(rc)
+		}
+		return f, nil
+	}
+	return fork, func(r forkRole) { role = r }
+}
+
+// TestGuardDetectsSharingBetweenConcurrentForksOnly is the measurement the
+// concurrent arm's independence check was added for: before it, this
+// walker produced ZERO witnesses.
+func TestGuardDetectsSharingBetweenConcurrentForksOnly(t *testing.T) {
+	t.Parallel()
+	fork, onFork := forkSharingBetweenConcurrentForks()
+	got, err := CheckTransactions(TransactionCheck{
+		Program: concurrentSharingProgram,
+		Tx:      concurrentSharingTx,
+		Fork:    fork,
+		onFork:  onFork,
+		Repro:   "a fork walker that shares one map between two CONCURRENT-arm forks",
+	})
+	if err != nil {
+		t.Fatalf("harness error: %v", err)
+	}
+	const want = "a fork that ran its transaction concurrently holds what it holds when it runs alone"
+	var found bool
+	for _, w := range got {
+		if w.Property == want {
+			found = true
+			continue
+		}
+		t.Errorf("a walker faithful on every SEQUENTIAL role was reported by another channel:\n%s", w)
+	}
+	if !found {
+		t.Fatalf("two concurrent-arm forks share one *MapData and the oracle reported %d witness(es), "+
+			"none of them the concurrent-arm independence property.\n"+
+			"The arm is back to re-checking the template's fingerprint and nothing else, so a defect "+
+			"confined to the concurrent forks is unobserved outside -race -- and this one does not "+
+			"race: the fork that inherits the map never touches it while the other writes.\n"+
+			"witnesses: %v", len(got), got)
+	}
+}
+
+// The other half: a CORRECT walker must be silent on the same arm, or the
+// check above proves only that the property is noisy.  The default Fork is
+// used deliberately -- this is the shape every caller of CheckTransactions
+// now runs through the arm.
+func TestACorrectForkIsSilentOnTheConcurrentArm(t *testing.T) {
+	t.Parallel()
+	got, err := CheckTransactions(TransactionCheck{
+		Program: concurrentSharingProgram,
+		Tx:      concurrentSharingTx,
+		Repro:   "the real Fork walker over the concurrent arm",
+	})
+	if err != nil {
+		t.Fatalf("harness error: %v", err)
+	}
+	for _, w := range got {
+		if strings.Contains(w.Property, "concurrently") {
+			t.Errorf("the real Fork walker was reported by the concurrent-arm independence "+
+				"property:\n%s\nA guard red on a correct walker is a guard that gets switched off.", w)
+		}
+	}
+	if len(got) != 0 {
+		t.Errorf("the real Fork walker produced %d witness(es): %v", len(got), got)
+	}
+}
+
+// The reference forks the independence check replays on must arrive under
+// their OWN role.  If they came through forkRoleConcurrent, a walker
+// broken on that role would break the reference in the same way and the
+// comparison could never fail -- the control above would pass on an oracle
+// that compares two identically broken environments.
+func TestTheSoloReplayForksHaveTheirOwnRole(t *testing.T) {
+	t.Parallel()
+	seen := map[forkRole]int{}
+	_, err := CheckTransactions(TransactionCheck{
+		Program: concurrentSharingProgram,
+		Tx:      concurrentSharingTx,
+		Fork:    func(env *lisp.LEnv) (*lisp.LEnv, error) { return env.Fork() },
+		onFork:  func(r forkRole) { seen[r]++ },
+	})
+	if err != nil {
+		t.Fatalf("harness error: %v", err)
+	}
+	if seen[forkRoleConcurrentSolo] != len(concurrentSharingTx) {
+		t.Errorf("the concurrent arm announced %d solo-replay fork(s), want one per transaction (%d).\n"+
+			"roles seen: %v", seen[forkRoleConcurrentSolo], len(concurrentSharingTx), seen)
+	}
+	if seen[forkRoleConcurrent] != len(concurrentSharingTx) {
+		t.Errorf("the concurrent arm announced %d concurrent fork(s), want %d: %v",
+			seen[forkRoleConcurrent], len(concurrentSharingTx), seen)
+	}
+}

--- a/elpstest/aliasguard_internal_test.go
+++ b/elpstest/aliasguard_internal_test.go
@@ -292,3 +292,46 @@ func TestQuotedIsEncoded(t *testing.T) {
 		t.Error("a value does not fingerprint equal to itself; the encoding is nondeterministic")
 	}
 }
+
+// TestIsStatelessPayloadClassifiesByTheOwnType is the negative half of
+// control 12 (aliasguard_broken_test.go), which cannot state it: a payload
+// held BY VALUE is never censused -- it has no identity to share -- so no
+// bare int reaches NativeDeclarations and the "still stateless" rows have
+// nowhere else to live.
+//
+// The rule is that the payload's OWN type decides.  Unwrapping one pointer
+// first, which this function used to do, reported a *int -- a shared
+// mutable cell -- as having no state to share.
+func TestIsStatelessPayloadClassifiesByTheOwnType(t *testing.T) {
+	t.Parallel()
+	n := 0
+	s := "s"
+	type box struct{ n int }
+	cases := []struct {
+		name    string
+		payload any
+		want    bool
+	}{
+		{"an int", 7, true},
+		{"a bool", true, true},
+		{"a float", 1.5, true},
+		{"a string", "abc", true},
+		{"a pointer to an int", &n, false},
+		{"a pointer to a string", &s, false},
+		{"a struct", box{n: 1}, false},
+		{"a pointer to a struct", &box{n: 1}, false},
+		{"a map", map[string]int{}, false},
+		{"a slice", []int{1}, false},
+		{"a func", func() {}, false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		if got := isStatelessPayload(tc.payload); got != tc.want {
+			t.Errorf("isStatelessPayload(%s) = %t, want %t.\n"+
+				"Declared() reads this: a payload it calls stateless is reported to an embedder as\n"+
+				"having said what happens when every transaction shares it. That is only true when\n"+
+				"the payload is held BY VALUE, so the two transactions hold two copies.",
+				tc.name, got, tc.want)
+		}
+	}
+}

--- a/elpstest/aliasguard_internal_test.go
+++ b/elpstest/aliasguard_internal_test.go
@@ -335,3 +335,95 @@ func TestIsStatelessPayloadClassifiesByTheOwnType(t *testing.T) {
 		}
 	}
 }
+
+// TestTheProbeSiteCensus is the site-count half of controls 13 and 15
+// (aliasguard_broken_test.go), stated as exact numbers because the failure
+// it guards against is a SILENT ZERO: comparePair returns early on
+// len(sSites)==0, so a graph the walk contributes no site for is a graph
+// the mutation channel does not check at all, with no witness saying so.
+//
+// Measured before ProbeCellSlot and the last-byte probe existed, and the
+// reason both were added: `(vector 1 2 3)` -> 0 sites, `(list 1 2 3)` -> 0,
+// a six-byte buffer -> 1.
+//
+// Both directions are pinned, as in TestASortedMapEntryIsAProbeSite: a
+// header with no cells must contribute NOTHING, or "everything is a site"
+// passes the first half while destroying the boundary the cap controls
+// rest on.
+func TestTheProbeSiteCensus(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		program string
+		want    int
+		why     string
+	}{
+		// One site per cells-carrying HEADER, at its slot 0.  A list is
+		// one header.  A vector is THREE -- the array header, its
+		// dimensions and its data are all cells-carrying headers (lisp's
+		// LArray representation), which is worth knowing here because it
+		// is what the numbers below are made of.
+		{`(set 'probe (list 1 2 3))`, 1, "a list's backing array"},
+		{`(set 'probe (vector 1 2 3))`, 3, "the array header, its dims and its data"},
+		{`(set 'probe (list (vector 1 2) (vector 1 2)))`, 7, "the outer list plus three per vector"},
+		// A sorted map is its entries; LSortMap carries no Cells.
+		{`(set 'probe (sorted-map "k" 1))`, 1, "one map entry"},
+		// A buffer is bounded at both ends, and a one-byte buffer must
+		// not yield two sites over one index -- two probes on one byte
+		// would read each other's write.
+		{`(set 'probe (to-bytes "abcdef"))`, 2, "the first and last byte"},
+		{`(set 'probe (to-bytes "ab"))`, 2, "the first and last byte"},
+		{`(set 'probe (to-bytes "a"))`, 1, "one byte is one site"},
+		// The negative half: nothing mutable, no sites.
+		{`(set 'probe (to-bytes ""))`, 0, "an empty buffer"},
+		{`(set 'probe (list))`, 0, "an empty list"},
+		{`(set 'probe 7)`, 0, "an int"},
+		{`(set 'probe "abc")`, 0, "a string, whose bytes are not mutable storage"},
+	}
+	for _, tc := range cases {
+		env, err := NewForkCheckEnv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rc := env.LoadString("p.lisp", tc.program); rc.Type == lisp.LError {
+			t.Fatalf("%s: %v", tc.program, rc)
+		}
+		sites, truncated := probeSites(env.Get(lisp.Symbol("probe")), ClosuresInScope, "probe", DefaultMaxProbeSites)
+		if truncated {
+			t.Fatalf("%s: the sweep truncated at the default cap, which none of these graphs can reach", tc.program)
+		}
+		if len(sites) != tc.want {
+			var paths []string
+			for _, s := range sites {
+				paths = append(paths, s.String())
+			}
+			t.Errorf("%s has %d probe site(s), want %d (%s).\n"+
+				"A graph with no site is a graph comparePair returns EARLY on, leaving only the\n"+
+				"fingerprint -- whose ordinals are per walk, so it cannot tell a copier that returns\n"+
+				"its own input from a real copy.\nsites: %v",
+				tc.program, len(sites), tc.want, tc.why, paths)
+		}
+	}
+}
+
+// A sealed header contributes no cell slot: a sealed value is immutable by
+// contract and Fork shares it outright (docs/sealed-ast.md), so writing
+// through one would report documented behaviour as a leak -- and would be
+// the guard itself writing into storage it does not own, the defect class
+// checkStamp exists for.
+func TestASealedHeaderIsNotACellSlotProbeSite(t *testing.T) {
+	t.Parallel()
+	v := lisp.QExpr([]*lisp.LVal{lisp.Int(1), lisp.Int(2)})
+	sites, _ := probeSites(v, ClosuresInScope, "probe", DefaultMaxProbeSites)
+	if len(sites) != 1 {
+		t.Fatalf("premise: an unsealed two-cell header is one probe site, got %d", len(sites))
+	}
+	v.SealAST()
+	if !v.IsSealed() {
+		t.Fatal("the fixture did not seal")
+	}
+	if sites, _ := probeSites(v, ClosuresInScope, "probe", DefaultMaxProbeSites); len(sites) != 0 {
+		t.Errorf("a SEALED header contributed %d probe site(s): %v\n"+
+			"The sweep would write into storage that is immutable by contract and shared with every "+
+			"fork, reporting a documented behaviour as a leak.", len(sites), sites)
+	}
+}

--- a/elpstest/aliasguard_internal_test.go
+++ b/elpstest/aliasguard_internal_test.go
@@ -358,13 +358,16 @@ func TestTheProbeSiteCensus(t *testing.T) {
 		why     string
 	}{
 		// One site per cells-carrying HEADER, at its slot 0.  A list is
-		// one header.  A vector is THREE -- the array header, its
-		// dimensions and its data are all cells-carrying headers (lisp's
-		// LArray representation), which is worth knowing here because it
-		// is what the numbers below are made of.
+		// one header.  A vector is TWO: its LArray representation is three
+		// cells-carrying headers -- the array header, its dimensions and
+		// its data -- but the ARRAY HEADER contributes nothing, because
+		// its Cells is the structural pair [dims, holder] that no writer
+		// assigns into.  ProbeCellSlot states why, and control 16 in
+		// aliasguard_broken_test.go pins both halves of it; this is where
+		// the number that follows from it is written down.
 		{`(set 'probe (list 1 2 3))`, 1, "a list's backing array"},
-		{`(set 'probe (vector 1 2 3))`, 3, "the array header, its dims and its data"},
-		{`(set 'probe (list (vector 1 2) (vector 1 2)))`, 7, "the outer list plus three per vector"},
+		{`(set 'probe (vector 1 2 3))`, 2, "a vector's dims and its data, not its array header"},
+		{`(set 'probe (list (vector 1 2) (vector 1 2)))`, 5, "the outer list plus two per vector"},
 		// A sorted map is its entries; LSortMap carries no Cells.
 		{`(set 'probe (sorted-map "k" 1))`, 1, "one map entry"},
 		// A buffer is bounded at both ends, and a one-byte buffer must

--- a/elpstest/aliasguard_isolation.go
+++ b/elpstest/aliasguard_isolation.go
@@ -913,8 +913,9 @@ type NativeDeclaration struct {
 	// Bound reports whether the type implements lisp.RuntimeBound: it has
 	// declared a runtime affinity, which checked builds enforce.
 	Bound bool
-	// Stateless reports whether the payload's underlying type is a basic Go
-	// type, which has no state to share.
+	// Stateless reports whether the payload's OWN type is a basic Go type,
+	// which is held by value and so has no state to share.  A POINTER to a
+	// basic type is not stateless: it is a shared mutable cell.
 	Stateless bool
 }
 
@@ -967,19 +968,27 @@ func NativeDeclarations(env *lisp.LEnv) []NativeDeclaration {
 	return out
 }
 
-// isStatelessPayload reports whether a payload's underlying type is a basic
-// Go type — a bool, an integer, a float, a complex or a string, possibly
-// behind one pointer.  Such a payload holds no reference to anything else,
-// so sharing it between two transactions shares nothing they can both
-// write.  Anything else (a struct, a slice, a map, a channel, a func) may
-// reach mutable state and has to declare.
+// isStatelessPayload reports whether a payload's OWN type is a basic Go
+// type — a bool, an integer, a float, a complex or a string.  Such a
+// payload is held by value, so two transactions that hold it hold two
+// copies and sharing it shares nothing either can write.  Anything else (a
+// struct, a slice, a map, a channel, a func, and a POINTER to any of them
+// including a pointer to a basic type) may reach mutable state and has to
+// declare.
+//
+// IT USED TO UNWRAP ONE POINTER, which made the claim above false for the
+// payload it mattered most for.  A *int is a shared mutable cell: two forks
+// holding one write through it and read each other's writes (measured,
+// TestAPointerToABasicTypeIsNotStateless).  The census reported
+// Declared()==true for it, so an embedder running the exported pre-ship
+// census over its loaded environment got a clean bill of health for a
+// payload that is one transaction's state and another's.  The doc comment
+// asserted the false half in so many words — "such a payload holds no
+// reference to anything else" — of a type that is nothing but a reference.
 func isStatelessPayload(payload any) bool {
 	t := reflect.TypeOf(payload)
 	if t == nil {
 		return false
-	}
-	if t.Kind() == reflect.Pointer {
-		t = t.Elem()
 	}
 	switch t.Kind() {
 	case reflect.Bool,

--- a/elpstest/aliasguard_isolation.go
+++ b/elpstest/aliasguard_isolation.go
@@ -687,8 +687,9 @@ func (s SharedNative) String() string {
 		s.Type, s.PathA, s.PathB, s.Cloner, s.Bound)
 }
 
-// SharedNativePayloads reports every native payload held by pointer that is
-// reachable from BOTH a and b.
+// SharedNativePayloads reports every native payload held by reference --
+// pointer, map, slice, chan, func or unsafe pointer (payloadIdentity) --
+// that is reachable from BOTH a and b.
 //
 // This is deliberately not the runtime-affinity check (lisp/runtime_bound.go).
 // That protocol is OPT-IN — a payload that never implements RuntimeBound is
@@ -707,17 +708,17 @@ func SharedNativePayloads(a, b *lisp.LEnv) []SharedNative {
 	na := reachableNatives(a)
 	nb := reachableNatives(b)
 	var out []SharedNative
-	for payload, pa := range na {
-		pb, ok := nb[payload]
+	for id, ra := range na {
+		rb, ok := nb[id]
 		if !ok {
 			continue
 		}
-		_, cloner := payload.(lisp.NativeCloner)
-		_, bound := payload.(lisp.RuntimeBound)
+		_, cloner := ra.payload.(lisp.NativeCloner)
+		_, bound := ra.payload.(lisp.RuntimeBound)
 		out = append(out, SharedNative{
-			Type:   fmt.Sprintf("%T", payload),
-			PathA:  pa,
-			PathB:  pb,
+			Type:   fmt.Sprintf("%T", ra.payload),
+			PathA:  ra.path,
+			PathB:  rb.path,
 			Cloner: cloner,
 			Bound:  bound,
 		})
@@ -778,11 +779,23 @@ func sharedNativeWitnesses(c TransactionCheck, aName string, a *lisp.LEnv, forks
 	return out
 }
 
-// reachableNatives maps every pointer-held native payload reachable from
-// env to the first path that reached it.  A payload held by value has no
-// identity to share, so it is not collected.
-func reachableNatives(env *lisp.LEnv) map[any]string {
-	out := map[any]string{}
+// reachableNative is one payload and the first path that reached it.  The
+// payload is carried beside the path because the map is keyed on the
+// payload's IDENTITY rather than on the payload -- a map- or slice-typed
+// payload is not a legal Go map key (nativeIdentity, elpstest/fingerprint.go)
+// -- and the callers still need the value itself to ask what it declares.
+type reachableNative struct {
+	payload any
+	path    string
+}
+
+// reachableNatives maps every native payload held by REFERENCE reachable
+// from env to the first path that reached it.  A payload held by value has
+// no identity to share, so it is not collected; see payloadIdentity for
+// which Go kinds are held by reference and why all six of them are, rather
+// than pointers alone.
+func reachableNatives(env *lisp.LEnv) map[nativeIdentity]reachableNative {
+	out := map[nativeIdentity]reachableNative{}
 	walkReachable(env, func(v *lisp.LVal, path string) {
 		// Keyed on the PAYLOAD, not on the type. Native is shared storage:
 		// LBytes holds a *[]byte there, LSortMap a *MapData, and an embedder
@@ -797,10 +810,12 @@ func reachableNatives(env *lisp.LEnv) map[any]string {
 		//
 		// A cell-view link is excluded: it is a reference to a root, not a
 		// payload (isCellViewLink, elpstest/fingerprint.go).
-		if isPointerPayload(v.Native) && !kernelOwnedPayload(v) {
-			if _, dup := out[v.Native]; !dup {
-				out[v.Native] = path
-			}
+		id, ok := payloadIdentity(v.Native)
+		if !ok || kernelOwnedPayload(v) {
+			return
+		}
+		if _, dup := out[id]; !dup {
+			out[id] = reachableNative{payload: v.Native, path: path}
 		}
 	})
 	return out
@@ -929,19 +944,19 @@ func (d NativeDeclaration) String() string {
 // environment before shipping a phylum.
 func NativeDeclarations(env *lisp.LEnv) []NativeDeclaration {
 	byType := map[string]NativeDeclaration{}
-	for payload, path := range reachableNatives(env) {
-		key := fmt.Sprintf("%T", payload)
+	for _, rn := range reachableNatives(env) {
+		key := fmt.Sprintf("%T", rn.payload)
 		if _, ok := byType[key]; ok {
 			continue
 		}
-		_, cloner := payload.(lisp.NativeCloner)
-		_, bound := payload.(lisp.RuntimeBound)
+		_, cloner := rn.payload.(lisp.NativeCloner)
+		_, bound := rn.payload.(lisp.RuntimeBound)
 		byType[key] = NativeDeclaration{
 			Type:      key,
-			Path:      path,
+			Path:      rn.path,
 			Cloner:    cloner,
 			Bound:     bound,
-			Stateless: isStatelessPayload(payload),
+			Stateless: isStatelessPayload(rn.payload),
 		}
 	}
 	out := make([]NativeDeclaration, 0, len(byType))

--- a/elpstest/aliasguard_isolation.go
+++ b/elpstest/aliasguard_isolation.go
@@ -226,6 +226,12 @@ const (
 	// forkRoleConcurrent is one of the concurrent arm's forks, over a
 	// template of its own.
 	forkRoleConcurrent forkRole = "a concurrent-arm fork"
+	// forkRoleConcurrentSolo is one of the forks the concurrent arm takes
+	// AFTERWARDS, to re-run each transaction with nothing else in flight.
+	// It is the reference the concurrent forks are compared against, so a
+	// control that models a walker broken on the concurrent arm can share
+	// between the concurrent forks without also poisoning the reference.
+	forkRoleConcurrentSolo forkRole = "a concurrent-arm solo-replay fork"
 	// forkRoleParity is one of the parity channel's forks
 	// (aliasguard_parity.go), each compared against a cold load.
 	forkRoleParity forkRole = "a parity-channel fork"
@@ -523,8 +529,71 @@ func CheckTransactions(c TransactionCheck) ([]Witness, error) {
 			Repro:    c.Repro,
 		})
 	}
+	out = append(out, concurrentForkIndependenceWitnesses(c, conc, cforks)...)
 
 	return out, nil
+}
+
+// concurrentForkIndependenceWitnesses is PROPERTY 2 ON THE CONCURRENT ARM:
+// a transaction that ran while every other transaction was in flight must
+// leave its fork exactly where the same transaction leaves a fork of the
+// same template with nothing else running.
+//
+// THE ARM USED TO RE-CHECK PROPERTY 1 AND NOTHING ELSE -- the template's
+// fingerprint -- so a defect confined to the concurrent forks was
+// unobserved.  Measured, with a walker that hands two concurrent-arm forks
+// ONE *MapData and is faithful for every other role: zero witnesses.  The
+// sequential sweep never sees those forks, the cell-view channel, the
+// native census and parity all run on the SEQUENTIAL forks, and outside
+// -race nothing looked at a concurrent fork at all.  -race does catch the
+// shape, but only when two goroutines actually write in one window; a fork
+// that merely READS another's state races with nothing.
+//
+// THE REFERENCE IS A SOLO REPLAY, taken after the concurrent run: a fresh
+// fork of the same template, running the same transaction alone.  A
+// snapshot taken BEFORE the transactions cannot serve on its own, because
+// every fork legitimately moves -- the question is not whether a fork
+// moved but whether it moved to where its own transaction takes it.
+//
+// Both sides are compared under crossEnvFingerprint: the two forks mint
+// any transaction-scoped gensym from a process-wide counter, so the
+// numbers differ by construction and are normalised exactly as parity's
+// arms are.
+//
+// The replay forks are announced under their OWN role
+// (forkRoleConcurrentSolo).  A control that models a walker broken on the
+// concurrent arm keys on the role, and if the reference forks arrived
+// under the same one, the walker would break the reference in the same way
+// and the comparison would agree -- a control that cannot fail.
+func concurrentForkIndependenceWitnesses(c TransactionCheck, conc *lisp.LEnv, cforks []*lisp.LEnv) []Witness {
+	var out []Witness
+	for i, tx := range c.Tx {
+		solo, err := c.forkAs(forkRoleConcurrentSolo, conc)
+		if err != nil {
+			// A fork walker that refuses here has already been reported
+			// by every arm above; there is nothing to compare against.
+			return out
+		}
+		if rc := solo.LoadString(fmt.Sprintf("tx%d.lisp", i), tx); rc.Type == lisp.LError {
+			// The same transaction ran on the concurrent arm without
+			// raising; a raise on the replay is a divergence parity owns.
+			continue
+		}
+		want := crossEnvFingerprint(solo, nil)
+		got := crossEnvFingerprint(cforks[i], nil)
+		if want.Equal(got) {
+			continue
+		}
+		out = append(out, Witness{
+			Walker:   "Fork",
+			Property: "a fork that ran its transaction concurrently holds what it holds when it runs alone",
+			Detail: fmt.Sprintf("concurrent fork %d ended somewhere else than a fork running transaction %d "+
+				"alone: it saw another transaction that was in flight at the same time\n%s", i, i, want.Diff(got)),
+			Leak:  firstDivergentPath(want, got),
+			Repro: c.Repro,
+		})
+	}
+	return out
 }
 
 // templateToForkWitnesses runs a transaction ON THE TEMPLATE and requires

--- a/elpstest/aliasguard_payloadkey_test.go
+++ b/elpstest/aliasguard_payloadkey_test.go
@@ -43,8 +43,8 @@ func payloadKeyEnv(t *testing.T) *lisp.LEnv {
 
 func censusPaths(env *lisp.LEnv) map[string]string {
 	out := map[string]string{}
-	for p, path := range reachableNatives(env) {
-		out[path] = fmt.Sprintf("%T", p)
+	for _, rn := range reachableNatives(env) {
+		out[rn.path] = fmt.Sprintf("%T", rn.payload)
 	}
 	return out
 }

--- a/elpstest/aliasguard_test.go
+++ b/elpstest/aliasguard_test.go
@@ -536,7 +536,7 @@ func TestABuiltinIsNotIdentifiedByItsGoPointer(t *testing.T) {
 	}
 }
 
-// PINNED SCOPE, not an aspiration:// PINNED SCOPE, not an aspiration: two environments whose `policy` returns
+// PINNED SCOPE, not an aspiration: two environments whose `policy` returns
 // 1 and 2 fingerprint IDENTICALLY.  Function identity in the encoding is
 // FID, package, builtin-ness and FunType, and none of those moves when the
 // Go implementation behind the name does.

--- a/elpstest/aliasguard_test.go
+++ b/elpstest/aliasguard_test.go
@@ -6,7 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"reflect"
+
 	"github.com/luthersystems/elps/elpstest"
+	"github.com/luthersystems/elps/elpsutil"
 	"github.com/luthersystems/elps/lisp"
 )
 
@@ -482,4 +485,100 @@ func TestFingerprintIsDeterministic(t *testing.T) {
 				"is being ranged directly")
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// A builtin's Go implementation, and why it is NOT in the encoding.
+//
+// The fingerprint identifies a function by FID, package, builtin-ness and
+// FunType, and its own doc used to justify leaving the implementation out
+// with "the Go function pointer is not comparable".  That is a fact about
+// `==`, which reflect.Value.Pointer sidesteps, so the justification was
+// wrong even though the decision was right.  The two tests below are the
+// measurements that replace it: the pointer identifies nothing here, and
+// what it would identify elsewhere is a value-channel question.
+// ---------------------------------------------------------------------------
+
+// TestABuiltinIsNotIdentifiedByItsGoPointer measures the first reason.
+//
+// Registration goes through LBuiltinDef.Eval (lisp.(*LEnv).AddBuiltins), so
+// every builtin value in every package holds a METHOD VALUE, and
+// reflect.Value.Pointer on a method value returns the compiler's shared
+// wrapper -- one address for every receiver.  An identity ordinal built
+// from it would say that `car` and `cdr` run the same Go code, which is
+// worse than saying nothing.
+//
+// If this test ever fails, the pointer HAS become an identity and the
+// decision is worth revisiting -- against the second reason, which the next
+// test states.
+func TestABuiltinIsNotIdentifiedByItsGoPointer(t *testing.T) {
+	t.Parallel()
+	env, err := elpstest.NewForkCheckEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	car, cdr := env.Get(lisp.Symbol("car")), env.Get(lisp.Symbol("cdr"))
+	if car.Type != lisp.LFun || cdr.Type != lisp.LFun {
+		t.Fatalf("premise: car and cdr are not function values (%v, %v)", car.Type, cdr.Type)
+	}
+	bc, bd := car.Builtin(), cdr.Builtin()
+	if bc == nil || bd == nil {
+		t.Fatal("premise: car and cdr carry no builtin implementation")
+	}
+	if pc, pd := reflect.ValueOf(bc).Pointer(), reflect.ValueOf(bd).Pointer(); pc != pd {
+		t.Errorf("car and cdr now have DIFFERENT reflect pointers (%#x, %#x).\n"+
+			"The measurement behind fingerprint.go's decision not to encode a builtin's Go\n"+
+			"implementation has changed: it held because registration wraps every implementation in\n"+
+			"a method value, whose reflect pointer is one shared wrapper. Re-read that note before\n"+
+			"encoding the pointer -- the other half of the argument (a closure gets a fresh address\n"+
+			"per environment, so a cold arm and a fork would diverge on correct code) still stands.",
+			pc, pd)
+	}
+}
+
+// PINNED SCOPE, not an aspiration:// PINNED SCOPE, not an aspiration: two environments whose `policy` returns
+// 1 and 2 fingerprint IDENTICALLY.  Function identity in the encoding is
+// FID, package, builtin-ness and FunType, and none of those moves when the
+// Go implementation behind the name does.
+//
+// An absolute pointer would not fix it, it would break the oracle: a
+// builtin registered as a CLOSURE gets a fresh address in every
+// environment, so every cold-vs-fork comparison over an embedder that
+// registers closures -- the ordinary way to give lisp a handle on Go state
+// -- would report a divergence on correct code.  What sees this divergence
+// is the channel that RUNS the program, which is why the second half here
+// measures the call.
+func TestABuiltinsBehaviourIsAValueChannelQuestion(t *testing.T) {
+	t.Parallel()
+	build := func(n int) *lisp.LEnv {
+		t.Helper()
+		env, err := elpstest.NewForkCheckEnv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		env.AddBuiltins(true, elpsutil.Function("policy", lisp.Formals(),
+			func(*lisp.LEnv, *lisp.LVal) *lisp.LVal { return lisp.Int(n) }))
+		if rc := env.LoadString("p.lisp", `(set 'probe policy)`); rc.Type == lisp.LError {
+			t.Fatal(rc)
+		}
+		return env
+	}
+	a, b := build(1), build(2)
+	opts := elpstest.FingerprintOptions{Seal: true, PackageMetadata: true}
+	fa, fb := elpstest.FingerprintEnv(a, opts), elpstest.FingerprintEnv(b, opts)
+	if !fa.Equal(fb) {
+		t.Errorf("two environments whose `policy` differs only in what it RETURNS now fingerprint\n"+
+			"differently:\n%s\nIf that is deliberate, check what it costs: a builtin registered as a\n"+
+			"closure has a fresh address in every environment, so a cold arm and a fork would\n"+
+			"diverge here on correct code. Delete this pin only with that measured.", fa.Diff(fb))
+	}
+	// And the channel that does see it: the call.
+	ra := a.LoadString("c.lisp", "(policy)").String()
+	rb := b.LoadString("c.lisp", "(policy)").String()
+	if ra == rb {
+		t.Fatalf("premise: the two implementations return the same value (%s), so this test is not "+
+			"about what it says", ra)
+	}
+	t.Logf("identical fingerprints; (policy) returns %s here and %s there -- a parity question, "+
+		"not a fingerprint one", ra, rb)
 }

--- a/elpstest/fingerprint.go
+++ b/elpstest/fingerprint.go
@@ -67,12 +67,14 @@ import (
 //     identified by its FID and package name (the substitution
 //     elpstest/forkcheck.go already made).
 //   - A native payload is an opaque interface{}, so it renders as its Go
-//     type name plus an identity ordinal.  The ordinal is the load-bearing
-//     half: it says whether two headers hold ONE payload, which is
-//     observable even when the payload's contents are not.  It is emitted
-//     for every payload held by REFERENCE -- pointer, map, slice, chan,
-//     func, unsafe pointer -- because Fork's default policy shares all six
-//     with every fork by reference; see payloadIdentity.
+//     type name plus an identity ordinal.  Its CONTENTS are compared only
+//     when the caller supplies FingerprintOptions.RenderNative, because
+//     only the payload's owner can render it canonically.  The ordinal is
+//     the load-bearing half: it says whether two headers hold ONE payload,
+//     which is observable even when the payload's contents are not.  It is
+//     emitted for every payload held by REFERENCE -- pointer, map, slice,
+//     chan, func, unsafe pointer -- because Fork's default policy shares
+//     all six with every fork by reference; see payloadIdentity.
 //
 // # Bounds
 //
@@ -173,6 +175,31 @@ type FingerprintOptions struct {
 	// the harm this channel carries is a pointer: a copy that kept the
 	// metadata hands out the SOURCE's nodes. See macroExpansionLeaks.
 	MacroExpansion bool
+	// RenderNative, when set, renders a native payload's CONTENTS into the
+	// stream, beside the type name and identity ordinal the encoding
+	// already carries.
+	//
+	// OPT-IN, AND NIL EVERYWHERE IN THIS PACKAGE, so no existing stream
+	// moves.  It is opt-in because a payload is an opaque interface{} and
+	// only its owner knows how to render it canonically: a rendering that
+	// includes a Go pointer, a map's range order or a wall clock would
+	// report a divergence on every comparison and the guard would be
+	// switched off within the day.
+	//
+	// WHAT IT BUYS.  Without it, NO CHANNEL OF THIS GUARD COMPARES A
+	// NATIVE'S CONTENTS.  The fingerprint emits type plus ordinal, and
+	// renderResult -- parity's per-transaction comparison, the backstop for
+	// everything the structural channels cannot see -- emits
+	// `native(<GoType>)`.  So a divergence whose only observable is a
+	// native is invisible to the whole oracle: measured, on a transaction
+	// that returns a native holding 41 on the fork arm and 0 on the cold
+	// arm, at zero witnesses (TestForkParity_ANativeObservationNeedsARenderer).
+	//
+	// The function must be a PURE function of the payload's observable
+	// state, and must not include identity: identity is the ordinal's job,
+	// and putting it here would report a fork that correctly cloned a
+	// payload as a divergence.
+	RenderNative func(payload any) string
 	// PackageMetadata records the per-package tables that live beside the
 	// symbol table: exports, symbol docs and the FID→name index.  Fork
 	// copies all three rather than sharing them (lisp/fork.go, issue #397),
@@ -501,6 +528,7 @@ func (w *fingerprinter) annotation(v *lisp.LVal) {
 		return
 	}
 	w.emitf("annot#%d(%T)", n, v.Native)
+	w.nativeContents(v.Native)
 }
 
 // kernelOwnedPayload reports whether a header's Native belongs to the
@@ -751,14 +779,27 @@ func (w *fingerprinter) native(payload any) {
 	key, ok := payloadIdentity(payload)
 	if !ok {
 		w.emitf("native(%T,by-value)", payload)
+		w.nativeContents(payload)
 		return
 	}
 	n, first := w.id(key)
 	if !first {
+		// The contents were written under the first arrival, with the
+		// ordinal that says this is the same payload.
 		w.emitf("native#%d", n)
 		return
 	}
 	w.emitf("native#%d(%T)", n, payload)
+	w.nativeContents(payload)
+}
+
+// nativeContents emits the payload's rendered contents, when the caller
+// supplied a renderer.  See FingerprintOptions.RenderNative.
+func (w *fingerprinter) nativeContents(payload any) {
+	if w.opts.RenderNative == nil {
+		return
+	}
+	w.emitf("nativev(%q)", w.opts.RenderNative(payload))
 }
 
 func (w *fingerprinter) fun(v *lisp.LVal) {

--- a/elpstest/fingerprint.go
+++ b/elpstest/fingerprint.go
@@ -69,7 +69,10 @@ import (
 //   - A native payload is an opaque interface{}, so it renders as its Go
 //     type name plus an identity ordinal.  The ordinal is the load-bearing
 //     half: it says whether two headers hold ONE payload, which is
-//     observable even when the payload's contents are not.
+//     observable even when the payload's contents are not.  It is emitted
+//     for every payload held by REFERENCE -- pointer, map, slice, chan,
+//     func, unsafe pointer -- because Fork's default policy shares all six
+//     with every fork by reference; see payloadIdentity.
 //
 // # Bounds
 //
@@ -389,11 +392,6 @@ func normalizeFunIDs(s string) string {
 	return funIDPattern.ReplaceAllString(s, "_fun#")
 }
 
-// isPointerPayload reports whether a native payload is held by pointer, and
-// therefore has an identity worth recording.  A payload held by value (an
-// int, a struct) has none: two copies of it are the same payload in every
-// sense the language can observe, and the kernel's own memos skip it for
-// the same reason (forker.native, detacher.cloneNative).
 // isCellViewLink reports whether v's Native is a KERNEL-INTERNAL cell-view
 // link rather than an embedder payload.
 //
@@ -493,10 +491,11 @@ func (w *fingerprinter) annotation(v *lisp.LVal) {
 	default:
 		// Every other type can carry an embedder annotation.
 	}
-	if !isPointerPayload(v.Native) || isCellViewLink(v) {
+	key, ok := payloadIdentity(v.Native)
+	if !ok || isCellViewLink(v) {
 		return
 	}
-	n, first := w.id(v.Native)
+	n, first := w.id(key)
 	if !first {
 		w.emitf("annot#%d", n)
 		return
@@ -540,12 +539,83 @@ func kernelOwnedPayload(v *lisp.LVal) bool {
 	return isCellViewLink(v)
 }
 
-func isPointerPayload(payload any) bool {
+// nativeIdentity is what "the same payload" means for a native held by
+// reference: the Go type plus the address the reference points at.
+//
+// It is a KEY, and the reason it exists rather than the payload itself is
+// that the payload may not be a legal map key at all.  The ordinal table
+// (fingerprinter.ord) and the cross-fork census are Go maps, and a
+// map-typed or slice-typed payload used as a key PANICS with "hash of
+// unhashable type" -- which is what the widening below would have done on
+// its first embedder payload of either kind.  The type is carried
+// alongside the address because two payloads of different Go types are
+// never the same payload, and addresses can coincide across types (a *T
+// pointing at the first element of a []T is the classic pair).
+type nativeIdentity struct {
+	typ reflect.Type
+	ptr uintptr
+}
+
+// payloadIdentity reports the identity of a native payload held by
+// REFERENCE, and whether it has one.
+//
+// WHAT COUNTS AS "BY REFERENCE", and why the earlier `Kind() == Pointer`
+// test was not it.  Fork's default policy shares an undeclared payload with
+// every fork by REFERENCE (docs/fork.md), and Go has six kinds for which
+// that means the two forks write through to one object: Pointer, Map,
+// Slice, Chan, Func and UnsafePointer.  Keying on Pointer alone made the
+// other five invisible to everything downstream -- reachableNatives (so
+// property 4 could not fire), NativeDeclarations (so an embedder's pre-ship
+// census reported them clean) and the fingerprint (which emitted
+// `native(T,by-value)`: no identity, and no contents either).  Measured, on
+// a payload of type `map[string]int` reached from two forks: zero census
+// entries, no declaration row, and a write of 999 through one fork moved no
+// fingerprint token.  A payload held by VALUE (an int, a struct) genuinely
+// has no identity: two copies of it are the same payload in every sense the
+// language can observe, and the kernel's own memos skip it for the same
+// reason (forker.native, detacher.cloneNative).
+//
+// TWO MEASURED IMPRECISIONS, stated rather than assumed, because both are
+// places this can report sharing that is not there:
+//
+//   - A FUNC's identity is reflect's func pointer.  For a closure that is
+//     the funcval the closure allocated, so two closures over different
+//     captured state compare UNEQUAL and one closure copied compares EQUAL
+//     -- measured, both directions.  For a func literal that captures
+//     NOTHING, Go may emit a single static funcval, so two such payloads
+//     can share an ordinal.  A payload with no captured state has no
+//     mutable state to share, so the report is harmless where it is wrong.
+//   - A SLICE of zero length AND zero capacity has no identity: every
+//     zero-size allocation in Go lives at one address (measured: two
+//     distinct `[]int{}` values compare equal by pointer).  Such a payload
+//     is reported by value rather than given an ordinal it would share with
+//     an unrelated one.  A zero-LENGTH slice with capacity, `s[:0]`, does
+//     alias its backing array and keeps its identity.
+func payloadIdentity(payload any) (nativeIdentity, bool) {
 	if payload == nil {
-		return false
+		return nativeIdentity{}, false
 	}
 	rv := reflect.ValueOf(payload)
-	return rv.Kind() == reflect.Pointer && !rv.IsNil()
+	switch rv.Kind() {
+	case reflect.Pointer, reflect.Map, reflect.Chan, reflect.Func:
+		if rv.IsNil() {
+			return nativeIdentity{}, false
+		}
+	case reflect.Slice:
+		// IsNil is not enough: see the zero-size note above.
+		if rv.IsNil() || (rv.Len() == 0 && rv.Cap() == 0) {
+			return nativeIdentity{}, false
+		}
+	case reflect.UnsafePointer:
+		// IsNil PANICS on this kind, so nil-ness is read off the address.
+		if rv.Pointer() == 0 {
+			return nativeIdentity{}, false
+		}
+	default:
+		// Held by value: no identity to record.
+		return nativeIdentity{}, false
+	}
+	return nativeIdentity{typ: rv.Type(), ptr: rv.Pointer()}, true
 }
 
 func (w *fingerprinter) value(v *lisp.LVal) {
@@ -670,18 +740,20 @@ func (w *fingerprinter) bytes(v *lisp.LVal) {
 }
 
 // native renders an opaque payload: its Go type, plus an identity ordinal
-// when it is held by pointer.  The ordinal is what makes payload sharing
-// observable through a value the walker cannot look inside.
+// when it is held by reference -- a pointer, map, slice, chan, func or
+// unsafe pointer (payloadIdentity).  The ordinal is what makes payload
+// sharing observable through a value the walker cannot look inside.
 func (w *fingerprinter) native(payload any) {
 	if payload == nil {
 		w.emit("native(nil)")
 		return
 	}
-	if !isPointerPayload(payload) {
+	key, ok := payloadIdentity(payload)
+	if !ok {
 		w.emitf("native(%T,by-value)", payload)
 		return
 	}
-	n, first := w.id(payload)
+	n, first := w.id(key)
 	if !first {
 		w.emitf("native#%d", n)
 		return

--- a/elpstest/fingerprint.go
+++ b/elpstest/fingerprint.go
@@ -63,9 +63,31 @@ import (
 // Two things cannot be compared by content, so they are compared by identity
 // and by a stable description instead:
 //
-//   - A builtin's Go function pointer is not comparable, so a function is
-//     identified by its FID and package name (the substitution
-//     elpstest/forkcheck.go already made).
+//   - A function is identified by its FID and package name (the
+//     substitution elpstest/forkcheck.go already made).  Its Go
+//     IMPLEMENTATION is not encoded, and the reason this list used to give
+//     -- "the Go function pointer is not comparable" -- is the wrong one:
+//     that is a fact about `==`, which reflect.Value.Pointer sidesteps.
+//     The real reasons are two, both measured:
+//
+//     EVERY BUILTIN HERE IS A METHOD VALUE.  Registration goes through
+//     LBuiltinDef.Eval (lisp.(*LEnv).AddBuiltins), and reflect.Value.Pointer
+//     on a method value returns the compiler's shared wrapper, the same
+//     address for every receiver -- so `car` and `cdr` compare EQUAL by
+//     pointer (TestABuiltinIsNotIdentifiedByItsGoPointer).  An ordinal
+//     built from it would state that every builtin in the standard library
+//     shares one implementation, which is worse than saying nothing.
+//
+//     AN ABSOLUTE POINTER WOULD BREAK THE ORACLE.  A builtin closing over
+//     Go state gets a fresh address in every environment, so every
+//     cold-vs-fork comparison over an embedder that registers such
+//     builtins -- the ordinary way to give lisp a handle on Go state --
+//     would report a divergence on correct code.
+//
+//     What that leaves: two environments whose `policy` returns 1 and 2
+//     fingerprint identically, and the divergence is a VALUE-channel
+//     question, which parity answers by running the program
+//     (TestABuiltinsBehaviourIsAValueChannelQuestion).
 //   - A native payload is an opaque interface{}, so it renders as its Go
 //     type name plus an identity ordinal.  Its CONTENTS are compared only
 //     when the caller supplies FingerprintOptions.RenderNative, because
@@ -810,9 +832,11 @@ func (w *fingerprinter) nativeContents(payload any) {
 }
 
 func (w *fingerprinter) fun(v *lisp.LVal) {
-	// FID and package name rather than the Go function pointer, which is
-	// not comparable.  The FID's environment number is normalised so a cold
-	// environment can be compared against a fork.
+	// FID and package name; the FID's environment number is normalised so
+	// a cold environment can be compared against a fork.  The Go
+	// IMPLEMENTATION is not here, for the two measured reasons in the file
+	// comment's substitution list -- not for the "not comparable" one that
+	// used to be given.
 	w.emitf("fun(fid=%s,pkg=%s,builtin=%t,type=%d)",
 		normalizeFunIDs(v.FID()), v.Package(), v.Builtin() != nil, v.FunType)
 	if w.opts.SkipCapturedEnvironments {

--- a/elpstest/fingerprint.go
+++ b/elpstest/fingerprint.go
@@ -413,6 +413,13 @@ func (w *fingerprinter) id(key any) (int, bool) {
 // Function identity within one walk is carried by the header ordinal and by
 // the captured environment, so normalising the number costs the stream
 // nothing and lets a cold arm be compared against a fork.
+//
+// APPLY IT TO AN ID, NOT TO RENDERED TEXT.  The pattern is ordinary
+// characters a program can put in a string, so rewriting it wherever it
+// appears erases user data: a fork/cold divergence between the strings
+// "_fun1" and "_fun2" was silent in the transaction-result channel until
+// this rule was written down (see the two call sites in fingerprint.go,
+// which pass v.FID(), and stateWalker's arms in forkcheck.go).
 var funIDPattern = regexp.MustCompile(`_fun\d+`)
 
 func normalizeFunIDs(s string) string {

--- a/elpstest/forkcheck.go
+++ b/elpstest/forkcheck.go
@@ -226,7 +226,16 @@ func renderResult(v *lisp.LVal) string {
 // write correctly.
 func renderResultWith(v *lisp.LVal, renderNative func(any) string) string {
 	if v.Type == lisp.LError {
-		return "error: " + normalizeFunIDs(v.String())
+		// THE ONE PLACE AN ID IS STILL NORMALISED IN FREE TEXT, and it is
+		// not an oversight.  An error's rendering is a message, not a
+		// structure: a lambda's FID and a libschema gensym both reach it
+		// through frame and function names, with nothing to key on that
+		// separates them from the message text.  So a fork/cold divergence
+		// confined to an ERROR MESSAGE that matches one of the ID patterns
+		// is still erased here.  Everywhere else the rewrite now happens
+		// at the ID itself (normalizeFunctionText below, and
+		// parityNormalizeToken in parity.go).
+		return "error: " + normalizeFunctionText(v.String())
 	}
 	var b strings.Builder
 	w := newStateWalker(&b)
@@ -343,11 +352,22 @@ func (w *stateWalker) value(v *lisp.LVal) {
 			fmt.Fprintf(w.sb, "(%q)", w.renderNative(v.Native))
 		}
 	case lisp.LFun:
-		w.sb.WriteString(normalizeFunIDs(v.String()))
+		// A FUNCTION's rendering embeds its ID, which a cold environment
+		// and a fork mint on independent counters; that is what is
+		// normalised, and only here, where the text IS an ID-bearing
+		// rendering.
+		w.sb.WriteString(normalizeFunctionText(v.String()))
 		w.env(funraw.Env(v))
 	default:
 		if len(v.Cells) == 0 {
-			w.sb.WriteString(normalizeFunIDs(v.String()))
+			// NOT NORMALISED.  This arm renders an int, a string, a
+			// symbol -- USER DATA.  Rewriting `_fun<n>` in it erased a
+			// fork/cold divergence between the strings "_fun1" and
+			// "_fun2": measured, the result channel went silent on a
+			// value the transaction returned.  An ID is normalised where
+			// it is an ID (the LFun arm above), not wherever its pattern
+			// happens to match.
+			w.sb.WriteString(v.String())
 			return
 		}
 		fmt.Fprintf(w.sb, "%s", v.Type)

--- a/elpstest/forkcheck.go
+++ b/elpstest/forkcheck.go
@@ -50,8 +50,9 @@ import (
 // because the oracles cannot see inside it: a native payload's contents
 // (rendered by Go type only, so a stateful native that is not a
 // NativeCloner is compared by the header that holds it, not by what it
-// holds), and package metadata outside the symbol table (exports,
-// docstrings, the function-name index).
+// holds -- ParityCheck.RenderNative is the opt-in that changes that), and
+// package metadata outside the symbol table (exports, docstrings, the
+// function-name index).
 type ForkCheck struct {
 	// NewEnv builds an environment with whatever library the program needs
 	// loaded and the user package selected.  It is called once for the
@@ -210,13 +211,26 @@ func RunForkCheck(t testing.TB, c ForkCheck) {
 }
 
 // renderResult renders a transaction result for comparison: the value's
-// type and rendering, or the error text for an error.
+// type and rendering, or the error text for an error.  A native renders as
+// its Go type alone; renderResultWith is the form that can look inside one.
 func renderResult(v *lisp.LVal) string {
+	return renderResultWith(v, nil)
+}
+
+// renderResultWith is renderResult with a native renderer, which is nil
+// everywhere in this package.  A caller that supplies one
+// (ParityCheck.RenderNative) makes a native's CONTENTS part of the
+// comparison; without one, two results that differ only inside a native
+// compare EQUAL -- see FingerprintOptions.RenderNative for what that costs
+// and why the hook is opt-in rather than a default rendering nobody can
+// write correctly.
+func renderResultWith(v *lisp.LVal, renderNative func(any) string) string {
 	if v.Type == lisp.LError {
 		return "error: " + normalizeFunIDs(v.String())
 	}
 	var b strings.Builder
 	w := newStateWalker(&b)
+	w.renderNative = renderNative
 	w.value(v)
 	return v.Type.String() + " " + b.String()
 }
@@ -285,6 +299,9 @@ type stateWalker struct {
 	sb   *strings.Builder
 	seen map[*lisp.LVal]int
 	envs map[*lisp.LEnv]int
+	// renderNative renders a native payload's contents.  Nil means the
+	// historical behaviour: the Go type name and nothing else.
+	renderNative func(any) string
 }
 
 func newStateWalker(sb *strings.Builder) *stateWalker {
@@ -322,6 +339,9 @@ func (w *stateWalker) value(v *lisp.LVal) {
 		fmt.Fprintf(w.sb, "bytes(%q)", v.Bytes())
 	case lisp.LNative:
 		fmt.Fprintf(w.sb, "native(%T)", v.Native)
+		if w.renderNative != nil {
+			fmt.Fprintf(w.sb, "(%q)", w.renderNative(v.Native))
+		}
 	case lisp.LFun:
 		w.sb.WriteString(normalizeFunIDs(v.String()))
 		w.env(funraw.Env(v))

--- a/elpstest/parity.go
+++ b/elpstest/parity.go
@@ -168,8 +168,19 @@ func parityNormalizeToken(tok string) string {
 // process-wide gensyms normalised (parityGensymPattern) and the check's
 // native renderer, if it supplied one, threaded in.
 func parityFingerprint(c ParityCheck, env *lisp.LEnv) *Fingerprint {
+	return crossEnvFingerprint(env, c.RenderNative)
+}
+
+// crossEnvFingerprint is the template-level fingerprint of an environment,
+// with the process-wide gensym counter normalised: the comparator for two
+// environments that numbered their own gensyms independently.  Every
+// comparison ACROSS independent loads needs it -- parity's arms, and the
+// concurrent arm's solo replay (aliasguard_isolation.go) -- and no
+// comparison WITHIN one template does, which is why FingerprintEnv itself
+// does not do it.
+func crossEnvFingerprint(env *lisp.LEnv, renderNative func(any) string) *Fingerprint {
 	opts := templateOpts
-	opts.RenderNative = c.RenderNative
+	opts.RenderNative = renderNative
 	fp := FingerprintEnv(env, opts)
 	for i, tok := range fp.tokens {
 		fp.tokens[i] = parityNormalizeToken(tok)

--- a/elpstest/parity.go
+++ b/elpstest/parity.go
@@ -114,9 +114,12 @@ func parityNormalize(s string) string {
 
 // parityFingerprint is the post-run state fingerprint the two arms are
 // compared under: FingerprintEnv under the template-level options, with
-// process-wide gensyms normalised (parityGensymPattern).
-func parityFingerprint(env *lisp.LEnv) *Fingerprint {
-	fp := FingerprintEnv(env, templateOpts)
+// process-wide gensyms normalised (parityGensymPattern) and the check's
+// native renderer, if it supplied one, threaded in.
+func parityFingerprint(c ParityCheck, env *lisp.LEnv) *Fingerprint {
+	opts := templateOpts
+	opts.RenderNative = c.RenderNative
+	fp := FingerprintEnv(env, opts)
 	for i, tok := range fp.tokens {
 		fp.tokens[i] = parityNormalize(tok)
 	}
@@ -154,6 +157,24 @@ type ParityCheck struct {
 	// through this oracle to prove it is not vacuous
 	// (TestForkParity_DetectsASharingFork, TestForkParity_DetectsADealiasingFork).
 	Fork func(*lisp.LEnv) (*lisp.LEnv, error)
+	// RenderNative renders a native payload's CONTENTS, for both channels:
+	// the per-transaction result comparison and the post-run state
+	// fingerprint.  Nil, the default, keeps the historical behaviour.
+	//
+	// WITHOUT IT A NATIVE IS COMPARED BY ITS HEADER ONLY.  The result
+	// rendering emits `native(<GoType>)` and the fingerprint emits the type
+	// plus an identity ordinal, so a divergence whose only observable is a
+	// native -- a transaction that returns a handle holding 41 on the fork
+	// arm and 0 on the cold arm -- produces NO witness from either channel.
+	// Parity is the backstop for everything the structural channels cannot
+	// see, and this is the one thing it cannot see either.  Measured at
+	// zero witnesses (TestForkParity_ANativeObservationNeedsARenderer).
+	//
+	// It is opt-in because only the payload's owner can render it
+	// canonically: see FingerprintOptions.RenderNative for the rules a
+	// renderer must obey (pure in the payload's observable state, and no
+	// identity -- identity is the ordinal's job).
+	RenderNative func(payload any) string
 	// Repro is attached to every witness.
 	Repro string
 }
@@ -217,6 +238,15 @@ func RunParityCheck(t TestingTB, c ParityCheck) {
 // a fork that could not be taken.  A transaction that raises is a result
 // like any other -- the cold arm defines what a fork must do, raising
 // included -- so an error value is compared, not reported.
+//
+// A NATIVE IS COMPARED BY ITS HEADER, NOT BY WHAT IT HOLDS, unless the
+// check supplies RenderNative.  Both channels are affected: the result
+// rendering emits `native(<GoType>)` and the state fingerprint emits the
+// type plus an identity ordinal.  So for an embedder whose transactions
+// observe state through a native handle -- which is how substrate reaches
+// its own values -- this oracle compares the handle and not the state, and
+// a fork that diverges only inside one is invisible to the backstop as
+// well as to the structural channels.  Supply RenderNative to close that.
 //
 // THE ONLY HARNESS ERROR IS A TEMPLATE THAT DOES NOT LOAD.  Then there is
 // nothing to compare.  Once the template has loaded, every later failure
@@ -327,7 +357,8 @@ func CheckParity(c ParityCheck) ([]Witness, error) {
 		name := fmt.Sprintf("env%d-tx%d.lisp", st.i, st.j)
 		wantRC := cold[st.i].LoadString(name, tx)
 		gotRC := forks[st.i].LoadString(name, tx)
-		want, got := parityNormalize(renderResult(wantRC)), parityNormalize(renderResult(gotRC))
+		want := parityNormalize(renderResultWith(wantRC, c.RenderNative))
+		got := parityNormalize(renderResultWith(gotRC, c.RenderNative))
 		if want == got {
 			continue
 		}
@@ -355,8 +386,8 @@ func CheckParity(c ParityCheck) ([]Witness, error) {
 				continue
 			}
 		}
-		want := parityFingerprint(cold[i])
-		got := parityFingerprint(forks[i])
+		want := parityFingerprint(c, cold[i])
+		got := parityFingerprint(c, forks[i])
 		if want.Equal(got) {
 			continue
 		}

--- a/elpstest/parity.go
+++ b/elpstest/parity.go
@@ -100,16 +100,67 @@ const (
 // template-level checks compare a fork against the template it was
 // numbered from.  TestTransactionIsolation_SchemaValidatorCredential is
 // the pin: it defines a validator in a transaction, and without this it
-// reports the counter as a state divergence at user:U.
+// reports the counter as a state divergence at user:U -- in the fid field
+// of a `fun(...)` token and in the fid field of a `funname(...)` token,
+// which are the only two places it reaches and the only two
+// parityNormalizeToken rewrites.
 var parityGensymPattern = regexp.MustCompile(`_validation_fun_\d+`)
 
 const parityGensymMarker = "_validation_fun_"
 
-func parityNormalize(s string) string {
+// normalizeGensymIDs rewrites the gensym's counter.  Like normalizeFunIDs
+// it is for an ID, never for free text: "_validation_fun_1" is a string a
+// program may hold, and rewriting it wherever it appears erases a real
+// divergence.  The one caller that does apply it to text is named at its
+// call site, with the reason.
+func normalizeGensymIDs(s string) string {
 	if !strings.Contains(s, parityGensymMarker) {
 		return s
 	}
 	return parityGensymPattern.ReplaceAllString(s, parityGensymMarker+"#")
+}
+
+// normalizeFunctionText normalises both ID counters in a FUNCTION's
+// rendering: the per-Runtime environment number in a FID, and libschema's
+// process-wide validator gensym.  It is applied where the text is an
+// ID-bearing rendering of a function, not to a value a program produced.
+func normalizeFunctionText(s string) string {
+	return normalizeGensymIDs(normalizeFunIDs(s))
+}
+
+// parityNormalizeToken rewrites the gensym inside a fingerprint token, and
+// ONLY where that token carries an ID FIELD.
+//
+// IT USED TO REWRITE EVERY TOKEN, string literals included, so a fork/cold
+// divergence confined to a value like "_validation_fun_1" against
+// "_validation_fun_2" was erased from the state channel as well as from
+// the result channel -- total silence from parity, measured, on a
+// divergence a program can produce with `set`.
+//
+// The two token shapes the counter actually reaches are `fun(fid=...)` and
+// `funname(<fid>,<name>)`, measured across the four transactions of
+// TestTransactionIsolation_SchemaValidatorCredential: two divergent tokens,
+// both an FID.  Only the FID field of each is rewritten, so a `str(%q)`
+// literal -- and a NAME that happens to look like a gensym -- is compared
+// as written.  TestParityNormalisesOnlyTheIDFieldOfARealToken pins this
+// against tokens the fingerprinter really emits, so a change to the token
+// format fails there rather than silently disarming the normalisation.
+func parityNormalizeToken(tok string) string {
+	if !strings.Contains(tok, parityGensymMarker) {
+		return tok
+	}
+	for _, prefix := range []string{"fun(fid=", "funname("} {
+		if !strings.HasPrefix(tok, prefix) {
+			continue
+		}
+		rest := tok[len(prefix):]
+		end := strings.IndexByte(rest, ',')
+		if end < 0 {
+			return tok
+		}
+		return prefix + normalizeGensymIDs(rest[:end]) + rest[end:]
+	}
+	return tok
 }
 
 // parityFingerprint is the post-run state fingerprint the two arms are
@@ -121,7 +172,7 @@ func parityFingerprint(c ParityCheck, env *lisp.LEnv) *Fingerprint {
 	opts.RenderNative = c.RenderNative
 	fp := FingerprintEnv(env, opts)
 	for i, tok := range fp.tokens {
-		fp.tokens[i] = parityNormalize(tok)
+		fp.tokens[i] = parityNormalizeToken(tok)
 	}
 	return fp
 }
@@ -357,8 +408,12 @@ func CheckParity(c ParityCheck) ([]Witness, error) {
 		name := fmt.Sprintf("env%d-tx%d.lisp", st.i, st.j)
 		wantRC := cold[st.i].LoadString(name, tx)
 		gotRC := forks[st.i].LoadString(name, tx)
-		want := parityNormalize(renderResultWith(wantRC, c.RenderNative))
-		got := parityNormalize(renderResultWith(gotRC, c.RenderNative))
+		// No post-pass over the rendered text: renderResultWith
+		// normalises the IDs it can identify AS IDs (a function's
+		// rendering, an error's message) and leaves everything else --
+		// the values the transaction produced -- as written.
+		want := renderResultWith(wantRC, c.RenderNative)
+		got := renderResultWith(gotRC, c.RenderNative)
 		if want == got {
 			continue
 		}

--- a/elpstest/parity_test.go
+++ b/elpstest/parity_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/luthersystems/elps/elpstest"
+	"github.com/luthersystems/elps/elpsutil"
 	"github.com/luthersystems/elps/lisp"
 )
 
@@ -315,5 +316,192 @@ func TestForkParity_DetectsARaiseAsymmetry(t *testing.T) {
 	}
 	if !raises || returns {
 		t.Fatalf("a fork that raises where the cold load returns: raise witness=%t, value witness=%t; want the raise property alone", raises, returns)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A transaction whose observation is a NATIVE.
+//
+// Parity is the backstop: it runs the program, so it sees divergences no
+// structural channel can.  It has one blind spot of its own, and it is the
+// shape an embedder meets first -- substrate reaches its own state through
+// native handles.  A native is rendered by its Go TYPE in the result
+// comparison (renderResult, forkcheck.go) and by type plus an identity
+// ordinal in the state fingerprint, so a transaction returning a handle
+// that holds 41 on the fork arm and 0 on the cold arm renders identically
+// on both and NOTHING fires.
+//
+// ParityCheck.RenderNative is the opt-in that closes it.  Both halves are
+// asserted below, because the first alone would pass on an oracle that had
+// simply become permissive and the second alone would not say what the
+// default costs.
+// ---------------------------------------------------------------------------
+
+// nativeLedger is an embedder payload two forks share, in the ordinary way:
+// it declares nothing, so Fork hands every fork the same one (docs/fork.md).
+type nativeLedger map[string]int
+
+// nativeHandle is what a transaction OBSERVES: a by-value snapshot of the
+// ledger, which is exactly the shape whose contents no channel compares.
+type nativeHandle struct{ n int }
+
+func nativeObservationEnv() (*lisp.LEnv, error) {
+	env, err := elpstest.NewForkCheckEnv()
+	if err != nil {
+		return nil, err
+	}
+	ledger := nativeLedger{"n": 0}
+	if rc := env.PutGlobal(lisp.Symbol("led"), lisp.Native(ledger)); rc.Type == lisp.LError {
+		return nil, lisp.GoError(rc)
+	}
+	env.AddBuiltins(true,
+		elpsutil.Function("ledger-set", lisp.Formals("l", "v"),
+			func(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+				if l, ok := args.Cells[0].Native.(nativeLedger); ok {
+					l["n"] = args.Cells[1].Int
+				}
+				return lisp.Nil()
+			}),
+		elpsutil.Function("ledger-peek", lisp.Formals("l"),
+			func(_ *lisp.LEnv, args *lisp.LVal) *lisp.LVal {
+				l, _ := args.Cells[0].Native.(nativeLedger)
+				return lisp.Native(nativeHandle{n: l["n"]})
+			}))
+	return env, nil
+}
+
+// nativeObservationCheck is the shared shape: environment 0 writes 41
+// through the shared ledger and observes it, environment 1 only observes.
+// On a cold load environment 1 reads 0; on a fork of a template whose
+// ledger is shared it reads 41.
+func nativeObservationCheck() elpstest.ParityCheck {
+	return elpstest.ParityCheck{
+		NewEnv:  nativeObservationEnv,
+		Program: `(set 'probe (list led))`,
+		Tx: [][]string{
+			{`(ledger-set led 41)`, `(ledger-peek led)`},
+			{`(ledger-peek led)`},
+		},
+		Repro: "an observation that is a native",
+	}
+}
+
+func TestForkParity_ANativeObservationNeedsARenderer(t *testing.T) {
+	t.Parallel()
+	// Ground truth, so neither half of this control can pass vacuously:
+	// the two arms really do observe different numbers.
+	c := nativeObservationCheck()
+	cold, err := c.NewEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc := cold.LoadString("p.lisp", c.Program); rc.Type == lisp.LError {
+		t.Fatal(rc)
+	}
+	fork, err := cold.Fork()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc := cold.LoadString("w.lisp", `(ledger-set led 41)`); rc.Type == lisp.LError {
+		t.Fatal(rc)
+	}
+	seen := fork.LoadString("o.lisp", `(ledger-peek led)`)
+	if h, ok := seen.Native.(nativeHandle); !ok || h.n != 41 {
+		t.Fatalf("premise: the fork does not observe the template's write through the shared "+
+			"ledger (%v); this control is not exercising the shape it describes", seen)
+	}
+
+	// Half one: with no renderer the divergence is invisible.  This is a
+	// STATEMENT OF THE DEFAULT, not an aspiration -- if it ever starts
+	// firing, delete this half and say so, do not weaken the other one.
+	got, err := elpstest.CheckParity(nativeObservationCheck())
+	if err != nil {
+		t.Fatalf("harness error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("parity reported %d witness(es) for a native-only divergence with no "+
+			"RenderNative set. The default has changed: either a canonical rendering was given to "+
+			"every payload (which only its owner can write) or the comparison has become noisy.\n%v",
+			len(got), got)
+	}
+
+	// Half two: the hook catches it, in the result channel.
+	withRenderer := nativeObservationCheck()
+	withRenderer.RenderNative = func(payload any) string {
+		if h, ok := payload.(nativeHandle); ok {
+			return fmt.Sprintf("handle(n=%d)", h.n)
+		}
+		return fmt.Sprintf("%T", payload)
+	}
+	got, err = elpstest.CheckParity(withRenderer)
+	if err != nil {
+		t.Fatalf("harness error: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("with RenderNative set, parity STILL reports nothing for a transaction that " +
+			"observes 41 on the fork arm and 0 on the cold arm. The hook is not reaching the " +
+			"comparison it exists for.")
+	}
+	var sawResult bool
+	for _, w := range got {
+		if w.Property == elpstest.ParityPropertyReturns {
+			sawResult = true
+		}
+	}
+	if !sawResult {
+		t.Errorf("the witnesses do not include a RESULT divergence, which is where the transaction's "+
+			"observation lives:\n%v", got)
+	}
+}
+
+// The state channel takes the renderer too, which is the half a
+// result-only threading would silently drop: a payload the transaction
+// mutated but did not return is post-run STATE.
+func TestForkParity_TheRendererReachesTheStateChannel(t *testing.T) {
+	t.Parallel()
+	// A fork that writes through the shared ledger without any transaction
+	// returning it: the divergence is confined to reachable state.
+	forkWrites := func(env *lisp.LEnv) (*lisp.LEnv, error) {
+		f, err := env.Fork()
+		if err != nil {
+			return nil, err
+		}
+		if l, ok := f.GetGlobal(lisp.Symbol("led")).Native.(nativeLedger); ok {
+			l["n"] = 41
+		}
+		return f, nil
+	}
+	c := elpstest.ParityCheck{
+		NewEnv:  nativeObservationEnv,
+		Program: `(set 'probe (list led))`,
+		Tx:      [][]string{{`(length probe)`}},
+		Fork:    forkWrites,
+		Repro:   "a divergence confined to a native's contents",
+	}
+	if got, err := elpstest.CheckParity(c); err != nil {
+		t.Fatalf("harness error: %v", err)
+	} else if len(got) != 0 {
+		t.Errorf("with no renderer, a divergence confined to a native's contents produced %d "+
+			"witness(es); the default is supposed to compare the header only:\n%v", len(got), got)
+	}
+	c.RenderNative = func(payload any) string {
+		if l, ok := payload.(nativeLedger); ok {
+			return fmt.Sprintf("ledger(n=%d)", l["n"])
+		}
+		return fmt.Sprintf("%T", payload)
+	}
+	got, err := elpstest.CheckParity(c)
+	if err != nil {
+		t.Fatalf("harness error: %v", err)
+	}
+	var sawState bool
+	for _, w := range got {
+		if w.Property == elpstest.ParityPropertyState {
+			sawState = true
+		}
+	}
+	if !sawState {
+		t.Errorf("RenderNative did not reach the post-run STATE fingerprint: a fork whose shared "+
+			"payload holds 41 where the cold arm's holds 0 produced no state witness.\n%v", got)
 	}
 }

--- a/elpstest/parity_test.go
+++ b/elpstest/parity_test.go
@@ -505,3 +505,105 @@ func TestForkParity_TheRendererReachesTheStateChannel(t *testing.T) {
 			"payload holds 41 where the cold arm's holds 0 produced no state witness.\n%v", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// The ID normalisations must not erase USER DATA.
+//
+// Two counters are normalised so a cold arm can be compared against a fork
+// that numbered its environments independently: a lambda's FID
+// ("_fun<envID>", funIDPattern) and libschema's process-wide validator
+// gensym ("_validation_fun_<n>", parityGensymPattern).  Both used to be
+// applied to RENDERED TEXT -- normalizeFunIDs to a transaction's result,
+// parityNormalize to every fingerprint token, string literals included --
+// and both patterns are ordinary characters a program can put in a string.
+//
+// Measured: a fork whose value diverged from the cold arm only inside the
+// string "_validation_fun_1" against "_validation_fun_2" produced TOTAL
+// SILENCE from parity, from BOTH channels.  The `_fun1`/`_fun2` pair went
+// silent in the result channel and survived in the state channel, which is
+// how narrow the difference between the two rewrites was.
+//
+// The ordinary-strings row is the control on the control: it must keep
+// firing, or this table would pass on an oracle that had stopped comparing
+// results at all.
+// ---------------------------------------------------------------------------
+
+// forkRewritingAString returns a fork walker that overwrites the binding
+// `s` in place, so the ONLY difference from the cold arm is character data
+// -- no seal bit, no sharing, nothing else to give the game away.
+func forkRewritingAString(to string) func(*lisp.LEnv) (*lisp.LEnv, error) {
+	return func(env *lisp.LEnv) (*lisp.LEnv, error) {
+		f, err := env.Fork()
+		if err != nil {
+			return nil, err
+		}
+		f.GetGlobal(lisp.Symbol("s")).Str = to
+		return f, nil
+	}
+}
+
+func TestForkParity_NormalisationDoesNotEraseUserData(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		from, to string
+	}{
+		{"ordinary strings", "alpha", "beta"},
+		{"strings matching the fun-ID pattern", "_fun1", "_fun2"},
+		{"strings matching the gensym pattern", "_validation_fun_1", "_validation_fun_2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := elpstest.CheckParity(elpstest.ParityCheck{
+				Program: `(set 's "` + tc.from + `") (set 'probe (list 1))`,
+				Tx:      [][]string{{`s`}},
+				Fork:    forkRewritingAString(tc.to),
+				Repro:   "a divergence confined to a string value",
+			})
+			if err != nil {
+				t.Fatalf("harness error: %v", err)
+			}
+			var sawResult, sawState bool
+			for _, w := range got {
+				switch w.Property {
+				case elpstest.ParityPropertyReturns:
+					sawResult = true
+				case elpstest.ParityPropertyState:
+					sawState = true
+				}
+			}
+			if !sawResult {
+				t.Errorf("the RESULT channel is silent: the transaction returns %q on the cold arm "+
+					"and %q on the fork, and the comparison rewrote the difference away. An ID is "+
+					"normalised where it is an ID, not wherever its pattern matches.", tc.from, tc.to)
+			}
+			if !sawState {
+				t.Errorf("the STATE channel is silent: the binding holds %q on the cold arm and %q "+
+					"on the fork. parityNormalizeToken is rewriting `str(...)` tokens, which carry "+
+					"user data, and not just the ID fields it is for.", tc.from, tc.to)
+			}
+		})
+	}
+}
+
+// The other half: the normalisation still does its job.  A validator
+// defined inside a transaction is numbered from a PROCESS-WIDE counter, so
+// the cold arm and the fork mint different numbers for the same
+// definition, and reporting that as a divergence would make the oracle red
+// on correct code.
+//
+// TestTransactionIsolation_SchemaValidatorCredential is the end-to-end pin;
+// this is the token-level one, built from tokens the fingerprinter really
+// emits rather than from literals, so a change to the token format fails
+// here instead of quietly disarming the rewrite.
+func TestParityNormalisesOnlyTheIDFieldOfARealToken(t *testing.T) {
+	t.Parallel()
+	elpstest.RunParityCheck(t, elpstest.ParityCheck{
+		Program: `(s:deftype "T" s:int)`,
+		Tx: [][]string{
+			{`(s:deftype "U" s:string) (s:validate U "x")`},
+			{`(s:deftype "V" s:string) (s:validate V "x")`},
+		},
+		Repro: "a validator defined inside a transaction",
+	})
+}

--- a/elpstest/parity_view_link_test.go
+++ b/elpstest/parity_view_link_test.go
@@ -84,7 +84,7 @@ func TestForkParity_ViewLinkIsInvisibleToTheOracle(t *testing.T) {
 	}
 
 	// The comparator: byte-identical post-load state.
-	cfp, ffp := parityFingerprint(cold), parityFingerprint(fork)
+	cfp, ffp := parityFingerprint(ParityCheck{}, cold), parityFingerprint(ParityCheck{}, fork)
 	if !cfp.Equal(ffp) {
 		t.Fatalf("a view at load scope fingerprints differently cold vs forked:\n%s", cfp.Diff(ffp))
 	}

--- a/elpstest/testdata/fuzz/FuzzAliasGuard/quasiquoted-vector-shares-an-array-header
+++ b/elpstest/testdata/fuzz/FuzzAliasGuard/quasiquoted-vector-shares-an-array-header
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("C$")


### PR DESCRIPTION
Stacked on the chain head (`claude/elps-perf-optimization-jcgfd2-loadcache-topology`, b076a2f) so the diff is only these seven commits. Draft: the base is itself unmerged.

From an adversarial review asking not "does the oracle pass" but **"what real bug could it miss"**. It found 8 misses with runnable proofs. Its own summary of the shape: the oracle is strongest exactly where elps's historical bugs were — pointer-held payloads reached from lisp source — and weakest exactly where substrate's risk lives, **Go-side payloads**.

## Commits

| | Finding closed |
|---|---|
| `79391de` | Census a native payload held by any reference kind, not only a pointer |
| `60d92db` | Call a native payload stateless only when its own type is basic |
| `27b0320` | Let a caller render a native payload's contents into both parity channels |
| `0aab15a` | Probe a header's cell slot, and both ends of a bytes buffer |
| `837375f` | Normalise the two ID counters where they are IDs, not wherever they match |
| `a667f95` | Replace the wrong reason a builtin's implementation is unencoded with the measured one |
| `8239420` | Check fork independence on the concurrent arm, not just the template |

## The three that composed

`isPointerPayload` keyed on `reflect.Pointer`, so a payload of kind **Map, Slice, Chan or Func** was invisible to `reachableNatives` (property 4 could not fire), to `NativeDeclarations` (the exported pre-ship census an embedder is told to run), *and* to the fingerprint. Separately, `isStatelessPayload` unwrapped one pointer before checking for a basic type, so a `*int` — a shared mutable cell — reported `stateless=true`. And no channel ever compared a native's **contents**, so parity, the backstop, went silent whenever the observation was itself a native.

Together: a map- or func-typed handle shared by every transaction was invisible to the census, invisible to the fingerprint, and invisible to parity *even when a transaction observed it*. The substrate-relevant instance is a func payload — a closure over mutable Go state, which presents as `reflect.Func`.

Independently verified for this PR, with a test written outside the branch: on the parent the census reports **0** shared payloads for a map both forks demonstrably write through; on this branch it reports **1**.

The widening documents its own limits rather than overclaiming: a zero-length, zero-capacity slice has no identity, and Go may emit one static funcval for non-capturing literals. The ordinal is keyed on a `uintptr`, not the payload value — a map- or slice-typed payload used as a Go map key would otherwise panic.

## One fix implemented, measured worthless, and reverted

Adding `reflect.ValueOf(v.Builtin()).Pointer()` as a builtin identity ordinal **does not work**: every builtin is registered as `LBuiltinDef.Eval`, a method value, so reflect returns the compiler's shared wrapper address and `car` and `cdr` collapse to the same ordinal. A token asserting "the whole stdlib shares one implementation" is worse than no token. An absolute pointer is not an option either — a closure builtin gets a fresh address per environment, so cold-vs-fork would redden on correct code.

What shipped instead is the wrong justification replaced with the two measured ones, plus `TestABuiltinIsNotIdentifiedByItsGoPointer`, which reddens the day reflect starts distinguishing them. **Closing the absolute-implementation half needs a design decision** — it needs unsafe (the eface data word), which has no precedent in this repo.

## New finding, pinned rather than fixed

The last-byte probe made visible that **Fork, `copy` and detach all de-alias an overlapping bytes view**: `(slice 'bytes b 3 6)` shares `b`'s array on a cold load and comes out of every rebuild with its own. For *cells* that is a Fork contract (#602) and a documented exemption for the other two; for **bytes nothing states either**, so a fork diverges from a cold load. It is the bytes analogue of #600 gap 3. `TestTheBytesProbeSeesAnOverlappingView` records it — green today, and it fails the day someone fixes it, at which point the fix is to state the contract, not to weaken the probe.

## Residual, narrowed and documented

An error's rendering is still normalised as free text — an error is a message, not a structure, so a FID or gensym reaches it through frame names with nothing to key on. A divergence confined to an *error message* matching either pattern is still erased. Narrowed from every value to that one case, and said at the call site.

## Gates

`go build ./...`; `go test ./elpstest/... ./lisp/...`; `-race ./elpstest/...`; `make elpsvet` and `make static-checks` both passes; `scripts/mutation-proof.sh` **10/10 caught with no needle changed**; `mutation-proof-selftest.sh` all three guarantees. Each of the seven commits builds and passes `./elpstest/` independently.

Two gate touches, neither a relaxation: `TestAProbeCountEqualToTheCapIsNotReportedAsPartial` now carries a cap equal to each graph's *real* site count with the arithmetic stated (the graphs genuinely hold more mutable payloads now, and "one over the cap" became the same graph at `cap-1` rather than a bigger graph); and the cell-slot write/undo carries an audited `//elps:mutates` with justification, the same hatch `elpstest/sortedmap.go`'s probe already uses.

`ProbeCellSlot` is excluded from the **alias-class** comparison for `WalkerCopy` — copy and detach declare they do not preserve cells backing-array sharing, and without the exemption both went red on documented behaviour. The leak check still covers every cell-slot site of every walker, which is what catches an identity copier.

## Not in this PR

Deliberately held: measuring cell-slot overlap independently instead of trusting the `cellsView` declaration (an undeclared window still reproduces the exact #602 signature invisibly); fuzzing with `lisplib` loaded; `Runtime`-level shared state (`Reader`, `Library`) which no walk reaches; and the arms that have no control. Those are design changes, not repairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3JiPj1sGKj8BtcmJjNvpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3JiPj1sGKj8BtcmJjNvpj)_