### PR TITLE
mcpserver: generate the help prompt's lint analyzer table from the registry

### DIFF
--- a/mcpserver/help_analyzers_test.go
+++ b/mcpserver/help_analyzers_test.go
@@ -1,0 +1,138 @@
+package mcpserver
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/lint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// helpAnalyzerRow is one parsed row of the help prompt's "Lint Analyzers"
+// table.
+type helpAnalyzerRow struct {
+	Name        string
+	Severity    string
+	Semantic    string
+	HasSemantic bool
+}
+
+// parseHelpAnalyzerRows extracts the rows of the "## Lint Analyzers" markdown
+// table out of the help prompt, resolving cells by their header name so the
+// test does not depend on column order.
+func parseHelpAnalyzerRows(t *testing.T, content string) []helpAnalyzerRow {
+	t.Helper()
+	_, after, found := strings.Cut(content, "## Lint Analyzers")
+	require.True(t, found, "help prompt must carry a Lint Analyzers section")
+	section, _, _ := strings.Cut(after, "\n## ")
+
+	cells := func(line string) []string {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "|")
+		line = strings.TrimSuffix(line, "|")
+		out := strings.Split(line, "|")
+		for i := range out {
+			out[i] = strings.TrimSpace(out[i])
+		}
+		return out
+	}
+
+	var header []string
+	var rows []helpAnalyzerRow
+	for _, line := range strings.Split(section, "\n") {
+		if !strings.HasPrefix(strings.TrimSpace(line), "|") {
+			continue
+		}
+		c := cells(line)
+		if header == nil {
+			header = c
+			continue
+		}
+		if strings.HasPrefix(c[0], "---") {
+			continue
+		}
+		col := func(name string) (string, bool) {
+			for i, h := range header {
+				if strings.EqualFold(h, name) && i < len(c) {
+					return c[i], true
+				}
+			}
+			return "", false
+		}
+		name, _ := col("Analyzer")
+		severity, _ := col("Severity")
+		semantic, hasSemantic := col("Semantic")
+		rows = append(rows, helpAnalyzerRow{
+			Name:        name,
+			Severity:    severity,
+			Semantic:    semantic,
+			HasSemantic: hasSemantic,
+		})
+	}
+	require.NotEmpty(t, rows, "Lint Analyzers table must have rows")
+	return rows
+}
+
+// TestHelpAnalyzerTableMatchesRegistry pins the help prompt's analyzer table to
+// lint.DefaultAnalyzers(). A hand-maintained table drifted: it advertised
+// analyzers that were never registered and omitted registered ones (#646).
+func TestHelpAnalyzerTableMatchesRegistry(t *testing.T) {
+	srv := New()
+	_, resp, err := srv.service.helpTool(t.Context(), nil, HelpInput{})
+	require.NoError(t, err)
+
+	rows := parseHelpAnalyzerRows(t, resp.Content)
+
+	registered := make(map[string]*lint.Analyzer)
+	for _, a := range lint.DefaultAnalyzers() {
+		registered[a.Name] = a
+	}
+
+	listed := make(map[string]bool)
+	var fictional []string
+	for _, row := range rows {
+		listed[row.Name] = true
+		if registered[row.Name] == nil {
+			fictional = append(fictional, row.Name)
+		}
+	}
+	var missing []string
+	for _, name := range lint.AnalyzerNames() {
+		if !listed[name] {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(fictional)
+	assert.Empty(t, fictional,
+		"help prompt advertises analyzers that lint.DefaultAnalyzers() does not register")
+	assert.Empty(t, missing,
+		"help prompt omits registered analyzers")
+
+	// Every row's severity and semantic flag must match the registered
+	// analyzer, so the table cannot drift in its cells either.
+	for _, row := range rows {
+		a := registered[row.Name]
+		if a == nil {
+			continue
+		}
+		assert.Equal(t, a.Severity.String(), row.Severity,
+			"severity for %s must match the registered analyzer", row.Name)
+		require.True(t, row.HasSemantic,
+			"Lint Analyzers table must carry a Semantic column (row %s)", row.Name)
+		want := "no"
+		if a.Semantic {
+			want = "yes"
+		}
+		assert.Equal(t, want, row.Semantic,
+			"semantic flag for %s must match the registered analyzer", row.Name)
+	}
+
+	// Rows are sorted by name.
+	names := make([]string, len(rows))
+	for i, row := range rows {
+		names[i] = row.Name
+	}
+	assert.True(t, sort.StringsAreSorted(names), "analyzer rows must be sorted by name: %v", names)
+}

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -2092,7 +2092,7 @@ func (s *service) helpTool(_ context.Context, _ *mcp.CallToolRequest, _ HelpInpu
 	return nil, HelpResponse{Content: helpContent}, nil
 }
 
-const helpContent = `# ELPS MCP Server — Usage Guide
+const helpContentPrefix = `# ELPS MCP Server — Usage Guide
 
 ## Coordinate System
 Lines and characters are **0-indexed** (LSP convention). Line 1 in your editor is line 0 in MCP tool calls.
@@ -2188,26 +2188,11 @@ Use ` + "`doc`" + ` with ` + "`package=true`" + ` to list symbols in any package
 Embedders may register additional packages via ` + "`WithRegistry`" + `.
 
 ## Lint Analyzers
-| Analyzer | Severity | Description |
-|----------|----------|-------------|
-| set-usage | warning | Flags repeated ` + "`set`" + ` on same symbol (use ` + "`set!`" + ` for mutation) |
-| in-package-toplevel | error | ` + "`in-package`" + ` must be at top level |
-| if-arity | error | ` + "`if`" + ` requires 2-3 arguments |
-| let-bindings | error | ` + "`let`" + ` binding list must be well-formed |
-| defun-structure | error | ` + "`defun`" + ` requires name, params, body |
-| cond-structure | error | ` + "`cond`" + ` clauses must be lists |
-| builtin-arity | error | Checks argument count for builtins |
-| rethrow-context | error | ` + "`rethrow`" + ` only valid inside ` + "`handler-bind`" + ` |
-| handler-bind-structure | error | ` + "`handler-bind`" + ` form must be well-formed |
-| cond-else | warning | ` + "`cond`" + ` ` + "`else`" + ` must be last clause |
-| test-structure | error | ` + "`test`" + ` form must have name and body |
-| lambda-structure | error | ` + "`lambda`" + ` requires params and body |
-| missing-package-qualifier | warning | Unexported symbol used without package qualifier |
-| deftype-structure | error | ` + "`deftype`" + ` requires name and field list |
-| export-form | warning | ` + "`export`" + ` argument must be a quoted symbol |
-| sort-stable-comparator | warning | ` + "`sort-stable`" + ` requires a comparator function |
-| assert-arity | warning | ` + "`assert-*`" + ` test macros have specific arity |
+Semantic checks need workspace analysis (pass ` + "`include_workspace`" + ` or a
+workspace root); without it they report nothing.
+`
 
+const helpContentSuffix = `
 ## Performance Rules
 | Rule | Description |
 |------|-------------|
@@ -2234,6 +2219,48 @@ Errors include structured JSON with:
 - ` + "`message`" + `: human-readable description
 - ` + "`path`" + `: relevant file path (when applicable)
 `
+
+// helpContent is the help tool's prompt. The lint analyzer table in it is
+// generated from lint.DefaultAnalyzers() at init rather than hand-written, so
+// the prompt cannot advertise checks the linter does not run (#646).
+var helpContent = helpContentPrefix + lintAnalyzerTable() + helpContentSuffix
+
+// lintAnalyzerTable renders the registered lint analyzers as the markdown table
+// the help prompt embeds: one row per analyzer, sorted by name, with the
+// severity the linter prints, the first sentence of the analyzer's doc, and
+// whether the check needs semantic analysis.
+func lintAnalyzerTable() string {
+	// DefaultAnalyzers returns a fresh slice, so sorting it is local.
+	analyzers := lint.DefaultAnalyzers()
+	sort.Slice(analyzers, func(i, j int) bool { return analyzers[i].Name < analyzers[j].Name })
+
+	var b strings.Builder
+	b.WriteString("| Analyzer | Severity | Description | Semantic |\n")
+	b.WriteString("|----------|----------|-------------|----------|\n")
+	for _, a := range analyzers {
+		semantic := "no"
+		if a.Semantic {
+			semantic = "yes"
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n",
+			a.Name, a.Severity, firstDocSentence(a.Doc), semantic)
+	}
+	return b.String()
+}
+
+// firstDocSentence extracts the leading sentence of an analyzer doc: everything
+// up to the first period or newline, trimmed. Pipes are escaped so a doc cannot
+// break the markdown table it lands in.
+func firstDocSentence(doc string) string {
+	if i := strings.IndexAny(doc, ".\n"); i >= 0 {
+		if doc[i] == '.' {
+			doc = doc[:i+1]
+		} else {
+			doc = doc[:i]
+		}
+	}
+	return strings.ReplaceAll(strings.TrimSpace(doc), "|", "\\|")
+}
 
 func (s *service) formatTool(_ context.Context, _ *mcp.CallToolRequest, in FormatInput) (*mcp.CallToolResult, FormatResponse, error) {
 	start := time.Now()

--- a/mcpserver/service.go
+++ b/mcpserver/service.go
@@ -2188,8 +2188,10 @@ Use ` + "`doc`" + ` with ` + "`package=true`" + ` to list symbols in any package
 Embedders may register additional packages via ` + "`WithRegistry`" + `.
 
 ## Lint Analyzers
-Semantic checks need workspace analysis (pass ` + "`include_workspace`" + ` or a
-workspace root); without it they report nothing.
+Semantic checks always run: they resolve symbols against the file's own
+definitions and the standard library. Pass ` + "`include_workspace`" + ` (and
+optionally ` + "`workspace_root`" + `) so they also see definitions in the other
+files of the workspace; without it a symbol defined elsewhere reads as undefined.
 `
 
 const helpContentSuffix = `


### PR DESCRIPTION
## Summary

The MCP server's help prompt carried a hand-written "Lint Analyzers" table that had drifted a long way from `lint.DefaultAnalyzers()`: nine rows named analyzers that do not exist (`assert-arity`, `cond-else`, `deftype-structure`, `export-form`, `handler-bind-structure`, `lambda-structure`, `missing-package-qualifier`, `sort-stable-comparator`, `test-structure`), eleven registered analyzers were missing, and `in-package-toplevel` was listed as `error` when the registry says `warning`. An MCP client reading the prompt was told to expect checks `elps lint` cannot run.

The table is now built at package init from the registry: one row per analyzer, sorted by name, with its name, severity, the first sentence of its `Doc`, and a new `Semantic` column saying whether it needs workspace analysis. The three existing columns keep their header text and order, so a consumer reading the first three cells sees the same shape. `mcpserver` already imported `lint` for its lint tool, so no new dependency and no cycle.

## Test

`TestHelpAnalyzerTableMatchesRegistry` parses the rendered prompt and asserts the row set equals `lint.AnalyzerNames()`, and that each row's severity and semantic flag match the registered analyzer. On the previous head it fails naming the nine fictional and eleven missing rows; on this head it passes. The existing `TestHelpTool` substring assertions are unchanged and still pass.

## Also found, not fixed here

Other hand-maintained analyzer lists outside `mcpserver`: `docs/lint-checks.md` has no section for `duplicate-definition`; `docs/lsp-guide.md` has a partial prose enumeration; two historical design docs under `docs/` list old tiers. `docs/nolint.md`'s `elps lint --list` transcript is regenerated in #647.

## Verification

- `go build ./...`, `go vet ./mcpserver/` clean; `gofmt -l mcpserver/` reports only the pre-existing `types.go` alignment on main, untouched
- `go test ./mcpserver/ -count=1 -v`: new test red on the previous head, green here; `go test ./... -count=1`: all ok
- `go run ./cmd/elpsvet -test=false ./...` in both modes: exit 0
- `make static-checks`: only the two documented pre-existing `nolintlint` findings from the golangci-lint version skew
- `scripts/ci-gates-test.sh`: 0 failed; `./elps doc -m`: all documented

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHMPMnEJgGRuJioE5ddat6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHMPMnEJgGRuJioE5ddat6)_