### PR TITLE
Document the LSP word-lookup allocation fix in the 1.61.2 changelog

### DIFF
--- a/editors/vscode/CHANGELOG.md
+++ b/editors/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ jumps from 0.2.0 to 1.50.0.
 
 - LSP: bound parsing and disk reads for oversized documents, avoid expensive
   handlers on those documents, and remove stale workspace definitions on save.
+- LSP: hover, completion and definition no longer allocate a document-sized
+  line slice per request when they fall back to the word under the cursor.
 - Lint: add `comparator-mutation` and `iteration-mutation` checks, with bounded
   callback analysis and quote handling that matches ELPS evaluation. These are
   conservative checks, not a proof that callbacks are free of side effects.


### PR DESCRIPTION
## Summary

#653 removed the per-request whole-document line slice from the LSP hover, completion and definition fallbacks. The extension ships that server, so the `1.61.2` section of `editors/vscode/CHANGELOG.md` names it before the tag is cut. One bullet, no other change.

This is the last change before dispatching `release-tag.yml` for v1.61.2, which the release skill requires to land on main first because the pipeline releases main HEAD.

## Verification

- Markdown only. The bullet sits under the existing `## 1.61.2` heading, matching the style of the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHMPMnEJgGRuJioE5ddat6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHMPMnEJgGRuJioE5ddat6)_