### PR TITLE
lint: report side effects in sort comparators and writes to an iterated collection

### DIFF
--- a/docs/lang.md
+++ b/docs/lang.md
@@ -661,6 +661,21 @@ $ elps lint sort.lisp
 error: stable-sort predicate mutates state: assoc! is called inside a comparator (comparator-mutation)
 ```
 
+The higher-order functions carry a milder version of the same hazard: a `map`,
+`foldl`, `foldr`, `select`, `reject`, `all?` or `any?` callback that writes
+through the sequence it is walking — or through an element that sequence handed
+it — is traversing a value that changes underneath it.  The
+`iteration-mutation` check reports that shape, leaving a fold's own accumulator
+alone, since threading it is the point of the fold.  `set!` is not a write of
+this kind and is not reported: it rebinds a name rather than the value the name
+held, so the traversal goes on walking exactly the sequence it was handed.
+
+```lisp
+(map 'list (lambda (x) (append! xs x)) xs)
+; lint: append! mutates xs while map iterates over it
+(foldl (lambda (acc x) (assoc! acc x 1)) (sorted-map) xs)  ; fine
+```
+
 ### Sorted Maps
 
 A sorted map is a mapping between keys and values which ensures that key

--- a/docs/lang.md
+++ b/docs/lang.md
@@ -635,6 +635,32 @@ empty literal-derived input — there is nothing in it to modify — and hand
 back fresh storage.  `(stable-sort < (rest xs))` therefore behaves the same
 however short `xs` is.
 
+#### The predicate must be pure
+
+`stable-sort` and `insert-sorted` call their predicate an unspecified number
+of times, in an unspecified order, and hand it the list's **own** elements —
+not copies.  A side effect inside a comparator therefore has no defined
+schedule, and writing through an element it was handed writes through to the
+list being sorted, while it is being sorted.
+
+```lisp
+;; BAD -- runs an unknown number of times, in an unknown order
+(stable-sort
+  (lambda (a b) (assoc! a 'visited true) (< (get a 'n) (get b 'n)))
+  records)
+
+;; GOOD -- compares, and does nothing else
+(stable-sort (lambda (a b) (< (get a 'n) (get b 'n))) records)
+```
+
+The `comparator-mutation` lint check reports a mutating call anywhere inside a
+comparator, whatever that call writes to:
+
+```
+$ elps lint sort.lisp
+error: stable-sort predicate mutates state: assoc! is called inside a comparator (comparator-mutation)
+```
+
 ### Sorted Maps
 
 A sorted map is a mapping between keys and values which ensures that key

--- a/docs/lint-checks.md
+++ b/docs/lint-checks.md
@@ -274,6 +274,32 @@ branch matches. While sometimes intentional, this is often an oversight.
   (error 'test "data"))
 ```
 
+### `comparator-mutation`
+
+**Flags a mutating call inside a `stable-sort` or `insert-sorted` predicate.**
+(Severity: error)
+
+A comparator runs an unspecified number of times, in an unspecified order, and
+it is handed the list's own elements — so any side effect inside one is
+nondeterministic, whatever it writes to. Every mutating builtin is reported:
+`assoc!`, `dissoc!`, `append!`, `append-bytes!`, `set!`, and `stable-sort`
+itself, which sorts in place despite carrying no `!`.
+
+```lisp
+;; BAD — the predicate mutates
+(stable-sort (lambda (a b) (assoc! a 'visited true) (< a b)) xs)
+(insert-sorted 'list xs (lambda (a b) (append! log a) (< a b)) item)
+
+;; GOOD — the predicate only compares
+(stable-sort (lambda (a b) (< a b)) xs)
+```
+
+Two spellings of the predicate are followed: an inline `lambda`, and a plain
+symbol naming a `defun` **in the same file**. That hop is one level deep — the
+named function's own body is scanned, but a call it in turn makes is not
+followed, so a comparator that mutates two hops away is not reported. Quoted
+subtrees are data and are skipped whole.
+
 ### `with-cleanup-forms`
 
 **Flags a degenerate `with-cleanup` spec list.** (Severity: warning)

--- a/docs/lint-checks.md
+++ b/docs/lint-checks.md
@@ -300,6 +300,46 @@ named function's own body is scanned, but a call it in turn makes is not
 followed, so a comparator that mutates two hops away is not reported. Quoted
 subtrees are data and are skipped whole.
 
+### `iteration-mutation`
+
+**Flags a callback that mutates the collection it is iterating.** (Severity:
+warning)
+
+Covers `map`, `foldl`, `foldr`, `select`, `reject`, `all?` and `any?`. A
+mutating call — `assoc!`, `dissoc!`, `append!`, `append-bytes!` or
+`stable-sort` — is reported when the value it writes through is the collection
+argument itself, or one of the callback's own parameters, which holds an
+element of that collection.
+
+`set!` is deliberately **not** on that list, unlike in `comparator-mutation`.
+It rebinds a name rather than writing through the value the name held, so
+`(set! x 1)` gives the callback's own parameter a new value and leaves the
+element alone, and `(set! xs ...)` rebinds the caller's variable while the
+builtin goes on walking the sequence it was already handed.
+
+```lisp
+;; BAD — writes through the sequence being walked
+(map 'list (lambda (x) (append! xs x)) xs)
+
+;; BAD — writes through an element the traversal handed over
+(map 'list (lambda (x) (assoc! x 'seen true)) xs)
+
+;; GOOD — the fold's own accumulator is neither the collection nor an element
+(foldl (lambda (acc x) (assoc! acc x 1)) (sorted-map) xs)
+
+;; GOOD — an unrelated binding
+(map 'list (lambda (x) (assoc! out x 1)) xs)
+```
+
+Both an inline `lambda` and a plain symbol naming a `defun` **in the same
+file** are followed, one hop deep.
+
+Blind spots worth knowing: the check is syntactic and keeps no scope of its
+own, so a callback parameter that an inner `let` rebinds is still treated as
+the element; a collection passed as an expression rather than a symbol has no
+name to match against and is invisible; and `zip` is not covered, because it
+takes no callback at all.
+
 ### `with-cleanup-forms`
 
 **Flags a degenerate `with-cleanup` spec list.** (Severity: warning)

--- a/docs/lint-checks.md
+++ b/docs/lint-checks.md
@@ -297,8 +297,15 @@ itself, which sorts in place despite carrying no `!`.
 Two spellings of the predicate are followed: an inline `lambda`, and a plain
 symbol naming a `defun` **in the same file**. That hop is one level deep — the
 named function's own body is scanned, but a call it in turn makes is not
-followed, so a comparator that mutates two hops away is not reported. Quoted
-subtrees are data and are skipped whole.
+followed, so a comparator that mutates two hops away is not reported.
+
+Data is skipped whole, and in all three spellings: a reader-quoted form
+(`'(assoc! a b)`), an explicit `(quote ...)` form, and a `quasiquote`
+template. The one exception is the standard one — an `(unquote ...)` or
+`(unquote-splicing ...)` subtree inside a template is evaluated where it
+stands, so a mutation in one is still reported. This applies to the sort form
+itself as much as to the predicate's body, and a `defun` written inside data
+defines nothing, so a symbol naming one resolves to no callback at all.
 
 ### `iteration-mutation`
 
@@ -332,7 +339,8 @@ builtin goes on walking the sequence it was already handed.
 ```
 
 Both an inline `lambda` and a plain symbol naming a `defun` **in the same
-file** are followed, one hop deep.
+file** are followed, one hop deep. Quoting is honoured exactly as it is for
+`comparator-mutation` above.
 
 Blind spots worth knowing: the check is syntactic and keeps no scope of its
 own, so a callback parameter that an inner `let` rebinds is still treated as

--- a/docs/lint-checks.md
+++ b/docs/lint-checks.md
@@ -299,7 +299,9 @@ itself, which sorts in place despite carrying no `!`.
 Two spellings of the predicate are followed: an inline `lambda`, and a plain
 symbol naming a `defun` **in the same file**. That hop is one level deep — the
 named function's own body is scanned, but a call it in turn makes is not
-followed, so a comparator that mutates two hops away is not reported.
+followed, so a comparator that mutates two hops away is not reported. When a
+file defines the same name twice, the **last** definition is the one followed,
+because `defun` overwrites and that is the body the interpreter runs.
 
 Data is skipped whole, and in all three spellings: a reader-quoted form
 (`'(assoc! a b)`), an explicit `(quote ...)` form, and a `quasiquote`

--- a/docs/lint-checks.md
+++ b/docs/lint-checks.md
@@ -279,9 +279,11 @@ branch matches. While sometimes intentional, this is often an oversight.
 **Flags a mutating call inside a `stable-sort` or `insert-sorted` predicate.**
 (Severity: error)
 
-A comparator runs an unspecified number of times, in an unspecified order, and
-it is handed the list's own elements — so any side effect inside one is
-nondeterministic, whatever it writes to. Every mutating builtin is reported:
+A comparator runs an unspecified number of times, in an unspecified order.
+Writes to shared state or input elements can therefore make sorting unreliable.
+This is a conservative syntactic rule: it also reports writes to callback-local
+scratch values, even when those writes cannot escape the callback. Every known
+mutating builtin is reported:
 `assoc!`, `dissoc!`, `append!`, `append-bytes!`, `set!`, and `stable-sort`
 itself, which sorts in place despite carrying no `!`.
 
@@ -301,11 +303,14 @@ followed, so a comparator that mutates two hops away is not reported.
 
 Data is skipped whole, and in all three spellings: a reader-quoted form
 (`'(assoc! a b)`), an explicit `(quote ...)` form, and a `quasiquote`
-template. The one exception is the standard one — an `(unquote ...)` or
+template. An `(unquote ...)` or
 `(unquote-splicing ...)` subtree inside a template is evaluated where it
 stands, so a mutation in one is still reported. This applies to the sort form
 itself as much as to the predicate's body, and a `defun` written inside data
 defines nothing, so a symbol naming one resolves to no callback at all.
+The evaluated forms `lisp:quote` and `lisp:quasiquote` are handled too.
+ELPS searches through nested quasiquote templates for unquotes; nesting another
+quasiquote does not protect an unquoted mutation from evaluation or this check.
 
 ### `iteration-mutation`
 

--- a/docs/lint-checks.md
+++ b/docs/lint-checks.md
@@ -312,6 +312,19 @@ The evaluated forms `lisp:quote` and `lisp:quasiquote` are handled too.
 ELPS searches through nested quasiquote templates for unquotes; nesting another
 quasiquote does not protect an unquoted mutation from evaluation or this check.
 
+Limits worth knowing. The package-qualified spelling of every operator this
+check matches on is recognised — `lisp:stable-sort`, `lisp:insert-sorted`,
+`lisp:lambda`, `lisp:defun` and `lisp:assoc!` and the other mutating builtins
+read exactly as their bare names, since `lisp` is the only package exporting
+them and the interpreter resolves both spellings to one function (the
+diagnostic always names the canonical spelling). A same-file **rebinding** is
+not tracked, however: the check keeps no scope of its own, so after
+`(defun quote (x) x)` — or a shadowing definition of `quasiquote` or of a
+mutating builtin — it goes on reading the shadowed builtin meaning rather than
+the new one. `lisp:unquote` is the one qualified spelling deliberately left as
+data, because ELPS itself recognises only the bare `unquote` marker inside a
+template.
+
 ### `iteration-mutation`
 
 **Flags a callback that mutates the collection it is iterating.** (Severity:
@@ -352,6 +365,13 @@ own, so a callback parameter that an inner `let` rebinds is still treated as
 the element; a collection passed as an expression rather than a symbol has no
 name to match against and is invisible; and `zip` is not covered, because it
 takes no callback at all.
+
+Qualified spellings are recognised here too — `lisp:map`, `lisp:foldl`,
+`lisp:lambda`, `lisp:defun`, `lisp:assoc!` and the rest read exactly as their
+bare names, and the diagnostic names the canonical one. And as with
+`comparator-mutation`, a same-file rebinding of `quote`, `quasiquote` or a
+builtin name (for example `(defun quote (x) x)`) is not tracked, so the check
+then reads the shadowed meaning.
 
 ### `with-cleanup-forms`
 

--- a/docs/nolint.md
+++ b/docs/nolint.md
@@ -86,6 +86,7 @@ cond-structure
 defun-structure
 if-arity
 in-package-toplevel
+iteration-mutation
 let-bindings
 quote-call
 rethrow-context

--- a/docs/nolint.md
+++ b/docs/nolint.md
@@ -84,6 +84,8 @@ comparator-mutation
 cond-missing-else
 cond-structure
 defun-structure
+deprecated
+duplicate-definition
 if-arity
 in-package-toplevel
 iteration-mutation
@@ -95,10 +97,14 @@ shadowing
 undefined-symbol
 unnecessary-progn
 unused-function
-unused-nolint
 unused-variable
 user-arity
+with-cleanup-forms
 ```
+
+`unused-nolint` is not in that list: it is synthetic, reported by the
+linter itself rather than by a registered analyzer, but it is a valid name in
+a directive (see above).
 
 Checks marked with `*` below require semantic analysis (`--workspace` flag):
 
@@ -109,6 +115,8 @@ Checks marked with `*` below require semantic analysis (`--workspace` flag):
 | `unused-function` | yes |
 | `shadowing` | yes |
 | `user-arity` | yes |
+| `duplicate-definition` | yes |
+| `deprecated` | yes |
 | all others | no |
 
 ## When to use nolint

--- a/docs/nolint.md
+++ b/docs/nolint.md
@@ -80,6 +80,7 @@ Run `elps lint --list` to see all available check names:
 
 ```
 builtin-arity
+comparator-mutation
 cond-missing-else
 cond-structure
 defun-structure

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -1553,6 +1553,44 @@ func isDeprecatedDefinition(v *lisp.LVal) bool {
 	return ok
 }
 
+// mutationOperatorPackage is the package qualifier the mutation checks
+// canonicalise away. Every operator they match on -- the sorting and
+// higher-order builtins, the mutating builtins, and the lambda, defun, quote
+// and quasiquote special operators -- is exported by `lisp` and by no other
+// package, so `lisp:stable-sort` names the same function as `stable-sort` and
+// nothing else can. A qualifier naming any OTHER package is somebody else's
+// function and is left alone.
+const mutationOperatorPackage = "lisp:"
+
+// unqualifiedLispName strips a leading `lisp:` from sym and returns it
+// unchanged otherwise. It rewrites nothing else: no other qualifier is
+// removed, and an unqualified name passes through.
+//
+// The mutation checks compare head symbols against fixed spellings, and the
+// interpreter resolves both spellings to one function, so matching only the
+// bare name left `(lisp:stable-sort (lisp:lambda (a b) (lisp:assoc! ...)) xs)`
+// -- which runs and mutates -- with no diagnostic at all.
+//
+// It is deliberately NOT applied to the unquote markers inside a quasiquote
+// template. lisp/macro.go's getUnquoteType compares the head symbol's Str to
+// the bare "unquote" and "unquote-splicing" literally, so `(lisp:unquote x)`
+// stays template data at runtime; canonicalising it here would report a
+// mutation the interpreter never performs.
+func unqualifiedLispName(sym string) string {
+	if name, ok := strings.CutPrefix(sym, mutationOperatorPackage); ok {
+		return name
+	}
+	return sym
+}
+
+// mutationHead returns the head symbol of sexpr with the `lisp:` qualifier
+// canonicalised away. Every head-symbol comparison in the two mutation checks
+// goes through it, so the qualified and bare spellings of one hazard are one
+// finding rather than one finding and one blind spot.
+func mutationHead(sexpr *lisp.LVal) string {
+	return unqualifiedLispName(HeadSymbol(sexpr))
+}
+
 // mutatingBuiltins maps a destructive builtin to the index, within an
 // s-expression's Cells, of the argument it writes through. Index 1 is the
 // first argument.
@@ -1612,7 +1650,7 @@ var AnalyzerComparatorMutation = &Analyzer{
 	Run: func(pass *Pass) error {
 		run := newMutationRun(pass)
 		walkEvaluatedSExprs(pass.Exprs, func(sexpr *lisp.LVal) {
-			form := HeadSymbol(sexpr)
+			form := mutationHead(sexpr)
 			idx, ok := comparatorPredicateArg[form]
 			if !ok || idx >= len(sexpr.Cells) {
 				return
@@ -1730,7 +1768,7 @@ var AnalyzerIterationMutation = &Analyzer{
 	Run: func(pass *Pass) error {
 		run := newMutationRun(pass)
 		walkEvaluatedSExprs(pass.Exprs, func(sexpr *lisp.LVal) {
-			form := HeadSymbol(sexpr)
+			form := mutationHead(sexpr)
 			spec, ok := iterationForms[form]
 			if !ok || spec.callback >= len(sexpr.Cells) {
 				return
@@ -1800,7 +1838,7 @@ func lambdaCallback(node *lisp.LVal) *callback {
 	if node == nil || node.Type != lisp.LSExpr || node.IsQuoted() {
 		return nil
 	}
-	if HeadSymbol(node) != "lambda" || len(node.Cells) < 2 {
+	if mutationHead(node) != "lambda" || len(node.Cells) < 2 {
 		return nil
 	}
 	return &callback{node: node, params: formalNames(node.Cells[1]), body: node.Cells[2:]}
@@ -1818,7 +1856,7 @@ func sameFileDefuns(exprs []*lisp.LVal) map[string]*lisp.LVal {
 	walkEvaluatedSExprs(exprs, func(sexpr *lisp.LVal) {
 		// A malformed defun with no formals list is skipped outright, so
 		// resolveCallback can index Cells[2] and Cells[3:] unconditionally.
-		if HeadSymbol(sexpr) != "defun" || len(sexpr.Cells) < 3 {
+		if mutationHead(sexpr) != "defun" || len(sexpr.Cells) < 3 {
 			return
 		}
 		name := sexpr.Cells[1]
@@ -1930,7 +1968,7 @@ func (r *mutationRun) index() {
 func (r *mutationRun) indexNode(node *lisp.LVal) {
 	walkEvaluated(node, func(sexpr *lisp.LVal) bool {
 		cb := lambdaCallback(sexpr)
-		if cb == nil && HeadSymbol(sexpr) == "defun" && len(sexpr.Cells) >= 3 {
+		if cb == nil && mutationHead(sexpr) == "defun" && len(sexpr.Cells) >= 3 {
 			cb = &callback{node: sexpr, params: formalNames(sexpr.Cells[2]), body: sexpr.Cells[3:]}
 		}
 		if cb != nil {
@@ -1942,7 +1980,7 @@ func (r *mutationRun) indexNode(node *lisp.LVal) {
 			cb.sites.end = len(r.sites)
 			return false
 		}
-		name := HeadSymbol(sexpr)
+		name := mutationHead(sexpr)
 		if _, ok := mutatingBuiltins[name]; ok {
 			index := len(r.sites)
 			r.sites = append(r.sites, sexpr)
@@ -2039,7 +2077,9 @@ func (r *mutationRun) reportQueries() {
 }
 
 func (r *mutationRun) reportSite(query mutationQuery, call *lisp.LVal) {
-	name := HeadSymbol(call)
+	// The canonical spelling, so one hazard written two ways reads as one
+	// finding: query.form is canonical because it keyed the query.
+	name := mutationHead(call)
 	var msg, note string
 	switch {
 	case query.target == "":
@@ -2106,10 +2146,10 @@ func walkEvaluated(node *lisp.LVal, fn func(sexpr *lisp.LVal) bool) {
 		return
 	}
 	if node.Type == lisp.LSExpr && len(node.Cells) > 0 {
-		switch HeadSymbol(node) {
-		case "quote", "lisp:quote":
+		switch mutationHead(node) {
+		case "quote":
 			return
-		case "quasiquote", "lisp:quasiquote":
+		case "quasiquote":
 			for _, cell := range node.Cells[1:] {
 				walkTemplate(cell, fn)
 			}

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -1553,6 +1553,175 @@ func isDeprecatedDefinition(v *lisp.LVal) bool {
 	return ok
 }
 
+// mutatingBuiltins maps a destructive builtin to the index, within an
+// s-expression's Cells, of the argument it writes through. Index 1 is the
+// first argument.
+//
+// Every entry but one is spelled with the trailing `!` docs/lang.md describes
+// as the naming rule for mutation. `stable-sort` is the documented exception:
+// it carries no `!`, yet it sorts its list in place and returns the sequence
+// it sorted -- and the value it writes through is its SECOND argument, the
+// first being the predicate.
+var mutatingBuiltins = map[string]int{
+	"assoc!":        1,
+	"dissoc!":       1,
+	"append!":       1,
+	"append-bytes!": 1,
+	"set!":          1,
+	"stable-sort":   2,
+}
+
+// comparatorPredicateArg maps a sorting form to the index, within its Cells,
+// of the comparator it calls. Read off the builtins rather than guessed --
+// the predicate is not in the same place in the two forms:
+//
+//	(stable-sort   less-predicate list      &optional key-fun)            ; builtinSortStable
+//	(insert-sorted type-specifier list predicate item &optional key-fun)  ; builtinInsertSorted
+var comparatorPredicateArg = map[string]int{
+	"stable-sort":   1,
+	"insert-sorted": 3,
+}
+
+// AnalyzerComparatorMutation reports a call to a mutating builtin inside a
+// sort comparator.
+//
+// A comparator is called an unspecified number of times, in an unspecified
+// order, on elements the caller still owns, so ANY side effect inside one is
+// nondeterministic -- the target of the mutation does not matter and the
+// check does not look at it.
+var AnalyzerComparatorMutation = &Analyzer{
+	Name:     "comparator-mutation",
+	Severity: SeverityError,
+	Doc: "Report a mutating call inside a stable-sort or insert-sorted predicate.\n\n" +
+		"A comparator runs an unspecified number of times in an unspecified order, " +
+		"and it is handed the list's own elements, so any side effect inside one is " +
+		"nondeterministic. Every mutating builtin is reported whatever it writes to: " +
+		"assoc!, dissoc!, append!, append-bytes!, set! and stable-sort itself, which " +
+		"sorts in place despite carrying no `!`.\n\n" +
+		"Two spellings of the predicate are followed: an inline lambda, and a plain " +
+		"symbol naming a defun in the same file. The symbol hop is ONE level deep -- " +
+		"the named defun's own body is scanned, but a call it makes to a third " +
+		"function is not followed, so a comparator that mutates two hops away is not " +
+		"reported. Quoted subtrees are data and are skipped whole.",
+	Run: func(pass *Pass) error {
+		defuns := sameFileDefuns(pass.Exprs)
+		WalkSExprs(pass.Exprs, func(sexpr *lisp.LVal, _ int) {
+			form := HeadSymbol(sexpr)
+			idx, ok := comparatorPredicateArg[form]
+			if !ok || idx >= len(sexpr.Cells) {
+				return
+			}
+			cb := resolveCallback(sexpr.Cells[idx], defuns)
+			if cb == nil {
+				return
+			}
+			for _, node := range cb.body {
+				walkUnquotedSExprs(node, func(call *lisp.LVal) {
+					name := HeadSymbol(call)
+					if _, ok := mutatingBuiltins[name]; !ok {
+						return
+					}
+					src := SourceOf(call)
+					pass.Report(Diagnostic{
+						Message: fmt.Sprintf(
+							"%s predicate mutates state: %s is called inside a comparator",
+							form, name),
+						Pos:    posFromSource(astutil.SourceLoc(src)),
+						EndPos: endPosFromNode(src),
+						Notes: []string{
+							"a comparator runs an unspecified number of times in an unspecified order, and it receives the list's own elements, so any side effect in it is nondeterministic",
+						},
+					})
+				})
+			}
+		})
+		return nil
+	},
+}
+
+// callback is a function argument a higher-order form was handed: the names
+// it binds its parameters to, and the body forms that run.
+type callback struct {
+	params map[string]bool
+	body   []*lisp.LVal
+}
+
+// resolveCallback returns the parameters and body of a function argument.
+//
+// Two spellings resolve. An inline lambda is read directly. A symbol is
+// looked up among the file's own defuns -- ONE hop: the named function's body
+// is scanned, but a call it in turn makes is not followed. Quoting is ignored
+// in this position because a callback slot holds a function reference either
+// way: (stable-sort 'less xs) and (stable-sort less xs) both call less.
+//
+// Anything else -- a builtin such as `<`, a symbol defined in another file, a
+// call returning a function -- yields nil, and the caller reports nothing.
+func resolveCallback(node *lisp.LVal, defuns map[string]*lisp.LVal) *callback {
+	if node == nil {
+		return nil
+	}
+	if node.Type == lisp.LSymbol {
+		def := defuns[node.Str]
+		if def == nil {
+			return nil
+		}
+		// (defun name (formals) body...) -- sameFileDefuns guarantees the
+		// formals cell exists.
+		return &callback{params: formalNames(def.Cells[2]), body: def.Cells[3:]}
+	}
+	if node.Type == lisp.LSExpr && !node.IsQuoted() && HeadSymbol(node) == "lambda" && len(node.Cells) >= 2 {
+		// (lambda (formals) body...)
+		return &callback{params: formalNames(node.Cells[1]), body: node.Cells[2:]}
+	}
+	return nil
+}
+
+// sameFileDefuns indexes the file's defuns, nested ones included, by name. A
+// duplicate name keeps the first definition, which is the one the
+// duplicate-definition check reports against.
+func sameFileDefuns(exprs []*lisp.LVal) map[string]*lisp.LVal {
+	defs := make(map[string]*lisp.LVal)
+	WalkSExprs(exprs, func(sexpr *lisp.LVal, _ int) {
+		// A malformed defun with no formals list is skipped outright, so
+		// resolveCallback can index Cells[2] and Cells[3:] unconditionally.
+		if HeadSymbol(sexpr) != "defun" || len(sexpr.Cells) < 3 {
+			return
+		}
+		name := sexpr.Cells[1]
+		if name.Type != lisp.LSymbol {
+			return
+		}
+		if _, ok := defs[name.Str]; !ok {
+			defs[name.Str] = sexpr
+		}
+	})
+	return defs
+}
+
+// formalNames collects the parameter names of a formals list, dropping the
+// &rest, &optional and &key markers.
+func formalNames(formals *lisp.LVal) map[string]bool {
+	names := make(map[string]bool)
+	CollectFormals(formals, names)
+	return names
+}
+
+// walkUnquotedSExprs calls fn for every unquoted s-expression at or below
+// node, skipping a quoted subtree whole rather than descending into it:
+// '(assoc! m k v) is data the program never calls, and its elements do not
+// individually carry the quote flag.
+func walkUnquotedSExprs(node *lisp.LVal, fn func(sexpr *lisp.LVal)) {
+	if node == nil || node.IsQuoted() {
+		return
+	}
+	if node.Type == lisp.LSExpr && len(node.Cells) > 0 {
+		fn(node)
+	}
+	for _, cell := range node.Cells {
+		walkUnquotedSExprs(cell, fn)
+	}
+}
+
 // AnalyzerNames returns a sorted list of all default analyzer names.
 func AnalyzerNames() []string {
 	analyzers := DefaultAnalyzers()

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -1604,34 +1604,32 @@ var AnalyzerComparatorMutation = &Analyzer{
 		"function is not followed, so a comparator that mutates two hops away is not " +
 		"reported. Quoted subtrees are data and are skipped whole.",
 	Run: func(pass *Pass) error {
-		defuns := sameFileDefuns(pass.Exprs)
+		run := newMutationRun(pass)
 		WalkSExprs(pass.Exprs, func(sexpr *lisp.LVal, _ int) {
 			form := HeadSymbol(sexpr)
 			idx, ok := comparatorPredicateArg[form]
 			if !ok || idx >= len(sexpr.Cells) {
 				return
 			}
-			cb := resolveCallback(sexpr.Cells[idx], defuns)
+			cb := resolveCallback(sexpr.Cells[idx], run.defuns)
 			if cb == nil {
 				return
 			}
-			for _, node := range cb.body {
-				walkUnquotedSExprs(node, func(call *lisp.LVal) {
-					name := HeadSymbol(call)
-					if _, ok := mutatingBuiltins[name]; !ok {
-						return
-					}
-					src := SourceOf(call)
-					pass.Report(Diagnostic{
-						Message: fmt.Sprintf(
-							"%s predicate mutates state: %s is called inside a comparator",
-							form, name),
-						Pos:    posFromSource(astutil.SourceLoc(src)),
-						EndPos: endPosFromNode(src),
-						Notes: []string{
-							"a comparator runs an unspecified number of times in an unspecified order, and it receives the list's own elements, so any side effect in it is nondeterministic",
-						},
-					})
+			if !run.enterScope(mutationScopeKey{form: form, node: cb.node}) {
+				return
+			}
+			for _, call := range run.mutationSites(cb) {
+				name := HeadSymbol(call)
+				src := SourceOf(call)
+				run.report(Diagnostic{
+					Message: fmt.Sprintf(
+						"%s predicate mutates state: %s is called inside a comparator",
+						form, name),
+					Pos:    posFromSource(astutil.SourceLoc(src)),
+					EndPos: endPosFromNode(src),
+					Notes: []string{
+						"a comparator runs an unspecified number of times in an unspecified order, and it receives the list's own elements, so any side effect in it is nondeterministic",
+					},
 				})
 			}
 		})
@@ -1735,22 +1733,33 @@ var AnalyzerIterationMutation = &Analyzer{
 		"a collection passed as an expression rather than a symbol is invisible; and " +
 		"zip is not covered because it takes no callback at all.",
 	Run: func(pass *Pass) error {
-		defuns := sameFileDefuns(pass.Exprs)
+		run := newMutationRun(pass)
 		WalkSExprs(pass.Exprs, func(sexpr *lisp.LVal, _ int) {
 			form := HeadSymbol(sexpr)
 			spec, ok := iterationForms[form]
 			if !ok || spec.callback >= len(sexpr.Cells) {
 				return
 			}
-			cb := resolveCallback(sexpr.Cells[spec.callback], defuns)
+			cb := resolveCallback(sexpr.Cells[spec.callback], run.defuns)
 			if cb == nil {
 				return
 			}
 			collections := make(map[string]bool)
+			var names []string
 			for _, idx := range spec.collections {
 				if idx < len(sexpr.Cells) && sexpr.Cells[idx].Type == lisp.LSymbol {
 					collections[sexpr.Cells[idx].Str] = true
+					names = append(names, sexpr.Cells[idx].Str)
 				}
+			}
+			sort.Strings(names)
+			key := mutationScopeKey{
+				form:        form,
+				node:        cb.node,
+				collections: strings.Join(names, " "),
+			}
+			if !run.enterScope(key) {
+				return
 			}
 			// Everything the callback is handed EXCEPT a threaded
 			// accumulator holds an element of the collection.
@@ -1761,37 +1770,35 @@ var AnalyzerIterationMutation = &Analyzer{
 				}
 				elements[name] = true
 			}
-			for _, node := range cb.body {
-				walkUnquotedSExprs(node, func(call *lisp.LVal) {
-					name := HeadSymbol(call)
-					target, ok := iterationMutatingTargets[name]
-					if !ok || target >= len(call.Cells) {
-						return
-					}
-					arg := call.Cells[target]
-					if arg.Type != lisp.LSymbol {
-						return
-					}
-					var msg string
-					switch {
-					case collections[arg.Str]:
-						msg = fmt.Sprintf("%s mutates %s while %s iterates over it",
-							name, arg.Str, form)
-					case elements[arg.Str]:
-						msg = fmt.Sprintf("%s mutates the element %s of %s",
-							name, arg.Str, form)
-					default:
-						return
-					}
-					src := SourceOf(call)
-					pass.Report(Diagnostic{
-						Message: msg,
-						Pos:     posFromSource(astutil.SourceLoc(src)),
-						EndPos:  endPosFromNode(src),
-						Notes: []string{
-							"iterate a copy (copy or concat) or build a new collection and return it, rather than writing through the one being traversed",
-						},
-					})
+			for _, call := range run.mutationSites(cb) {
+				name := HeadSymbol(call)
+				target, ok := iterationMutatingTargets[name]
+				if !ok || target >= len(call.Cells) {
+					continue
+				}
+				arg := call.Cells[target]
+				if arg.Type != lisp.LSymbol {
+					continue
+				}
+				var msg string
+				switch {
+				case collections[arg.Str]:
+					msg = fmt.Sprintf("%s mutates %s while %s iterates over it",
+						name, arg.Str, form)
+				case elements[arg.Str]:
+					msg = fmt.Sprintf("%s mutates the element %s of %s",
+						name, arg.Str, form)
+				default:
+					continue
+				}
+				src := SourceOf(call)
+				run.report(Diagnostic{
+					Message: msg,
+					Pos:     posFromSource(astutil.SourceLoc(src)),
+					EndPos:  endPosFromNode(src),
+					Notes: []string{
+						"iterate a copy (copy or concat) or build a new collection and return it, rather than writing through the one being traversed",
+					},
 				})
 			}
 		})
@@ -1806,6 +1813,10 @@ var AnalyzerIterationMutation = &Analyzer{
 // rather than an element of the collection, and which one differs between
 // foldl and foldr.
 type callback struct {
+	// node is the lambda or defun the body was read off. It is the memo key
+	// mutationRun uses, so the 300 references that name one defun share a
+	// single scan of it.
+	node   *lisp.LVal
 	params []string
 	body   []*lisp.LVal
 }
@@ -1831,13 +1842,21 @@ func resolveCallback(node *lisp.LVal, defuns map[string]*lisp.LVal) *callback {
 		}
 		// (defun name (formals) body...) -- sameFileDefuns guarantees the
 		// formals cell exists.
-		return &callback{params: formalNames(def.Cells[2]), body: def.Cells[3:]}
+		return &callback{node: def, params: formalNames(def.Cells[2]), body: def.Cells[3:]}
 	}
-	if node.Type == lisp.LSExpr && !node.IsQuoted() && HeadSymbol(node) == "lambda" && len(node.Cells) >= 2 {
-		// (lambda (formals) body...)
-		return &callback{params: formalNames(node.Cells[1]), body: node.Cells[2:]}
+	return lambdaCallback(node)
+}
+
+// lambdaCallback reads (lambda (formals) body...) off node, or returns nil
+// when node is anything else.
+func lambdaCallback(node *lisp.LVal) *callback {
+	if node == nil || node.Type != lisp.LSExpr || node.IsQuoted() {
+		return nil
 	}
-	return nil
+	if HeadSymbol(node) != "lambda" || len(node.Cells) < 2 {
+		return nil
+	}
+	return &callback{node: node, params: formalNames(node.Cells[1]), body: node.Cells[2:]}
 }
 
 // sameFileDefuns indexes the file's defuns, nested ones included, by name. A
@@ -1889,20 +1908,157 @@ func formalNames(formals *lisp.LVal) []string {
 	return names
 }
 
-// walkUnquotedSExprs calls fn for every unquoted s-expression at or below
-// node, skipping a quoted subtree whole rather than descending into it:
-// '(assoc! m k v) is data the program never calls, and its elements do not
-// individually carry the quote flag.
-func walkUnquotedSExprs(node *lisp.LVal, fn func(sexpr *lisp.LVal)) {
-	if node == nil || node.IsQuoted() {
+// mutationDiagKey identifies a diagnostic by where it points and what it
+// says. Two findings that agree on both are the same finding reported twice.
+type mutationDiagKey struct {
+	pos Position
+	msg string
+}
+
+// mutationScopeKey identifies everything a reference to a callback can
+// contribute: the form that names it, the body it names, and -- for the
+// iteration check, whose message depends on which collection is being walked
+// -- the collection names read off that call site. Two references agreeing
+// on all three produce character-for-character the same diagnostics, so the
+// second one has no work to do.
+type mutationScopeKey struct {
+	form        string
+	node        *lisp.LVal
+	collections string
+}
+
+// mutationRun is the state comparator-mutation and iteration-mutation each
+// build once per pass. It exists to keep both checks LINEAR in the size of
+// the file, which the first cut of them was not.
+//
+// The shape that broke them is ordinary: one helper defun that mutates,
+// named as the callback of many traversals. Resolving the callback at every
+// reference and rescanning the named body there made the work -- and the
+// output -- the product of the two counts. A 24.7 KB file of that shape
+// produced roughly 360,000 diagnostics, every one of them a duplicate of one
+// of the ~400 real findings, and allocated about 713 MB doing it. Nested
+// lambdas compounded it from the other side: an inner body was rewalked once
+// per enclosing form.
+//
+// Three pieces fix it, and each covers something the others do not.
+//
+//   - sites memoizes the scan of a callback body on the node the body hangs
+//     off, so a body is walked exactly ONCE per pass however many routes
+//     reach it -- 300 references to one defun, and an inner lambda that is
+//     both nested inside an outer callback and handed to a traversal of its
+//     own.
+//   - scopes skips a reference whose (form, callback, collections) triple has
+//     already been examined, because those three fix the diagnostics word for
+//     word. Without it the memo is consulted 300 times and 300 sets of
+//     identical messages are formatted for the dedup to discard, which is
+//     where most of the allocation went.
+//   - reported deduplicates the OUTPUT by position and message. The two memos
+//     alone do not: a body reached from genuinely different scopes -- five
+//     comparators nested one inside the next -- reports its inner sites once
+//     per enclosing form. Position and message together are the right key
+//     rather than position alone, because the message names the form: one
+//     predicate used by both stable-sort and insert-sorted is genuinely two
+//     findings at one position, and each wants saying once.
+//
+// Pass offers none of the three: Report appends unconditionally (a check that
+// reports each node once has no use for a memo), so the state lives here,
+// scoped to the run, rather than being pushed into every analyzer's way.
+type mutationRun struct {
+	pass   *Pass
+	defuns map[string]*lisp.LVal
+	// sites memoizes mutationSites, keyed by callback.node.
+	sites map[*lisp.LVal][]*lisp.LVal
+	// reported is the set of diagnostics already emitted this pass.
+	reported map[mutationDiagKey]bool
+	// scopes is the set of (form, callback, collections) triples already
+	// examined this pass.
+	scopes map[mutationScopeKey]bool
+}
+
+func newMutationRun(pass *Pass) *mutationRun {
+	return &mutationRun{
+		pass:     pass,
+		defuns:   sameFileDefuns(pass.Exprs),
+		sites:    make(map[*lisp.LVal][]*lisp.LVal),
+		reported: make(map[mutationDiagKey]bool),
+		scopes:   make(map[mutationScopeKey]bool),
+	}
+}
+
+// enterScope reports whether key is being examined for the first time this
+// pass, recording it either way.
+//
+// The report dedup below is what makes the OUTPUT right; this is what makes
+// the WORK proportional to the file. Without it the 300 references to a
+// 400-mutation defun still each formatted 400 messages for report to throw
+// away, which is most of the allocation the explosion cost.
+func (r *mutationRun) enterScope(key mutationScopeKey) bool {
+	if r.scopes[key] {
+		return false
+	}
+	r.scopes[key] = true
+	return true
+}
+
+// report emits d unless a diagnostic with the same position and message has
+// already been emitted this pass.
+func (r *mutationRun) report(d Diagnostic) {
+	key := mutationDiagKey{pos: d.Pos, msg: d.Message}
+	if r.reported[key] {
 		return
 	}
+	r.reported[key] = true
+	r.pass.Report(d)
+}
+
+// mutationSites returns every call to a mutating builtin that runs when cb
+// runs: the ones written directly in its body, plus those in the bodies of
+// the lambdas nested inside it, which run when the enclosing callback calls
+// them.
+//
+// The result is memoized on cb.node, and a nested lambda is scanned through
+// mutationSites rather than inline, so every body in the file is walked once
+// per pass no matter how many callers or enclosing forms reach it.
+func (r *mutationRun) mutationSites(cb *callback) []*lisp.LVal {
+	if sites, ok := r.sites[cb.node]; ok {
+		return sites
+	}
+	// Seed the memo before recursing. The parser yields a tree, so a body
+	// cannot contain itself, but a cycle would otherwise recurse forever
+	// rather than terminate with an empty answer.
+	r.sites[cb.node] = nil
+	var sites []*lisp.LVal
+	for _, node := range cb.body {
+		sites = r.collectMutationSites(node, sites)
+	}
+	r.sites[cb.node] = sites
+	return sites
+}
+
+// collectMutationSites appends to sites every unquoted call to a mutating
+// builtin at or below node, skipping a quoted subtree whole rather than
+// descending into it: '(assoc! m k v) is data the program never calls, and
+// its elements do not individually carry the quote flag.
+//
+// A nested lambda is not walked here. It is handed back to mutationSites,
+// which caches it under its own node -- that is what keeps a body reached
+// through two routes from being scanned twice.
+func (r *mutationRun) collectMutationSites(node *lisp.LVal, sites []*lisp.LVal) []*lisp.LVal {
+	if node == nil || node.IsQuoted() {
+		return sites
+	}
 	if node.Type == lisp.LSExpr && len(node.Cells) > 0 {
-		fn(node)
+		if inner := lambdaCallback(node); inner != nil {
+			return append(sites, r.mutationSites(inner)...)
+		}
+		if _, ok := mutatingBuiltins[HeadSymbol(node)]; ok {
+			sites = append(sites, node)
+		}
 	}
 	for _, cell := range node.Cells {
-		walkUnquotedSExprs(cell, fn)
+		sites = r.collectMutationSites(cell, sites)
 	}
+	return sites
 }
 
 // AnalyzerNames returns a sorted list of all default analyzer names.

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -2096,21 +2096,22 @@ func walkEvaluatedSExprs(exprs []*lisp.LVal, fn func(sexpr *lisp.LVal)) {
 //     subtree is skipped whole.
 //   - a (quote ...) FORM, which the reader leaves entirely unflagged -- the
 //     operand is an ordinary s-expression and only the head says otherwise.
-//   - a (quasiquote ...) template, which is data too, with the standard
-//     exception: an (unquote ...) or (unquote-splicing ...) subtree at the
-//     template own level is evaluated where it stands, so those subtrees are
-//     walked and the rest of the template is not.
+//   - a (quasiquote ...) template, which is data except for its unquote and
+//     unquote-splicing operands. ELPS finds these even under nested quotes or
+//     quasiquotes; see findAndUnquote in lisp/macro.go.
+//
+// The canonical lisp:quote and lisp:quasiquote spellings have the same effect.
 func walkEvaluated(node *lisp.LVal, fn func(sexpr *lisp.LVal) bool) {
 	if node == nil || node.IsQuoted() {
 		return
 	}
 	if node.Type == lisp.LSExpr && len(node.Cells) > 0 {
 		switch HeadSymbol(node) {
-		case "quote":
+		case "quote", "lisp:quote":
 			return
-		case "quasiquote":
+		case "quasiquote", "lisp:quasiquote":
 			for _, cell := range node.Cells[1:] {
-				walkTemplate(cell, 1, fn)
+				walkTemplate(cell, fn)
 			}
 			return
 		}
@@ -2126,36 +2127,24 @@ func walkEvaluated(node *lisp.LVal, fn func(sexpr *lisp.LVal) bool) {
 // walkTemplate walks the inside of a quasiquote template looking only for the
 // subtrees that escape it, and hands each of those back to walkEvaluated.
 //
-// level counts the templates in force. A nested quasiquote raises it and an
-// unquote lowers it, so an unquote only escapes to running code at level 1:
-// two quasiquotes deep, one unquote still leaves the form inside the inner
-// template. Nothing else about the template matters here -- a quote form or a
-// reader-quoted list within it is still just data that may hold an unquote,
-// so the walk descends through both rather than stopping at them.
-func walkTemplate(node *lisp.LVal, level int, fn func(sexpr *lisp.LVal) bool) {
+// Match findAndUnquote: nested quasiquotes, quote forms and reader quotes
+// do not hide unquote operands. Only the bare unquote/unquote-splicing markers
+// are recognized by getUnquoteType; lisp:unquote is ordinary template data.
+func walkTemplate(node *lisp.LVal, fn func(sexpr *lisp.LVal) bool) {
 	if node == nil {
 		return
 	}
 	if node.Type == lisp.LSExpr && len(node.Cells) > 0 {
 		switch HeadSymbol(node) {
-		case "quasiquote":
-			for _, cell := range node.Cells[1:] {
-				walkTemplate(cell, level+1, fn)
-			}
-			return
 		case "unquote", "unquote-splicing":
 			for _, cell := range node.Cells[1:] {
-				if level <= 1 {
-					walkEvaluated(cell, fn)
-				} else {
-					walkTemplate(cell, level-1, fn)
-				}
+				walkEvaluated(cell, fn)
 			}
 			return
 		}
 	}
 	for _, cell := range node.Cells {
-		walkTemplate(cell, level, fn)
+		walkTemplate(cell, fn)
 	}
 }
 

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -1845,8 +1845,20 @@ func lambdaCallback(node *lisp.LVal) *callback {
 }
 
 // sameFileDefuns indexes the file's defuns, nested ones included, by name. A
-// duplicate name keeps the first definition, which is the one the
-// duplicate-definition check reports against.
+// duplicate name keeps the LAST definition, because that is the one the
+// interpreter runs: ELPS defun overwrites, so a second definition of a name
+// replaces the first and every later call reaches the second body.
+//
+// Keeping the first instead -- which is what the duplicate-definition check
+// reports against, a different question -- made a clean-first/dirty-second
+// duplicate a silent false negative, and a dirty-first/clean-second duplicate
+// a finding against a body no call reaches.
+//
+// Last in TRAVERSAL order, which for the top-level definitions this resolves
+// in practice is source order. A nested defun does not take effect until its
+// enclosing form runs, so the shape it wins against is one this ordering does
+// not model; that is the same syntactic approximation the rest of the check
+// makes.
 //
 // A defun spelled inside quoted data or a macro template is not indexed: it
 // defines nothing, so a symbol naming it resolves to no callback at all
@@ -1863,9 +1875,7 @@ func sameFileDefuns(exprs []*lisp.LVal) map[string]*lisp.LVal {
 		if name.Type != lisp.LSymbol {
 			return
 		}
-		if _, ok := defs[name.Str]; !ok {
-			defs[name.Str] = sexpr
-		}
+		defs[name.Str] = sexpr
 	})
 	return defs
 }

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -1602,10 +1602,16 @@ var AnalyzerComparatorMutation = &Analyzer{
 		"symbol naming a defun in the same file. The symbol hop is ONE level deep -- " +
 		"the named defun's own body is scanned, but a call it makes to a third " +
 		"function is not followed, so a comparator that mutates two hops away is not " +
-		"reported. Quoted subtrees are data and are skipped whole.",
+		"reported.\n\n" +
+		"Data is skipped whole, in all three spellings: a reader-quoted form, an " +
+		"explicit (quote ...) form, and a quasiquote template -- except for the " +
+		"(unquote ...) and (unquote-splicing ...) subtrees inside a template, which " +
+		"are evaluated where they stand and so are still checked. That applies to the " +
+		"sort form itself as much as to its predicate's body, and a defun written " +
+		"inside data defines nothing, so a symbol naming one resolves to no callback.",
 	Run: func(pass *Pass) error {
 		run := newMutationRun(pass)
-		WalkSExprs(pass.Exprs, func(sexpr *lisp.LVal, _ int) {
+		walkEvaluatedSExprs(pass.Exprs, func(sexpr *lisp.LVal) {
 			form := HeadSymbol(sexpr)
 			idx, ok := comparatorPredicateArg[form]
 			if !ok || idx >= len(sexpr.Cells) {
@@ -1731,10 +1737,14 @@ var AnalyzerIterationMutation = &Analyzer{
 		"Known blind spots: the check is syntactic and keeps no scope of its own, so a " +
 		"callback parameter that an inner let rebinds is still treated as the element; " +
 		"a collection passed as an expression rather than a symbol is invisible; and " +
-		"zip is not covered because it takes no callback at all.",
+		"zip is not covered because it takes no callback at all.\n\n" +
+		"Data is skipped whole, in all three spellings: a reader-quoted form, an " +
+		"explicit (quote ...) form, and a quasiquote template -- except for the " +
+		"(unquote ...) and (unquote-splicing ...) subtrees inside a template, which " +
+		"are evaluated where they stand and so are still checked.",
 	Run: func(pass *Pass) error {
 		run := newMutationRun(pass)
-		WalkSExprs(pass.Exprs, func(sexpr *lisp.LVal, _ int) {
+		walkEvaluatedSExprs(pass.Exprs, func(sexpr *lisp.LVal) {
 			form := HeadSymbol(sexpr)
 			spec, ok := iterationForms[form]
 			if !ok || spec.callback >= len(sexpr.Cells) {
@@ -1862,9 +1872,13 @@ func lambdaCallback(node *lisp.LVal) *callback {
 // sameFileDefuns indexes the file's defuns, nested ones included, by name. A
 // duplicate name keeps the first definition, which is the one the
 // duplicate-definition check reports against.
+//
+// A defun spelled inside quoted data or a macro template is not indexed: it
+// defines nothing, so a symbol naming it resolves to no callback at all
+// rather than to a body whose mutations get attributed to a live sort.
 func sameFileDefuns(exprs []*lisp.LVal) map[string]*lisp.LVal {
 	defs := make(map[string]*lisp.LVal)
-	WalkSExprs(exprs, func(sexpr *lisp.LVal, _ int) {
+	walkEvaluatedSExprs(exprs, func(sexpr *lisp.LVal) {
 		// A malformed defun with no formals list is skipped outright, so
 		// resolveCallback can index Cells[2] and Cells[3:] unconditionally.
 		if HeadSymbol(sexpr) != "defun" || len(sexpr.Cells) < 3 {
@@ -2035,30 +2049,112 @@ func (r *mutationRun) mutationSites(cb *callback) []*lisp.LVal {
 	return sites
 }
 
-// collectMutationSites appends to sites every unquoted call to a mutating
-// builtin at or below node, skipping a quoted subtree whole rather than
-// descending into it: '(assoc! m k v) is data the program never calls, and
-// its elements do not individually carry the quote flag.
+// collectMutationSites appends to sites every call to a mutating builtin at
+// or below node that the program actually evaluates. Quoted data is skipped
+// by walkEvaluated, so the three data spellings its comment lists are lists
+// rather than calls.
 //
 // A nested lambda is not walked here. It is handed back to mutationSites,
 // which caches it under its own node -- that is what keeps a body reached
 // through two routes from being scanned twice.
 func (r *mutationRun) collectMutationSites(node *lisp.LVal, sites []*lisp.LVal) []*lisp.LVal {
+	walkEvaluated(node, func(sexpr *lisp.LVal) bool {
+		if inner := lambdaCallback(sexpr); inner != nil {
+			sites = append(sites, r.mutationSites(inner)...)
+			return false
+		}
+		if _, ok := mutatingBuiltins[HeadSymbol(sexpr)]; ok {
+			sites = append(sites, sexpr)
+		}
+		return true
+	})
+	return sites
+}
+
+// walkEvaluatedSExprs calls fn for every s-expression in exprs that the
+// program evaluates, skipping the ones that are data.
+func walkEvaluatedSExprs(exprs []*lisp.LVal, fn func(sexpr *lisp.LVal)) {
+	for _, expr := range exprs {
+		walkEvaluated(expr, func(sexpr *lisp.LVal) bool {
+			fn(sexpr)
+			return true
+		})
+	}
+}
+
+// walkEvaluated calls fn for every s-expression at or below node that the
+// program evaluates, descending into a node's children only when fn returns
+// true for it.
+//
+// Three spellings put a form beyond evaluation, and honouring only the first
+// of them was what left ONE of them clean and reported the other two:
+//
+//   - the reader's quote flag, which a leading apostrophe sets on the node
+//     itself. The elements of a quoted list do not each carry it, so the
+//     subtree is skipped whole.
+//   - a (quote ...) FORM, which the reader leaves entirely unflagged -- the
+//     operand is an ordinary s-expression and only the head says otherwise.
+//   - a (quasiquote ...) template, which is data too, with the standard
+//     exception: an (unquote ...) or (unquote-splicing ...) subtree at the
+//     template own level is evaluated where it stands, so those subtrees are
+//     walked and the rest of the template is not.
+func walkEvaluated(node *lisp.LVal, fn func(sexpr *lisp.LVal) bool) {
 	if node == nil || node.IsQuoted() {
-		return sites
+		return
 	}
 	if node.Type == lisp.LSExpr && len(node.Cells) > 0 {
-		if inner := lambdaCallback(node); inner != nil {
-			return append(sites, r.mutationSites(inner)...)
+		switch HeadSymbol(node) {
+		case "quote":
+			return
+		case "quasiquote":
+			for _, cell := range node.Cells[1:] {
+				walkTemplate(cell, 1, fn)
+			}
+			return
 		}
-		if _, ok := mutatingBuiltins[HeadSymbol(node)]; ok {
-			sites = append(sites, node)
+		if !fn(node) {
+			return
 		}
 	}
 	for _, cell := range node.Cells {
-		sites = r.collectMutationSites(cell, sites)
+		walkEvaluated(cell, fn)
 	}
-	return sites
+}
+
+// walkTemplate walks the inside of a quasiquote template looking only for the
+// subtrees that escape it, and hands each of those back to walkEvaluated.
+//
+// level counts the templates in force. A nested quasiquote raises it and an
+// unquote lowers it, so an unquote only escapes to running code at level 1:
+// two quasiquotes deep, one unquote still leaves the form inside the inner
+// template. Nothing else about the template matters here -- a quote form or a
+// reader-quoted list within it is still just data that may hold an unquote,
+// so the walk descends through both rather than stopping at them.
+func walkTemplate(node *lisp.LVal, level int, fn func(sexpr *lisp.LVal) bool) {
+	if node == nil {
+		return
+	}
+	if node.Type == lisp.LSExpr && len(node.Cells) > 0 {
+		switch HeadSymbol(node) {
+		case "quasiquote":
+			for _, cell := range node.Cells[1:] {
+				walkTemplate(cell, level+1, fn)
+			}
+			return
+		case "unquote", "unquote-splicing":
+			for _, cell := range node.Cells[1:] {
+				if level <= 1 {
+					walkEvaluated(cell, fn)
+				} else {
+					walkTemplate(cell, level-1, fn)
+				}
+			}
+			return
+		}
+	}
+	for _, cell := range node.Cells {
+		walkTemplate(cell, level, fn)
+	}
 }
 
 // AnalyzerNames returns a sorted list of all default analyzer names.

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -1639,10 +1639,174 @@ var AnalyzerComparatorMutation = &Analyzer{
 	},
 }
 
+// iterationForm locates the callback and the collection arguments of a
+// higher-order builtin. Indices are into the s-expression's Cells, so 1 is
+// the first argument.
+type iterationForm struct {
+	// collections holds the indices of the arguments that are iterated.
+	collections []int
+	// callback is the index of the user function applied to the elements.
+	callback int
+	// accumulator is the position, among the callback's own parameters, of
+	// the value the form threads rather than an element of the collection.
+	// -1 for a form that threads nothing.
+	accumulator int
+}
+
+// iterationForms is read off the builtins in lisp/builtins.go, not guessed --
+// the callback is first in some of these and second in others, and one
+// argument that looks like a collection is not one:
+//
+//	(map    type-specifier fn        seq)  ; builtinMap: exactly one seq
+//	(foldl  fn             z         seq)  ; builtinFoldLeft:  z is the accumulator
+//	(foldr  fn             z         seq)  ; builtinFoldRight: z is the accumulator
+//	(select type-specifier predicate seq)  ; builtinSelect
+//	(reject type-specifier predicate seq)  ; builtinReject
+//	(all?   predicate      seq)            ; builtinAllP
+//	(any?   predicate      seq)            ; builtinAnyP
+//
+// The fold accumulator is deliberately NOT a collection, and it is not an
+// element either: the standard idiom
+// (foldl (lambda (acc x) (assoc! acc k v)) (sorted-map) xs) mutates a map the
+// fold itself threads, which is correct code. Which PARAMETER holds it
+// differs between the two folds -- builtinFoldLeft calls (fn acc elem) and
+// builtinFoldRight calls (fn elem acc) -- so each names its own position.
+//
+// `zip` is absent on purpose. It does read several collections --
+// (zip type-specifier list &rest lists) -- but builtinZip takes NO user
+// callback, so there is no callback body for this check to look inside.
+var iterationForms = map[string]iterationForm{
+	"map":    {callback: 2, collections: []int{3}, accumulator: -1},
+	"foldl":  {callback: 1, collections: []int{3}, accumulator: 0},
+	"foldr":  {callback: 1, collections: []int{3}, accumulator: 1},
+	"select": {callback: 2, collections: []int{3}, accumulator: -1},
+	"reject": {callback: 2, collections: []int{3}, accumulator: -1},
+	"all?":   {callback: 1, collections: []int{2}, accumulator: -1},
+	"any?":   {callback: 1, collections: []int{2}, accumulator: -1},
+}
+
+// iterationMutatingTargets is mutatingBuiltins MINUS set!, and the omission is
+// the point rather than an oversight.
+//
+// set! rebinds a NAME; it does not write through the value the name held. A
+// callback's (set! x 1) gives the local parameter a new value and leaves the
+// element the traversal handed it untouched, and a (set! xs ...) rebinds the
+// caller's variable while the builtin goes on walking the sequence it was
+// already given. Neither changes anything underneath the traversal, so
+// reporting either would be a false positive -- the comparator check still
+// counts set!, because there ANY side effect is a finding whatever it writes
+// to.
+//
+// It is derived rather than spelled out a second time so the target index of
+// each builtin -- the reason stable-sort's is 2 -- has one definition.
+var iterationMutatingTargets = func() map[string]int {
+	targets := make(map[string]int, len(mutatingBuiltins))
+	for name, target := range mutatingBuiltins {
+		if name == "set!" {
+			continue
+		}
+		targets[name] = target
+	}
+	return targets
+}()
+
+// AnalyzerIterationMutation reports a callback that mutates the very
+// collection it is iterating, or an element that collection handed it.
+var AnalyzerIterationMutation = &Analyzer{
+	Name:     "iteration-mutation",
+	Severity: SeverityWarning,
+	Doc: "Report a callback that mutates the collection a higher-order builtin is iterating.\n\n" +
+		"Covers map, foldl, foldr, select, reject, all? and any?. A mutating call " +
+		"(assoc!, dissoc!, append!, append-bytes! or stable-sort) is reported when " +
+		"the value it writes through is the collection argument itself -- which " +
+		"must be a plain symbol for the check to see it -- or one of the callback's " +
+		"own parameters, which holds an element of that collection.\n\n" +
+		"set! is NOT on that list, unlike in comparator-mutation: it rebinds a name " +
+		"rather than writing through the value the name held, so a callback's " +
+		"(set! x 1) leaves the element alone and a (set! xs ...) leaves the sequence " +
+		"the builtin is already walking alone.\n\n" +
+		"A fold's accumulator is neither: not the collection, and not an element, " +
+		"even though the callback receives it as a parameter -- so the usual " +
+		"(foldl (lambda (acc x) (assoc! acc k v)) (sorted-map) xs) idiom is clean, and " +
+		"so is a mutation of any unrelated binding. Both an inline lambda and a plain " +
+		"symbol naming a same-file defun are followed, one hop deep.\n\n" +
+		"Known blind spots: the check is syntactic and keeps no scope of its own, so a " +
+		"callback parameter that an inner let rebinds is still treated as the element; " +
+		"a collection passed as an expression rather than a symbol is invisible; and " +
+		"zip is not covered because it takes no callback at all.",
+	Run: func(pass *Pass) error {
+		defuns := sameFileDefuns(pass.Exprs)
+		WalkSExprs(pass.Exprs, func(sexpr *lisp.LVal, _ int) {
+			form := HeadSymbol(sexpr)
+			spec, ok := iterationForms[form]
+			if !ok || spec.callback >= len(sexpr.Cells) {
+				return
+			}
+			cb := resolveCallback(sexpr.Cells[spec.callback], defuns)
+			if cb == nil {
+				return
+			}
+			collections := make(map[string]bool)
+			for _, idx := range spec.collections {
+				if idx < len(sexpr.Cells) && sexpr.Cells[idx].Type == lisp.LSymbol {
+					collections[sexpr.Cells[idx].Str] = true
+				}
+			}
+			// Everything the callback is handed EXCEPT a threaded
+			// accumulator holds an element of the collection.
+			elements := make(map[string]bool, len(cb.params))
+			for i, name := range cb.params {
+				if i == spec.accumulator {
+					continue
+				}
+				elements[name] = true
+			}
+			for _, node := range cb.body {
+				walkUnquotedSExprs(node, func(call *lisp.LVal) {
+					name := HeadSymbol(call)
+					target, ok := iterationMutatingTargets[name]
+					if !ok || target >= len(call.Cells) {
+						return
+					}
+					arg := call.Cells[target]
+					if arg.Type != lisp.LSymbol {
+						return
+					}
+					var msg string
+					switch {
+					case collections[arg.Str]:
+						msg = fmt.Sprintf("%s mutates %s while %s iterates over it",
+							name, arg.Str, form)
+					case elements[arg.Str]:
+						msg = fmt.Sprintf("%s mutates the element %s of %s",
+							name, arg.Str, form)
+					default:
+						return
+					}
+					src := SourceOf(call)
+					pass.Report(Diagnostic{
+						Message: msg,
+						Pos:     posFromSource(astutil.SourceLoc(src)),
+						EndPos:  endPosFromNode(src),
+						Notes: []string{
+							"iterate a copy (copy or concat) or build a new collection and return it, rather than writing through the one being traversed",
+						},
+					})
+				})
+			}
+		})
+		return nil
+	},
+}
+
 // callback is a function argument a higher-order form was handed: the names
-// it binds its parameters to, and the body forms that run.
+// it binds its parameters to, in order, and the body forms that run.
+//
+// The order matters: a fold hands one parameter the accumulator it threads
+// rather than an element of the collection, and which one differs between
+// foldl and foldr.
 type callback struct {
-	params map[string]bool
+	params []string
 	body   []*lisp.LVal
 }
 
@@ -1698,11 +1862,30 @@ func sameFileDefuns(exprs []*lisp.LVal) map[string]*lisp.LVal {
 	return defs
 }
 
-// formalNames collects the parameter names of a formals list, dropping the
-// &rest, &optional and &key markers.
-func formalNames(formals *lisp.LVal) map[string]bool {
-	names := make(map[string]bool)
-	CollectFormals(formals, names)
+// formalNames collects the parameter names of a formals list in order,
+// dropping the &rest, &optional and &key markers.
+//
+// It keeps the order that lint.CollectFormals discards, because a caller has
+// to be able to say which POSITION a parameter occupies. Dropping the markers
+// does shift the positions of what follows them, so a fold whose callback
+// declares &optional or &rest parameters before its accumulator is read
+// wrongly -- a shape neither fold can actually call.
+func formalNames(formals *lisp.LVal) []string {
+	if formals == nil || formals.Type != lisp.LSExpr {
+		return nil
+	}
+	var names []string
+	for _, sym := range formals.Cells {
+		if sym.Type != lisp.LSymbol {
+			continue
+		}
+		switch sym.Str {
+		case "&rest", "&optional", "&key":
+			// markers, not parameters
+		default:
+			names = append(names, sym.Str)
+		}
+	}
 	return names
 }
 

--- a/lint/analyzers.go
+++ b/lint/analyzers.go
@@ -1585,17 +1585,17 @@ var comparatorPredicateArg = map[string]int{
 // AnalyzerComparatorMutation reports a call to a mutating builtin inside a
 // sort comparator.
 //
-// A comparator is called an unspecified number of times, in an unspecified
-// order, on elements the caller still owns, so ANY side effect inside one is
-// nondeterministic -- the target of the mutation does not matter and the
-// check does not look at it.
+// A comparator is called an unspecified number of times and in an unspecified
+// order. This conservative policy rejects every mutating builtin, including
+// writes to callback-local scratch values; it does not prove impurity.
 var AnalyzerComparatorMutation = &Analyzer{
 	Name:     "comparator-mutation",
 	Severity: SeverityError,
 	Doc: "Report a mutating call inside a stable-sort or insert-sorted predicate.\n\n" +
 		"A comparator runs an unspecified number of times in an unspecified order, " +
-		"and it is handed the list's own elements, so any side effect inside one is " +
-		"nondeterministic. Every mutating builtin is reported whatever it writes to: " +
+		"so writes to shared state or input elements are unsafe. This conservative " +
+		"check also reports writes to callback-local scratch values. Every mutating " +
+		"builtin is reported whatever it writes to: " +
 		"assoc!, dissoc!, append!, append-bytes!, set! and stable-sort itself, which " +
 		"sorts in place despite carrying no `!`.\n\n" +
 		"Two spellings of the predicate are followed: an inline lambda, and a plain " +
@@ -1617,28 +1617,13 @@ var AnalyzerComparatorMutation = &Analyzer{
 			if !ok || idx >= len(sexpr.Cells) {
 				return
 			}
-			cb := resolveCallback(sexpr.Cells[idx], run.defuns)
+			cb := run.resolveCallback(sexpr.Cells[idx])
 			if cb == nil {
 				return
 			}
-			if !run.enterScope(mutationScopeKey{form: form, node: cb.node}) {
-				return
-			}
-			for _, call := range run.mutationSites(cb) {
-				name := HeadSymbol(call)
-				src := SourceOf(call)
-				run.report(Diagnostic{
-					Message: fmt.Sprintf(
-						"%s predicate mutates state: %s is called inside a comparator",
-						form, name),
-					Pos:    posFromSource(astutil.SourceLoc(src)),
-					EndPos: endPosFromNode(src),
-					Notes: []string{
-						"a comparator runs an unspecified number of times in an unspecified order, and it receives the list's own elements, so any side effect in it is nondeterministic",
-					},
-				})
-			}
+			run.query(mutationQuery{form: form}, cb.sites)
 		})
+		run.reportQueries()
 		return nil
 	},
 }
@@ -1750,68 +1735,22 @@ var AnalyzerIterationMutation = &Analyzer{
 			if !ok || spec.callback >= len(sexpr.Cells) {
 				return
 			}
-			cb := resolveCallback(sexpr.Cells[spec.callback], run.defuns)
+			cb := run.resolveCallback(sexpr.Cells[spec.callback])
 			if cb == nil {
 				return
 			}
 			collections := make(map[string]bool)
-			var names []string
 			for _, idx := range spec.collections {
 				if idx < len(sexpr.Cells) && sexpr.Cells[idx].Type == lisp.LSymbol {
-					collections[sexpr.Cells[idx].Str] = true
-					names = append(names, sexpr.Cells[idx].Str)
+					name := sexpr.Cells[idx].Str
+					collections[name] = true
+					run.query(mutationQuery{form: form, target: name}, cb.sites)
 				}
 			}
-			sort.Strings(names)
-			key := mutationScopeKey{
-				form:        form,
-				node:        cb.node,
-				collections: strings.Join(names, " "),
-			}
-			if !run.enterScope(key) {
-				return
-			}
-			// Everything the callback is handed EXCEPT a threaded
-			// accumulator holds an element of the collection.
-			elements := make(map[string]bool, len(cb.params))
-			for i, name := range cb.params {
-				if i == spec.accumulator {
-					continue
-				}
-				elements[name] = true
-			}
-			for _, call := range run.mutationSites(cb) {
-				name := HeadSymbol(call)
-				target, ok := iterationMutatingTargets[name]
-				if !ok || target >= len(call.Cells) {
-					continue
-				}
-				arg := call.Cells[target]
-				if arg.Type != lisp.LSymbol {
-					continue
-				}
-				var msg string
-				switch {
-				case collections[arg.Str]:
-					msg = fmt.Sprintf("%s mutates %s while %s iterates over it",
-						name, arg.Str, form)
-				case elements[arg.Str]:
-					msg = fmt.Sprintf("%s mutates the element %s of %s",
-						name, arg.Str, form)
-				default:
-					continue
-				}
-				src := SourceOf(call)
-				run.report(Diagnostic{
-					Message: msg,
-					Pos:     posFromSource(astutil.SourceLoc(src)),
-					EndPos:  endPosFromNode(src),
-					Notes: []string{
-						"iterate a copy (copy or concat) or build a new collection and return it, rather than writing through the one being traversed",
-					},
-				})
-			}
+			run.iterationScope(form, cb, collections)
 		})
+		run.elementQueries()
+		run.reportQueries()
 		return nil
 	},
 }
@@ -1823,12 +1762,12 @@ var AnalyzerIterationMutation = &Analyzer{
 // rather than an element of the collection, and which one differs between
 // foldl and foldr.
 type callback struct {
-	// node is the lambda or defun the body was read off. It is the memo key
-	// mutationRun uses, so the 300 references that name one defun share a
-	// single scan of it.
+	// node is the lambda or defun the body was read off.
 	node   *lisp.LVal
 	params []string
 	body   []*lisp.LVal
+	// sites indexes a shared DFS array, not a copy of descendant sites.
+	sites mutationSpan
 }
 
 // resolveCallback returns the parameters and body of a function argument.
@@ -1841,20 +1780,18 @@ type callback struct {
 //
 // Anything else -- a builtin such as `<`, a symbol defined in another file, a
 // call returning a function -- yields nil, and the caller reports nothing.
-func resolveCallback(node *lisp.LVal, defuns map[string]*lisp.LVal) *callback {
+func (r *mutationRun) resolveCallback(node *lisp.LVal) *callback {
 	if node == nil {
 		return nil
 	}
 	if node.Type == lisp.LSymbol {
-		def := defuns[node.Str]
-		if def == nil {
-			return nil
-		}
-		// (defun name (formals) body...) -- sameFileDefuns guarantees the
-		// formals cell exists.
-		return &callback{node: def, params: formalNames(def.Cells[2]), body: def.Cells[3:]}
+		node = r.defuns[node.Str]
 	}
-	return lambdaCallback(node)
+	if node == nil {
+		return nil
+	}
+	r.index()
+	return r.callbacks[node]
 }
 
 // lambdaCallback reads (lambda (formals) body...) off node, or returns nil
@@ -1929,89 +1866,200 @@ type mutationDiagKey struct {
 	msg string
 }
 
-// mutationScopeKey identifies everything a reference to a callback can
-// contribute: the form that names it, the body it names, and -- for the
-// iteration check, whose message depends on which collection is being walked
-// -- the collection names read off that call site. Two references agreeing
-// on all three produce character-for-character the same diagnostics, so the
-// second one has no work to do.
-type mutationScopeKey struct {
-	form        string
-	node        *lisp.LVal
-	collections string
+// mutationSpan is a half-open range in mutationRun.sites. Every callback
+// body is contiguous in DFS order, including its nested callback bodies.
+// Keeping just the range avoids copying descendants once per ancestor.
+type mutationSpan struct {
+	start, end int
 }
 
-// mutationRun is the state comparator-mutation and iteration-mutation each
-// build once per pass. It exists to keep both checks LINEAR in the size of
-// the file, which the first cut of them was not.
-//
-// The shape that broke them is ordinary: one helper defun that mutates,
-// named as the callback of many traversals. Resolving the callback at every
-// reference and rescanning the named body there made the work -- and the
-// output -- the product of the two counts. A 24.7 KB file of that shape
-// produced roughly 360,000 diagnostics, every one of them a duplicate of one
-// of the ~400 real findings, and allocated about 713 MB doing it. Nested
-// lambdas compounded it from the other side: an inner body was rewalked once
-// per enclosing form.
-//
-// Three pieces fix it, and each covers something the others do not.
-//
-//   - sites memoizes the scan of a callback body on the node the body hangs
-//     off, so a body is walked exactly ONCE per pass however many routes
-//     reach it -- 300 references to one defun, and an inner lambda that is
-//     both nested inside an outer callback and handed to a traversal of its
-//     own.
-//   - scopes skips a reference whose (form, callback, collections) triple has
-//     already been examined, because those three fix the diagnostics word for
-//     word. Without it the memo is consulted 300 times and 300 sets of
-//     identical messages are formatted for the dedup to discard, which is
-//     where most of the allocation went.
-//   - reported deduplicates the OUTPUT by position and message. The two memos
-//     alone do not: a body reached from genuinely different scopes -- five
-//     comparators nested one inside the next -- reports its inner sites once
-//     per enclosing form. Position and message together are the right key
-//     rather than position alone, because the message names the form: one
-//     predicate used by both stable-sort and insert-sorted is genuinely two
-//     findings at one position, and each wants saying once.
-//
-// Pass offers none of the three: Report appends unconditionally (a check that
-// reports each node once has no use for a memo), so the state lives here,
-// scoped to the run, rather than being pushed into every analyzer's way.
+// An empty target denotes a comparator query (every mutator). Iteration
+// queries select only calls writing through target; element distinguishes
+// the two diagnostic messages possible at the same site.
+type mutationQuery struct {
+	form, target string
+	element      bool
+}
+
+type iterationScopeKey struct {
+	callback *callback
+	form     string
+}
+
+// mutationRun builds one site array and an index by mutation target. A
+// callback contributes ranges to queries rather than walking its sites.
+// Merging overlapping ranges before reporting bounds work by input size
+// (plus sorting and actual findings), even for deeply nested callbacks or
+// one large callback used with many distinct collections. No diagnostic is
+// formatted merely to discard it because another scope already covered it.
 type mutationRun struct {
-	pass   *Pass
-	defuns map[string]*lisp.LVal
-	// sites memoizes mutationSites, keyed by callback.node.
-	sites map[*lisp.LVal][]*lisp.LVal
-	// reported is the set of diagnostics already emitted this pass.
+	pass      *Pass
+	defuns    map[string]*lisp.LVal
+	callbacks map[*lisp.LVal]*callback
+	sites     []*lisp.LVal
+	targets   map[string][]int
+	queries   map[mutationQuery][]mutationSpan
+	// scopes records collection names common to EVERY use of a callback
+	// with this form. Only those names always override element findings.
+	scopes   map[iterationScopeKey]map[string]bool
 	reported map[mutationDiagKey]bool
-	// scopes is the set of (form, callback, collections) triples already
-	// examined this pass.
-	scopes map[mutationScopeKey]bool
 }
 
 func newMutationRun(pass *Pass) *mutationRun {
 	return &mutationRun{
 		pass:     pass,
 		defuns:   sameFileDefuns(pass.Exprs),
-		sites:    make(map[*lisp.LVal][]*lisp.LVal),
+		queries:  make(map[mutationQuery][]mutationSpan),
+		scopes:   make(map[iterationScopeKey]map[string]bool),
 		reported: make(map[mutationDiagKey]bool),
-		scopes:   make(map[mutationScopeKey]bool),
 	}
 }
 
-// enterScope reports whether key is being examined for the first time this
-// pass, recording it either way.
-//
-// The report dedup below is what makes the OUTPUT right; this is what makes
-// the WORK proportional to the file. Without it the 300 references to a
-// 400-mutation defun still each formatted 400 messages for report to throw
-// away, which is most of the allocation the explosion cost.
-func (r *mutationRun) enterScope(key mutationScopeKey) bool {
-	if r.scopes[key] {
-		return false
+// index is lazy: files with no resolvable callback need no site index.
+func (r *mutationRun) index() {
+	if r.callbacks != nil {
+		return
 	}
-	r.scopes[key] = true
-	return true
+	r.callbacks = make(map[*lisp.LVal]*callback)
+	r.targets = make(map[string][]int)
+	for _, expr := range r.pass.Exprs {
+		r.indexNode(expr)
+	}
+}
+
+func (r *mutationRun) indexNode(node *lisp.LVal) {
+	walkEvaluated(node, func(sexpr *lisp.LVal) bool {
+		cb := lambdaCallback(sexpr)
+		if cb == nil && HeadSymbol(sexpr) == "defun" && len(sexpr.Cells) >= 3 {
+			cb = &callback{node: sexpr, params: formalNames(sexpr.Cells[2]), body: sexpr.Cells[3:]}
+		}
+		if cb != nil {
+			r.callbacks[sexpr] = cb
+			cb.sites.start = len(r.sites)
+			for _, body := range cb.body {
+				r.indexNode(body)
+			}
+			cb.sites.end = len(r.sites)
+			return false
+		}
+		name := HeadSymbol(sexpr)
+		if _, ok := mutatingBuiltins[name]; ok {
+			index := len(r.sites)
+			r.sites = append(r.sites, sexpr)
+			if target, ok := iterationMutatingTargets[name]; ok && target < len(sexpr.Cells) {
+				if arg := sexpr.Cells[target]; arg.Type == lisp.LSymbol {
+					r.targets[arg.Str] = append(r.targets[arg.Str], index)
+				}
+			}
+		}
+		return true
+	})
+}
+
+func (r *mutationRun) query(key mutationQuery, span mutationSpan) {
+	if span.start < span.end {
+		r.queries[key] = append(r.queries[key], span)
+	}
+}
+
+func (r *mutationRun) iterationScope(form string, cb *callback, collections map[string]bool) {
+	key := iterationScopeKey{callback: cb, form: form}
+	common, exists := r.scopes[key]
+	if !exists {
+		r.scopes[key] = collections
+		return
+	}
+	for name := range common {
+		if !collections[name] {
+			delete(common, name)
+		}
+	}
+}
+
+func (r *mutationRun) elementQueries() {
+	for scope, collections := range r.scopes {
+		for i, name := range scope.callback.params {
+			if i != iterationForms[scope.form].accumulator && !collections[name] {
+				r.query(mutationQuery{form: scope.form, target: name, element: true}, scope.callback.sites)
+			}
+		}
+	}
+}
+
+// visitMutationSpans visits each site in the union exactly once. Sorting
+// works for references in any source order, including named callbacks whose
+// definitions are in the opposite order. Adjacent half-open spans merge too.
+func visitMutationSpans(spans []mutationSpan, visit func(mutationSpan)) {
+	sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
+	for i := 0; i < len(spans); {
+		span := spans[i]
+		i++
+		for i < len(spans) && spans[i].start <= span.end {
+			span.end = max(span.end, spans[i].end)
+			i++
+		}
+		visit(span)
+	}
+}
+
+func (r *mutationRun) reportQueries() {
+	// Query maps group identical work, but must not choose diagnostic order.
+	// Linter's final source sort leaves same-line ties in reporting order.
+	keys := make([]mutationQuery, 0, len(r.queries))
+	for key := range r.queries {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].form != keys[j].form {
+			return keys[i].form < keys[j].form
+		}
+		if keys[i].target != keys[j].target {
+			return keys[i].target < keys[j].target
+		}
+		return !keys[i].element && keys[j].element
+	})
+	for _, query := range keys {
+		visitMutationSpans(r.queries[query], func(span mutationSpan) {
+			if query.target == "" {
+				for _, call := range r.sites[span.start:span.end] {
+					r.reportSite(query, call)
+				}
+				return
+			}
+			sites := r.targets[query.target]
+			first := sort.SearchInts(sites, span.start)
+			for _, index := range sites[first:] {
+				if index >= span.end {
+					break
+				}
+				r.reportSite(query, r.sites[index])
+			}
+		})
+	}
+}
+
+func (r *mutationRun) reportSite(query mutationQuery, call *lisp.LVal) {
+	name := HeadSymbol(call)
+	var msg, note string
+	switch {
+	case query.target == "":
+		msg = fmt.Sprintf("%s predicate mutates state: %s is called inside a comparator", query.form, name)
+		note = "comparators run in unspecified order and may receive the list's own elements; this conservative check also reports writes to callback-local scratch values"
+	case query.element:
+		msg = fmt.Sprintf("%s mutates the element %s of %s", name, query.target, query.form)
+	default:
+		msg = fmt.Sprintf("%s mutates %s while %s iterates over it", name, query.target, query.form)
+	}
+	if note == "" {
+		note = "iterate a copy (copy or concat) or build a new collection and return it, rather than writing through the one being traversed"
+	}
+	src := SourceOf(call)
+	r.report(Diagnostic{
+		Message: msg,
+		Pos:     posFromSource(astutil.SourceLoc(src)),
+		EndPos:  endPosFromNode(src),
+		Notes:   []string{note},
+	})
 }
 
 // report emits d unless a diagnostic with the same position and message has
@@ -2023,52 +2071,6 @@ func (r *mutationRun) report(d Diagnostic) {
 	}
 	r.reported[key] = true
 	r.pass.Report(d)
-}
-
-// mutationSites returns every call to a mutating builtin that runs when cb
-// runs: the ones written directly in its body, plus those in the bodies of
-// the lambdas nested inside it, which run when the enclosing callback calls
-// them.
-//
-// The result is memoized on cb.node, and a nested lambda is scanned through
-// mutationSites rather than inline, so every body in the file is walked once
-// per pass no matter how many callers or enclosing forms reach it.
-func (r *mutationRun) mutationSites(cb *callback) []*lisp.LVal {
-	if sites, ok := r.sites[cb.node]; ok {
-		return sites
-	}
-	// Seed the memo before recursing. The parser yields a tree, so a body
-	// cannot contain itself, but a cycle would otherwise recurse forever
-	// rather than terminate with an empty answer.
-	r.sites[cb.node] = nil
-	var sites []*lisp.LVal
-	for _, node := range cb.body {
-		sites = r.collectMutationSites(node, sites)
-	}
-	r.sites[cb.node] = sites
-	return sites
-}
-
-// collectMutationSites appends to sites every call to a mutating builtin at
-// or below node that the program actually evaluates. Quoted data is skipped
-// by walkEvaluated, so the three data spellings its comment lists are lists
-// rather than calls.
-//
-// A nested lambda is not walked here. It is handed back to mutationSites,
-// which caches it under its own node -- that is what keeps a body reached
-// through two routes from being scanned twice.
-func (r *mutationRun) collectMutationSites(node *lisp.LVal, sites []*lisp.LVal) []*lisp.LVal {
-	walkEvaluated(node, func(sexpr *lisp.LVal) bool {
-		if inner := lambdaCallback(sexpr); inner != nil {
-			sites = append(sites, r.mutationSites(inner)...)
-			return false
-		}
-		if _, ok := mutatingBuiltins[HeadSymbol(sexpr)]; ok {
-			sites = append(sites, sexpr)
-		}
-		return true
-	})
-	return sites
 }
 
 // walkEvaluatedSExprs calls fn for every s-expression in exprs that the

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -826,6 +826,7 @@ func DefaultAnalyzers() []*Analyzer {
 		AnalyzerCondMissingElse,
 		AnalyzerRethrowContext,
 		AnalyzerComparatorMutation,
+		AnalyzerIterationMutation,
 		AnalyzerUnnecessaryProgn,
 		AnalyzerWithCleanupForms,
 		AnalyzerUndefinedSymbol,

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -825,6 +825,7 @@ func DefaultAnalyzers() []*Analyzer {
 		AnalyzerQuoteCall,
 		AnalyzerCondMissingElse,
 		AnalyzerRethrowContext,
+		AnalyzerComparatorMutation,
 		AnalyzerUnnecessaryProgn,
 		AnalyzerWithCleanupForms,
 		AnalyzerUndefinedSymbol,

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -902,6 +902,142 @@ func TestRethrowContext_Nolint(t *testing.T) {
 	assertNoDiags(t, diags)
 }
 
+// --- comparator-mutation ---
+
+func TestComparatorMutation_Positive_InlineLambda(t *testing.T) {
+	source := `(stable-sort (lambda (a b) (assoc! m 'k 1) (< a b)) xs)`
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	require.Len(t, diags, 1)
+	assert.Equal(t,
+		"stable-sort predicate mutates state: assoc! is called inside a comparator",
+		diags[0].Message)
+	assert.Equal(t, SeverityError, diags[0].Severity)
+	assertDiagOnLine(t, diags, 1, "assoc!")
+}
+
+// TestComparatorMutation_Positive_EveryMutatingBuiltin walks the whole
+// mutation vocabulary through the check, stable-sort included: it carries no
+// `!` but sorts in place, so a comparator that sorts is as nondeterministic
+// as one that assoc!s.
+func TestComparatorMutation_Positive_EveryMutatingBuiltin(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		call string
+	}{
+		{"assoc", "(assoc! m 'k 1)"},
+		{"dissoc", "(dissoc! m 'k)"},
+		{"append", "(append! acc a)"},
+		{"append-bytes", "(append-bytes! buf a)"},
+		{"set", "(set! seen true)"},
+		{"stable-sort", "(stable-sort < inner)"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			source := fmt.Sprintf("(stable-sort (lambda (a b) %s (< a b)) xs)", tt.call)
+			diags := lintCheck(t, AnalyzerComparatorMutation, source)
+			require.Len(t, diags, 1)
+			assert.Contains(t, diags[0].Message,
+				"stable-sort predicate mutates state:")
+			assert.Equal(t, SeverityError, diags[0].Severity)
+		})
+	}
+}
+
+// TestComparatorMutation_Positive_InsertSorted pins the predicate position:
+// insert-sorted takes it THIRD, after the type specifier and the list, so a
+// check that assumed stable-sort's layout would read the list instead.
+func TestComparatorMutation_Positive_InsertSorted(t *testing.T) {
+	source := `(insert-sorted 'list xs (lambda (a b) (append! log a) (< a b)) item)`
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	require.Len(t, diags, 1)
+	assert.Equal(t,
+		"insert-sorted predicate mutates state: append! is called inside a comparator",
+		diags[0].Message)
+}
+
+func TestComparatorMutation_Positive_NestedLambda(t *testing.T) {
+	source := "(stable-sort\n" +
+		"  (lambda (a b)\n" +
+		"    (map 'list (lambda (x) (assoc! m x 1)) '(1 2))\n" +
+		"    (< a b))\n" +
+		"  xs)"
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	require.Len(t, diags, 1)
+	assertDiagOnLine(t, diags, 3, "assoc! is called inside a comparator")
+}
+
+func TestComparatorMutation_Positive_SameFileDefun(t *testing.T) {
+	source := "(defun bad-less (a b)\n" +
+		"  (append! acc a)\n" +
+		"  (< a b))\n" +
+		"(stable-sort bad-less xs)"
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	require.Len(t, diags, 1)
+	assertDiagOnLine(t, diags, 2, "append! is called inside a comparator")
+}
+
+func TestComparatorMutation_Positive_HasNotes(t *testing.T) {
+	diags := lintCheck(t, AnalyzerComparatorMutation,
+		`(stable-sort (lambda (a b) (assoc! m 'k 1)) xs)`)
+	require.Len(t, diags, 1)
+	require.NotEmpty(t, diags[0].Notes)
+	assert.Contains(t, diags[0].Notes[0], "unspecified order")
+	assert.Contains(t, diags[0].Notes[0], "list's own elements")
+}
+
+func TestComparatorMutation_Negative_PurePredicate(t *testing.T) {
+	diags := lintCheck(t, AnalyzerComparatorMutation,
+		`(stable-sort (lambda (a b) (< a b)) xs)`)
+	assertNoDiags(t, diags)
+}
+
+func TestComparatorMutation_Negative_BuiltinPredicate(t *testing.T) {
+	diags := lintCheck(t, AnalyzerComparatorMutation, `(stable-sort < xs)`)
+	assertNoDiags(t, diags)
+}
+
+func TestComparatorMutation_Negative_LetWithoutMutation(t *testing.T) {
+	source := `(stable-sort (lambda (a b) (let ([x a] [y b]) (< x y))) xs)`
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	assertNoDiags(t, diags)
+}
+
+// TestComparatorMutation_Negative_MutationOutsideComparator is the boundary
+// the check has to hold: a mutating function in the same file is only a
+// finding when the sort actually passes it as its predicate.
+func TestComparatorMutation_Negative_MutationOutsideComparator(t *testing.T) {
+	source := "(defun helper (m k)\n" +
+		"  (assoc! m k 1))\n" +
+		"(stable-sort (lambda (a b) (< a b)) xs)\n" +
+		"(append! xs 4)"
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	assertNoDiags(t, diags)
+}
+
+// TestComparatorMutation_Negative_QuotedData checks a quoted subtree is
+// skipped whole: '(assoc! a b) is a list of three symbols, not a call.
+func TestComparatorMutation_Negative_QuotedData(t *testing.T) {
+	source := `(stable-sort (lambda (a b) (nil? '(assoc! a b)) (< a b)) xs)`
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	assertNoDiags(t, diags)
+}
+
+// TestComparatorMutation_Negative_TwoHops documents the blind spot the Doc
+// names: the symbol hop is one level deep, so a comparator whose mutation
+// lives in a function it calls is not reported.
+func TestComparatorMutation_Negative_TwoHops(t *testing.T) {
+	source := "(defun inner (m) (assoc! m 'k 1))\n" +
+		"(defun outer-less (a b) (inner m) (< a b))\n" +
+		"(stable-sort outer-less xs)"
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	assertNoDiags(t, diags)
+}
+
+func TestComparatorMutation_Nolint(t *testing.T) {
+	source := "(stable-sort (lambda (a b) (assoc! m 'k 1)) xs) ; nolint:comparator-mutation\n"
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	assertNoDiags(t, diags)
+}
+
 // --- unnecessary-progn ---
 
 func TestUnnecessaryProgn_Positive_Lambda(t *testing.T) {
@@ -1236,10 +1372,11 @@ func TestBracketListIgnored(t *testing.T) {
 
 func TestDefaultAnalyzers(t *testing.T) {
 	analyzers := DefaultAnalyzers()
-	assert.Len(t, analyzers, 19)
+	assert.Len(t, analyzers, 20)
 	names := AnalyzerNames()
 	assert.Equal(t, []string{
 		"builtin-arity",
+		"comparator-mutation",
 		"cond-missing-else",
 		"cond-structure",
 		"defun-structure",
@@ -1579,17 +1716,21 @@ func TestSeverity_UnsetRendersTheSameEverywhere(t *testing.T) {
 func TestSeverity_AnalyzerDefaults(t *testing.T) {
 	// Table-driven: verify each analyzer has the expected severity.
 	expected := map[string]Severity{
-		"set-usage":            SeverityWarning,
-		"in-package-toplevel":  SeverityWarning,
-		"if-arity":             SeverityError,
-		"let-bindings":         SeverityError,
-		"defun-structure":      SeverityError,
-		"cond-structure":       SeverityError,
-		"builtin-arity":        SeverityError,
-		"quote-call":           SeverityWarning,
-		"cond-missing-else":    SeverityInfo,
-		"rethrow-context":      SeverityError,
-		"unnecessary-progn":    SeverityInfo,
+		"set-usage":           SeverityWarning,
+		"in-package-toplevel": SeverityWarning,
+		"if-arity":            SeverityError,
+		"let-bindings":        SeverityError,
+		"defun-structure":     SeverityError,
+		"cond-structure":      SeverityError,
+		"builtin-arity":       SeverityError,
+		"quote-call":          SeverityWarning,
+		"cond-missing-else":   SeverityInfo,
+		"rethrow-context":     SeverityError,
+		"unnecessary-progn":   SeverityInfo,
+		// Error: a comparator with a side effect does not merely read
+		// oddly, it makes the sort's result depend on how many times the
+		// runtime happened to call the predicate.
+		"comparator-mutation":  SeverityError,
 		"undefined-symbol":     SeverityError,
 		"unused-variable":      SeverityWarning,
 		"unused-function":      SeverityWarning,

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1246,6 +1246,182 @@ func TestIterationMutation_Nolint(t *testing.T) {
 	assertNoDiags(t, diags)
 }
 
+// --- mutation checks: fan-out and rescanning ---
+
+// diagCount is len, named so a count assertion reads as a count rather than
+// as assert.Len -- which prints every diagnostic in the slice when it fails,
+// and these fixtures fail with thousands of them.
+func diagCount(diags []Diagnostic) int { return len(diags) }
+
+// mutationFanoutSource builds the shape that made the two mutation checks
+// quadratic: ONE defun carrying mutations mutation sites, named as the
+// callback of refs separate higher-order forms.
+//
+// The defun's body is scanned once per reference on a naive implementation,
+// and every mutation in it is reported again at the same source location, so
+// the diagnostic count is refs*mutations rather than mutations. A 24.7 KB
+// file of this shape measured ~360,000 diagnostics and ~713 MB of allocation
+// before the memo and the dedup landed.
+func mutationFanoutSource(refs, mutations int, head string) string {
+	var b strings.Builder
+	if head == "stable-sort" {
+		b.WriteString("(defun cb (a b)\n")
+	} else {
+		b.WriteString("(defun cb (x)\n")
+	}
+	for i := range mutations {
+		if head == "stable-sort" {
+			fmt.Fprintf(&b, "  (assoc! m 'k%d %d)\n", i, i)
+		} else {
+			fmt.Fprintf(&b, "  (append! x %d)\n", i)
+		}
+	}
+	if head == "stable-sort" {
+		b.WriteString("  (< a b))\n")
+	} else {
+		b.WriteString("  x)\n")
+	}
+	for range refs {
+		if head == "stable-sort" {
+			b.WriteString("(stable-sort cb xs)\n")
+		} else {
+			b.WriteString("(map 'list cb xs)\n")
+		}
+	}
+	return b.String()
+}
+
+// mutationNestSource builds depth callback bodies nested one inside the next,
+// each level a traversal over the value the level above handed it and each
+// body mutating one thing. A naive walk rescans an inner body once per
+// enclosing form, so the work -- and, for comparator-mutation, the diagnostic
+// count -- grows with the square of the depth.
+func mutationNestSource(depth int, head string) string {
+	var b strings.Builder
+	indent := func(n int) { b.WriteString(strings.Repeat("  ", n)) }
+	for i := 1; i <= depth; i++ {
+		indent(i - 1)
+		if head == "stable-sort" {
+			fmt.Fprintf(&b, "(stable-sort (lambda (a%d b%d)\n", i, i)
+			indent(i)
+			fmt.Fprintf(&b, "(assoc! m 'k%d %d)\n", i, i)
+		} else {
+			fmt.Fprintf(&b, "(map 'list (lambda (x%d)\n", i)
+			indent(i)
+			fmt.Fprintf(&b, "(append! x%d %d)\n", i, i)
+		}
+	}
+	for i := depth; i >= 1; i-- {
+		indent(i - 1)
+		if head == "stable-sort" {
+			fmt.Fprintf(&b, "(< a%d b%d))", i, i)
+		} else {
+			fmt.Fprintf(&b, "x%d)", i)
+		}
+		if i == 1 {
+			b.WriteString(" xs)\n")
+		} else if head == "stable-sort" {
+			fmt.Fprintf(&b, " ys%d)\n", i)
+		} else {
+			fmt.Fprintf(&b, " x%d)\n", i-1)
+		}
+	}
+	return b.String()
+}
+
+// TestComparatorMutation_FanoutReportsEachSiteOnce is the regression test for
+// the diagnostic explosion: 300 references to one 20-mutation predicate must
+// yield 20 diagnostics, not 6000.
+func TestComparatorMutation_FanoutReportsEachSiteOnce(t *testing.T) {
+	source := mutationFanoutSource(300, 20, "stable-sort")
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	// Counted into a variable rather than asserted with assert.Len: a failing
+	// Len prints all 6000 diagnostics, which is 70 KB of test output.
+	assert.Equal(t, 20, diagCount(diags))
+}
+
+// TestIterationMutation_FanoutReportsEachSiteOnce is the same shape for the
+// iteration check.
+func TestIterationMutation_FanoutReportsEachSiteOnce(t *testing.T) {
+	source := mutationFanoutSource(300, 20, "map")
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	assert.Equal(t, 20, diagCount(diags))
+}
+
+// TestComparatorMutation_NestedCallbacksScannedOnce pins the nesting half:
+// five comparators nested one inside the next, each mutating once. An inner
+// body runs when the outer comparator runs, so every level really is a
+// finding for every sort enclosing it -- but always at the SAME source
+// location with the same message, so the whole truth is nine diagnostics:
+// the five assoc! calls, plus the four nested stable-sort calls, which are
+// themselves mutating builtins sitting inside a comparator. A naive walk
+// rescans each inner body once per enclosing sort and reports 25.
+func TestComparatorMutation_NestedCallbacksScannedOnce(t *testing.T) {
+	source := mutationNestSource(5, "stable-sort")
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	require.Equal(t, 9, diagCount(diags))
+	for i := 1; i <= 5; i++ {
+		assertDiagOnLine(t, diags, 2*i, "assoc! is called inside a comparator")
+	}
+	for i := 2; i <= 5; i++ {
+		assertDiagOnLine(t, diags, 2*i-1, "stable-sort is called inside a comparator")
+	}
+}
+
+// TestIterationMutation_NestedCallbacksScannedOnce is the iteration form of
+// the same fixture: each level maps over the element the level above handed
+// it and mutates its own element, so each level is exactly one finding.
+func TestIterationMutation_NestedCallbacksScannedOnce(t *testing.T) {
+	source := mutationNestSource(5, "map")
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	require.Equal(t, 5, diagCount(diags))
+	for i := 1; i <= 5; i++ {
+		assertDiagOnLine(t, diags, 2*i,
+			fmt.Sprintf("append! mutates the element x%d of map", i))
+	}
+}
+
+// TestComparatorMutation_SameDefunTwoForms keeps the dedup from swallowing a
+// real second finding: one predicate used by both sorting forms names each
+// form in its own message, so the two are distinct diagnostics at the same
+// position rather than one.
+func TestComparatorMutation_SameDefunTwoForms(t *testing.T) {
+	source := "(defun cb (a b) (assoc! m 'k 1) (< a b))\n" +
+		"(stable-sort cb xs)\n" +
+		"(insert-sorted 'list ys cb z)"
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	require.Len(t, diags, 2)
+	assertHasDiag(t, diags, "stable-sort predicate mutates state")
+	assertHasDiag(t, diags, "insert-sorted predicate mutates state")
+}
+
+// TestMutationChecks_FanoutAllocationBound is the guard against a silent
+// return to quadratic behaviour. The bound is deliberately generous -- it is
+// there to catch an order-of-magnitude regression, not to pin an allocation
+// count. Before the memo and dedup this fixture allocated well over a
+// million times.
+func TestMutationChecks_FanoutAllocationBound(t *testing.T) {
+	for _, tt := range []struct {
+		analyzer *Analyzer
+		head     string
+	}{
+		{AnalyzerComparatorMutation, "stable-sort"},
+		{AnalyzerIterationMutation, "map"},
+	} {
+		t.Run(tt.analyzer.Name, func(t *testing.T) {
+			source := []byte(mutationFanoutSource(300, 400, tt.head))
+			l := &Linter{Analyzers: []*Analyzer{tt.analyzer}}
+			allocs := testing.AllocsPerRun(1, func() {
+				if _, err := l.LintFile(source, "test.lisp"); err != nil {
+					t.Fatal(err)
+				}
+			})
+			t.Logf("%s: %.0f allocations", tt.analyzer.Name, allocs)
+			assert.Less(t, allocs, 200000.0)
+		})
+	}
+}
+
 // --- unnecessary-progn ---
 
 func TestUnnecessaryProgn_Positive_Lambda(t *testing.T) {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1246,6 +1246,151 @@ func TestIterationMutation_Nolint(t *testing.T) {
 	assertNoDiags(t, diags)
 }
 
+// --- mutation checks: qualified lisp: spellings ---
+
+// TestMutationChecks_QualifiedSpellings pins the HAZARD side of both checks
+// against the package-qualified spelling of every operator they match on.
+//
+// `lisp:` is the only package that exports these -- stable-sort,
+// insert-sorted, map, foldl, assoc!, append! and set! come from
+// lisp.DefaultBuiltins, lambda and defun from the special operators -- and the
+// interpreter resolves the qualified symbol to exactly the same function.
+// Each source below runs and mutates; a check matching only the bare name
+// saw none of them.
+func TestMutationChecks_QualifiedSpellings(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		source   string
+		analyzer *Analyzer
+		want     []string
+	}{
+		{
+			name:     "qualified sort form",
+			source:   `(lisp:stable-sort (lambda (a b) (assoc! a "k" 1) (< a b)) xs)`,
+			analyzer: AnalyzerComparatorMutation,
+			want:     []string{"stable-sort predicate mutates state: assoc! is called inside a comparator"},
+		},
+		{
+			name:     "qualified lambda",
+			source:   `(stable-sort (lisp:lambda (a b) (assoc! a "k" 1) (< a b)) xs)`,
+			analyzer: AnalyzerComparatorMutation,
+			want:     []string{"stable-sort predicate mutates state: assoc! is called inside a comparator"},
+		},
+		{
+			name:     "qualified mutator",
+			source:   `(stable-sort (lambda (a b) (lisp:assoc! a "k" 1) (< a b)) xs)`,
+			analyzer: AnalyzerComparatorMutation,
+			want:     []string{"stable-sort predicate mutates state: assoc! is called inside a comparator"},
+		},
+		{
+			// Every layer qualified at once: the sort form, the predicate
+			// spelling and the mutator.
+			name:     "qualified throughout",
+			source:   `(lisp:stable-sort (lisp:lambda (a b) (lisp:assoc! a "k" 1) (< a b)) xs)`,
+			analyzer: AnalyzerComparatorMutation,
+			want:     []string{"stable-sort predicate mutates state: assoc! is called inside a comparator"},
+		},
+		{
+			name:     "qualified insert-sorted",
+			source:   `(lisp:insert-sorted 'list xs (lambda (a b) (append! log a) (< a b)) item)`,
+			analyzer: AnalyzerComparatorMutation,
+			want:     []string{"insert-sorted predicate mutates state: append! is called inside a comparator"},
+		},
+		{
+			name: "qualified defun resolves as a predicate",
+			source: "(lisp:defun bad-less (a b)\n" +
+				"  (lisp:append! acc a)\n" +
+				"  (< a b))\n" +
+				"(lisp:stable-sort bad-less xs)",
+			analyzer: AnalyzerComparatorMutation,
+			want:     []string{"stable-sort predicate mutates state: append! is called inside a comparator"},
+		},
+		{
+			// set! is on the comparator check's list, qualified or not.
+			name:     "qualified set! in a comparator",
+			source:   `(stable-sort (lambda (a b) (lisp:set! seen true) (< a b)) xs)`,
+			analyzer: AnalyzerComparatorMutation,
+			want:     []string{"stable-sort predicate mutates state: set! is called inside a comparator"},
+		},
+		{
+			name:     "qualified iteration form",
+			source:   `(lisp:map 'list (lambda (x) (assoc! x "k" 1) x) xs)`,
+			analyzer: AnalyzerIterationMutation,
+			want:     []string{`assoc! mutates the element x of map`},
+		},
+		{
+			name:     "qualified iteration collection write",
+			source:   `(lisp:map 'list (lisp:lambda (x) (lisp:append! xs x)) xs)`,
+			analyzer: AnalyzerIterationMutation,
+			want:     []string{"append! mutates xs while map iterates over it"},
+		},
+		{
+			name:     "qualified foldl element write",
+			source:   `(lisp:foldl (lambda (acc x) (assoc! x "k" 1)) (sorted-map) xs)`,
+			analyzer: AnalyzerIterationMutation,
+			want:     []string{"assoc! mutates the element x of foldl"},
+		},
+		{
+			// The accumulator exemption survives the qualified spelling:
+			// the fold threads this value, so writing it is correct code.
+			name:     "qualified foldl accumulator idiom stays clean",
+			source:   `(lisp:foldl (lambda (acc x) (lisp:assoc! acc x 1)) (sorted-map) xs)`,
+			analyzer: AnalyzerIterationMutation,
+		},
+		{
+			// set! stays OFF the iteration list whichever way it is spelled:
+			// it rebinds the parameter, it does not write through the element.
+			name:     "qualified set! on an element is exempt",
+			source:   `(map 'list (lambda (x) (lisp:set! x 1)) xs)`,
+			analyzer: AnalyzerIterationMutation,
+		},
+		{
+			name:     "qualified set! on the collection is exempt",
+			source:   `(lisp:map 'list (lambda (x) (lisp:set! xs ())) xs)`,
+			analyzer: AnalyzerIterationMutation,
+		},
+		{
+			name: "qualified defun resolves as an iteration callback",
+			source: "(lisp:defun visit (x)\n" +
+				"  (lisp:assoc! x \"k\" 1))\n" +
+				"(lisp:map 'list visit xs)",
+			analyzer: AnalyzerIterationMutation,
+			want:     []string{"assoc! mutates the element x of map"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := lintCheck(t, tt.analyzer, tt.source)
+			require.Len(t, diags, len(tt.want))
+			for _, want := range tt.want {
+				assertHasDiag(t, diags, want)
+			}
+		})
+	}
+}
+
+// TestMutationChecks_QualifiedNamesReportCanonically pins the wording: the
+// message names the canonical operator whichever spelling the source used, so
+// the two spellings of one hazard read as one finding rather than two.
+func TestMutationChecks_QualifiedNamesReportCanonically(t *testing.T) {
+	diags := lintCheck(t, AnalyzerComparatorMutation,
+		`(lisp:stable-sort (lisp:lambda (a b) (lisp:assoc! a "k" 1)) xs)`)
+	require.Len(t, diags, 1)
+	assert.Equal(t,
+		"stable-sort predicate mutates state: assoc! is called inside a comparator",
+		diags[0].Message)
+	assert.NotContains(t, diags[0].Message, "lisp:")
+}
+
+// TestMutationChecks_OtherPackageQualifierIsNotStripped keeps the helper to
+// the one package that exports these operators. A `foo:map` is somebody
+// else's function and its callback is not this check's business.
+func TestMutationChecks_OtherPackageQualifierIsNotStripped(t *testing.T) {
+	assertNoDiags(t, lintCheck(t, AnalyzerIterationMutation,
+		`(foo:map 'list (lambda (x) (assoc! x "k" 1)) xs)`))
+	assertNoDiags(t, lintCheck(t, AnalyzerComparatorMutation,
+		`(stable-sort (lambda (a b) (foo:assoc! a "k" 1) (< a b)) xs)`))
+}
+
 // --- mutation checks: fan-out and rescanning ---
 
 // diagCount is len, named so a count assertion reads as a count rather than

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1522,13 +1522,13 @@ func TestComparatorMutation_Positive_UnquotedFormInTemplate(t *testing.T) {
 	assertDiagOnLine(t, diags, 2, "assoc! is called inside a comparator")
 }
 
-// TestComparatorMutation_Negative_NestedQuasiquoteLevel pins the level
-// counting: an unquote one level down from a nested quasiquote belongs to the
-// inner template and is still data at this one.
-func TestComparatorMutation_Negative_NestedQuasiquoteLevel(t *testing.T) {
+// ELPS evaluates unquote even under a nested quasiquote. Unlike some Lisps,
+// nesting quasiquotes does not add a barrier to unquote evaluation.
+func TestComparatorMutation_Positive_NestedQuasiquote(t *testing.T) {
 	source := `(stable-sort (lambda (a b) (quasiquote (quasiquote ((unquote (assoc! a 1 2))))) (< a b)) xs)`
 	diags := lintCheck(t, AnalyzerComparatorMutation, source)
-	assertNoDiags(t, diags)
+	require.Len(t, diags, 1)
+	assertHasDiag(t, diags, "assoc! is called inside a comparator")
 }
 
 // --- unnecessary-progn ---

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1422,6 +1422,115 @@ func TestMutationChecks_FanoutAllocationBound(t *testing.T) {
 	}
 }
 
+// --- mutation checks: quoting ---
+
+// TestComparatorMutation_Negative_ExplicitQuoteForm covers the spelling the
+// reader's quote flag does not: (quote (assoc! ...)) is the same data as
+// '(assoc! ...), but the flag sits on nothing, so the list has to be
+// recognised by its head.
+func TestComparatorMutation_Negative_ExplicitQuoteForm(t *testing.T) {
+	source := `(stable-sort (lambda (a b) (quote (assoc! a 1 2)) (< a b)) xs)`
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	assertNoDiags(t, diags)
+}
+
+func TestIterationMutation_Negative_ExplicitQuoteForm(t *testing.T) {
+	source := `(map 'list (lambda (x) (quote (append! xs x))) xs)`
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	assertNoDiags(t, diags)
+}
+
+// TestComparatorMutation_Negative_FormInsideQuotedData is the other half:
+// the sort form itself is data. Both spellings are checked, because only the
+// second one used to reach the check -- the reader's flag lands on the outer
+// list of '(stable-sort ...), while a (quote (stable-sort ...)) form leaves
+// its operand unflagged.
+func TestComparatorMutation_Negative_FormInsideQuotedData(t *testing.T) {
+	t.Run("reader quote", func(t *testing.T) {
+		source := `'(stable-sort (lambda (a b) (assoc! a 1 2)) xs)`
+		assertNoDiags(t, lintCheck(t, AnalyzerComparatorMutation, source))
+	})
+	t.Run("quote form", func(t *testing.T) {
+		source := `(quote (stable-sort (lambda (a b) (assoc! a 1 2)) xs))`
+		assertNoDiags(t, lintCheck(t, AnalyzerComparatorMutation, source))
+	})
+}
+
+func TestIterationMutation_Negative_FormInsideQuotedData(t *testing.T) {
+	t.Run("reader quote", func(t *testing.T) {
+		source := `'(map 'list (lambda (x) (append! xs x)) xs)`
+		assertNoDiags(t, lintCheck(t, AnalyzerIterationMutation, source))
+	})
+	t.Run("quote form", func(t *testing.T) {
+		source := `(quote (map 'list (lambda (x) (append! xs x)) xs))`
+		assertNoDiags(t, lintCheck(t, AnalyzerIterationMutation, source))
+	})
+}
+
+// TestMutationChecks_DefunInsideQuotedDataIsNotACallback keeps the callback
+// index off data: a defun spelled inside a quote never runs, so a symbol
+// naming it resolves to nothing and the sort is clean.
+func TestMutationChecks_DefunInsideQuotedDataIsNotACallback(t *testing.T) {
+	source := "(quote (defun cb (a b) (assoc! a 1 2)))\n" +
+		"(stable-sort cb xs)\n" +
+		"(map 'list cb xs)"
+	assertNoDiags(t, lintCheck(t, AnalyzerComparatorMutation, source))
+	assertNoDiags(t, lintCheck(t, AnalyzerIterationMutation, source))
+}
+
+// TestComparatorMutation_Negative_QuasiquoteTemplate treats a quasiquote
+// template as the data it is: the mutation is spelled into a list the macro
+// returns, and whether it ever runs is the expansion site's business.
+func TestComparatorMutation_Negative_QuasiquoteTemplate(t *testing.T) {
+	source := `(stable-sort (lambda (a b) (quasiquote ((assoc! a 1 2))) (< a b)) xs)`
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	assertNoDiags(t, diags)
+}
+
+func TestIterationMutation_Negative_QuasiquoteTemplate(t *testing.T) {
+	source := `(map 'list (lambda (x) (quasiquote ((append! xs x)))) xs)`
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	assertNoDiags(t, diags)
+}
+
+// TestComparatorMutation_Positive_QuasiquoteUnquote is the exception that
+// keeps the template rule honest: an unquote subtree is evaluated where it
+// stands, so a mutation inside one runs every time the comparator does.
+func TestComparatorMutation_Positive_QuasiquoteUnquote(t *testing.T) {
+	source := `(stable-sort (lambda (a b) (quasiquote ((unquote (assoc! a 1 2)))) (< a b)) xs)`
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	require.Len(t, diags, 1)
+	assertHasDiag(t, diags, "assoc! is called inside a comparator")
+}
+
+func TestIterationMutation_Positive_QuasiquoteUnquote(t *testing.T) {
+	source := `(map 'list (lambda (x) (quasiquote ((unquote-splicing (append! xs x))))) xs)`
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	require.Len(t, diags, 1)
+	assertHasDiag(t, diags, "append! mutates xs while map iterates over it")
+}
+
+// TestComparatorMutation_Positive_UnquotedFormInTemplate is the same rule
+// applied to the OUTER traversal rather than to a callback body: the sort
+// form itself sits in an unquote, so it is a call the macro definition makes,
+// not a shape the macro emits.
+func TestComparatorMutation_Positive_UnquotedFormInTemplate(t *testing.T) {
+	source := "(defmacro m ()\n" +
+		"  (quasiquote (list (unquote (stable-sort (lambda (a b) (assoc! a 1 2)) xs)))))"
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	require.Len(t, diags, 1)
+	assertDiagOnLine(t, diags, 2, "assoc! is called inside a comparator")
+}
+
+// TestComparatorMutation_Negative_NestedQuasiquoteLevel pins the level
+// counting: an unquote one level down from a nested quasiquote belongs to the
+// inner template and is still data at this one.
+func TestComparatorMutation_Negative_NestedQuasiquoteLevel(t *testing.T) {
+	source := `(stable-sort (lambda (a b) (quasiquote (quasiquote ((unquote (assoc! a 1 2))))) (< a b)) xs)`
+	diags := lintCheck(t, AnalyzerComparatorMutation, source)
+	assertNoDiags(t, diags)
+}
+
 // --- unnecessary-progn ---
 
 func TestUnnecessaryProgn_Positive_Lambda(t *testing.T) {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1391,6 +1391,98 @@ func TestMutationChecks_OtherPackageQualifierIsNotStripped(t *testing.T) {
 		`(stable-sort (lambda (a b) (foo:assoc! a "k" 1) (< a b)) xs)`))
 }
 
+// --- mutation checks: duplicated defuns ---
+
+// TestMutationChecks_DuplicateDefunLastWins pins callback resolution to the
+// definition the interpreter actually runs.
+//
+// ELPS `defun` overwrites: a second definition of a name replaces the first,
+// and every later call reaches the second body. Verified with the built
+// binary on a two-defun file whose bodies print which one ran -- only
+// "SECOND body ran" appears. Indexing the FIRST definition therefore made a
+// clean-first/dirty-second duplicate a silent false negative, and a
+// dirty-first/clean-second duplicate a false positive against a body no call
+// reaches.
+func TestMutationChecks_DuplicateDefunLastWins(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		source   string
+		analyzer *Analyzer
+		line     int
+		want     string
+	}{
+		{
+			name: "comparator dirty definition second is reported",
+			source: "(defun dup (a b) (< a b))\n" +
+				"(defun dup (a b) (assoc! a \"second\" 1) (< a b))\n" +
+				"(stable-sort dup xs)",
+			analyzer: AnalyzerComparatorMutation,
+			line:     2,
+			want:     "assoc! is called inside a comparator",
+		},
+		{
+			name: "comparator dirty definition first is not",
+			source: "(defun dup (a b) (assoc! a \"first\" 1) (< a b))\n" +
+				"(defun dup (a b) (< a b))\n" +
+				"(stable-sort dup xs)",
+			analyzer: AnalyzerComparatorMutation,
+		},
+		{
+			name: "iteration dirty definition second is reported",
+			source: "(defun visit (x) x)\n" +
+				"(defun visit (x) (assoc! x \"second\" 1))\n" +
+				"(map 'list visit xs)",
+			analyzer: AnalyzerIterationMutation,
+			line:     2,
+			want:     "assoc! mutates the element x of map",
+		},
+		{
+			name: "iteration dirty definition first is not",
+			source: "(defun visit (x) (assoc! x \"first\" 1))\n" +
+				"(defun visit (x) x)\n" +
+				"(map 'list visit xs)",
+			analyzer: AnalyzerIterationMutation,
+		},
+		{
+			// Three definitions: only the last one is live, whichever of the
+			// earlier two mutates.
+			name: "the last of three definitions wins",
+			source: "(defun dup (a b) (assoc! a \"first\" 1) (< a b))\n" +
+				"(defun dup (a b) (append! log a) (< a b))\n" +
+				"(defun dup (a b) (dissoc! a \"third\") (< a b))\n" +
+				"(stable-sort dup xs)",
+			analyzer: AnalyzerComparatorMutation,
+			line:     3,
+			want:     "dissoc! is called inside a comparator",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := lintCheck(t, tt.analyzer, tt.source)
+			if tt.want == "" {
+				assertNoDiags(t, diags)
+				return
+			}
+			require.Len(t, diags, 1)
+			assertDiagOnLine(t, diags, tt.line, tt.want)
+		})
+	}
+}
+
+// TestMutationChecks_DuplicateDefunStillDedupes keeps the memo intact: one
+// live definition referenced by many forms is still scanned once and reported
+// once per distinct finding, not once per reference.
+func TestMutationChecks_DuplicateDefunStillDedupes(t *testing.T) {
+	source := "(defun cb (x) x)\n" +
+		"(defun cb (x) (assoc! x \"k\" 1))\n" +
+		"(map 'list cb xs)\n" +
+		"(select 'list cb xs)\n" +
+		"(map 'list cb xs)"
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	require.Len(t, diags, 2)
+	assertHasDiag(t, diags, "assoc! mutates the element x of map")
+	assertHasDiag(t, diags, "assoc! mutates the element x of select")
+}
+
 // --- mutation checks: fan-out and rescanning ---
 
 // diagCount is len, named so a count assertion reads as a count rather than

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -1038,6 +1038,214 @@ func TestComparatorMutation_Nolint(t *testing.T) {
 	assertNoDiags(t, diags)
 }
 
+// --- iteration-mutation ---
+
+func TestIterationMutation_Positive_MutatesCollection(t *testing.T) {
+	source := `(map 'list (lambda (x) (append! xs x)) xs)`
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	require.Len(t, diags, 1)
+	assert.Equal(t, "append! mutates xs while map iterates over it", diags[0].Message)
+	assert.Equal(t, SeverityWarning, diags[0].Severity)
+	assertDiagOnLine(t, diags, 1, "append!")
+}
+
+func TestIterationMutation_Positive_MutatesElement(t *testing.T) {
+	source := `(map 'list (lambda (x) (assoc! x 'seen true)) xs)`
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	require.Len(t, diags, 1)
+	assert.Equal(t, "assoc! mutates the element x of map", diags[0].Message)
+	assert.Equal(t, SeverityWarning, diags[0].Severity)
+}
+
+// TestIterationMutation_Positive_EveryForm pins the argument layout of each
+// covered builtin: the callback comes first in foldl, foldr, all? and any?,
+// and second in map, select and reject, so a single assumed position would
+// silently check the wrong cell for half of them.
+func TestIterationMutation_Positive_EveryForm(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "map",
+			source: `(map 'list (lambda (x) (append! xs x)) xs)`,
+			want:   "append! mutates xs while map iterates over it",
+		},
+		{
+			name:   "select",
+			source: `(select 'list (lambda (x) (dissoc! xs 'k)) xs)`,
+			want:   "dissoc! mutates xs while select iterates over it",
+		},
+		{
+			name:   "reject",
+			source: `(reject 'list (lambda (x) (dissoc! x 'k)) xs)`,
+			want:   "dissoc! mutates the element x of reject",
+		},
+		{
+			name:   "foldl",
+			source: `(foldl (lambda (acc x) (append! xs x)) (list) xs)`,
+			want:   "append! mutates xs while foldl iterates over it",
+		},
+		{
+			name:   "foldr",
+			source: `(foldr (lambda (x acc) (append! xs x)) (list) xs)`,
+			want:   "append! mutates xs while foldr iterates over it",
+		},
+		{
+			name:   "all?",
+			source: `(all? (lambda (x) (append! xs x)) xs)`,
+			want:   "append! mutates xs while all? iterates over it",
+		},
+		{
+			name:   "any?",
+			source: `(any? (lambda (x) (append-bytes! xs x)) xs)`,
+			want:   "append-bytes! mutates xs while any? iterates over it",
+		},
+		{
+			// stable-sort mutates its SECOND argument, not its first --
+			// the first is the comparator.
+			name:   "stable-sort-as-mutator",
+			source: `(map 'list (lambda (x) (stable-sort < xs)) xs)`,
+			want:   "stable-sort mutates xs while map iterates over it",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := lintCheck(t, AnalyzerIterationMutation, tt.source)
+			require.Len(t, diags, 1)
+			assert.Equal(t, tt.want, diags[0].Message)
+		})
+	}
+}
+
+func TestIterationMutation_Positive_NestedLambda(t *testing.T) {
+	source := "(map 'list\n" +
+		"  (lambda (x)\n" +
+		"    (map 'list (lambda (y) (append! xs y)) '(1 2)))\n" +
+		"  xs)"
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	require.Len(t, diags, 1)
+	assertDiagOnLine(t, diags, 3, "append! mutates xs while map iterates over it")
+}
+
+func TestIterationMutation_Positive_SameFileDefun(t *testing.T) {
+	source := "(defun visit (x)\n" +
+		"  (assoc! x 'seen true))\n" +
+		"(map 'list visit xs)"
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	require.Len(t, diags, 1)
+	assertDiagOnLine(t, diags, 2, "assoc! mutates the element x of map")
+}
+
+func TestIterationMutation_Positive_HasNotes(t *testing.T) {
+	diags := lintCheck(t, AnalyzerIterationMutation,
+		`(map 'list (lambda (x) (append! xs x)) xs)`)
+	require.Len(t, diags, 1)
+	require.NotEmpty(t, diags[0].Notes)
+	assert.Contains(t, diags[0].Notes[0], "copy")
+	assert.Contains(t, diags[0].Notes[0], "new collection")
+}
+
+// TestIterationMutation_Negative_AccumulatorIdiom is the shape the check
+// exists to leave alone: the fold's accumulator is threaded by the fold
+// itself, so mutating it is correct code and is not a collection write.
+func TestIterationMutation_Negative_AccumulatorIdiom(t *testing.T) {
+	source := `(foldl (lambda (acc x) (assoc! acc x 1)) (sorted-map) xs)`
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	assertNoDiags(t, diags)
+}
+
+// TestIterationMutation_Negative_SetRebindsNotMutates keeps set! off this
+// check's list. It rebinds a NAME rather than writing through the value the
+// name held: (set! x 1) gives the callback's own parameter a new value and
+// leaves the element alone, and (set! xs ...) rebinds the caller's variable
+// while the builtin goes on walking the sequence it was already handed.
+// Neither changes anything underneath the traversal.
+//
+// comparator-mutation still reports set!, because there any side effect is a
+// finding whatever it writes to.
+func TestIterationMutation_Negative_SetRebindsNotMutates(t *testing.T) {
+	t.Run("element", func(t *testing.T) {
+		diags := lintCheck(t, AnalyzerIterationMutation,
+			`(map 'list (lambda (x) (set! x 1)) xs)`)
+		assertNoDiags(t, diags)
+	})
+	t.Run("collection", func(t *testing.T) {
+		diags := lintCheck(t, AnalyzerIterationMutation,
+			`(map 'list (lambda (x) (set! xs ())) xs)`)
+		assertNoDiags(t, diags)
+	})
+	t.Run("comparator-check-still-reports-it", func(t *testing.T) {
+		diags := lintCheck(t, AnalyzerComparatorMutation,
+			`(stable-sort (lambda (a b) (set! seen true) (< a b)) xs)`)
+		require.Len(t, diags, 1)
+		assert.Equal(t,
+			"stable-sort predicate mutates state: set! is called inside a comparator",
+			diags[0].Message)
+	})
+}
+
+func TestIterationMutation_Negative_UnrelatedSymbol(t *testing.T) {
+	source := `(map 'list (lambda (x) (assoc! out x 1)) xs)`
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	assertNoDiags(t, diags)
+}
+
+func TestIterationMutation_Negative_PureCallback(t *testing.T) {
+	source := `(map 'list (lambda (x) (+ x 1)) xs)`
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	assertNoDiags(t, diags)
+}
+
+func TestIterationMutation_Negative_LetWithoutMutation(t *testing.T) {
+	source := `(map 'list (lambda (x) (let ([y x]) (+ y 1))) xs)`
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	assertNoDiags(t, diags)
+}
+
+// TestIterationMutation_Negative_MutationOutsideCallback keeps the check
+// inside the callback body: the same file mutating the same collection before
+// or after the traversal is ordinary code.
+func TestIterationMutation_Negative_MutationOutsideCallback(t *testing.T) {
+	source := "(map 'list (lambda (x) (+ x 1)) xs)\n" +
+		"(append! xs 4)\n" +
+		"(assoc! m 'k 1)"
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	assertNoDiags(t, diags)
+}
+
+// TestIterationMutation_Negative_QuotedData checks a quoted subtree is
+// skipped whole: '(assoc! xs k) is data, not a call.
+func TestIterationMutation_Negative_QuotedData(t *testing.T) {
+	source := `(map 'list (lambda (x) (nil? '(assoc! xs x))) xs)`
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	assertNoDiags(t, diags)
+}
+
+// TestIterationMutation_Negative_CollectionNotASymbol documents the blind
+// spot the Doc names: a collection built inline has no name to match against.
+func TestIterationMutation_Negative_CollectionNotASymbol(t *testing.T) {
+	source := `(map 'list (lambda (x) (append! xs x)) (list 1 2))`
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	assertNoDiags(t, diags)
+}
+
+// TestIterationMutation_ShadowedParameterIsStillReported documents the other
+// blind spot: the walk keeps no scope of its own, so a parameter rebound by
+// an inner let is still treated as the element.
+func TestIterationMutation_ShadowedParameterIsStillReported(t *testing.T) {
+	source := `(map 'list (lambda (x) (let ([x m]) (assoc! x 'k 1))) xs)`
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	require.Len(t, diags, 1)
+	assert.Equal(t, "assoc! mutates the element x of map", diags[0].Message)
+}
+
+func TestIterationMutation_Nolint(t *testing.T) {
+	source := "(map 'list (lambda (x) (append! xs x)) xs) ; nolint:iteration-mutation\n"
+	diags := lintCheck(t, AnalyzerIterationMutation, source)
+	assertNoDiags(t, diags)
+}
+
 // --- unnecessary-progn ---
 
 func TestUnnecessaryProgn_Positive_Lambda(t *testing.T) {
@@ -1372,7 +1580,7 @@ func TestBracketListIgnored(t *testing.T) {
 
 func TestDefaultAnalyzers(t *testing.T) {
 	analyzers := DefaultAnalyzers()
-	assert.Len(t, analyzers, 20)
+	assert.Len(t, analyzers, 21)
 	names := AnalyzerNames()
 	assert.Equal(t, []string{
 		"builtin-arity",
@@ -1384,6 +1592,7 @@ func TestDefaultAnalyzers(t *testing.T) {
 		"duplicate-definition",
 		"if-arity",
 		"in-package-toplevel",
+		"iteration-mutation",
 		"let-bindings",
 		"quote-call",
 		"rethrow-context",
@@ -1730,7 +1939,11 @@ func TestSeverity_AnalyzerDefaults(t *testing.T) {
 		// Error: a comparator with a side effect does not merely read
 		// oddly, it makes the sort's result depend on how many times the
 		// runtime happened to call the predicate.
-		"comparator-mutation":  SeverityError,
+		"comparator-mutation": SeverityError,
+		// Warning, not error: a callback that writes to the collection it is
+		// walking is sometimes deliberate, and unlike a comparator it runs a
+		// defined number of times in a defined order.
+		"iteration-mutation":   SeverityWarning,
 		"undefined-symbol":     SeverityError,
 		"unused-variable":      SeverityWarning,
 		"unused-function":      SeverityWarning,

--- a/lint/mutation_quote_test.go
+++ b/lint/mutation_quote_test.go
@@ -33,6 +33,25 @@ func TestMutationChecks_QuoteRuntimeParity(t *testing.T) {
 			message:  "assoc! mutates the element m of map",
 			analyzer: AnalyzerIterationMutation,
 		},
+		// The same table again with every enclosing operator spelled
+		// `lisp:`. The interpreter resolves those to the same functions, so
+		// the lint verdict has to be the same one -- including for the two
+		// qualified-unquote rows, which stay data because getUnquoteType
+		// matches the bare marker only.
+		{
+			name:     "qualified comparator",
+			prefix:   `(set 'm (sorted-map)) (lisp:stable-sort (lisp:lambda (a b) `,
+			suffix:   ` (< a b)) (list 2 1)) (get m "k")`,
+			message:  "assoc! is called inside a comparator",
+			analyzer: AnalyzerComparatorMutation,
+		},
+		{
+			name:     "qualified iteration",
+			prefix:   `(set 'xs (list (sorted-map))) (lisp:map 'list (lisp:lambda (m) `,
+			suffix:   ` m) xs) (get (first xs) "k")`,
+			message:  "assoc! mutates the element m of map",
+			analyzer: AnalyzerIterationMutation,
+		},
 	} {
 		t.Run(context.name, func(t *testing.T) {
 			for _, test := range []struct {
@@ -41,6 +60,9 @@ func TestMutationChecks_QuoteRuntimeParity(t *testing.T) {
 			}{
 				{"explicit quote", `(quote (assoc! m "k" 1))`, false},
 				{"reader quote", `'(assoc! m "k" 1)`, false},
+				{"qualified mutator", `(lisp:assoc! m "k" 1)`, true},
+				{"qualified mutator under unquote", `(quasiquote ((unquote (lisp:assoc! m "k" 1))))`, true},
+				{"qualified mutator under quote", `(quote (lisp:assoc! m "k" 1))`, false},
 				{"qualified quote", `(lisp:quote (assoc! m "k" 1))`, false},
 				{"qualified quasiquote", `(lisp:quasiquote ((assoc! m "k" 1)))`, false},
 				{"plain template", `(quasiquote ((assoc! m "k" 1)))`, false},

--- a/lint/mutation_quote_test.go
+++ b/lint/mutation_quote_test.go
@@ -1,0 +1,106 @@
+// Copyright © 2026 The ELPS authors
+
+package lint
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/luthersystems/elps/lisp"
+	"github.com/luthersystems/elps/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// Keep the lint walk tied to ELPS evaluation rather than another Lisp's quote
+// rules. Each case independently asserts the resulting map value before
+// checking the diagnostic, so an interpreter error cannot masquerade as data.
+func TestMutationChecks_QuoteRuntimeParity(t *testing.T) {
+	for _, context := range []struct {
+		name, prefix, suffix, message string
+		analyzer                      *Analyzer
+	}{
+		{
+			name:     "comparator",
+			prefix:   `(set 'm (sorted-map)) (stable-sort (lambda (a b) `,
+			suffix:   ` (< a b)) (list 2 1)) (get m "k")`,
+			message:  "assoc! is called inside a comparator",
+			analyzer: AnalyzerComparatorMutation,
+		},
+		{
+			name:     "iteration",
+			prefix:   `(set 'xs (list (sorted-map))) (map 'list (lambda (m) `,
+			suffix:   ` m) xs) (get (first xs) "k")`,
+			message:  "assoc! mutates the element m of map",
+			analyzer: AnalyzerIterationMutation,
+		},
+	} {
+		t.Run(context.name, func(t *testing.T) {
+			for _, test := range []struct {
+				name, body string
+				mutated    bool
+			}{
+				{"explicit quote", `(quote (assoc! m "k" 1))`, false},
+				{"reader quote", `'(assoc! m "k" 1)`, false},
+				{"qualified quote", `(lisp:quote (assoc! m "k" 1))`, false},
+				{"qualified quasiquote", `(lisp:quasiquote ((assoc! m "k" 1)))`, false},
+				{"plain template", `(quasiquote ((assoc! m "k" 1)))`, false},
+				{"unquote", `(quasiquote ((unquote (assoc! m "k" 1))))`, true},
+				{"qualified template unquote", `(lisp:quasiquote ((unquote (assoc! m "k" 1))))`, true},
+				{"nested template unquote", `(quasiquote (quasiquote ((unquote (assoc! m "k" 1)))))`, true},
+				{"reader quoted unquote", `(quasiquote '(unquote (assoc! m "k" 1)))`, true},
+				{"explicit quoted unquote", `(quasiquote (quote (unquote (assoc! m "k" 1))))`, true},
+				{"unquote splicing", `(quasiquote ((unquote-splicing (list (assoc! m "k" 1)))))`, true},
+				{"nested template splicing", `(quasiquote (quasiquote ((unquote-splicing (list (assoc! m "k" 1))))))`, true},
+				// getUnquoteType recognizes only the bare marker, not a
+				// qualified symbol that happens to end in the same name.
+				{"qualified unquote is data", `(quasiquote ((lisp:unquote (assoc! m "k" 1))))`, false},
+				{"qualified splicing is data", `(quasiquote ((lisp:unquote-splicing (list (assoc! m "k" 1)))))`, false},
+			} {
+				t.Run(test.name, func(t *testing.T) {
+					source := context.prefix + test.body + context.suffix
+					env := lisp.NewEnv(nil)
+					env.Runtime.Reader = parser.NewReader()
+					require.NotEqual(t, lisp.LError, lisp.InitializeUserEnv(env).Type)
+					value := env.LoadString("quote-parity.lisp", source)
+					require.NotEqual(t, lisp.LError, value.Type, "%s", value)
+					want := 0
+					if test.mutated {
+						require.Equal(t, lisp.LInt, value.Type)
+						require.Equal(t, 1, value.Int)
+						want = 1
+					} else {
+						require.True(t, value.IsNil(), "%s", value)
+					}
+					diags := lintCheck(t, context.analyzer, source)
+					require.Len(t, diags, want)
+					if test.mutated {
+						assertHasDiag(t, diags, context.message)
+					}
+				})
+			}
+		})
+	}
+}
+
+// The same quote rules must govern discovery of the callback form itself,
+// not just discovery of mutators within a previously discovered callback.
+func TestMutationChecks_QuotedCallbackForms(t *testing.T) {
+	for _, test := range []struct {
+		name, form string
+		analyzer   *Analyzer
+	}{
+		{"comparator", `(stable-sort (lambda (a b) (assoc! a "k" 1)) xs)`, AnalyzerComparatorMutation},
+		{"iteration", `(map 'list (lambda (x) (assoc! x "k" 1)) xs)`, AnalyzerIterationMutation},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, quote := range []string{"quote", "lisp:quote", "quasiquote", "lisp:quasiquote"} {
+				t.Run(quote, func(t *testing.T) {
+					source := fmt.Sprintf("(%s %s)", quote, test.form)
+					assertNoDiags(t, lintCheck(t, test.analyzer, source))
+				})
+			}
+			source := fmt.Sprintf("(quasiquote (quasiquote ((unquote %s))))", test.form)
+			require.Len(t, lintCheck(t, test.analyzer, source), 1)
+		})
+	}
+}

--- a/lint/mutation_scaling_test.go
+++ b/lint/mutation_scaling_test.go
@@ -1,0 +1,171 @@
+// Copyright © 2026 The ELPS authors
+
+package lint
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These bounds cover actual analysis work, not merely deduplicated output.
+// The old flattened descendant cache and repeated distinct-collection scans
+// produced the right findings while doing quadratic work (issue #649).
+func TestMutationChecks_NestedWorkBound(t *testing.T) {
+	const depth = 800
+	for _, head := range []string{"stable-sort", "map"} {
+		t.Run(head, func(t *testing.T) {
+			source := compactMutationNest(depth, head)
+			analyzer, count := AnalyzerComparatorMutation, 2*depth-1
+			if head == "map" {
+				analyzer, count = AnalyzerIterationMutation, depth
+			}
+			assertMutationWorkBound(t, analyzer, source, count)
+		})
+	}
+}
+
+func TestMutationChecks_DistinctCollectionsWorkBound(t *testing.T) {
+	const size = 800
+	assertMutationWorkBound(t, AnalyzerIterationMutation, distinctCollectionSource(size), size)
+}
+
+func compactMutationNest(depth int, head string) []byte {
+	// Indentation must not make the input itself quadratic in depth.
+	lines := strings.Split(mutationNestSource(depth, head), "\n")
+	for i := range lines {
+		lines[i] = strings.TrimSpace(lines[i])
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+func distinctCollectionSource(size int) []byte {
+	var source strings.Builder
+	source.WriteString("(defun cb (x)\n")
+	for range size {
+		source.WriteString("(assoc! x \"key\" 1)\n")
+	}
+	source.WriteString("x)\n")
+	for i := range size {
+		fmt.Fprintf(&source, "(map 'list cb xs%d)\n", i)
+	}
+	return []byte(source.String())
+}
+
+func assertMutationWorkBound(t *testing.T, analyzer *Analyzer, source []byte, count int) {
+	t.Helper()
+	linter := &Linter{Analyzers: []*Analyzer{analyzer}}
+	allocs := testing.AllocsPerRun(2, func() {
+		diags, err := linter.LintFile(source, "scaling.lisp")
+		require.NoError(t, err)
+		require.Equal(t, count, diagCount(diags))
+	})
+	// Includes parsing, lint setup and output. This intentionally allows
+	// ample linear overhead across toolchains while rejecting the old
+	// millions of repeated allocations for these sub-64 KB inputs.
+	require.Less(t, allocs, float64(220_000), "analysis must not redo nested or shared callback work")
+	t.Logf("source=%d bytes diagnostics=%d allocations=%.0f", len(source), count, allocs)
+}
+
+func TestIterationMutation_CollectionPrecedenceIsPerUse(t *testing.T) {
+	diags := lintCheck(t, AnalyzerIterationMutation, `(defun cb (x)
+  (assoc! x "key" 1))
+(map 'list cb x)
+(map 'list cb ys)
+(map 'list cb x)
+(select 'list cb ys)`)
+	require.Len(t, diags, 3)
+	assertHasDiag(t, diags, "assoc! mutates x while map iterates over it")
+	assertHasDiag(t, diags, "assoc! mutates the element x of map")
+	assertHasDiag(t, diags, "assoc! mutates the element x of select")
+}
+
+func TestIterationMutation_NestedCapturedTargets(t *testing.T) {
+	diags := lintCheck(t, AnalyzerIterationMutation, `(map 'list (lambda (outer)
+  (map 'list (lambda (inner)
+    (assoc! outer "key" 1)
+    (assoc! inner "key" 2)
+    (append! xs inner)) ys)) xs)`)
+	require.Len(t, diags, 3)
+	assertHasDiag(t, diags, "assoc! mutates the element outer of map")
+	assertHasDiag(t, diags, "assoc! mutates the element inner of map")
+	assertHasDiag(t, diags, "append! mutates xs while map iterates over it")
+}
+
+func TestMutationChecks_DiagnosticOrder(t *testing.T) {
+	// Different query groups report at the same site and on the same line.
+	// The global linter sort does not break such ties; map order must not leak.
+	const source = `(defun cb (a b) (assoc! a "key" 1) (append! b a)) (map 'list cb a) (select 'list cb b) (map 'list cb c) (stable-sort cb xs) (insert-sorted 'list xs cb x)`
+	for _, analyzer := range []*Analyzer{AnalyzerComparatorMutation, AnalyzerIterationMutation} {
+		want := lintCheck(t, analyzer, source)
+		count := 4
+		if analyzer == AnalyzerIterationMutation {
+			count = 5
+		}
+		require.Equal(t, count, diagCount(want))
+		for range 30 {
+			require.Equal(t, want, lintCheck(t, analyzer, source))
+		}
+	}
+}
+
+func TestMutationSpans_UnionVisitsEachSiteOnce(t *testing.T) {
+	// An independent bitset model covers nesting, duplicates, adjacency,
+	// disjoint spans and reverse reference order. Counting visits BEFORE
+	// diagnostic dedup catches a removed merge even if output stays correct.
+	var candidates []mutationSpan
+	for start := range 4 {
+		for end := start + 1; end <= 4; end++ {
+			candidates = append(candidates, mutationSpan{start: start, end: end})
+		}
+	}
+	for _, a := range candidates {
+		for _, b := range candidates {
+			for _, c := range candidates {
+				spans := []mutationSpan{a, b, c}
+				var want, got [4]int
+				for _, span := range spans {
+					for i := span.start; i < span.end; i++ {
+						want[i] = 1
+					}
+				}
+				visitMutationSpans(spans, func(span mutationSpan) {
+					for i := span.start; i < span.end; i++ {
+						got[i]++
+					}
+				})
+				require.Equal(t, want, got, "spans %v, %v, %v", a, b, c)
+			}
+		}
+	}
+	visitMutationSpans(nil, func(mutationSpan) { t.Fatal("empty input must not visit a span") })
+}
+
+func BenchmarkMutationChecksScaling(b *testing.B) {
+	for _, size := range []int{200, 800} {
+		for _, shape := range []struct {
+			name     string
+			analyzer *Analyzer
+			source   []byte
+			findings int
+		}{
+			{"NestedComparator", AnalyzerComparatorMutation, compactMutationNest(size, "stable-sort"), 2*size - 1},
+			{"NestedIteration", AnalyzerIterationMutation, compactMutationNest(size, "map"), size},
+			{"DistinctCollections", AnalyzerIterationMutation, distinctCollectionSource(size), size},
+		} {
+			b.Run(fmt.Sprintf("%s/%d", shape.name, size), func(b *testing.B) {
+				linter := &Linter{Analyzers: []*Analyzer{shape.analyzer}}
+				b.ReportAllocs()
+				b.SetBytes(int64(len(shape.source)))
+				for b.Loop() {
+					diags, err := linter.LintFile(shape.source, "scaling.lisp")
+					if err != nil || len(diags) != shape.findings {
+						b.Fatalf("findings=%d want=%d err=%v", len(diags), shape.findings, err)
+					}
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two conservative structural lint checks, with callback-work bounds and quote handling matched to the ELPS interpreter.

| Check | Severity | Reports |
|---|---|---|
| `comparator-mutation` | error | Known mutating calls inside `stable-sort` or `insert-sorted` predicates. This intentionally includes callback-local scratch writes; it is not proof that every reported write changes the result. |
| `iteration-mutation` | warning | Writes through a collection symbol or callback element in `map`, `foldl`, `foldr`, `select`, `reject`, `all?` or `any?`. Fold accumulators and `set!` rebinding are exempt. |

Both follow inline lambdas and same-file defuns one hop, respect `nolint`, and skip quoted data. ELPS unquotes inside nested quasiquotes still execute and must be checked. Canonical `lisp:quote` and `lisp:quasiquote` spellings are recognized, and so is the `lisp:` spelling of every operator on the hazard side.

This supports the comparator-by-reference change in #642; it does not alter runtime evaluation, copying or template performance. MCP help-table drift is handled separately by #648.

## Limits

- These are syntactic checks, not an effect system: cross-file helpers, indirect calls and aliases are not resolved.
- The iteration check does not track inner rebinding/shadowing; collection expressions rather than plain symbols are not followed.
- A same-file rebinding of `quote`, `quasiquote` or a builtin name (for example `(defun quote (x) x)`) is not tracked; the checks then read the shadowed meaning. Every syntactic analyzer in `lint/` shares this property.
- `zip` has no callback and is intentionally outside the check.

## Final review follow-up

- #649: bound work for deeply nested callbacks and helpers reused across distinct collection names, not just diagnostic count.
- #650: pair quote diagnostics with actual interpreter execution; correct the previous nested-quasiquote expectation without changing the interpreter.
- Clarify the comparator rule's conservative policy in help text and docs.
- #651: recognise `lisp:`-qualified spellings on the hazard side (the quote fix had only covered the data side), and resolve a duplicated same-file `defun` to the last definition, which is the one the interpreter runs. `lisp:unquote` inside a template deliberately stays data, matching `getUnquoteType`.

## Verification

- Focused lint package tests and mutation tests under `-tags elpscheck -race` pass on Go 1.25.13.
- CI-matching golangci-lint 2.6.2 reports zero issues in the changed package.
- 28 paired evaluator/linter quote cases; eight failed before the fix. Two further qualified-spelling contexts added with #651's fix, run through the real evaluator.
- Independent before/after comparison preserves diagnostic messages and positions for 1,080 synthetic callback cases.
- Allocation bounds fail on the old implementation. Disabling range merging also fails the new 1,000-case exact-once model and allocation guard, even though output counts remain correct.
- 800-deep comparator allocations: approximately 2.68 million before, 124 thousand after. Distinct-collection fixture: 3.26 million before, 71 thousand after. These include parsing and diagnostics, not just the walker.
- New `BenchmarkMutationChecksScaling` rows cover nested comparators, nested iteration and distinct collections at 200/800 sizes. A short local warm MCP lint comparison found no significant timing difference; overhead was eight allocations (+0.13%) and about 330 bytes (+0.05%). No VM/request execution code changed. The #651 commits leave the scaling allocations unchanged to within one allocation.
- Independent QA/security review: no remaining blocker on 97e5ac6. Independent adversarial re-check of the final-round commits against the interpreter: work bounds exactly linear, dedupe swallows nothing, fold accumulator positions correct, docs claims hold; its two findings are the #651 fixes.
- Final head `265113f` passes all 25 CI checks, including full tests, fuzz shards and the benchmark gate.
- Combined #647 + #648 overlay passes the MCP Help/Lint tests under race, including the generated analyzer registry table with both new rows.

Closes #644
Closes #645
Closes #649
Closes #650
Closes #651
