### PR TITLE
Close ELPS backlog gaps in LSP lookup and walker verification

### DIFF
--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -9,16 +9,12 @@ on:
 
 jobs:
   diagnose-marketplace:
-    name: Diagnose Marketplace (${{ matrix.runner }})
+    name: Diagnose Marketplace (ARM)
     if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 3
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: [ubuntu-24.04-arm, ubuntu-24.04]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
@@ -34,6 +30,9 @@ jobs:
       - name: Report unauthenticated discovery and published version inventory
         run: node scripts/marketplace-diagnostics.cjs
 
+  # TODO(marketplace-638): authenticated discovery and missing-target publication
+  # recovery remain unverified; diagnostics above intentionally cannot use a PAT
+  # or publish. Track recovery at https://github.com/luthersystems/elps/issues/638.
   build-binaries:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     name: Build elps (${{ matrix.target }})

--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -1,12 +1,41 @@
 name: Publish VS Code Extension
 
 on:
+  # Manual runs are read-only diagnostics; only tag pushes can publish.
+  workflow_dispatch:
   push:
     tags:
       - "v*"
 
 jobs:
+  diagnose-marketplace:
+    name: Diagnose Marketplace (${{ matrix.runner }})
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 3
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04-arm, ubuntu-24.04]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
+        with:
+          node-version: "20"
+      - name: Install the locked publishing client without lifecycle scripts
+        working-directory: editors/vscode
+        run: npm ci --ignore-scripts --no-audit --no-fund
+      - name: Verify the locked SDK probe against local HTTP servers
+        run: node --test scripts/marketplace-sdk.test.cjs
+      - name: Report unauthenticated discovery and published version inventory
+        run: node scripts/marketplace-diagnostics.cjs
+
   build-binaries:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     name: Build elps (${{ matrix.target }})
     # ARM for the reason spelled out on elps.yml's lint-and-test job -- this
     # is the HOST the cross-compile runs on, and nothing else.
@@ -65,6 +94,7 @@ jobs:
           path: editors/vscode/bin/
 
   publish-platform:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     name: Publish (${{ matrix.target }})
     needs: build-binaries
     # ARM for the reason on elps.yml's lint-and-test job. `--target` below is
@@ -126,6 +156,7 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
   publish-universal:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     name: Publish (universal)
     needs: build-binaries
     # ARM for the reason on elps.yml's lint-and-test job; same npm/esbuild

--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -15,6 +15,11 @@ jobs:
       contents: read
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 3
+    # One read-only probe at a time, including dispatches from other branches.
+    # Job scope is deliberate: tag publication must never share cancellation.
+    concurrency:
+      group: elps-marketplace-readonly-diagnostics
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:

--- a/docs/marketplace-recovery.md
+++ b/docs/marketplace-recovery.md
@@ -1,0 +1,75 @@
+# VS Code Marketplace diagnostics and recovery
+
+The Go release and the Marketplace extension are separate publications. A
+published Go module does not establish that every VSIX target is available.
+
+## Diagnose without publishing
+
+The existing `Publish VS Code Extension` workflow has a **read-only manual
+mode**. Tag pushes still build and publish the original five packages. Manual
+runs cannot build or publish, and do not receive `VSCE_PAT`.
+
+```sh
+gh workflow run vscode-publish.yml --repo luthersystems/elps --ref <reviewed-branch>
+```
+
+Two jobs compare Ubuntu 24.04 ARM and x64 using Node 20, the publishing runtime.
+They report only public addresses, timings, HTTP status codes, and a validated
+version/platform inventory for `LutherSystems.elps-lang`:
+
+- unauthenticated `OPTIONS /_apis/gallery`, including DNS, connect, TLS and
+  first-byte timing;
+- the public, read-only extension query (POST is the API's query method);
+- the locked `azure-devops-node-api` client's `getExtension` call used by `vsce`
+  before upload, **without** an authentication handler.
+
+Raw requests have a 15-second absolute deadline and a 1 MiB response limit. The
+SDK subprocess has an independent 20-second deadline. Response headers, bodies,
+exception messages, cookies, and environment variables are never logged. The
+SDK subprocess receives an empty environment; dependency lifecycle scripts are
+disabled. Its authenticated behavior is deliberately not tested.
+
+**A green diagnostic job means the diagnostic ran, not that publishing works.**
+Read its JSON report. `401` from unauthenticated discovery proves an HTTP
+response arrived, not that a PAT is invalid. A successful public query establishes
+what is currently indexed, not whether an unindexed upload has been accepted.
+Compare raw transport with the SDK result and compare both runner hosts before
+attributing a failure to the client or host. An SDK-only failure warrants examining
+the locked client's request behavior; neither result justifies rotating secrets.
+
+Local checks (Node and Python with PyYAML, also used by the existing CI guards):
+
+```sh
+node --test scripts/marketplace-diagnostics.test.cjs
+python3 scripts/marketplace-workflow-test.py
+```
+
+## Recovery requires an explicitly approved publishing operation
+
+1. Record the diagnostic run and the desired release's five targets: universal,
+   linux-x64, linux-arm64, darwin-x64, darwin-arm64. Confirm missing targets in the
+   publisher's management view too: the public index may lag an accepted upload.
+2. Resolve the diagnosed cause. Do not speculate about PAT expiry from a network
+   timeout, or switch runner architectures merely because the failing host is ARM.
+3. Publish **only missing targets**, using the immutable release source and
+   artifacts. A failed-job rerun is safe only after checking that none of those
+   jobs already uploaded its target. Do not move a release tag or rerun all jobs
+   blindly. Manual diagnostic dispatch is not a recovery/publishing command.
+4. Verify all five version/target entries after indexing and record the recovery
+   evidence on [#638](https://github.com/luthersystems/elps/issues/638).
+
+## Current evidence for #638
+
+The original [v1.61.0](https://github.com/luthersystems/elps/actions/runs/34292740674)
+and [v1.61.1](https://github.com/luthersystems/elps/actions/runs/34308282015) failures
+stop at `/_apis/gallery` discovery, before the extension lookup/upload completes.
+Both time out at 180 seconds; binary builds and packaging succeed. The same ARM
+workflow successfully published v1.60.0. The relevant `vsce` 3.9.2,
+`azure-devops-node-api` 12.5.0 and transport dependency pins did not change.
+
+On September 9, 2026, an unauthenticated local probe returned discovery HTTP 401
+and public-query HTTP 200; the public inventory contained all five v1.60.0
+targets and no v1.61.0/v1.61.1 targets. This is **not runner-side or authenticated
+recovery evidence**. #638 remains open until Marketplace publication is actually
+recovered. The diagnostic workflow supplies the missing runner-side evidence
+without turning an investigation into an accidental release.

--- a/docs/marketplace-recovery.md
+++ b/docs/marketplace-recovery.md
@@ -13,8 +13,8 @@ runs cannot build or publish, and do not receive `VSCE_PAT`.
 gh workflow run vscode-publish.yml --repo luthersystems/elps --ref <reviewed-branch>
 ```
 
-Two jobs compare Ubuntu 24.04 ARM and x64 using Node 20, the publishing runtime.
-They report only public addresses, timings, HTTP status codes, and a validated
+The diagnostic job uses Ubuntu 24.04 ARM and Node 20, matching publication.
+It reports only public addresses, timings, HTTP status codes, and a validated
 version/platform inventory for `LutherSystems.elps-lang`:
 
 - unauthenticated `OPTIONS /_apis/gallery`, including DNS, connect, TLS and
@@ -33,8 +33,8 @@ disabled. Its authenticated behavior is deliberately not tested.
 Read its JSON report. `401` from unauthenticated discovery proves an HTTP
 response arrived, not that a PAT is invalid. A successful public query establishes
 what is currently indexed, not whether an unindexed upload has been accepted.
-Compare raw transport with the SDK result and compare both runner hosts before
-attributing a failure to the client or host. An SDK-only failure warrants examining
+Compare raw transport with the SDK result before attributing a failure to the
+client. An SDK-only failure warrants examining
 the locked client's request behavior; neither result justifies rotating secrets.
 
 Local checks (Node and Python with PyYAML, also used by the existing CI guards):
@@ -73,3 +73,13 @@ targets and no v1.61.0/v1.61.1 targets. This is **not runner-side or authenticat
 recovery evidence**. #638 remains open until Marketplace publication is actually
 recovered. The diagnostic workflow supplies the missing runner-side evidence
 without turning an investigation into an accidental release.
+
+The [September 10 UTC runner comparison](https://github.com/luthersystems/elps/actions/runs/34444476770)
+then reproduced the checks on both hosted fleets: raw discovery returned 401,
+the public query returned 200, and the locked SDK returned 401 in 67 ms on ARM
+and 163 ms on x64. The inventory still ended at 1.60.0. All three production
+build/publish jobs were skipped. There is no evidence from this run of a general
+runner-connectivity or unauthenticated SDK failure; authenticated requests remain
+untested, so neither changing hosts nor declaring the outage resolved is justified.
+The one-off x64 comparison has been removed from the shipped workflow: future
+diagnostics stay on the production-equivalent ARM host, with no fleet exception.

--- a/docs/walker-oracle.md
+++ b/docs/walker-oracle.md
@@ -1,0 +1,96 @@
+# Value-walker behavioral guard
+
+Issues [#598](https://github.com/luthersystems/elps/issues/598) and
+[#600](https://github.com/luthersystems/elps/issues/600) originally described a
+guard tied to the removed `Fork` API. The surviving requirement is a shared
+behavioral guard for every current rebuilding walker, not restoring that API.
+
+`lisp/walker_oracle_test.go` drives actual entry points on one generated graph:
+
+| Entry point | Registered implementation | Contract checked |
+| --- | --- | --- |
+| Lisp `copy` builtin | `detacher` | Private containers and cloneable natives; preserve payload aliases |
+| Private `detach` | `detacher` | Same data ownership; refuse opaque annotations |
+| `(*LVal).Copy` | `copier` | Private containers and cloneable natives; preserve payload aliases |
+| `stampMacroExpansion` with a non-nil debug context | `macroStamper` | Private stamps, untouched input, shared value payloads, cyclic syntax remains cyclic |
+| `NewTemplate` followed by two `NewVM` calls | `templateInventory`, `templateCompiler` | Private mutable state; preserve aliases and overlapping cell slots; share admitted immutable values |
+
+The registry test requires every registered walker to have a behavioral adapter
+and every cross-walker payload kind to appear in the graph census. Existing
+memo-field, payload-switch and struct-copy source scans remain in place. These
+are complementary: behavioral tests observe mistakes in real copying, while
+source scans require an explicit decision about newly added fields and walkers.
+
+## What the oracle observes
+
+- Independently traversed source/result paths, with cycle and size bounds.
+- Distinct equal-content maps, bytes and native objects, plus multiple headers
+  over one payload. Pairwise identity must agree in both directions: neither
+  de-aliasing nor coalescing equal but distinct objects is allowed.
+- Source, result and sibling writes to map entries, bytes, cloneable natives,
+  list slots and array backing-list slots. The target must actually change,
+  while both other arms remain unchanged.
+- Scalar values, quote/splice flags, source locations and format metadata.
+  Snapshots encode token/location contents, not just their addresses.
+- Debug metadata on changed descendants, including the cyclic rerun, not only
+  the root. The input is observed before construction, catching metadata-only
+  writes even when location stamping is otherwise correct.
+- Native annotations under non-`LNative` headers, without losing the annotated
+  container's descendant payloads. Separate fixtures check the different
+  refusal/sharing contracts rather than labeling every native a leak.
+- Positive immutable-code/native sharing, distinct-header cell views, and
+  construction failures returning no usable partial container.
+
+The stamper is not a deep-copy operation. Its acyclic syntax headers need not
+retain identity, and its value payloads intentionally remain shared. Likewise,
+copy/detach do **not** preserve overlapping cell-slot aliases; templates do.
+These differences are explicit policies, not a known-broken-walker allowlist.
+
+Template source/format metadata is frozen program state, shared by contract.
+Writing an internal field of a frozen location is not a valid VM operation.
+The guard instead checks public `SetSource` header replacement isolation;
+copy/detach also get direct mutation probes for their independently owned
+locations/comment tokens. No claim is made that templates deep-copy metadata.
+
+## Negative controls and reproduction
+
+The permanent controls run clean real walks before injecting a defect and
+require a witness from the relevant channel. They cover lost payload aliases,
+coalescing equal payloads, retained bytes, sibling sharing, wrong byte contents,
+lost flags/locations/comments, retained debugger state, input-only metadata
+writes, a no-op stamper and missing descendant stamps.
+
+The following production mutations were also applied individually during
+development. Each made **only the common behavioral test** fail; all were
+restored afterwards. To reproduce, change the named lookup's `ok` condition to
+`ok && false`, except for the two explicitly stated assignment mutations:
+
+| Function / mutation | Common oracle witness |
+| --- | --- |
+| `detacher.detachMapData`: bypass `d.maps[md]` lookup | `copy` and `detach`: map payload alias |
+| `detacher.byteSlice`: bypass `d.bytes[b]` lookup | `copy` and `detach`: byte payload alias |
+| `detacher.cloneNative`: bypass `d.natives[payload]` lookup | `copy` and `detach`: native payload alias |
+| `copier.mapData`: bypass `c.maps[md]` lookup | `LVal.Copy`: map payload alias |
+| `copier.byteSlice`: bypass `c.bytes[b]` lookup | `LVal.Copy`: byte payload alias |
+| `copier.cloneNative`: bypass `c.natives[payload]` lookup | `LVal.Copy`: native payload alias |
+| `templateCompiler.mapData`: bypass `c.maps[source]` lookup | `Template.NewVM`: map payload alias |
+| `macroStamper.syntax`: store `s.copies[v] = v` instead of `cp` | Cyclic seed: extra output paths instead of a closed back-edge |
+| `macroStamper.stampedCopy`: assign debug metadata to `v`, not `cp` | Source changed during construction |
+
+```sh
+go test ./lisp -run '^TestWalkerBehaviorOracle$' -count=1
+go test -race -tags=elpscheck ./lisp -run '^(TestWalkerBehaviorOracle|FuzzWalkerBehaviorOracle)' -count=1
+go test ./lisp -run '^$' -fuzz '^FuzzWalkerBehaviorOracle$' -fuzztime=30s
+```
+
+`FuzzWalkerBehaviorOracle` runs one adapter and at most eight graph-building
+instructions per input, varying payload groups, header aliases, list/array
+nesting, flags and cyclic syntax. It never evaluates unbounded Lisp code and
+has no inconclusive-success path. On the development machine the initial
+10-second run executed 6,897 inputs; this is a bounded structural oracle, not
+a replacement for the existing cold-load/template transaction parity fuzzers.
+
+Not every memo has an independently observable identity effect. In particular,
+the template native descriptor memo deduplicates already-approved immutable
+objects that remain shared anyway. Its structural registry guard matters; a
+promise that removing *every* memo must break alias semantics would be false.

--- a/docs/walker-oracle.md
+++ b/docs/walker-oracle.md
@@ -61,8 +61,11 @@ lost flags/locations/comments, retained debugger state, input-only metadata
 writes, a no-op stamper and missing descendant stamps.
 
 The following production mutations were also applied individually during
-development. Each made **only the common behavioral test** fail; all were
-restored afterwards. To reproduce, change the named lookup's `ok` condition to
+development. For each mutation, we ran the common behavioral test alone
+(`TestWalkerBehaviorOracle`, command below), and it detected the defect. This
+demonstrates coverage by the common oracle, not that it is the first or only
+detector; existing targeted regressions also cover some of these defects. All
+mutations were restored afterwards. To reproduce, change the named lookup's `ok` condition to
 `ok && false`, except for the two explicitly stated assignment mutations:
 
 | Function / mutation | Common oracle witness |
@@ -86,9 +89,10 @@ go test ./lisp -run '^$' -fuzz '^FuzzWalkerBehaviorOracle$' -fuzztime=30s
 `FuzzWalkerBehaviorOracle` runs one adapter and at most eight graph-building
 instructions per input, varying payload groups, header aliases, list/array
 nesting, flags and cyclic syntax. It never evaluates unbounded Lisp code and
-has no inconclusive-success path. On the development machine the initial
-10-second run executed 6,897 inputs; this is a bounded structural oracle, not
-a replacement for the existing cold-load/template transaction parity fuzzers.
+has no inconclusive-success path. Use the command above to measure throughput
+at the current revision; counts from different revisions or machines are not
+directly comparable. This is a bounded structural oracle, not a replacement
+for the existing cold-load/template transaction parity fuzzers.
 
 Not every memo has an independently observable identity effect. In particular,
 the template native descriptor memo deduplicates already-approved immutable

--- a/lisp/walker_oracle_controls_test.go
+++ b/lisp/walker_oracle_controls_test.go
@@ -3,9 +3,40 @@
 package lisp
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
+
+func TestWalkerBehaviorOracleReportsPostWriteTraversalFailure(t *testing.T) {
+	for _, w := range oracleWalkers() {
+		if w.stamps {
+			continue // Stamping intentionally performs no payload mutation probes.
+		}
+		t.Run(w.name, func(t *testing.T) {
+			cells := make([]*LVal, 200)
+			for i := range cells {
+				cells[i] = SortedMap()
+				cells[i].Map().Set(String("n"), Int(i))
+			}
+			root := SExpr(cells)
+			nodes, err := oracleNodes(root)
+			if err != nil || len(nodes) != 401 {
+				t.Fatalf("fixture must fit before probing: nodes=%d error=%v", len(nodes), err)
+			}
+			// Adding a probe entry to each map exceeds the census bound on
+			// the mutated arm itself. That is not evidence of a sibling leak.
+			err = oracleCheck(w, root)
+			if err == nil || !strings.Contains(err.Error(), "snapshot arm 0 after writes to arm 0") || strings.Contains(err.Error(), "isolation:") {
+				t.Fatalf("want a contextual traversal error, not an isolation claim: %v", err)
+			}
+			cause := errors.Unwrap(err)
+			if cause == nil || !strings.Contains(cause.Error(), "graph traversal exceeded bound") {
+				t.Fatalf("underlying traversal failure was lost: %v", err)
+			}
+		})
+	}
+}
 
 type oracleImmutable struct{ n int }
 

--- a/lisp/walker_oracle_controls_test.go
+++ b/lisp/walker_oracle_controls_test.go
@@ -1,0 +1,256 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"strings"
+	"testing"
+)
+
+type oracleImmutable struct{ n int }
+
+type oracleFailingMap struct{ Map }
+
+func (*oracleFailingMap) Entries([]*LVal) *LVal { return Errorf("oracle map enumeration failure") }
+
+func TestWalkerBehaviorOracleFailedCopyIsNotAContainer(t *testing.T) {
+	for _, w := range oracleWalkers() {
+		t.Run(w.name, func(t *testing.T) {
+			m := SortedMapFromData(NewMapData(&oracleFailingMap{Map: SortedMap().Map()}))
+			root := SExpr([]*LVal{Bytes([]byte{1}), m, Quote(m), m})
+			a, b, err := w.makeCopies(root)
+			if w.stamps {
+				// Stamping does not enumerate value payloads: a map callback
+				// failure is not an error for an operation that never calls it.
+				if err != nil || a.Cells[1].Native != m.Native || b.Cells[1].Native != m.Native {
+					t.Fatal("stamper walked or rebuilt an opaque value payload")
+				}
+				return
+			}
+			// Templates reject external maps at admission. The copy walkers
+			// try Entries and must discard the entire partially built graph.
+			if err == nil || a != nil || b != nil {
+				t.Fatal("failed graph construction returned a usable container")
+			}
+			want := "oracle map enumeration failure"
+			if w.template {
+				want = "not interpreter-owned"
+			}
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("wrong refusal: %v", err)
+			}
+		})
+	}
+}
+
+func TestWalkerBehaviorOracleImmutableNative(t *testing.T) {
+	// No mutation hooks and no writes after this declaration: approval means
+	// transitive immutability, not permission to skip a required clone.
+	p := &oracleImmutable{n: 7}
+	v := Native(p)
+	root := SExpr([]*LVal{v, Quote(v)})
+	a, b, err := oracleTemplateCopiesWithOptions(root, TemplateWithNativePolicy(func(value any) bool { return value == p }))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, result := range []*LVal{a, b} {
+		if result == root || result.Cells[0] == v || result.Cells[0] == result.Cells[1] || result.Cells[0].Native != p || result.Cells[1].Native != p {
+			t.Fatal("approved immutable native must be shared behind private, distinct headers")
+		}
+	}
+}
+
+// These mutations wrap REAL successful walks. Checking the clean arm first
+// prevents an unrelated fixture failure from masquerading as a killed mutant.
+func TestWalkerBehaviorOracleNegativeControls(t *testing.T) {
+	for _, tc := range []struct {
+		name, channel string
+		mutate        func(source, a, b *LVal)
+	}{
+		{"source byte retained", "ownership", func(source, a, _ *LVal) { a.Cells[0].Cells[3].Native = source.Cells[0].Cells[3].Native }},
+		{"payload memo lost", "alias", func(_, a, _ *LVal) { a.Cells[0].Cells[1].Native = a.Cells[0].Cells[1].Copy().Native }},
+		{"equal payloads coalesced", "alias", func(_, a, _ *LVal) { a.Cells[0].Cells[2].Native = a.Cells[0].Cells[0].Native }},
+		{"sibling sharing", "isolation", func(_, a, b *LVal) {
+			b.Cells[0].Cells[3].Native = a.Cells[0].Cells[3].Native
+			b.Cells[0].Cells[4].Native = a.Cells[0].Cells[4].Native
+		}},
+		{"sibling map sharing", "isolation", func(_, a, b *LVal) {
+			b.Cells[4].Native = a.Cells[4].Native
+		}},
+		{"sibling native sharing", "isolation", func(_, a, b *LVal) {
+			b.Cells[0].Cells[6].Native = a.Cells[0].Cells[6].Native
+			b.Cells[0].Cells[7].Native = a.Cells[0].Cells[7].Native
+		}},
+		{"sibling cell slot sharing", "isolation", func(_, a, b *LVal) { b.Cells[3].Cells = a.Cells[3].Cells }},
+		{"sibling array slot sharing", "isolation", func(_, a, b *LVal) { b.Cells[5].Cells[1].Cells = a.Cells[5].Cells[1].Cells }},
+		{"sibling source location sharing", "isolation", func(_, a, b *LVal) { b.source = a.source }},
+		{"sibling format metadata sharing", "isolation", func(_, a, b *LVal) { b.meta = a.meta }},
+		{"zeroed bytes", "contents", func(_, a, _ *LVal) { a.Cells[0].Cells[3].Bytes()[0] = 0 }},
+		{"lost quote", "flags", func(_, a, _ *LVal) { a.quoted = false }},
+		{"retained debugger metadata", "retained macro", func(source, a, _ *LVal) { a.macroExpansion = source.macroExpansion }},
+		{"metadata only input write", "source changed", func(source, _, _ *LVal) { source.macroExpansion.ID++ }},
+		{"macro argument slot input write", "source changed", func(source, _, _ *LVal) { source.macroExpansion.Args[0] = Int(99) }},
+		{"macro location hidden field input write", "source changed", func(source, _, _ *LVal) { source.macroExpansion.CallSite.EndCol++ }},
+		{"comment location input write", "source changed", func(source, _, _ *LVal) { source.meta.TrailingComment.Source.Line++ }},
+		{"lost source location", "source/format", func(_, a, _ *LVal) { a.source = nil }},
+		{"lost format metadata", "source/format", func(_, a, _ *LVal) { a.meta = nil }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := oracleWalkers()[2]
+			if err := oracleCheck(w, oracleGraph(8, true)); err != nil {
+				t.Fatalf("clean control: %v", err)
+			}
+			clean := w.makeCopies
+			w.makeCopies = func(v *LVal) (*LVal, *LVal, error) {
+				a, b, err := clean(v)
+				if err == nil {
+					tc.mutate(v, a, b)
+				}
+				return a, b, err
+			}
+			err := oracleCheck(w, oracleGraph(8, true))
+			if err == nil || !strings.Contains(err.Error(), tc.channel) {
+				t.Fatalf("mutant must hit %q channel, got %v", tc.channel, err)
+			}
+		})
+	}
+}
+
+func TestWalkerBehaviorOracleStampLiveControl(t *testing.T) {
+	w := oracleWalkers()[3]
+	if err := oracleCheck(w, oracleGraph(4, true)); err != nil {
+		t.Fatal(err)
+	}
+	w.makeCopies = func(v *LVal) (*LVal, *LVal, error) { return v, v, nil }
+	if err := oracleCheck(w, oracleGraph(4, true)); err == nil || !strings.Contains(err.Error(), "debug stamp path did not execute") {
+		t.Fatalf("a no-op stamp must fail its live-path assertion, got %v", err)
+	}
+	w = oracleWalkers()[3]
+	clean := w.makeCopies
+	w.makeCopies = func(v *LVal) (*LVal, *LVal, error) {
+		a, b, err := clean(v)
+		if err == nil {
+			a.Cells[0].macroExpansion = nil
+		}
+		return a, b, err
+	}
+	if err := oracleCheck(w, oracleGraph(4, true)); err == nil || !strings.Contains(err.Error(), "missing descendant debug stamp") {
+		t.Fatalf("child-only missing metadata must fail: %v", err)
+	}
+	w = oracleWalkers()[3]
+	clean = w.makeCopies
+	w.makeCopies = func(v *LVal) (*LVal, *LVal, error) {
+		a, b, err := clean(v)
+		if err == nil {
+			truncated := *a
+			truncated.Cells = nil
+			a.Cells[len(a.Cells)-1] = &truncated
+		}
+		return a, b, err
+	}
+	if err := oracleCheck(w, oracleGraph(4, true)); err == nil || !strings.Contains(err.Error(), "cell arity") {
+		t.Fatalf("a truncated cycle edge must fail even with the same traversal paths: %v", err)
+	}
+}
+
+func TestWalkerBehaviorOracleSealedCode(t *testing.T) {
+	for _, w := range oracleWalkers() {
+		t.Run(w.name, func(t *testing.T) {
+			root := SExpr([]*LVal{Symbol("+"), Int(1), Int(2)})
+			root.SealAST()
+			a, b, err := w.makeCopies(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			shared := w.stamps || w.template
+			if (a == root) != shared || a.IsSealed() != shared || (a == b) != shared {
+				t.Fatal("immutable program sharing policy changed")
+			}
+			if !shared {
+				a.Cells[1] = Int(97)
+				if root.Cells[1].Int != 1 || b.Cells[1].Int != 1 || a.Cells[0].IsSealed() {
+					t.Fatal("mutable copy of sealed code retained shared storage or a seal")
+				}
+			}
+		})
+	}
+}
+
+// Native annotations outside LNative are legal at Copy's within-runtime
+// boundary (shared, NOT cloned); strict detach and publication refuse them.
+// The census must still see them, without skipping container descendants.
+func TestWalkerBehaviorOracleNativeAnnotations(t *testing.T) {
+	for _, typ := range []LType{LNative, LString, LSExpr} {
+		t.Run(typ.String(), func(t *testing.T) {
+			p := &oracleNative{n: 7}
+			v := &LVal{Type: typ, Native: p}
+			if typ == LSExpr {
+				v.Cells = []*LVal{Bytes([]byte{1}), SortedMap()}
+			}
+			nodes, err := oracleNodes(v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := 1
+			if typ == LSExpr {
+				want = 3
+			}
+			count := 0
+			for _, n := range nodes {
+				if n.payload != nil {
+					count++
+				}
+			}
+			if count != want || nodes[0].payload != p {
+				t.Fatalf("census: %d payloads, want %d including the root annotation", count, want)
+			}
+			before, err := oracleSnapshot(v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			p.n++
+			after, err := oracleSnapshot(v)
+			if err != nil || before == after {
+				t.Fatal("annotation mutation was invisible")
+			}
+			cp := v.Copy()
+			if (cp.Native == p) != (typ != LNative) {
+				t.Fatal("Copy's annotation/NativeCloner contract changed")
+			}
+			_, err = v.detach()
+			if (err == nil) != (typ == LNative) {
+				t.Fatalf("strict detach annotation contract: %v", err)
+			}
+			if a, _, err := oracleTemplateCopies(v); err == nil || a != nil {
+				t.Fatal("template admitted a mutable native annotation")
+			}
+		})
+	}
+}
+
+// Cell-slot preservation is a VM invariant, not a deep-copy invariant. Test
+// the policy explicitly so extending the shared oracle cannot weaken one to
+// accommodate the other (the historical #600 cdr/sort blind spot).
+func TestWalkerBehaviorOracleCellSlots(t *testing.T) {
+	for _, w := range oracleWalkers() {
+		if w.stamps {
+			continue // Syntax stamping is not a container ownership operation.
+		}
+		t.Run(w.name, func(t *testing.T) {
+			cells := []*LVal{Int(1), Int(2), Int(3)}
+			root := SExpr([]*LVal{SExpr(cells), SExpr(cells[1:])})
+			a, b, err := w.makeCopies(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			a.Cells[0].Cells[1] = Int(97)
+			want := 2
+			if w.template {
+				want = 97
+			}
+			if a.Cells[1].Cells[0].Int != want || root.Cells[1].Cells[0].Int != 2 || b.Cells[1].Cells[0].Int != 2 {
+				t.Fatal("cell-slot fidelity or isolation contract changed")
+			}
+		})
+	}
+}

--- a/lisp/walker_oracle_controls_test.go
+++ b/lisp/walker_oracle_controls_test.go
@@ -4,9 +4,63 @@ package lisp
 
 import (
 	"errors"
+	"fmt"
+	"slices"
 	"strings"
 	"testing"
 )
+
+func TestWalkerBehaviorOracleSelectionSurvivesReordering(t *testing.T) {
+	walkers := oracleWalkers()
+	// Every adapter occupies every index in these rotations. Check actual
+	// operation behavior too, not just a name copied onto the wrong callback.
+	for shift := range walkers {
+		reordered := append(slices.Clone(walkers[shift:]), walkers[:shift]...)
+		for _, tc := range []struct {
+			name, owners                      string
+			shares, refuses, stamps, template bool
+		}{
+			{name: "copy", owners: "detacher", shares: true},
+			{name: "detach", owners: "detacher", refuses: true},
+			{name: "LVal.Copy", owners: "copier"},
+			{name: "macro stamp", owners: "macroStamper", stamps: true},
+			{name: "Template.NewVM", owners: "templateInventory templateCompiler", template: true},
+		} {
+			t.Run(fmt.Sprintf("rotation%d/%s", shift, tc.name), func(t *testing.T) {
+				w, err := oracleWalkerByName(reordered, tc.name)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if w.name != tc.name || w.owners != tc.owners || w.stamps != tc.stamps || w.template != tc.template {
+					t.Fatalf("wrong adapter for %q: name=%q owners=%q stamps=%t template=%t", tc.name, w.name, w.owners, w.stamps, w.template)
+				}
+				v := Native(int64(7))
+				a, b, err := w.makeCopies(v)
+				if tc.refuses {
+					if err == nil || a != nil || b != nil || !strings.Contains(err.Error(), "cannot be detached") {
+						t.Fatalf("strict detach selected the wrong operation: %v", err)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, result := range []*LVal{a, b} {
+					if result == nil || result.Type != LNative || result.Native != int64(7) || (result == v) != tc.shares || (result.macroExpansion != nil) != tc.stamps {
+						t.Fatalf("%s selected the wrong behavior: %v", tc.name, result)
+					}
+				}
+			})
+		}
+	}
+	if _, err := oracleWalkerByName(walkers, "removed operation"); err == nil || !strings.Contains(err.Error(), "missing oracle walker") {
+		t.Fatalf("a missing adapter must not fall back to another operation: %v", err)
+	}
+	duplicate := append(slices.Clone(walkers), mustOracleWalker(t, walkers, "copy"))
+	if _, err := oracleWalkerByName(duplicate, "copy"); err == nil || !strings.Contains(err.Error(), "duplicate oracle walker") {
+		t.Fatalf("ambiguous names must not pick whichever adapter came first: %v", err)
+	}
+}
 
 func TestWalkerBehaviorOracleReportsPostWriteTraversalFailure(t *testing.T) {
 	for _, w := range oracleWalkers() {
@@ -94,6 +148,20 @@ func TestWalkerBehaviorOracleImmutableNative(t *testing.T) {
 // These mutations wrap REAL successful walks. Checking the clean arm first
 // prevents an unrelated fixture failure from masquerading as a killed mutant.
 func TestWalkerBehaviorOracleNegativeControls(t *testing.T) {
+	runOracleControlOrders(t, checkOracleNegativeControls)
+}
+
+func runOracleControlOrders(t *testing.T, check func(*testing.T, []oracleWalker)) {
+	t.Helper()
+	walkers := oracleWalkers()
+	for shift := range walkers {
+		reordered := append(slices.Clone(walkers[shift:]), walkers[:shift]...)
+		t.Run(fmt.Sprintf("rotation%d", shift), func(t *testing.T) { check(t, reordered) })
+	}
+}
+
+func checkOracleNegativeControls(t *testing.T, walkers []oracleWalker) {
+	t.Helper()
 	for _, tc := range []struct {
 		name, channel string
 		mutate        func(source, a, b *LVal)
@@ -127,7 +195,7 @@ func TestWalkerBehaviorOracleNegativeControls(t *testing.T) {
 		{"lost format metadata", "source/format", func(_, a, _ *LVal) { a.meta = nil }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			w := oracleWalkers()[2]
+			w := mustOracleWalker(t, walkers, "LVal.Copy")
 			if err := oracleCheck(w, oracleGraph(8, true)); err != nil {
 				t.Fatalf("clean control: %v", err)
 			}
@@ -148,7 +216,12 @@ func TestWalkerBehaviorOracleNegativeControls(t *testing.T) {
 }
 
 func TestWalkerBehaviorOracleStampLiveControl(t *testing.T) {
-	w := oracleWalkers()[3]
+	runOracleControlOrders(t, checkOracleStampLiveControl)
+}
+
+func checkOracleStampLiveControl(t *testing.T, walkers []oracleWalker) {
+	t.Helper()
+	w := mustOracleWalker(t, walkers, "macro stamp")
 	if err := oracleCheck(w, oracleGraph(4, true)); err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +229,7 @@ func TestWalkerBehaviorOracleStampLiveControl(t *testing.T) {
 	if err := oracleCheck(w, oracleGraph(4, true)); err == nil || !strings.Contains(err.Error(), "debug stamp path did not execute") {
 		t.Fatalf("a no-op stamp must fail its live-path assertion, got %v", err)
 	}
-	w = oracleWalkers()[3]
+	w = mustOracleWalker(t, walkers, "macro stamp")
 	clean := w.makeCopies
 	w.makeCopies = func(v *LVal) (*LVal, *LVal, error) {
 		a, b, err := clean(v)
@@ -168,7 +241,7 @@ func TestWalkerBehaviorOracleStampLiveControl(t *testing.T) {
 	if err := oracleCheck(w, oracleGraph(4, true)); err == nil || !strings.Contains(err.Error(), "missing descendant debug stamp") {
 		t.Fatalf("child-only missing metadata must fail: %v", err)
 	}
-	w = oracleWalkers()[3]
+	w = mustOracleWalker(t, walkers, "macro stamp")
 	clean = w.makeCopies
 	w.makeCopies = func(v *LVal) (*LVal, *LVal, error) {
 		a, b, err := clean(v)

--- a/lisp/walker_oracle_controls_test.go
+++ b/lisp/walker_oracle_controls_test.go
@@ -142,9 +142,12 @@ func TestWalkerBehaviorOracleStampLiveControl(t *testing.T) {
 	w.makeCopies = func(v *LVal) (*LVal, *LVal, error) {
 		a, b, err := clean(v)
 		if err == nil {
-			truncated := *a
+			// Use the audited header-view constructor, retaining every flag
+			// and metadata field so only the cycle edge's arity is corrupted.
+			truncated := shallowUnquote(a)
+			truncated.quoted = a.quoted
 			truncated.Cells = nil
-			a.Cells[len(a.Cells)-1] = &truncated
+			a.Cells[len(a.Cells)-1] = truncated
 		}
 		return a, b, err
 	}

--- a/lisp/walker_oracle_test.go
+++ b/lisp/walker_oracle_test.go
@@ -1,0 +1,499 @@
+// Copyright © 2026 The ELPS authors
+
+package lisp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/elps/internal/fmtmeta"
+	"github.com/luthersystems/elps/parser/token"
+)
+
+// Issues #598 and #600: one behavioral oracle drives the real entry points,
+// including the debugger-only stamp path. Keep this private: detach and the
+// stamper are kernel operations, not new embedding APIs.
+//
+// The contract is NOT identical across walkers. Copying preserves container
+// headers/payloads, but not immutable leaf identity or overlapping cell slots.
+// The stamper shares value payloads and may duplicate acyclic syntax headers;
+// it owns only the newly stamped syntax/metadata. Templates preserve cell slots
+// and share only admitted immutable code/natives. Existing field/registry source
+// scans complement these finite behavioral graphs; this is not a claim to model
+// arbitrary Go payloads or every evaluator state.
+type oracleWalker struct {
+	name, owners string
+	makeCopies   func(*LVal) (*LVal, *LVal, error)
+	stamps       bool
+	template     bool
+}
+
+func oracleWalkers() []oracleWalker {
+	copyTwice := func(copyValue func(*LVal) (*LVal, error)) func(*LVal) (*LVal, *LVal, error) {
+		return func(v *LVal) (*LVal, *LVal, error) {
+			a, err := copyValue(v)
+			if err != nil {
+				return nil, nil, err
+			}
+			b, err := copyValue(v)
+			return a, b, err
+		}
+	}
+	return []oracleWalker{
+		{name: "copy", owners: "detacher", makeCopies: copyTwice(func(v *LVal) (*LVal, error) {
+			cp := builtinCopy(NewEnv(nil), SExpr([]*LVal{v}))
+			return cp, GoError(cp)
+		})},
+		{name: "detach", owners: "detacher", makeCopies: copyTwice((*LVal).detach)},
+		{name: "LVal.Copy", owners: "copier", makeCopies: copyTwice(func(v *LVal) (*LVal, error) {
+			cp := v.Copy()
+			return cp, GoError(cp)
+		})},
+		{name: "macro stamp", owners: "macroStamper", stamps: true, makeCopies: copyTwice(func(v *LVal) (*LVal, error) {
+			loc := &token.Location{File: "oracle-call.lisp", Pos: 17, Line: 3, Col: 4}
+			ctx := &macroExpansionContext{Name: "oracle-macro", CallSite: loc, Args: []*LVal{v}}
+			return stampMacroExpansion(v, loc, ctx, StandardRuntime()), nil
+		})},
+		{name: "Template.NewVM", owners: "templateInventory templateCompiler", template: true, makeCopies: oracleTemplateCopies},
+	}
+}
+
+func oracleTemplateCopies(v *LVal) (*LVal, *LVal, error) {
+	return oracleTemplateCopiesWithOptions(v)
+}
+
+func oracleTemplateCopiesWithOptions(v *LVal, opts ...TemplateOption) (*LVal, *LVal, error) {
+	env := NewEnv(nil)
+	env.Runtime.Package = env.Runtime.Registry.DefinePackage("user")
+	if rc := env.PutGlobal(Symbol("oracle-value"), v); rc.Type == LError {
+		return nil, nil, GoError(rc)
+	}
+	// No builtin or foreign native approval: this isolates the graph walker
+	// without paying for a stdlib bootstrap on every fuzz input.
+	tmpl, err := NewTemplate(env, opts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	a, err := tmpl.NewVM()
+	if err != nil {
+		return nil, nil, err
+	}
+	b, err := tmpl.NewVM()
+	if err != nil {
+		return nil, nil, err
+	}
+	return a.Get(Symbol("oracle-value")), b.Get(Symbol("oracle-value")), nil
+}
+
+type oracleNative struct{ n int }
+
+func (v *oracleNative) CloneNative() interface{} { return &oracleNative{n: v.n} }
+
+// Equal-content distinct payloads are deliberate: an oracle that compares only
+// values, or assumes every equal value aliases, must fail the negative controls.
+func oracleGraph(seed byte, native bool) *LVal {
+	m := SortedMap()
+	m.Map().Set(String("n"), Int(7))
+	n := SortedMap()
+	n.Map().Set(String("n"), Int(7))
+	b := Bytes([]byte{7, seed})
+	m.Map().Set(String("bytes"), b)
+	n.Map().Set(String("bytes"), Bytes([]byte{7, seed}))
+	leaf := SExpr([]*LVal{m, Quote(m), n, b, Quote(b), Bytes([]byte{7, seed})})
+	if native {
+		p := Native(&oracleNative{n: 7})
+		leaf.Cells = append(leaf.Cells, p, Quote(p), Native(&oracleNative{n: 7}))
+	}
+	scalarMap := SortedMap()
+	scalarMap.Map().Set(String("n"), Int(7))
+	root := SExpr([]*LVal{leaf, leaf, Array(nil, []*LVal{m, b}), SExpr([]*LVal{Int(9)}), scalarMap, Array(nil, []*LVal{Int(13)})})
+	for i := range int(seed % 4) {
+		root.Cells = append(root.Cells, SExpr([]*LVal{Int(i), leaf}))
+	}
+	// A syntax back-edge forces the stamper's memoized cyclic rerun. The
+	// non-cyclic seeds exercise its optimistic, non-memoized fast path too.
+	if seed&4 != 0 {
+		root.Cells = append(root.Cells, root)
+	}
+	root.quoted = seed&8 != 0
+	root.spliced = seed&16 != 0
+	root.source = &token.Location{File: "oracle-source.lisp", Pos: -1, Line: 7, Col: 2}
+	root.meta = &fmtmeta.Meta{OriginalText: "oracle", TrailingComment: &token.Token{
+		Text: "; retained comment", Source: &token.Location{File: "comment.lisp", Line: 7, Col: 10},
+	}}
+	root.macroExpansion = &macroExpansionInfo{
+		macroExpansionContext: &macroExpansionContext{
+			Name: "old", Args: []*LVal{leaf},
+			CallSite: &token.Location{File: "old-call.lisp", Pos: 1, EndCol: 3},
+			DefSite:  &token.Location{File: "old-def.lisp", Pos: 2, EndCol: 5},
+		}, ID: 91,
+	}
+	return root
+}
+
+type oracleNode struct {
+	v       *LVal
+	path    string
+	state   string
+	payload any
+}
+
+// Traverse paths independently on each arm, stopping back-edges only on the
+// active path. A lost alias therefore cannot hide nodes behind the SOURCE's
+// visited set. Bounds turn an incorrectly unrolled cycle into a witness.
+func oracleNodes(root *LVal) ([]oracleNode, error) {
+	var out []oracleNode
+	active := make(map[*LVal]bool)
+	var visit func(*LVal, string) error
+	visit = func(v *LVal, path string) error {
+		if len(out) >= 512 || len(path) > 1024 {
+			return fmt.Errorf("graph traversal exceeded bound at %s", path)
+		}
+		if v == nil {
+			out = append(out, oracleNode{path: path, state: "nil"})
+			return nil
+		}
+		// JSON walks token/location fields by value, not pointer address: an
+		// in-place metadata-only write must change the saved observation.
+		metadata, err := json.Marshal([]any{v.source, v.meta})
+		if err != nil {
+			return err
+		}
+		state := fmt.Sprintf("%d/%d/%q/%d/%g/%t/%t/%t/%s", v.Type, v.FunType, v.Str, v.Int, v.Float, v.quoted, v.spliced, v.sealed, metadata)
+		if info := v.macroExpansion; info != nil {
+			locations, err := json.Marshal([]any{info.CallSite, info.DefSite})
+			if err != nil {
+				return err
+			}
+			state += fmt.Sprintf("/macro=%p/%p/%d/%s/%s", info, info.macroExpansionContext, info.ID, info.Name, locations)
+			var args strings.Builder
+			for _, arg := range info.Args {
+				fmt.Fprintf(&args, "/arg=%p", arg)
+			}
+			state += args.String()
+		}
+		var payload any
+		switch p := v.Native.(type) {
+		case *MapData, *[]byte:
+			payload = p
+		case *oracleNative:
+			payload = p
+			state += fmt.Sprintf("/native=%d", p.n)
+		default:
+			// Annotations are observed under EVERY header tag, not only
+			// LNative. Kernel map/bytes dispatch above still reaches cells.
+			state += fmt.Sprintf("/native=%T:%v", p, p)
+		}
+		if v.Type == LBytes {
+			state += fmt.Sprintf("/bytes=%v", v.Bytes())
+		}
+		out = append(out, oracleNode{v: v, path: path, state: state, payload: payload})
+		if active[v] {
+			return nil
+		}
+		active[v] = true
+		defer delete(active, v)
+		for i, c := range v.Cells {
+			if err := visit(c, fmt.Sprintf("%s/c%d", path, i)); err != nil {
+				return err
+			}
+		}
+		if v.Type == LSortMap {
+			entries := sortedMapEntries(v.Map())
+			if entries.Type == LError {
+				return GoError(entries)
+			}
+			for _, pair := range entries.Cells {
+				if err := visit(pair.Cells[1], fmt.Sprintf("%s/m%q", path, pair.Cells[0].Str)); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	err := visit(root, "root")
+	return out, err
+}
+
+func oracleSnapshot(root *LVal) (string, error) {
+	nodes, err := oracleNodes(root)
+	var out strings.Builder
+	for _, n := range nodes {
+		fmt.Fprintf(&out, "%s:%p:%p:%s\n", n.path, n.v, n.payload, n.state)
+	}
+	return out.String(), err
+}
+
+func oracleCompare(w oracleWalker, source, copyValue *LVal) error {
+	src, err := oracleNodes(source)
+	if err != nil {
+		return err
+	}
+	dst, err := oracleNodes(copyValue)
+	if err != nil {
+		return err
+	}
+	if len(src) != len(dst) {
+		return fmt.Errorf("topology: %d source paths, %d output paths", len(src), len(dst))
+	}
+	for i, s := range src {
+		d := dst[i]
+		if s.path != d.path || (s.v == nil) != (d.v == nil) {
+			return fmt.Errorf("topology at %s", s.path)
+		}
+		if s.v == nil {
+			continue
+		}
+		a, b := s.v, d.v
+		if len(a.Cells) != len(b.Cells) {
+			return fmt.Errorf("cell arity at %s", s.path)
+		}
+		if a.Type != b.Type || a.FunType != b.FunType || a.Int != b.Int || a.Float != b.Float || a.Str != b.Str || a.quoted != b.quoted || a.spliced != b.spliced {
+			return fmt.Errorf("value/flags at %s", s.path)
+		}
+		if !w.stamps && b.macroExpansion != nil {
+			return fmt.Errorf("retained macro metadata at %s", s.path)
+		}
+		if !w.stamps && (!reflect.DeepEqual(a.source, b.source) || !reflect.DeepEqual(a.meta, b.meta)) {
+			return fmt.Errorf("source/format metadata at %s", s.path)
+		}
+		if w.stamps && a != b && needsStamp(a) {
+			info := b.macroExpansion
+			if info == nil || info.Name != "oracle-macro" || info.ID <= 0 || b.source == nil || b.source.File != "oracle-call.lisp" || b.source.Pos != 17 {
+				return fmt.Errorf("missing descendant debug stamp at %s", s.path)
+			}
+		}
+		if a.Type == LBytes && !slices.Equal(a.Bytes(), b.Bytes()) {
+			return fmt.Errorf("byte contents at %s", s.path)
+		}
+		if p, ok := a.Native.(*oracleNative); ok {
+			q, ok := b.Native.(*oracleNative)
+			if !ok || p.n != q.n {
+				return fmt.Errorf("native contents at %s", s.path)
+			}
+		}
+		if !w.stamps && (len(a.Cells) > 0 || a.Native != nil) && a == b {
+			return fmt.Errorf("header ownership at %s", s.path)
+		}
+		if s.payload != nil {
+			if (s.payload == d.payload) != w.stamps {
+				return fmt.Errorf("payload ownership at %s", s.path)
+			}
+		}
+		for j := range i {
+			if s.payload != nil && src[j].payload != nil && (s.payload == src[j].payload) != (d.payload == dst[j].payload) {
+				return fmt.Errorf("payload alias at %s and %s", s.path, src[j].path)
+			}
+			// Leaf identity and stamp DAG identity are not contracts.
+			if !w.stamps && (len(a.Cells) > 0 || a.Native != nil) && (a == src[j].v) != (b == dst[j].v) {
+				return fmt.Errorf("header alias at %s and %s", s.path, src[j].path)
+			}
+		}
+	}
+	return nil
+}
+
+func oracleCheck(w oracleWalker, source *LVal) error {
+	before, err := oracleSnapshot(source)
+	if err != nil {
+		return err
+	}
+	a, b, err := w.makeCopies(source)
+	if err != nil {
+		return err
+	}
+	after, err := oracleSnapshot(source)
+	if err != nil {
+		return fmt.Errorf("source traversal after construction: %w", err)
+	}
+	if before != after {
+		return errors.New("source changed during construction")
+	}
+	for _, result := range []*LVal{a, b} {
+		if err := oracleCompare(w, source, result); err != nil {
+			return err
+		}
+	}
+	if w.stamps {
+		if a == source || a.macroExpansion == nil || a.macroExpansion.Name != "oracle-macro" || a.macroExpansion.ID != 1 || a.source == nil || a.source.File != "oracle-call.lisp" {
+			return errors.New("debug stamp path did not execute")
+		}
+		if a.macroExpansion == b.macroExpansion || a.source == b.source {
+			return errors.New("sibling expansions share writable metadata")
+		}
+		first, _ := oracleNodes(a) // Both traversals were validated above.
+		second, _ := oracleNodes(b)
+		original, _ := oracleNodes(source)
+		for i, n := range first {
+			if n.v != nil && n.v != original[i].v && n.v.macroExpansion != nil && n.v.macroExpansion == second[i].v.macroExpansion {
+				return fmt.Errorf("sibling expansions share descendant metadata at %s", n.path)
+			}
+		}
+		return nil // Shared value payloads are intentional; never mutate them here.
+	}
+	// All three directions: copy -> source, copy -> sibling, source -> copies.
+	// Snapshot each unaffected arm BEFORE every write; do not compare two copies
+	// with one another and accidentally accept both leaking in the same way.
+	arms := []*LVal{a, b, source}
+	for i, arm := range arms {
+		var old [3]string
+		for j, other := range arms {
+			old[j], err = oracleSnapshot(other)
+			if err != nil {
+				return err
+			}
+		}
+		nodes, err := oracleNodes(arm)
+		if err != nil {
+			return err
+		}
+		dimensions := make(map[*LVal]bool)
+		for _, n := range nodes {
+			if n.v != nil && n.v.Type == LArray {
+				dimensions[n.v.Cells[0]] = true
+			}
+		}
+		writes := 0
+		// Template source/format metadata is private immutable program state
+		// and shared by contract, including with the source (field policy).
+		// Do not invent an in-place kernel write as a VM operation. Copy/detach
+		// instead own mutable metadata, so exercise all directions there.
+		if !w.template {
+			if arm.source != nil {
+				arm.source.Line++
+			}
+			if arm.meta != nil && arm.meta.TrailingComment != nil {
+				arm.meta.TrailingComment.Source.Line++
+			}
+		} else {
+			// SetSource replaces a mutable header's location; it does not
+			// write the frozen location object shared by the plan.
+			arm.SetSource(&token.Location{File: "probe.lisp", Line: 100 + i})
+		}
+		for _, n := range nodes {
+			if n.v == nil {
+				continue
+			}
+			if n.v.Type == LSExpr && len(n.v.Cells) > 0 && !dimensions[n.v] && !n.v.IsSealed() {
+				// Lists and array backing lists: write slots, not just the
+				// values stored in them. Take the census first so disconnecting
+				// a graph edge cannot silently remove later probe sites.
+				n.v.Cells[0] = Int(200 + i)
+				writes++
+			}
+			switch p := n.payload.(type) {
+			case *MapData:
+				p.Set(String("probe"), Int(100+i))
+				writes++
+			case *[]byte:
+				(*p)[0] = byte(100 + i)
+				writes++
+			case *oracleNative:
+				p.n = 100 + i
+				writes++
+			}
+		}
+		if writes == 0 {
+			return errors.New("isolation probe performed no writes")
+		}
+		for j, other := range arms {
+			now, err := oracleSnapshot(other)
+			if err != nil || (j != i && now != old[j]) {
+				return fmt.Errorf("isolation: arm %d changed arm %d", i, j)
+			}
+			if j == i && now == old[j] {
+				return errors.New("isolation probe did not change its target")
+			}
+		}
+	}
+	return nil
+}
+
+func TestWalkerBehaviorOracle(t *testing.T) {
+	for _, w := range oracleWalkers() {
+		t.Run(w.name, func(t *testing.T) {
+			for _, seed := range []byte{0, 3, 4, 8, 16, 31} {
+				if err := oracleCheck(w, oracleGraph(seed, !w.template)); err != nil {
+					t.Fatalf("seed %d: %v", seed, err)
+				}
+			}
+		})
+	}
+}
+
+func TestWalkerBehaviorOracleCoversRegistry(t *testing.T) {
+	var registered, driven []string
+	nodes, err := oracleNodes(oracleGraph(0, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	exercised := make(map[payloadKind]bool)
+	for _, n := range nodes {
+		switch n.payload.(type) {
+		case *MapData:
+			exercised[payloadSortedMap] = true
+		case *[]byte:
+			exercised[payloadBytes] = true
+		case *oracleNative:
+			exercised[payloadNative] = true
+		}
+	}
+	for _, m := range registeredWalkerMemos() {
+		registered = append(registered, m.Walker)
+		for _, kind := range m.Payloads {
+			if !exercised[kind] {
+				t.Errorf("%s memoizes %s but the behavioral graph does not exercise it", m.Walker, kind)
+			}
+		}
+	}
+	for _, w := range oracleWalkers() {
+		driven = append(driven, strings.Fields(w.owners)...)
+	}
+	slices.Sort(registered)
+	slices.Sort(driven)
+	driven = slices.Compact(driven)
+	if !reflect.DeepEqual(registered, driven) {
+		t.Fatalf("registered walkers %v != behaviorally driven walkers %v", registered, driven)
+	}
+}
+
+func FuzzWalkerBehaviorOracle(f *testing.F) {
+	for i := range oracleWalkers() {
+		for _, seed := range []byte{0, 4, 31} {
+			f.Add(byte(i), []byte{seed, 0, 17, 34, 51})
+		}
+	}
+	f.Fuzz(func(t *testing.T, which byte, data []byte) {
+		walkers := oracleWalkers()
+		w := walkers[int(which)%len(walkers)]
+		var seed byte
+		if len(data) > 0 {
+			seed = data[0]
+		}
+		root := oracleGraph(seed, !w.template)
+		payloads := root.Cells[0].Cells
+		// A bounded graph program: choose alias groups, distinct headers,
+		// nesting and array edges independently. It is not evaluator fuzzing
+		// and cannot consume an unbounded execution budget.
+		for _, op := range data[:min(len(data), 8)] {
+			v := payloads[int(op)%len(payloads)]
+			switch op >> 4 & 3 {
+			case 1:
+				v = Quote(v)
+			case 2:
+				v = SExpr([]*LVal{v, v})
+			case 3:
+				v = Array(nil, []*LVal{v})
+			}
+			root.Cells = append(root.Cells, v)
+		}
+		if err := oracleCheck(w, root); err != nil {
+			t.Fatalf("%s program %x: %v", w.name, data[:min(len(data), 8)], err)
+		}
+	})
+}

--- a/lisp/walker_oracle_test.go
+++ b/lisp/walker_oracle_test.go
@@ -63,6 +63,32 @@ func oracleWalkers() []oracleWalker {
 	}
 }
 
+func oracleWalkerByName(walkers []oracleWalker, name string) (oracleWalker, error) {
+	var result oracleWalker
+	for _, w := range walkers {
+		if w.name != name {
+			continue
+		}
+		if result.name != "" {
+			return oracleWalker{}, fmt.Errorf("duplicate oracle walker %q", name)
+		}
+		result = w
+	}
+	if result.name == "" {
+		return oracleWalker{}, fmt.Errorf("missing oracle walker %q", name)
+	}
+	return result, nil
+}
+
+func mustOracleWalker(t *testing.T, walkers []oracleWalker, name string) oracleWalker {
+	t.Helper()
+	w, err := oracleWalkerByName(walkers, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return w
+}
+
 func oracleTemplateCopies(v *LVal) (*LVal, *LVal, error) {
 	return oracleTemplateCopiesWithOptions(v)
 }

--- a/lisp/walker_oracle_test.go
+++ b/lisp/walker_oracle_test.go
@@ -345,12 +345,12 @@ func oracleCheck(w oracleWalker, source *LVal) error {
 		for j, other := range arms {
 			old[j], err = oracleSnapshot(other)
 			if err != nil {
-				return err
+				return fmt.Errorf("snapshot arm %d before writes to arm %d: %w", j, i, err)
 			}
 		}
 		nodes, err := oracleNodes(arm)
 		if err != nil {
-			return err
+			return fmt.Errorf("probe census for arm %d before writes: %w", i, err)
 		}
 		dimensions := make(map[*LVal]bool)
 		for _, n := range nodes {
@@ -403,7 +403,10 @@ func oracleCheck(w oracleWalker, source *LVal) error {
 		}
 		for j, other := range arms {
 			now, err := oracleSnapshot(other)
-			if err != nil || (j != i && now != old[j]) {
+			if err != nil {
+				return fmt.Errorf("snapshot arm %d after writes to arm %d: %w", j, i, err)
+			}
+			if j != i && now != old[j] {
 				return fmt.Errorf("isolation: arm %d changed arm %d", i, j)
 			}
 			if j == i && now == old[j] {

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -17,10 +17,9 @@ func (s *Server) textDocumentCompletion(_ *glsp.Context, params *protocol.Comple
 	if doc == nil {
 		return nil, nil
 	}
-	// An over-limit document has no AST or analysis (see Document.parse), and
-	// wordAtPosition below splits the whole content to find the prefix under
-	// the cursor -- linear allocation over a document the size limit exists to
-	// keep off the hot path. No completions.
+	// An over-limit document has no AST or analysis (see Document.parse).
+	// Skip textual fallbacks too: locating a late line still scans the content
+	// even though word lookup no longer allocates a document-sized line slice.
 	if doc.OverLimit() {
 		return nil, nil
 	}

--- a/lsp/definition.go
+++ b/lsp/definition.go
@@ -16,10 +16,9 @@ func (s *Server) textDocumentDefinition(_ *glsp.Context, params *protocol.Defini
 	if doc == nil {
 		return nil, nil
 	}
-	// An over-limit document has no AST or analysis (see Document.parse), and
-	// wordAtPosition below splits the whole content to find the word under the
-	// cursor -- linear allocation over a document the size limit exists to keep
-	// off the hot path. No definition to report.
+	// An over-limit document has no AST or analysis (see Document.parse).
+	// Skip textual fallbacks too: locating a late line still scans the content
+	// even though word lookup no longer allocates a document-sized line slice.
 	if doc.OverLimit() {
 		return nil, nil
 	}

--- a/lsp/hover.go
+++ b/lsp/hover.go
@@ -19,11 +19,9 @@ func (s *Server) textDocumentHover(_ *glsp.Context, params *protocol.HoverParams
 	if doc == nil {
 		return nil, nil
 	}
-	// An over-limit document has no AST or analysis (see Document.parse),
-	// and the registry fallback below would split the whole text per
-	// request to find the word under the cursor -- linear allocation over a
-	// document the size limit exists to keep off the hot path. Nothing to
-	// hover.
+	// An over-limit document has no AST or analysis (see Document.parse).
+	// Skip textual fallbacks too: locating a late line still scans the content
+	// even though word lookup no longer allocates a document-sized line slice.
 	if doc.OverLimit() {
 		return nil, nil
 	}

--- a/lsp/position.go
+++ b/lsp/position.go
@@ -130,14 +130,15 @@ func locContainsCol(loc *token.Location, name string, col int) bool {
 
 // wordAtPosition extracts the symbol-like word at the given 0-based LSP
 // position from the document content. The cursor can be inside or at the
-// end of a word; in both cases the full word is returned.
+// end of a word; in both cases the full word is returned. Columns are bytes,
+// after the handler converts the wire position with Server.cursorAt.
 func wordAtPosition(content string, line, col int) string {
-	start, end, ok := wordBoundsAtPosition(content, line, col)
+	ln := lineOf(content, line)
+	start, end, ok := wordBoundsInLine(ln, col)
 	if !ok {
 		return ""
 	}
-	lines := strings.Split(content, "\n")
-	return lines[line][start:end]
+	return ln[start:end]
 }
 
 // wordRangeAtPosition returns the LSP range for the symbol-like word at the
@@ -155,11 +156,13 @@ func wordRangeAtPosition(content string, line, col int) *protocol.Range {
 }
 
 func wordBoundsAtPosition(content string, line, col int) (int, int, bool) {
-	lines := strings.Split(content, "\n")
-	if line < 0 || line >= len(lines) {
-		return 0, 0, false
-	}
-	ln := lines[line]
+	return wordBoundsInLine(lineOf(content, line), col)
+}
+
+// A missing line and an empty line both contain no word. Work only on the
+// selected line: splitting the document here allocated a line slice on every
+// completion/definition/hover request (#641).
+func wordBoundsInLine(ln string, col int) (int, int, bool) {
 	if col < 0 || col > len(ln) {
 		return 0, 0, false
 	}

--- a/lsp/position_word_test.go
+++ b/lsp/position_word_test.go
@@ -1,0 +1,162 @@
+// Copyright © 2026 The ELPS authors
+
+package lsp
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// The independent model enumerates complete ASCII symbol tokens, rather than
+// scanning outward from the cursor. In particular, a word's end is a hit but
+// the next column is not. Non-ASCII bytes remain separators; #641 changes
+// allocation, not the existing fallback's symbol alphabet or byte units.
+func TestWordPositionBoundaries(t *testing.T) {
+	symbol := regexp.MustCompile(`[-a-zA-Z0-9_!?+*/<>=:.#^&]+`)
+	for _, content := range []string{
+		"", "\n", "\r\n", "hello", "hello\n", "hello\r\n\r\nworld",
+		"(pkg:some-name! a)\n\n&rest :key\nlast",
+		" é🙂 target\r\n加算 ascii\n\xffbad",
+		"a\tb\r(c)[d] 'e\"f\";g\x00h",
+	} {
+		t.Run(content, func(t *testing.T) {
+			lines := strings.Split(content, "\n")
+			for line := -1; line <= len(lines); line++ {
+				text := ""
+				if line >= 0 && line < len(lines) {
+					text = lines[line]
+				}
+				matches := symbol.FindAllStringIndex(text, -1)
+				for col := -1; col <= len(text)+1; col++ {
+					var start, end int
+					var ok bool
+					for _, span := range matches {
+						if col >= span[0] && col <= span[1] {
+							start, end, ok = span[0], span[1], true
+							break
+						}
+					}
+					gotStart, gotEnd, gotOK := wordBoundsAtPosition(content, line, col)
+					require.Equal(t, start, gotStart, "line %d col %d", line, col)
+					require.Equal(t, end, gotEnd, "line %d col %d", line, col)
+					require.Equal(t, ok, gotOK, "line %d col %d", line, col)
+					require.Equal(t, text[start:end], wordAtPosition(content, line, col), "line %d col %d", line, col)
+					var wantRange *protocol.Range
+					if ok {
+						wantRange = &protocol.Range{
+							Start: protocol.Position{Line: safeUint(line), Character: safeUint(start)},
+							End:   protocol.Position{Line: safeUint(line), Character: safeUint(end)},
+						}
+					}
+					require.Equal(t, wantRange, wordRangeAtPosition(content, line, col), "line %d col %d", line, col)
+				}
+			}
+		})
+	}
+}
+
+func TestWordPositionWireEncoding(t *testing.T) {
+	const content = "header\r\n é🙂 target\r\n"
+	for _, tc := range []struct {
+		name string
+		enc  positionEncoding
+		col  int
+	}{
+		{"utf16", encodingUTF16, 5},
+		{"utf8", encodingUTF8, 8},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := testServer()
+			s.posEncoding.Store(int32(tc.enc))
+			line, col := s.cursorAt(&Document{Content: content}, protocol.Position{Line: 1, Character: safeUint(tc.col)})
+			require.Equal(t, 1, line)
+			require.Equal(t, 8, col)
+			require.Equal(t, "target", wordAtPosition(content, line, col))
+			require.Equal(t, &protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 8},
+				End:   protocol.Position{Line: 1, Character: 14},
+			}, wordRangeAtPosition(content, line, col))
+		})
+	}
+}
+
+// #641: document line slices must not be allocated per word lookup. Check
+// successful results too, so an always-empty fast path cannot satisfy the gate.
+func TestWordPositionAllocations(t *testing.T) {
+	content := strings.Repeat("target\n", 1<<14)
+	for _, line := range []int{0, (1 << 14) - 1} {
+		var word string
+		allocs := testing.AllocsPerRun(10, func() { word = wordAtPosition(content, line, 3) })
+		require.Equal(t, "target", word)
+		assert.Zero(t, allocs, "word lookup must not allocate a document-sized line slice")
+		var start, end int
+		var ok bool
+		allocs = testing.AllocsPerRun(10, func() { start, end, ok = wordBoundsAtPosition(content, line, 3) })
+		require.Equal(t, 0, start)
+		require.Equal(t, 6, end)
+		require.True(t, ok)
+		assert.Zero(t, allocs, "bounds lookup must not allocate a document-sized line slice")
+		var rng *protocol.Range
+		allocs = testing.AllocsPerRun(10, func() { rng = wordRangeAtPosition(content, line, 3) })
+		require.Equal(t, &protocol.Range{
+			Start: protocol.Position{Line: safeUint(line), Character: 0},
+			End:   protocol.Position{Line: safeUint(line), Character: 6},
+		}, rng)
+		assert.LessOrEqual(t, allocs, float64(1), "only the returned range may allocate")
+	}
+}
+
+// Keep both ordinary files and newline-dense adversarial documents visible.
+// First/last-line rows distinguish avoiding a whole-document split from the
+// still-linear scan to a late line. Construction is outside the timed region.
+func BenchmarkWordPosition(b *testing.B) {
+	for _, doc := range []struct {
+		name  string
+		width int
+		lines int
+	}{
+		{"small", 64, 16},
+		{"1MiB-lines64", 64, 1 << 14},
+		{"1MiB-lines2", 2, 1 << 19},
+	} {
+		content := strings.Repeat("x"+strings.Repeat(" ", doc.width-2)+"\n", doc.lines)
+		for _, pos := range []struct {
+			name string
+			line int
+		}{
+			{"first", 0}, {"last", doc.lines - 1},
+		} {
+			b.Run(doc.name+"/"+pos.name+"/word", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					if wordAtPosition(content, pos.line, 0) != "x" {
+						b.Fatal("incorrect word")
+					}
+				}
+			})
+			b.Run(doc.name+"/"+pos.name+"/bounds", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					start, end, ok := wordBoundsAtPosition(content, pos.line, 0)
+					if start != 0 || end != 1 || !ok {
+						b.Fatal("incorrect bounds")
+					}
+				}
+			})
+			b.Run(doc.name+"/"+pos.name+"/range", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					rng := wordRangeAtPosition(content, pos.line, 0)
+					if rng == nil || rng.Start.Line != safeUint(pos.line) || rng.Start.Character != 0 || rng.End.Line != safeUint(pos.line) || rng.End.Character != 1 {
+						b.Fatal("incorrect range")
+					}
+				}
+			})
+		}
+	}
+}

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -1133,8 +1133,12 @@ assert_exit 0 "govulncheck installs a pinned Go-compatible scanner (#634)" \
 
 assert_exit 0 "manual Marketplace diagnostics cannot publish or receive secrets (#638)" \
 	python3 "${SCRIPT_DIR}/marketplace-workflow-test.py"
-assert_exit 0 "Marketplace diagnostics enforce time, response, and output bounds (#638)" \
-	node --test "${SCRIPT_DIR}/marketplace-diagnostics.test.cjs"
+if command -v node >/dev/null 2>&1; then
+	assert_exit 0 "Marketplace diagnostics enforce time, response, and output bounds (#638)" \
+		node --test "${SCRIPT_DIR}/marketplace-diagnostics.test.cjs"
+else
+	echo "SKIP  node not installed; cannot test Marketplace diagnostics"
+fi
 
 echo "== govulncheck fail-summary: the gate must not un-fail its own caller ===="
 

--- a/scripts/ci-gates-test.sh
+++ b/scripts/ci-gates-test.sh
@@ -1131,6 +1131,11 @@ rm -rf "$reqjobs_tmp"
 assert_exit 0 "govulncheck installs a pinned Go-compatible scanner (#634)" \
 	python3 "${SCRIPT_DIR}/govulncheck-toolchain-test.py"
 
+assert_exit 0 "manual Marketplace diagnostics cannot publish or receive secrets (#638)" \
+	python3 "${SCRIPT_DIR}/marketplace-workflow-test.py"
+assert_exit 0 "Marketplace diagnostics enforce time, response, and output bounds (#638)" \
+	node --test "${SCRIPT_DIR}/marketplace-diagnostics.test.cjs"
+
 echo "== govulncheck fail-summary: the gate must not un-fail its own caller ===="
 
 # scripts/govulncheck-fail-summary.sh is the final step of

--- a/scripts/marketplace-diagnostics.cjs
+++ b/scripts/marketplace-diagnostics.cjs
@@ -1,0 +1,135 @@
+'use strict';
+
+// Read-only, unauthenticated diagnostics for #638. Never print headers, response
+// bodies, environment variables or exception messages. A reachable service is
+// not evidence that the publishing PAT works or that an upload will succeed.
+const http = require('node:http');
+const https = require('node:https');
+const { execFile } = require('node:child_process');
+const { performance } = require('node:perf_hooks');
+const { isIP } = require('node:net');
+
+const MARKETPLACE = 'https://marketplace.visualstudio.com';
+const TARGETS = new Set(['universal', 'linux-x64', 'linux-arm64', 'darwin-x64', 'darwin-arm64',
+  'win32-x64', 'win32-arm64', 'win32-ia32', 'linux-armhf', 'alpine-x64', 'alpine-arm64', 'web']);
+const QUERY = JSON.stringify({ filters: [{ criteria: [{ filterType: 7, value: 'LutherSystems.elps-lang' }] }], flags: 1 });
+
+function versionInventory(body) {
+  const extensions = body.results?.flatMap(result => result.extensions ?? []);
+  const extension = extensions?.find(value => value.publisher?.publisherName?.toLowerCase() === 'luthersystems'
+    && value.extensionName === 'elps-lang');
+  if (!Array.isArray(extension?.versions) || extension.versions.length === 0) throw new Error('INVALID_INVENTORY');
+  return extension.versions.map(value => {
+    const target = value.targetPlatform == null ? 'universal' : value.targetPlatform;
+    if (typeof value.version !== 'string' || !/^\d+\.\d+\.\d+$/.test(value.version)
+      || typeof target !== 'string' || !TARGETS.has(target)) throw new Error('INVALID_INVENTORY');
+    return { version: value.version, target };
+  }).sort((a, b) => a.version.localeCompare(b.version) || a.target.localeCompare(b.target));
+}
+
+function observe(url, method, { timeoutMs = 15000, maxBytes = 1048576, inventory = false } = {}) {
+  return new Promise(resolve => {
+    const started = performance.now();
+    const result = { bytes: 0, timing: {} };
+    const stamp = name => { result.timing[name] = Math.round(performance.now() - started); };
+    let finished = false;
+    let timer;
+    const finish = error => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      if (error) result.error = error;
+      stamp('totalMs');
+      resolve(result);
+    };
+    const request = (url.startsWith('https:') ? https : http).request(url, {
+      method,
+      headers: inventory ? { 'Content-Type': 'application/json', Accept: 'application/json;api-version=7.2-preview.1' } : {},
+    }, response => {
+      result.status = response.statusCode;
+      stamp('firstByteMs');
+      const chunks = [];
+      response.on('data', chunk => {
+        result.bytes += chunk.length;
+        if (result.bytes > maxBytes) {
+          finish('BODY_LIMIT');
+          request.destroy();
+        } else if (inventory) chunks.push(chunk);
+      });
+      response.on('error', () => finish('RESPONSE_ERROR'));
+      response.on('end', () => {
+        if (finished) return;
+        if (inventory) {
+          if (result.status !== 200) return finish('HTTP_STATUS');
+          try { result.versions = versionInventory(JSON.parse(Buffer.concat(chunks).toString())); }
+          catch { return finish('INVALID_INVENTORY'); }
+        }
+        finish();
+      });
+    });
+    request.on('socket', socket => {
+      socket.on('lookup', (error, address, family) => {
+        stamp('dnsMs');
+        if (!error && isIP(address)) result.dns = { address, family };
+      });
+      socket.on('connect', () => stamp('connectMs'));
+      socket.on('secureConnect', () => stamp('tlsMs'));
+    });
+    request.on('error', () => finish('REQUEST_ERROR'));
+    // An absolute deadline, not socket inactivity: a slow stream cannot extend it.
+    timer = setTimeout(() => { finish('TIMEOUT'); request.destroy(); }, timeoutMs);
+    request.end(inventory ? QUERY : undefined);
+  });
+}
+
+async function azureClientProbe(endpoint = MARKETPLACE) {
+  // Same locked API client and call that vsce 3.9.2 uses before uploading. No
+  // BasicAuth handler: deliberately cannot test the secret's validity/permissions.
+  const { GalleryApi } = require('../editors/vscode/node_modules/azure-devops-node-api/GalleryApi');
+  const api = new GalleryApi(endpoint, [], { socketTimeout: 15000, allowRedirects: false });
+  const started = performance.now();
+  let status;
+  try { await api.getExtension(null, 'LutherSystems', 'elps-lang', undefined, 1); status = 'OK'; }
+  catch (error) {
+    status = Number.isInteger(error.statusCode) ? `HTTP_${error.statusCode}` : 'CLIENT_ERROR';
+  }
+  return { status, elapsedMs: Math.round(performance.now() - started) };
+}
+
+function observeAzureClient({ args = [__filename, '--azure-client'], timeoutMs = 20000 } = {}) {
+  return new Promise(resolve => {
+    // The subprocess bound covers DNS, TLS, SDK retries and SDK import, not just
+    // one socket. Empty environment and no handlers keep this probe unauthenticated.
+    execFile(process.execPath, args, { timeout: timeoutMs, maxBuffer: 4096, env: {} }, (error, stdout) => {
+      if (error) return resolve({ status: error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' ? 'OUTPUT_LIMIT'
+        : error.killed ? 'TIMEOUT' : 'CLIENT_FAILED' });
+      try {
+        const value = JSON.parse(stdout);
+        if (typeof value.status !== 'string' || !/^(OK|HTTP_\d{3}|CLIENT_ERROR)$/.test(value.status)
+          || !Number.isInteger(value.elapsedMs) || value.elapsedMs < 0) throw new Error();
+        resolve({ status: value.status, elapsedMs: value.elapsedMs });
+      } catch { resolve({ status: 'INVALID_CLIENT_RESULT' }); }
+    });
+  });
+}
+
+async function main() {
+  const [discovery, inventory, azureClient] = await Promise.all([
+    observe(`${MARKETPLACE}/_apis/gallery`, 'OPTIONS'),
+    observe(`${MARKETPLACE}/_apis/public/gallery/extensionquery`, 'POST', { inventory: true }),
+    observeAzureClient(),
+  ]);
+  console.log(JSON.stringify({ node: process.version, architecture: process.arch, discovery, inventory, azureClient }, null, 2));
+  // Network failures are evidence, not a CI gate. The manual workflow's log is a
+  // diagnostic report; successful execution must not be called publication success.
+}
+
+module.exports = { observe, versionInventory, azureClientProbe, observeAzureClient };
+if (require.main === module) {
+  (process.argv[2] === '--azure-client'
+    ? azureClientProbe().then(value => process.stdout.write(JSON.stringify(value)))
+    : main()).catch(() => {
+    console.error('Diagnostic program failed; no response content was logged.');
+    process.exitCode = 1;
+  });
+}

--- a/scripts/marketplace-diagnostics.cjs
+++ b/scripts/marketplace-diagnostics.cjs
@@ -14,6 +14,20 @@ const TARGETS = new Set(['universal', 'linux-x64', 'linux-arm64', 'darwin-x64', 
   'win32-x64', 'win32-arm64', 'win32-ia32', 'linux-armhf', 'alpine-x64', 'alpine-arm64', 'web']);
 const QUERY = JSON.stringify({ filters: [{ criteria: [{ filterType: 7, value: 'LutherSystems.elps-lang' }] }], flags: 1 });
 
+function compareVersions(left, right) {
+  const a = left.split('.');
+  const b = right.split('.');
+  for (let i = 0; i < 3; i++) {
+    // Inputs are validated digit triplets. Length then lexical comparison is
+    // numeric without rounding components larger than Number.MAX_SAFE_INTEGER.
+    const x = a[i].replace(/^0+(?=\d)/, '');
+    const y = b[i].replace(/^0+(?=\d)/, '');
+    if (x.length !== y.length) return x.length - y.length;
+    if (x !== y) return x < y ? -1 : 1;
+  }
+  return left.localeCompare(right);
+}
+
 function versionInventory(body) {
   const extensions = body.results?.flatMap(result => result.extensions ?? []);
   const extension = extensions?.find(value => value.publisher?.publisherName?.toLowerCase() === 'luthersystems'
@@ -24,7 +38,7 @@ function versionInventory(body) {
     if (typeof value.version !== 'string' || !/^\d+\.\d+\.\d+$/.test(value.version)
       || typeof target !== 'string' || !TARGETS.has(target)) throw new Error('INVALID_INVENTORY');
     return { version: value.version, target };
-  }).sort((a, b) => a.version.localeCompare(b.version) || a.target.localeCompare(b.target));
+  }).sort((a, b) => compareVersions(a.version, b.version) || a.target.localeCompare(b.target));
 }
 
 function observe(url, method, { timeoutMs = 15000, maxBytes = 1048576, inventory = false } = {}) {

--- a/scripts/marketplace-diagnostics.test.cjs
+++ b/scripts/marketplace-diagnostics.test.cjs
@@ -1,0 +1,129 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { test } = require('node:test');
+const { observe, versionInventory, observeAzureClient } = require('./marketplace-diagnostics.cjs');
+
+async function serve(t, handler) {
+  const server = http.createServer(handler);
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => { server.closeAllConnections(); server.close(); });
+  return `http://127.0.0.1:${server.address().port}`;
+}
+
+test('discovery uses OPTIONS without credentials and does not print response content', async t => {
+  const url = await serve(t, (req, res) => {
+    assert.equal(req.method, 'OPTIONS');
+    assert.equal(req.headers.authorization, undefined);
+    assert.equal(req.headers.cookie, undefined);
+    res.writeHead(401, { 'Set-Cookie': 'private-marker' });
+    res.end('private-marker');
+  });
+  const result = await observe(url, 'OPTIONS');
+  assert.equal(result.status, 401);
+  assert.equal(result.error, undefined);
+  assert.equal(result.bytes, 14);
+  assert.equal(JSON.stringify(result).includes('private-marker'), false);
+  assert.equal(typeof result.timing.firstByteMs, 'number');
+});
+
+test('request has an absolute timeout even when the server keeps sending bytes', { timeout: 1000 }, async t => {
+  const url = await serve(t, (_req, res) => {
+    res.writeHead(200);
+    const ticker = setInterval(() => res.write('x'), 5);
+    res.on('close', () => clearInterval(ticker));
+  });
+  const result = await observe(url, 'GET', { timeoutMs: 50 });
+  assert.equal(result.error, 'TIMEOUT');
+});
+
+test('socket failure is a diagnostic error, not a successful empty response', async t => {
+  const url = await serve(t, req => req.socket.destroy());
+  const result = await observe(url, 'OPTIONS');
+  assert.equal(result.error, 'REQUEST_ERROR');
+  assert.equal(result.status, undefined);
+});
+
+test('response body limit aborts a successful HTTP response', async t => {
+  const url = await serve(t, (_req, res) => res.end('x'.repeat(100)));
+  const result = await observe(url, 'GET', { maxBytes: 32 });
+  assert.equal(result.error, 'BODY_LIMIT');
+});
+
+test('public query reports only exact matching extension version/target fields', async t => {
+  const url = await serve(t, async (req, res) => {
+    assert.equal(req.method, 'POST');
+    let body = '';
+    for await (const chunk of req) body += chunk;
+    assert.equal(JSON.parse(body).filters[0].criteria[0].value, 'LutherSystems.elps-lang');
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ results: [{ extensions: [
+      { publisher: { publisherName: 'Other' }, extensionName: 'elps-lang', versions: [{ version: '9.0.0' }] },
+      { publisher: { publisherName: 'LutherSystems' }, extensionName: 'elps-lang', private: 'private-marker', versions: [
+        { version: '1.61.1', targetPlatform: 'linux-arm64', private: 'private-marker' },
+        { version: '1.61.1' }, { version: '1.60.0', targetPlatform: 'darwin-x64' },
+      ] },
+    ] }] }));
+  });
+  const result = await observe(url, 'POST', { inventory: true });
+  assert.deepEqual(result.versions, [
+    { version: '1.60.0', target: 'darwin-x64' },
+    { version: '1.61.1', target: 'linux-arm64' },
+    { version: '1.61.1', target: 'universal' },
+  ]);
+  assert.equal(JSON.stringify(result).includes('private-marker'), false);
+});
+
+test('non-JSON, HTTP errors and wrong schema are failures, never an empty inventory', async t => {
+  for (const [status, body, error] of [
+    [200, 'not json private-marker', 'INVALID_INVENTORY'],
+    [503, '{"error":"private-marker"}', 'HTTP_STATUS'],
+    [200, '{"results":[]}', 'INVALID_INVENTORY'],
+    [302, '', 'HTTP_STATUS'],
+  ]) {
+    const url = await serve(t, (_req, res) => { res.writeHead(status); res.end(body); });
+    const result = await observe(url, 'POST', { inventory: true });
+    assert.equal(result.error, error);
+    assert.equal(result.versions, undefined);
+    assert.equal(JSON.stringify(result).includes('private-marker'), false);
+  }
+});
+
+test('inventory rejects unexpected version/target text instead of logging it', () => {
+  const extension = { publisher: { publisherName: 'LutherSystems' }, extensionName: 'elps-lang' };
+  for (const versions of [[], [{ version: 'secret-value' }], [{ version: ['1.2.3'] }],
+    [{ version: '1.2.3', targetPlatform: 'secret-value' }], [{ version: '1.2.3', targetPlatform: false }]]) {
+    assert.throws(() => versionInventory({ results: [{ extensions: [{ ...extension, versions }] }] }));
+  }
+});
+
+test('SDK subprocess does not inherit environment or expose extra output fields', async t => {
+  process.env.ELPS_DIAGNOSTIC_TEST_SENTINEL = 'private-marker';
+  t.after(() => { delete process.env.ELPS_DIAGNOSTIC_TEST_SENTINEL; });
+  const result = await observeAzureClient({ args: ['-e', `
+    console.log(JSON.stringify({
+      status: process.env.ELPS_DIAGNOSTIC_TEST_SENTINEL ? 'INHERITED_ENV' : 'OK',
+      elapsedMs: 1, private: 'private-marker'
+    }));
+  `] });
+  assert.deepEqual(result, { status: 'OK', elapsedMs: 1 });
+});
+
+test('SDK subprocess has an absolute deadline', { timeout: 2000 }, async () => {
+  const result = await observeAzureClient({ args: ['-e', 'setInterval(() => {}, 10)'], timeoutMs: 50 });
+  assert.deepEqual(result, { status: 'TIMEOUT' });
+});
+
+test('SDK subprocess failures and malformed output cannot masquerade as probe results', async () => {
+  for (const [script, status] of [
+    ['process.exit(1)', 'CLIENT_FAILED'],
+    ['console.log("private-marker")', 'INVALID_CLIENT_RESULT'],
+    ['console.log(JSON.stringify({status:"private-marker", elapsedMs:1}))', 'INVALID_CLIENT_RESULT'],
+    ['console.log(JSON.stringify({status:["OK"], elapsedMs:1}))', 'INVALID_CLIENT_RESULT'],
+    ['console.log(JSON.stringify({status:"OK", elapsedMs:-1}))', 'INVALID_CLIENT_RESULT'],
+    ['console.log("x".repeat(5000))', 'OUTPUT_LIMIT'],
+  ]) {
+    assert.deepEqual(await observeAzureClient({ args: ['-e', script] }), { status });
+  }
+});

--- a/scripts/marketplace-diagnostics.test.cjs
+++ b/scripts/marketplace-diagnostics.test.cjs
@@ -98,6 +98,28 @@ test('inventory rejects unexpected version/target text instead of logging it', (
   }
 });
 
+test('inventory orders numeric version components before target names, without number rounding', () => {
+  const expected = [
+    { version: '1.9.0', target: 'universal' },
+    { version: '1.10.0', target: 'universal' },
+    { version: '1.99.0', target: 'universal' },
+    { version: '1.100.0', target: 'universal' },
+    { version: '2.0.9', target: 'universal' },
+    { version: '2.0.10', target: 'darwin-x64' },
+    { version: '2.0.10', target: 'universal' },
+    { version: '9.0.0', target: 'universal' },
+    { version: '10.0.0', target: 'universal' },
+    // Number() rounds both major components to the same value. The opposite
+    // target order ensures that losing this distinction fails the assertion.
+    { version: '9007199254740992.0.0', target: 'universal' },
+    { version: '9007199254740993.0.0', target: 'darwin-x64' },
+  ];
+  const versions = [...expected].reverse().map(({ version, target }) => ({ version, targetPlatform: target }));
+  const body = { results: [{ extensions: [{ publisher: { publisherName: 'LutherSystems' },
+    extensionName: 'elps-lang', versions }] }] };
+  assert.deepEqual(versionInventory(body), expected);
+});
+
 test('SDK subprocess does not inherit environment or expose extra output fields', async t => {
   process.env.ELPS_DIAGNOSTIC_TEST_SENTINEL = 'private-marker';
   t.after(() => { delete process.env.ELPS_DIAGNOSTIC_TEST_SENTINEL; });

--- a/scripts/marketplace-sdk.test.cjs
+++ b/scripts/marketplace-sdk.test.cjs
@@ -1,0 +1,35 @@
+'use strict';
+
+// Runs after npm ci in manual diagnostics, against the actual locked SDK.
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { test } = require('node:test');
+const { azureClientProbe } = require('./marketplace-diagnostics.cjs');
+
+async function serve(t, handler) {
+  const server = http.createServer(handler);
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => { server.closeAllConnections(); server.close(); });
+  return `http://127.0.0.1:${server.address().port}`;
+}
+
+test('actual SDK makes unauthenticated discovery and sanitizes its error', { timeout: 2000 }, async t => {
+  const calls = [];
+  const url = await serve(t, (req, res) => {
+    calls.push([req.method, req.url, req.headers.authorization, req.headers.cookie]);
+    res.writeHead(401, { 'Content-Type': 'application/json' });
+    res.end('{"message":"private-marker"}');
+  });
+  const result = await azureClientProbe(url);
+  assert.deepEqual(calls, [['OPTIONS', '/_apis/gallery', undefined, undefined]]);
+  assert.equal(result.status, 'HTTP_401');
+  assert.equal(JSON.stringify(result).includes('private-marker'), false);
+});
+
+test('actual SDK does not follow a discovery redirect to another host', { timeout: 2000 }, async t => {
+  let redirectedCalls = 0;
+  const redirect = await serve(t, (_req, res) => { redirectedCalls++; res.writeHead(401); res.end(); });
+  const url = await serve(t, (_req, res) => { res.writeHead(302, { Location: redirect }); res.end(); });
+  await azureClientProbe(url);
+  assert.equal(redirectedCalls, 0);
+});

--- a/scripts/marketplace-workflow-test.py
+++ b/scripts/marketplace-workflow-test.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Manual diagnostics must never build, publish, or receive secrets (#638)."""
+
+import copy
+import pathlib
+import unittest
+
+import yaml
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+TAG_ONLY = "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')"
+MANUAL_ONLY = "github.event_name == 'workflow_dispatch'"
+
+
+def validate(doc):
+    events = doc.get("on", doc.get(True))  # PyYAML's YAML 1.1 parses on as True.
+    assert events == {"push": {"tags": ["v*"]}, "workflow_dispatch": None}
+    jobs = doc["jobs"]
+    assert set(jobs) == {"build-binaries", "publish-platform", "publish-universal", "diagnose-marketplace"}
+    for name in ("build-binaries", "publish-platform", "publish-universal"):
+        assert jobs[name]["if"] == TAG_ONLY
+    job = jobs["diagnose-marketplace"]
+    assert job["if"] == MANUAL_ONLY
+    assert job["permissions"] == {"contents": "read"}
+    assert job["timeout-minutes"] == 3
+    assert job["strategy"]["fail-fast"] is False
+    assert job["strategy"]["matrix"]["runner"] == ["ubuntu-24.04-arm", "ubuntu-24.04"]
+    assert job["runs-on"] == "${{ matrix.runner }}"
+    assert "env" not in doc and "env" not in job and "needs" not in job
+    steps = job["steps"]
+    assert len(steps) == 5
+    assert steps[0]["uses"].startswith("actions/checkout@")
+    assert steps[0]["with"] == {"persist-credentials": False}
+    assert steps[1]["uses"].startswith("actions/setup-node@")
+    assert steps[1]["with"] == {"node-version": "20"}
+    assert steps[2]["run"] == "npm ci --ignore-scripts --no-audit --no-fund"
+    assert steps[2]["working-directory"] == "editors/vscode"
+    assert steps[3]["run"] == "node --test scripts/marketplace-sdk.test.cjs"
+    assert steps[4]["run"] == "node scripts/marketplace-diagnostics.cjs"
+    for step in steps:
+        assert "env" not in step
+    assert "secrets." not in yaml.safe_dump(job)
+
+
+class PublicationIsolation(unittest.TestCase):
+    def test_workflow_and_negative_controls(self):
+        source = (ROOT / ".github/workflows/vscode-publish.yml").read_text()
+        doc = yaml.safe_load(source)
+        validate(doc)
+        for name in ("build-binaries", "publish-platform", "publish-universal"):
+            for condition in (None, "always()", "startsWith(github.ref, 'refs/tags/v')"):
+                with self.subTest(job=name, condition=condition):
+                    changed = copy.deepcopy(doc)
+                    changed["jobs"][name]["if"] = condition
+                    with self.assertRaises(AssertionError):
+                        validate(changed)
+        for field, value in (("env", {"VSCE_PAT": "${{ secrets.VSCE_PAT }}"}),
+                             ("permissions", {"contents": "write"}),
+                             ("if", "always()"), ("needs", "publish-platform")):
+            with self.subTest(field=field):
+                changed = copy.deepcopy(doc)
+                changed["jobs"]["diagnose-marketplace"][field] = value
+                with self.assertRaises(AssertionError):
+                    validate(changed)
+        changed = copy.deepcopy(doc)
+        changed["jobs"]["diagnose-marketplace"]["steps"][4]["run"] = "npx vsce publish"
+        with self.assertRaises(AssertionError):
+            validate(changed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/marketplace-workflow-test.py
+++ b/scripts/marketplace-workflow-test.py
@@ -20,14 +20,18 @@ def validate(doc):
     assert set(jobs) == {"build-binaries", "publish-platform", "publish-universal", "diagnose-marketplace"}
     for name in ("build-binaries", "publish-platform", "publish-universal"):
         assert jobs[name]["if"] == TAG_ONLY
-    job = jobs["diagnose-marketplace"]
+        assert jobs[name]["runs-on"] == "ubuntu-24.04-arm"
+    assert "env" not in doc
+    validate_diagnostic(jobs["diagnose-marketplace"])
+
+
+def validate_diagnostic(job):
     assert job["if"] == MANUAL_ONLY
     assert job["permissions"] == {"contents": "read"}
     assert job["timeout-minutes"] == 3
-    assert job["strategy"]["fail-fast"] is False
-    assert job["strategy"]["matrix"]["runner"] == ["ubuntu-24.04-arm", "ubuntu-24.04"]
-    assert job["runs-on"] == "${{ matrix.runner }}"
-    assert "env" not in doc and "env" not in job and "needs" not in job
+    assert "strategy" not in job
+    assert job["runs-on"] == "ubuntu-24.04-arm"
+    assert "env" not in job and "needs" not in job
     steps = job["steps"]
     assert len(steps) == 5
     assert steps[0]["uses"].startswith("actions/checkout@")
@@ -67,6 +71,13 @@ class PublicationIsolation(unittest.TestCase):
         changed["jobs"]["diagnose-marketplace"]["steps"][4]["run"] = "npx vsce publish"
         with self.assertRaises(AssertionError):
             validate(changed)
+        # Both diagnostics and production must stay on the declared ARM fleet.
+        for name in doc["jobs"]:
+            with self.subTest(runner_drift=name):
+                changed = copy.deepcopy(doc)
+                changed["jobs"][name]["runs-on"] = "ubuntu-latest"
+                with self.assertRaises(AssertionError):
+                    validate(changed)
 
 
 if __name__ == "__main__":

--- a/scripts/marketplace-workflow-test.py
+++ b/scripts/marketplace-workflow-test.py
@@ -2,7 +2,10 @@
 """Manual diagnostics must never build, publish, or receive secrets (#638)."""
 
 import copy
+import os
 import pathlib
+import shutil
+import subprocess
 import unittest
 
 import yaml
@@ -99,6 +102,32 @@ class PublicationIsolation(unittest.TestCase):
                 destination["concurrency"] = doc["jobs"]["diagnose-marketplace"]["concurrency"]
                 with self.assertRaises(AssertionError):
                     validate(changed)
+
+
+class OptionalNodeGate(unittest.TestCase):
+    def run_node_gate(self, path, script_dir):
+        # Exercise the shipped conditional and real assert_exit helper. The
+        # small verdict sinks replace only the outer suite's reporting counters.
+        source = (ROOT / "scripts/ci-gates-test.sh").read_text()
+        helper = "assert_exit() {" + source.split("assert_exit() {", 1)[1].split("\n}\n", 1)[0] + "\n}"
+        block = source.split('python3 "${SCRIPT_DIR}/marketplace-workflow-test.py"', 1)[1]
+        block = block.split('echo "== govulncheck fail-summary:', 1)[0]
+        self.assertIn("marketplace-diagnostics.test.cjs", block)
+        script = 'fail=0\nok() { :; }\nbad() { fail=1; }\n' + helper + block + '\nexit "$fail"\n'
+        return subprocess.run(["/bin/bash", "-c", script], check=False, text=True,
+                              capture_output=True, timeout=15,
+                              env={**os.environ, "PATH": path, "SCRIPT_DIR": str(script_dir)})
+
+    def test_missing_node_skips_with_an_explicit_reason(self):
+        result = self.run_node_gate("", ROOT / "scripts")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("SKIP  node not installed", result.stdout)
+
+    @unittest.skipUnless(shutil.which("node"), "node not installed")
+    def test_present_node_does_not_hide_failed_test_execution(self):
+        result = self.run_node_gate(os.environ["PATH"], ROOT / "scripts/nonexistent-test-directory")
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertNotIn("SKIP  node not installed", result.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/marketplace-workflow-test.py
+++ b/scripts/marketplace-workflow-test.py
@@ -21,7 +21,9 @@ def validate(doc):
     for name in ("build-binaries", "publish-platform", "publish-universal"):
         assert jobs[name]["if"] == TAG_ONLY
         assert jobs[name]["runs-on"] == "ubuntu-24.04-arm"
+        assert "concurrency" not in jobs[name]
     assert "env" not in doc
+    assert "concurrency" not in doc
     validate_diagnostic(jobs["diagnose-marketplace"])
 
 
@@ -29,6 +31,7 @@ def validate_diagnostic(job):
     assert job["if"] == MANUAL_ONLY
     assert job["permissions"] == {"contents": "read"}
     assert job["timeout-minutes"] == 3
+    assert job["concurrency"] == {"group": "elps-marketplace-readonly-diagnostics", "cancel-in-progress": True}
     assert "strategy" not in job
     assert job["runs-on"] == "ubuntu-24.04-arm"
     assert "env" not in job and "needs" not in job
@@ -76,6 +79,24 @@ class PublicationIsolation(unittest.TestCase):
             with self.subTest(runner_drift=name):
                 changed = copy.deepcopy(doc)
                 changed["jobs"][name]["runs-on"] = "ubuntu-latest"
+                with self.assertRaises(AssertionError):
+                    validate(changed)
+
+    def test_concurrency_cancels_only_duplicate_manual_diagnostics(self):
+        doc = yaml.safe_load((ROOT / ".github/workflows/vscode-publish.yml").read_text())
+        validate(doc)
+        for concurrency in (None, {"group": "${{ github.ref }}", "cancel-in-progress": True},
+                            {"group": "elps-marketplace-readonly-diagnostics", "cancel-in-progress": False}):
+            with self.subTest(concurrency=concurrency):
+                changed = copy.deepcopy(doc)
+                changed["jobs"]["diagnose-marketplace"]["concurrency"] = concurrency
+                with self.assertRaises(AssertionError):
+                    validate(changed)
+        for location in ("workflow", "build-binaries", "publish-platform", "publish-universal"):
+            with self.subTest(cancellation_leak=location):
+                changed = copy.deepcopy(doc)
+                destination = changed if location == "workflow" else changed["jobs"][location]
+                destination["concurrency"] = doc["jobs"]["diagnose-marketplace"]["concurrency"]
                 with self.assertRaises(AssertionError):
                     validate(changed)
 


### PR DESCRIPTION
## Summary

ELPS backlog closeout on one branch, with a separate commit for each work item. Substrate is untouched and remains under user review.

| Ticket | Work / status |
|---|---|
| #641 | Remove whole-document line-slice allocations from LSP word/bounds/range lookups; preserve cursor and symbol semantics. |
| #598 / #600 | Shared behavioral checker over current copy/detach/Go Copy/macro-stamp/template operations, with real mutation controls and bounded fuzzing. |
| #637 | Closed separately: actual release-helper dry run proves upstream CLI startup recovery, without local workflow/secret changes. |
| #638 | Add guarded read-only manual Marketplace diagnostics and recovery runbook. Both runner hosts answered promptly; authenticated discovery and publication remain unverified. **Not claimed fixed or closed**. |

Closes #641. Closes #598. Closes #600. Partially addresses #638.

## Verification

- LSP: six allocation assertions fail old code and pass the fix. Independent token-boundary model and UTF-8/UTF-16 cursor tests; targeted normal, checked and race tests pass. Exact CI linter passes.
- LSP allocation counts: word 2→0, bounds 1→0, range 2→1. Eighteen before/after benchmark rows are directionally faster; noisy timing intervals prevent exact timing certification. Late-line lookup still scans preceding lines.
- Walkers: five real adapters, structural registry coverage, independent alias/isolation/metadata observations, and per-channel broken-adapter controls. Nine production mutations were each detected and restored. Tests/docs only: no runtime performance or public API change. Targeted checked/race tests pass; bounded fuzz smoke completed 7,831 executions in 10 seconds. Independent final QA passes. See `docs/walker-oracle.md` for the finite supported contracts, exceptions, and reproduction commands; existing cold/template parity tests remain intact.
- Diagnostics: 12 real HTTP, locked SDK, and subprocess tests plus workflow isolation checks pass. Removing body/deadline/environment/redirect protections fails controls. Independent QA/security review passes.
- Manual diagnostics have read-only contents permission, no publishing token and no lifecycle scripts. Build and publication jobs require a tag-push event. Diagnostic success is not evidence of successful publication.
- Actual read-only [runner comparison](https://github.com/luthersystems/elps/actions/runs/34444476770): public inventory HTTP 200, unauthenticated SDK HTTP 401 in 67 ms on ARM / 163 ms on x64; all production jobs skipped. Latest public version remained 1.60.0. This does not establish authenticated recovery. Shipped diagnostics use one literal production-equivalent ARM runner.
- First-head CI correctly rejected the diagnostic runner matrix under two existing fleet guards. The follow-up removes the matrix; no fleet exemption or guard weakening. Final local gate in benchmark-CI configuration: 210 passed, 0 failed.
- Combined-head CI also caught a direct header struct copy in the new truncated-cycle negative control. Reproduced locally, then routed through the existing audited header-view constructor, preserving the exact intentional defect. The source-copy guard and behavioral controls now pass together under checked/race; no exemption was added.
- Previously reviewed head `83c6aee`: full tests, full race, lint, both analyzer modes and all 11 fuzz shards passed in CI. The new walker target ran 18,842 executions during its 30-second CI budget. These historical run counts are not comparable across revisions/machines.
- [Benchmark gate on reviewed head 83c6aee](https://github.com/luthersystems/elps/actions/runs/34445842926): PASS, 47 delta rows + 801 no-change rows, zero rows at or above the unchanged 15% timing / 5% allocation thresholds; ten interleaved samples per arm on the same runner. Five statistically significant bad-direction metric rows were below the gate (timing changes at most +2.74%); this is not a claim that every timing row improved. LSP allocation improvement is separately measured above; these new LSP microbenchmarks are not in the existing CI comparison set.

## Review follow-up

| Finding | Commit | Fix / proof |
|---|---|---|
| Post-write snapshot errors mislabeled as isolation failures | ab7db35 | Wrap the real cause with arm/phase context. A 200-map regression fails old code; both error cause and classification are asserted. |
| Control suites silently change walkers after registry reorder | f9c6d69 | Select by stable names, reject missing/duplicate names, and run the real control suites under every rotation. Reverting their actual selections to indices fails. |
| Mutation/throughput documentation overclaim | e70ed91 | State that the common test was run alone, not that other tests stayed green. Remove stale machine-specific throughput from the committed guide. |
| Lexicographic version ordering | 0e27792 | Numeric triplet comparison without integer rounding, tested across digit boundaries and components above 2^53. |
| Unbounded manual diagnostics | 50b25bc | Fixed cross-branch, diagnostic-only job concurrency. Tag publication cannot share its cancellation group; mutation tests guard scope. |
| Missing Node handling differs from existing gate | 3c2a65b | Explicit optional-Node skip; a present Node must still propagate failed test execution. Both paths run in the test. |

Combined local verification on `e70ed91`: targeted checked/race oracle and structural guards pass (7.872s); exact CI linter reports zero issues; 11 Node and 4 Python tests pass; benchmark-CI-config gate 210/0. Independent QA/security review: PASS.

Final-head CI on `e70ed91`: **25/25 checks passed**, including full tests/race, both analyzer modes, all 11 fuzz shards and the unchanged benchmark gate. The walker fuzz target completed 18,744 executions during its 30-second budget. [Benchmark result](https://github.com/luthersystems/elps/actions/runs/34494138586): 49 delta rows + 799 no-change rows, zero rows at or above the 15% timing / 5% allocation thresholds, ten interleaved samples per arm. Nine significant adverse timing rows remained below the gate (largest +4.88%); not a claim that every timing row improved.

The [updated manual diagnostic run](https://github.com/luthersystems/elps/actions/runs/34494073897) passed with all three production build/publish jobs skipped. No authenticated probe or publication was performed.

Pre-existing MCP whole-document splitting and ampersand lookup mismatch independently reproduced and filed as #654. No MCP runtime change is bundled here. The minor existing repeated hover line scans are not a correctness regression; this follow-up leaves that separate optimization unchanged.

Not merged. Marketplace #638 remains explicitly unresolved, with authenticated diagnosis/publication recovery outside this read-only implementation.

No customer code, new embedding APIs, gate waivers, or production publication are included.
