### PR TITLE
Reduce template publication overhead without changing VM ownership

### DIFF
--- a/lisp/template.go
+++ b/lisp/template.go
@@ -359,9 +359,12 @@ func (s *templateInventory) val(v *LVal) error {
 	// Function bodies whose cells are all shared have immutable backing under
 	// the existing function construction contract. Keep that fast path.
 	sharedCells := v.Type == LFun && cap(v.Cells) == len(v.Cells)
-	for _, child := range v.Cells {
-		if child != nil && !child.sealed {
-			sharedCells = false
+	if sharedCells {
+		for _, child := range v.Cells {
+			if child != nil && !child.sealed {
+				sharedCells = false
+				break
+			}
 		}
 	}
 	if cap(v.Cells) > 0 && !sharedCells {
@@ -391,16 +394,23 @@ func (s *templateInventory) val(v *LVal) error {
 // at admission, including wrappers over a function's shared body/formals.
 func (s *templateInventory) checkSharedStorage() error {
 	slices.SortFunc(s.cells, compareTemplateCellSpans)
-	slices.SortFunc(s.sharedCells, compareTemplateCellSpans)
-	i, j := 0, 0
-	for i < len(s.cells) && j < len(s.sharedCells) {
-		mutable, shared := s.cells[i], s.sharedCells[j]
-		switch {
-		case mutable.end <= shared.start:
-			i++
-		case shared.end <= mutable.start:
-			j++
-		default:
+	if len(s.cells) == 0 || len(s.sharedCells) == 0 {
+		return nil
+	}
+	// Shared program spans usually greatly outnumber mutable spans. Index
+	// the mutable side instead of sorting the whole shared program again.
+	// Prefix maxima retain earlier containing spans when views are nested.
+	maxEnds := make([]uintptr, len(s.cells))
+	var end uintptr
+	for i, span := range s.cells {
+		end = max(end, span.end)
+		maxEnds[i] = end
+	}
+	for _, shared := range s.sharedCells {
+		// Half-open spans overlap iff a mutable start is before shared.end
+		// and that prefix contains an end strictly after shared.start.
+		i := sort.Search(len(s.cells), func(i int) bool { return s.cells[i].start >= shared.end })
+		if i > 0 && maxEnds[i-1] > shared.start {
 			return errors.New("template: mutable cells backing overlaps shared program storage")
 		}
 	}

--- a/lisp/template_check_default.go
+++ b/lisp/template_check_default.go
@@ -1,0 +1,9 @@
+// Copyright © 2026 The ELPS authors
+
+//go:build !elpscheck
+
+package lisp
+
+// checkTemplateStorageOrder compiles out in production: admission already
+// sorts mutable spans. Checked builds assert this internal precondition.
+func checkTemplateStorageOrder(_ []templateCellSpan) {}

--- a/lisp/template_check_elpscheck.go
+++ b/lisp/template_check_elpscheck.go
@@ -1,0 +1,13 @@
+// Copyright © 2026 The ELPS authors
+
+//go:build elpscheck
+
+package lisp
+
+import "slices"
+
+func checkTemplateStorageOrder(cells []templateCellSpan) {
+	if !slices.IsSortedFunc(cells, compareTemplateCellSpans) {
+		panic("template: storage requires sorted mutable cell spans")
+	}
+}

--- a/lisp/template_descriptor_test.go
+++ b/lisp/template_descriptor_test.go
@@ -1,0 +1,61 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// Issue #639: compilation needs the descriptors, not a second allocation of
+// sorted keys. Admission still establishes callback and rejection order.
+func TestTemplateDescriptorsPreserveOrderWithOneAllocation(t *testing.T) {
+	values := make(map[string]*LVal)
+	metadata := make(map[string]string)
+	leaves := []*LVal{Int(17), Int(29)}
+	for n := range 32 {
+		key := fmt.Sprintf("key-%02d", n)
+		values[key] = leaves[n%len(leaves)]
+		metadata[key] = "doc:" + key
+	}
+	c := templateCompiler{values: map[*LVal]int{leaves[0]: 1, leaves[1]: 2}, plan: templatePlan{values: make([]templateValue, 2)}}
+	t.Run("bindings", func(t *testing.T) {
+		var got []templateBinding
+		allocs := testing.AllocsPerRun(100, func() { got = c.bindings(values) })
+		if allocs > 1 {
+			t.Fatalf("descriptor construction allocated %.0f objects, want at most the output slice", allocs)
+		}
+		seen := make(map[string]bool)
+		for n, binding := range got {
+			want, present := values[binding.name]
+			if binding.name != fmt.Sprintf("key-%02d", n) || seen[binding.name] || !present || binding.value.index != c.values[want] || binding.value.shared != nil {
+				t.Fatalf("binding lost its key, admitted identity or alias: %+v", binding)
+			}
+			seen[binding.name] = true
+		}
+		if len(seen) != len(values) || c.err != nil {
+			t.Fatalf("bindings omitted values or rejected an admitted reference: count=%d error=%v", len(seen), c.err)
+		}
+	})
+	t.Run("metadata", func(t *testing.T) {
+		var got []templateStringPair
+		allocs := testing.AllocsPerRun(100, func() { got = templateStringPairs(metadata) })
+		if allocs > 1 {
+			t.Fatalf("metadata construction allocated %.0f objects, want at most the output slice", allocs)
+		}
+		reconstructed := make(map[string]string)
+		for n, entry := range got {
+			if entry.key != fmt.Sprintf("key-%02d", n) {
+				t.Fatalf("metadata insertion order changed at %d: %q", n, entry.key)
+			}
+			if _, duplicate := reconstructed[entry.key]; duplicate {
+				t.Fatalf("duplicate metadata key %q", entry.key)
+			}
+			reconstructed[entry.key] = entry.value
+		}
+		if !reflect.DeepEqual(reconstructed, metadata) {
+			t.Fatalf("metadata changed: %v", reconstructed)
+		}
+	})
+}

--- a/lisp/template_overlap_index_test.go
+++ b/lisp/template_overlap_index_test.go
@@ -1,0 +1,78 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import "testing"
+
+// Issue #639: overlap admission may change its index, but not its half-open
+// interval semantics. These synthetic numeric spans are never dereferenced;
+// the model deliberately uses no sorting, binary search or prefix maxima.
+func TestTemplateOverlapIndexMatchesPairwiseModel(t *testing.T) {
+	var intervals []templateCellSpan
+	for start := uintptr(0); start < 4; start++ {
+		for end := start + 1; end <= 4; end++ {
+			intervals = append(intervals, templateCellSpan{start: start, end: end})
+		}
+	}
+	// Ten nonempty intervals produce 1 + 10 + 10*10 ordered collections.
+	// Ordered pairs include reversed inputs, duplicates, nested spans and
+	// adjacency. Empty collections cover both sides of the early return.
+	collections := [][]templateCellSpan{nil}
+	for _, first := range intervals {
+		collections = append(collections, []templateCellSpan{first})
+		for _, second := range intervals {
+			collections = append(collections, []templateCellSpan{first, second})
+		}
+	}
+	cases := 0
+	for _, mutable := range collections {
+		for _, shared := range collections {
+			wantOverlap := false
+			for _, m := range mutable {
+				for _, s := range shared {
+					if m.start < s.end && s.start < m.end {
+						wantOverlap = true
+					}
+				}
+			}
+			inventory := templateInventory{
+				cells:       append([]templateCellSpan(nil), mutable...),
+				sharedCells: append([]templateCellSpan(nil), shared...),
+			}
+			err := inventory.checkSharedStorage()
+			if (err != nil) != wantOverlap {
+				t.Fatalf("mutable=%+v shared=%+v: overlap=%t, got error %v", mutable, shared, wantOverlap, err)
+			}
+			if err != nil && err.Error() != "template: mutable cells backing overlaps shared program storage" {
+				t.Fatalf("mutable=%+v shared=%+v: wrong rejection: %v", mutable, shared, err)
+			}
+			// storage() consumes this order after admission. In particular,
+			// a successful no-shared-spans shortcut must not skip the sort.
+			for i := 1; i < len(inventory.cells); i++ {
+				if inventory.cells[i-1].start > inventory.cells[i].start {
+					t.Fatalf("mutable=%+v shared=%+v: admission left storage input unsorted: %+v", mutable, shared, inventory.cells)
+				}
+			}
+			cases++
+		}
+	}
+	if cases != 12321 { // (1 + 10 + 10*10)^2, not sampled inputs.
+		t.Fatalf("exhaustive interval coverage changed: got %d cases, want 12321", cases)
+	}
+}
+
+func TestTemplateOverlapIndexKeepsEarlierContainingSpan(t *testing.T) {
+	// The last mutable span starting before the shared end does not overlap.
+	// Its earlier containing span does: an index must retain the prefix's
+	// maximum end, not merely the end of its last span.
+	inventory := templateInventory{
+		cells: []templateCellSpan{
+			{start: 2, end: 3},
+			{start: 0, end: 10},
+		},
+		sharedCells: []templateCellSpan{{start: 5, end: 6}},
+	}
+	if err := inventory.checkSharedStorage(); err == nil || err.Error() != "template: mutable cells backing overlaps shared program storage" {
+		t.Fatalf("earlier containing interval was missed: %v", err)
+	}
+}

--- a/lisp/template_plan.go
+++ b/lisp/template_plan.go
@@ -3,9 +3,11 @@
 package lisp
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 )
 
 // A template plan represents mutable VM state with immutable descriptors.
@@ -153,9 +155,10 @@ func templateStringPairs(values map[string]string) []templateStringPair {
 		return nil
 	}
 	out := make([]templateStringPair, 0, len(values))
-	for _, key := range sortedTemplateKeys(values) {
-		out = append(out, templateStringPair{key: key, value: values[key]})
+	for key, value := range values {
+		out = append(out, templateStringPair{key: key, value: value})
 	}
+	slices.SortFunc(out, func(a, b templateStringPair) int { return cmp.Compare(a.key, b.key) })
 	return out
 }
 
@@ -188,11 +191,19 @@ func (c *templateCompiler) env(env *LEnv) int {
 	return 0
 }
 func (c *templateCompiler) bindings(values map[string]*LVal) []templateBinding {
+	// Sort the final descriptors, avoiding temporary keys and a second map
+	// lookup per entry. Preserve the existing lexicographic descriptor order,
+	// and therefore the order in which each instance populates its maps.
 	out := make([]templateBinding, 0, len(values))
-	for _, name := range sortedTemplateKeys(values) {
-		out = append(out, templateBinding{name: name, value: c.ref(values[name])})
+	for name, value := range values {
+		out = append(out, templateBinding{name: name, value: c.ref(value)})
 	}
+	sortTemplateBindings(out)
 	return out
+}
+
+func sortTemplateBindings(bindings []templateBinding) {
+	slices.SortFunc(bindings, func(a, b templateBinding) int { return cmp.Compare(a.name, b.name) })
 }
 func (c *templateCompiler) function(fd *funData) int {
 	if index, ok := c.functions[fd]; ok {
@@ -336,9 +347,10 @@ func (c *templateCompiler) mapData(source *MapData) (int, error) {
 		}
 		backing.entries = c.bindings(sourceMap.m)
 		backing.types = make([]templateKeyType, 0, len(sourceMap.tm))
-		for _, key := range sortedTemplateKeys(sourceMap.tm) {
-			backing.types = append(backing.types, templateKeyType{key: key, kind: sourceMap.tm[key]})
+		for key, kind := range sourceMap.tm {
+			backing.types = append(backing.types, templateKeyType{key: key, kind: kind})
 		}
+		slices.SortFunc(backing.types, func(a, b templateKeyType) int { return cmp.Compare(a.key, b.key) })
 	case jsonMap:
 		id = templateMapIdentity{values: reflect.ValueOf(sourceMap).Pointer(), json: true}
 		if existing := c.mapBackings[id]; existing != 0 {
@@ -347,9 +359,10 @@ func (c *templateCompiler) mapData(source *MapData) (int, error) {
 		}
 		backing.json = true
 		backing.entries = make([]templateBinding, 0, len(sourceMap))
-		for _, key := range sortedTemplateKeys(sourceMap) {
-			backing.entries = append(backing.entries, templateBinding{name: key, value: c.ref(jsonMapLVal(sourceMap[key]))})
+		for key, value := range sourceMap {
+			backing.entries = append(backing.entries, templateBinding{name: key, value: c.ref(jsonMapLVal(value))})
 		}
+		sortTemplateBindings(backing.entries)
 	default:
 		return index, fmt.Errorf("template: map backing %T is not interpreter-owned", source.mapBacking)
 	}

--- a/lisp/template_storage.go
+++ b/lisp/template_storage.go
@@ -57,12 +57,14 @@ func newTemplateByteSpan(v *[]byte) templateByteSpan {
 	return templateByteSpan{value: v, start: start, end: start + uintptr(cap(*v))}
 }
 
+// storage consumes a successfully scanned inventory. The shared-storage check
+// already sorted mutable cell spans; no graph discovery occurs after that check.
 func (s *templateInventory) storage() *templateStorage {
+	checkTemplateStorageOrder(s.cells)
 	p := &templateStorage{
 		cellViews: make(map[*LVal]templateView, len(s.cells)),
 		byteViews: make(map[*[]byte]templateView, len(s.bytes)),
 	}
-	slices.SortFunc(s.cells, compareTemplateCellSpans)
 	width := reflect.TypeFor[*LVal]().Size()
 	for first := 0; first < len(s.cells); {
 		start, end := s.cells[first].start, s.cells[first].end
@@ -73,11 +75,22 @@ func (s *templateInventory) storage() *templateStorage {
 			}
 			last++
 		}
-		data := make([]*LVal, int((end-start)/width))
+		// The compiler immediately converts these slots into owned indexed
+		// references. A disjoint span can be borrowed read-only for that step;
+		// it never becomes VM storage or escapes into the published plan.
+		var data []*LVal
+		if last == first+1 {
+			v := s.cells[first].value
+			data = v.Cells[:cap(v.Cells)]
+		} else {
+			data = make([]*LVal, int((end-start)/width))
+		}
 		index := len(p.cells)
 		for _, span := range s.cells[first:last] {
 			offset := int((span.start - start) / width)
-			copy(data[offset:], span.value.Cells[:cap(span.value.Cells)])
+			if last != first+1 {
+				copy(data[offset:], span.value.Cells[:cap(span.value.Cells)])
+			}
 			p.cellViews[span.value] = templateView{storage: index, offset: offset,
 				length: len(span.value.Cells), capacity: cap(span.value.Cells)}
 		}

--- a/lisp/template_storage_borrow_test.go
+++ b/lisp/template_storage_borrow_test.go
@@ -1,0 +1,95 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import "testing"
+
+// Issue #639: borrowing a single cell span removes a staging allocation, not
+// ownership at publication. Hidden capacity slots must still be snapshotted
+// into indexed references, including cycles, before the source can change.
+func TestTemplateBorrowedCellScratchDoesNotEscapePublication(t *testing.T) {
+	source := templateOwnershipEnv()
+	leaf := Int(17)
+	backing := make([]*LVal, 2)
+	subject := QExpr(backing[:0:2])
+	backing[0], backing[1] = subject, leaf
+	source.Runtime.Package.symbols["subject"] = subject
+	inventory := newTemplateInventory(templateConfig{})
+	if err := inventory.scan(source); err != nil {
+		t.Fatal(err)
+	}
+	if len(inventory.cells) != 1 || inventory.cells[0].value != subject {
+		t.Fatal("fixture must contain exactly one mutable cell span")
+	}
+	scratch := inventory.storage()
+	if len(scratch.cells) != 1 || len(scratch.cells[0]) != 2 {
+		t.Fatal("scratch storage lost the hidden capacity slots")
+	}
+	if &scratch.cells[0][0] != &backing[0] {
+		t.Error("single-span scratch copied the backing instead of borrowing it")
+	}
+	if scratch.cells[0][0] != subject || scratch.cells[0][1] != leaf {
+		t.Fatal("scratch storage changed the hidden cycle or leaf")
+	}
+	plan, err := compileTemplate(source, inventory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.cells) != 1 || len(plan.cells[0]) != 2 {
+		t.Fatal("compiled plan lost the capacity-tail references")
+	}
+	for slot, value := range []*LVal{subject, leaf} {
+		index := inventory.values[value]
+		ref := plan.cells[0][slot]
+		if index <= 0 || ref.index != index || ref.shared != nil {
+			t.Fatalf("slot %d did not become its admitted private index: got=%d want=%d shared=%t", slot, ref.index, index, ref.shared != nil)
+		}
+		if plan.values[index-1].header.Cells != nil {
+			t.Fatalf("slot %d retained source cell backing in the plan header", slot)
+		}
+	}
+	if len(subject.Cells) != 0 || cap(subject.Cells) != 2 || backing[0] != subject || backing[1] != leaf || leaf.Int != 17 {
+		t.Fatal("publication changed source storage, bounds or contents")
+	}
+	tmpl := &Template{plan: plan}
+	newSubject := func() *LVal {
+		t.Helper()
+		vm, err := tmpl.NewVM()
+		if err != nil {
+			t.Fatal(err)
+		}
+		value := vm.Get(Symbol("subject"))
+		if value.Type != LSExpr || len(value.Cells) != 0 || cap(value.Cells) != 2 {
+			t.Fatalf("VM changed the empty positive-capacity view: type=%v len=%d cap=%d", value.Type, len(value.Cells), cap(value.Cells))
+		}
+		slots := value.Cells[:cap(value.Cells)]
+		if slots[0] != value || slots[1] == nil || slots[1].Type != LInt || slots[1].Int != 17 {
+			t.Fatal("VM lost its private capacity-tail self-cycle or published leaf")
+		}
+		if value == subject || slots[1] == leaf || &slots[0] == &backing[0] {
+			t.Fatal("VM retained mutable source identities")
+		}
+		return value
+	}
+	// Mutate both source objects and slots after publication, before any VM.
+	leaf.Int = 99
+	backing[0], backing[1] = Int(101), Int(102)
+	first, second := newSubject(), newSubject()
+	firstSlots, secondSlots := first.Cells[:2], second.Cells[:2]
+	if first == second || firstSlots[1] == secondSlots[1] || &firstSlots[0] == &secondSlots[0] {
+		t.Fatal("sibling VMs share mutable objects or cell storage")
+	}
+	firstSlots[1].Int = 41
+	firstSlots[0], firstSlots[1] = Int(201), Int(202)
+	if secondSlots[0] != second || secondSlots[1].Type != LInt || secondSlots[1].Int != 17 {
+		t.Fatal("first VM mutation changed the existing sibling")
+	}
+	third := newSubject()
+	thirdSlots := third.Cells[:2]
+	if third == first || third == second || thirdSlots[1] == secondSlots[1] || &thirdSlots[0] == &firstSlots[0] || &thirdSlots[0] == &secondSlots[0] {
+		t.Fatal("later VM reused an existing VM's mutable storage")
+	}
+	if leaf.Int != 99 || backing[0].Int != 101 || backing[1].Int != 102 || len(subject.Cells) != 0 || cap(subject.Cells) != 2 {
+		t.Fatal("VM construction or mutation changed the already-modified source")
+	}
+}

--- a/lisp/template_storage_elpscheck_test.go
+++ b/lisp/template_storage_elpscheck_test.go
@@ -1,0 +1,63 @@
+// Copyright © 2026 The ELPS authors
+
+//go:build elpscheck
+
+package lisp
+
+import "testing"
+
+// Issue #639: storage relies on admission sorting mutable spans. A caller
+// that skips that step must fail at the invariant, not during materialization.
+func TestTemplateStorageRejectsUnsortedSpans(t *testing.T) {
+	backing := []*LVal{Int(1), Int(2)}
+	low := QExpr(backing[:1:1])
+	high := QExpr(backing[1:2:2])
+	inventory := &templateInventory{cells: []templateCellSpan{
+		newTemplateCellSpan(high), newTemplateCellSpan(low),
+	}}
+	defer func() {
+		if got := recover(); got != "template: storage requires sorted mutable cell spans" {
+			t.Fatalf("expected storage ordering assertion, got %v", got)
+		}
+	}()
+	inventory.storage()
+}
+
+func TestTemplateStorageAcceptsSortedSpans(t *testing.T) {
+	backing := []*LVal{Int(1), Int(2)}
+	whole := QExpr(backing)
+	prefix := QExpr(backing[:1:1])
+	suffix := QExpr(backing[1:2:2])
+	for _, tc := range []struct {
+		name   string
+		values []*LVal
+	}{
+		{"empty", nil},
+		{"single", []*LVal{whole}},
+		{"adjacent", []*LVal{prefix, suffix}},
+		{"equal_start_long_first", []*LVal{whole, prefix}},
+		{"equal_start_short_first", []*LVal{prefix, whole}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			inventory := &templateInventory{}
+			for _, value := range tc.values {
+				inventory.cells = append(inventory.cells, newTemplateCellSpan(value))
+			}
+			storage := inventory.storage()
+			if len(storage.cellViews) != len(tc.values) {
+				t.Fatalf("got %d views, want %d", len(storage.cellViews), len(tc.values))
+			}
+			for _, value := range tc.values {
+				view, ok := storage.cellViews[value]
+				if !ok || view.length != len(value.Cells) || view.capacity != cap(value.Cells) {
+					t.Fatalf("incorrect view for source: %+v (present=%t)", view, ok)
+				}
+				for i, want := range value.Cells {
+					if got := storage.cells[view.storage][view.offset+i]; got != want {
+						t.Fatalf("slot %d: got %p, want source value %p", i, got, want)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

**Released:** merged at `03e7c95` and published as [v1.61.1](https://github.com/luthersystems/elps/releases/tag/v1.61.1). The merge/tag tree is byte-identical to approved head `52b792b` (25/25 checks passed); post-merge full CI and fuzz also passed. [Substrate #483](https://github.com/luthersystems/substrate/pull/483) now pins the actual release at `c819672` and passes all 18 checks on original attempts. Its [released-tag benchmark](https://github.com/luthersystems/substrate/actions/runs/34308611665/job/102330399023) passes the unchanged 10% gate: startup +2.93%, steady checkout −51.01%. Consumer remains unmerged. VS Code Marketplace publication separately hit the existing [#638](https://github.com/luthersystems/elps/issues/638) gallery timeout; the Go release is available and verified.

Review follow-up: `elpscheck` now asserts the mutable-span ordering precondition before storage materialization; the production hook is empty and confirmed inlined away. The descriptor-order comment is clarified; the allocation guard is unchanged. New checked-mode regression fails before the guard and passes after it, with sorted/empty/equal-start controls. Targeted normal/checked template race tests and both production analyzer modes pass; independent Go/security/QA review passes. New head `52b792b` passes **all 25 checks on their original attempts**, including [full CI](https://github.com/luthersystems/elps/actions/runs/34303615440), [all eleven fuzz shards](https://github.com/luthersystems/elps/actions/runs/34303615408), and the [unchanged benchmark gates](https://github.com/luthersystems/elps/actions/runs/34303615422). Core and extra tests remain separate commits: `ff22c3c` and `52b792b`. The numeric performance results below belong to the previous tested head `3f3f2bd`.

Small publication-only optimizations for immutable templates. No public API, VM ownership, admission policy, native payload, seal, or benchmark-gate changes; per-VM instantiation code is unchanged.

- Build ordered compiler descriptors directly, then sort the output: remove temporary key slices and second lookups while preserving the original insertion order.
- Skip the sharing-eligibility probe for values that cannot qualify, and reuse the mutable span order already established by admission.
- Borrow a single cell span read-only as compilation scratch; still convert full capacity into owned indexed references before publication. Byte buffers and multi-span groups retain their copying paths.
- Index mutable span prefix end maxima, then query shared spans. Preserve exactly the same half-open overlap rejection without sorting the typically much larger shared-code population.

Closes #639. Coordinated consumer: [Substrate #483](https://github.com/luthersystems/substrate/pull/483), passing its startup gate with the final v1.61.1 release pin. Existing v1.61.0 tag remains immutable.

## Verification

- Targeted template tests pass, including alias/cycle/capacity, rejection, retention, metadata and concurrency controls.
- Default and checked race tests pass (1.465s / 1.543s); both production ownership-analyzer modes pass.
- Targeted load-cache topology, broken-constructor negative controls and historical stable-sort parity pass (1.484s).
- Allocation/order guard fails on the actual released compiler (two allocations versus one); single-span scratch guard fails before its optimization. Both now pass with content/ownership assertions.
- Independent pairwise interval oracle checks all 12,321 cases from zero/one/two ordered spans over endpoints 0..4; also checks nested containing spans and mutable sorting with no shared spans. Baseline and candidate agree.
- Three separately injected overlay mutations fail the intended tests: prefix maximum replaced by last end, strict overlap changed to include adjacency, and early return moved before required sorting. The unchanged implementation passes; no mutations are committed.
- Independent Go/security/QA review passes; no tests deleted. All 25 previous-head (`3f3f2bd`) checks pass on original attempts: [full CI](https://github.com/luthersystems/elps/actions/runs/34298442692), [all fuzz shards](https://github.com/luthersystems/elps/actions/runs/34298442724), and [unchanged benchmark gates](https://github.com/luthersystems/elps/actions/runs/34298442698/job/102300024046).

## Performance evidence and rejected experiments

Local public-fixture consumer measurements use identical consumer source, Go 1.26.5, GOMAXPROCS=4 and frozen binaries; ten order-balanced pairs per experiment, every sample retained. These are not the consumer CI gate.

| Experiment | Startup | Steady checkout | Decision |
|---|---:|---:|---|
| Unordered compiler descriptors, pointer loops | −5.93% | +2.95% | Rejected tradeoff |
| Unordered descriptors, unchanged VM loops | −5.93% | +4.54% | Rejected tradeoff |
| Ordered final descriptors | No significant change | No significant change | Allocation saving only |
| Add single-span scratch borrowing | No significant change | No significant change | Startup allocations −0.72% |
| Add mutable overlap index | −9.62% | No significant change | Initial 500ms samples |
| Same indexed binary, longer confirmation | −5.19% | No significant change | Ten balanced 1000ms pairs |

The initial indexed result is 9.349ms→8.450ms startup (p=.001) and 145.9µs→148.3µs checkout (p=.853), with wider intervals than earlier experiments. Longer confirmation with identical binaries found 8.791ms±7%→8.334ms±2% startup (−5.19%, p<.001), and 150.0µs±4%→146.1µs±5% checkout (p=.218, not significant). Both complete datasets are retained; use the smaller ~5% local signal, not the favorable initial result alone. Do not infer a passing 10% consumer gate from either. The original released-tag consumer run remains recorded as +12.25% startup against its base. No CI benchmark retries, threshold changes or waivers.

No customer source, private application fixtures, copied consumer test files, local replacements or profiling binaries are included.

## Previous-head CI performance (before checked-only review follow-up)

ELPS `3f3f2bd`: template publication improved 7.06% for the zero-function fixture (402.5µs→374.1µs) and 5.38% for 250 functions (2.445ms→2.314ms), both p<.001,n=10. Publication allocations fell 39.12% and 31.41%, respectively. All four VM-construction timing rows show no significant change; their allocation counts/bytes are unchanged. The full gate interpreted 60 delta and 736 unchanged rows, with 14 adverse moves below the unchanged thresholds and zero breaches (15% timing, 5% allocation).

The [coordinated Substrate candidate benchmark](https://github.com/luthersystems/substrate/actions/runs/34298812944/job/102301146522), head `852416ea`, **passes its unchanged 10% gate on the original attempt**:

| Metric | Base | Candidate | Change |
|---|---:|---:|---:|
| Initial concurrent warming | 14.77ms | 15.37ms | +4.04%, p=.019 |
| Steady checkout | 558.0µs | 273.2µs | −51.04%, p<.001 |

Checkout allocated bytes fall 33.28% and allocation counts fall 37.01%.

Ten interleaved samples per arm; 100 delta and 11 unchanged rows; zero gate breaches. These base/candidate results are from the same job. The previous released-tag failure and this passing candidate ran on different CI runners, so subtracting their percentages is not an isolated measurement of this optimization. The controlled local comparisons above independently establish its effect.

All 18 checks on the previous Substrate head `852416ea` passed on original attempts, including [full CI and all three end-to-end environments](https://github.com/luthersystems/substrate/actions/runs/34298812993). ELPS is now merged and released as v1.61.1; the final consumer tag-pin checks are tracked on Substrate #483. The consumer remains unmerged. The existing v1.61.0 tag was not moved.
